### PR TITLE
Clean up events and properties

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,12 @@ disable_error_code = [
     "var-annotated",
 ]
 
+[[tool.mypy.overrides]]
+module = [
+  "tests.*",
+]
+warn_unreachable = false
+
 [tool.pylint]
 max-line-length = 120
 disable = ["C0103", "W0212"]

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -53,7 +53,7 @@ async def async_test_binary_sensor_occupancy(
     assert entity.is_on is False
 
     # test refresh
-    cluster.read_attributes.reset_mock()  # type: ignore[unreachable]
+    cluster.read_attributes.reset_mock()
     assert entity.is_on is False
     cluster.PLUGGED_ATTR_READS = plugs
     update_attribute_cache(cluster)
@@ -84,7 +84,7 @@ async def async_test_iaszone_on_off(
     assert entity.is_on is False
 
     # check that binary sensor remains off when non-alarm bits change
-    cluster.listener_event("cluster_command", 1, 0, [0b1111111100])  # type: ignore[unreachable]
+    cluster.listener_event("cluster_command", 1, 0, [0b1111111100])
     await zha_gateway.async_block_till_done()
     assert entity.is_on is False
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -384,7 +384,6 @@ async def test_climate_hvac_action_running_state(
 @pytest.mark.looptime
 async def test_sinope_time(
     device_climate_sinope: Device,
-    zha_gateway: Gateway,
 ):
     """Test hvac action via running state."""
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -315,10 +315,10 @@ async def test_climate_local_temperature(
     assert entity is not None
 
     assert isinstance(entity, ThermostatEntity)
-    assert entity.get_state()["current_temperature"] is None
+    assert entity.state["current_temperature"] is None
 
     await send_attributes_report(zha_gateway, thrm_cluster, {0: 2100})
-    assert entity.get_state()["current_temperature"] == 21.0
+    assert entity.state["current_temperature"] == 21.0
 
 
 async def test_climate_hvac_action_running_state(
@@ -341,44 +341,44 @@ async def test_climate_hvac_action_running_state(
     assert sensor_entity is not None
     assert isinstance(sensor_entity, SinopeHVACAction)
 
-    assert entity.get_state()["hvac_action"] == "off"
-    assert sensor_entity.get_state()["state"] == "off"
+    assert entity.state["hvac_action"] == "off"
+    assert sensor_entity.state["state"] == "off"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001E: Thermostat.RunningMode.Off}
     )
-    assert entity.get_state()["hvac_action"] == "off"
-    assert sensor_entity.get_state()["state"] == "off"
+    assert entity.state["hvac_action"] == "off"
+    assert sensor_entity.state["state"] == "off"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001C: Thermostat.SystemMode.Auto}
     )
-    assert entity.get_state()["hvac_action"] == "idle"
-    assert sensor_entity.get_state()["state"] == "idle"
+    assert entity.state["hvac_action"] == "idle"
+    assert sensor_entity.state["state"] == "idle"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001E: Thermostat.RunningMode.Cool}
     )
-    assert entity.get_state()["hvac_action"] == "cooling"
-    assert sensor_entity.get_state()["state"] == "cooling"
+    assert entity.state["hvac_action"] == "cooling"
+    assert sensor_entity.state["state"] == "cooling"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001E: Thermostat.RunningMode.Heat}
     )
-    assert entity.get_state()["hvac_action"] == "heating"
-    assert sensor_entity.get_state()["state"] == "heating"
+    assert entity.state["hvac_action"] == "heating"
+    assert sensor_entity.state["state"] == "heating"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001E: Thermostat.RunningMode.Off}
     )
-    assert entity.get_state()["hvac_action"] == "idle"
-    assert sensor_entity.get_state()["state"] == "idle"
+    assert entity.state["hvac_action"] == "idle"
+    assert sensor_entity.state["state"] == "idle"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Fan_State_On}
     )
-    assert entity.get_state()["hvac_action"] == "fan"
-    assert sensor_entity.get_state()["state"] == "fan"
+    assert entity.state["hvac_action"] == "fan"
+    assert sensor_entity.state["state"] == "fan"
 
 
 @pytest.mark.looptime
@@ -424,62 +424,62 @@ async def test_climate_hvac_action_running_state_zen(
     assert sensor_entity is not None
     assert isinstance(sensor_entity, ThermostatHVACAction)
 
-    assert entity.get_state()["hvac_action"] is None
-    assert sensor_entity.get_state()["state"] is None
+    assert entity.state["hvac_action"] is None
+    assert sensor_entity.state["state"] is None
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Cool_2nd_Stage_On}
     )
-    assert entity.get_state()["hvac_action"] == "cooling"
-    assert sensor_entity.get_state()["state"] == "cooling"
+    assert entity.state["hvac_action"] == "cooling"
+    assert sensor_entity.state["state"] == "cooling"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Fan_State_On}
     )
-    assert entity.get_state()["hvac_action"] == "fan"
-    assert sensor_entity.get_state()["state"] == "fan"
+    assert entity.state["hvac_action"] == "fan"
+    assert sensor_entity.state["state"] == "fan"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Heat_2nd_Stage_On}
     )
-    assert entity.get_state()["hvac_action"] == "heating"
-    assert sensor_entity.get_state()["state"] == "heating"
+    assert entity.state["hvac_action"] == "heating"
+    assert sensor_entity.state["state"] == "heating"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Fan_2nd_Stage_On}
     )
-    assert entity.get_state()["hvac_action"] == "fan"
-    assert sensor_entity.get_state()["state"] == "fan"
+    assert entity.state["hvac_action"] == "fan"
+    assert sensor_entity.state["state"] == "fan"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Cool_State_On}
     )
-    assert entity.get_state()["hvac_action"] == "cooling"
-    assert sensor_entity.get_state()["state"] == "cooling"
+    assert entity.state["hvac_action"] == "cooling"
+    assert sensor_entity.state["state"] == "cooling"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Fan_3rd_Stage_On}
     )
-    assert entity.get_state()["hvac_action"] == "fan"
-    assert sensor_entity.get_state()["state"] == "fan"
+    assert entity.state["hvac_action"] == "fan"
+    assert sensor_entity.state["state"] == "fan"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Heat_State_On}
     )
-    assert entity.get_state()["hvac_action"] == "heating"
-    assert sensor_entity.get_state()["state"] == "heating"
+    assert entity.state["hvac_action"] == "heating"
+    assert sensor_entity.state["state"] == "heating"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Idle}
     )
-    assert entity.get_state()["hvac_action"] == "off"
-    assert sensor_entity.get_state()["state"] == "off"
+    assert entity.state["hvac_action"] == "off"
+    assert sensor_entity.state["state"] == "off"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001C: Thermostat.SystemMode.Heat}
     )
-    assert entity.get_state()["hvac_action"] == "idle"
-    assert sensor_entity.get_state()["state"] == "idle"
+    assert entity.state["hvac_action"] == "idle"
+    assert sensor_entity.state["state"] == "idle"
 
 
 async def test_climate_hvac_action_pi_demand(
@@ -496,28 +496,28 @@ async def test_climate_hvac_action_pi_demand(
     assert entity is not None
     assert isinstance(entity, ThermostatEntity)
 
-    assert entity.get_state()["hvac_action"] is None
+    assert entity.state["hvac_action"] is None
 
     await send_attributes_report(zha_gateway, thrm_cluster, {0x0007: 10})
-    assert entity.get_state()["hvac_action"] == "cooling"
+    assert entity.state["hvac_action"] == "cooling"
 
     await send_attributes_report(zha_gateway, thrm_cluster, {0x0008: 20})
-    assert entity.get_state()["hvac_action"] == "heating"
+    assert entity.state["hvac_action"] == "heating"
 
     await send_attributes_report(zha_gateway, thrm_cluster, {0x0007: 0})
     await send_attributes_report(zha_gateway, thrm_cluster, {0x0008: 0})
 
-    assert entity.get_state()["hvac_action"] == "off"
+    assert entity.state["hvac_action"] == "off"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001C: Thermostat.SystemMode.Heat}
     )
-    assert entity.get_state()["hvac_action"] == "idle"
+    assert entity.state["hvac_action"] == "idle"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001C: Thermostat.SystemMode.Cool}
     )
-    assert entity.get_state()["hvac_action"] == "idle"
+    assert entity.state["hvac_action"] == "idle"
 
 
 @pytest.mark.parametrize(
@@ -547,18 +547,18 @@ async def test_hvac_mode(
     assert entity is not None
     assert isinstance(entity, ThermostatEntity)
 
-    assert entity.get_state()["hvac_mode"] == "off"
+    assert entity.state["hvac_mode"] == "off"
 
     await send_attributes_report(zha_gateway, thrm_cluster, {0x001C: sys_mode})
-    assert entity.get_state()["hvac_mode"] == hvac_mode
+    assert entity.state["hvac_mode"] == hvac_mode
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001C: Thermostat.SystemMode.Off}
     )
-    assert entity.get_state()["hvac_mode"] == "off"
+    assert entity.state["hvac_mode"] == "off"
 
     await send_attributes_report(zha_gateway, thrm_cluster, {0x001C: 0xFF})
-    assert entity.get_state()["hvac_mode"] is None
+    assert entity.state["hvac_mode"] is None
 
 
 @pytest.mark.parametrize(
@@ -631,7 +631,7 @@ async def test_target_temperature(
         await entity.async_set_preset_mode(preset)
         await zha_gateway.async_block_till_done()
 
-    assert entity.get_state()["target_temperature"] == target_temp
+    assert entity.state["target_temperature"] == target_temp
 
 
 @pytest.mark.parametrize(
@@ -670,7 +670,7 @@ async def test_target_temperature_high(
         await entity.async_set_preset_mode(preset)
         await zha_gateway.async_block_till_done()
 
-    assert entity.get_state()["target_temperature_high"] == target_temp
+    assert entity.state["target_temperature_high"] == target_temp
 
 
 @pytest.mark.parametrize(
@@ -709,7 +709,7 @@ async def test_target_temperature_low(
         await entity.async_set_preset_mode(preset)
         await zha_gateway.async_block_till_done()
 
-    assert entity.get_state()["target_temperature_low"] == target_temp
+    assert entity.state["target_temperature_low"] == target_temp
 
 
 @pytest.mark.parametrize(
@@ -738,27 +738,27 @@ async def test_set_hvac_mode(
     assert entity is not None
     assert isinstance(entity, ThermostatEntity)
 
-    assert entity.get_state()["hvac_mode"] == "off"
+    assert entity.state["hvac_mode"] == "off"
 
     await entity.async_set_hvac_mode(hvac_mode)
     await zha_gateway.async_block_till_done()
 
     if sys_mode is not None:
-        assert entity.get_state()["hvac_mode"] == hvac_mode
+        assert entity.state["hvac_mode"] == hvac_mode
         assert thrm_cluster.write_attributes.call_count == 1
         assert thrm_cluster.write_attributes.call_args[0][0] == {
             "system_mode": sys_mode
         }
     else:
         assert thrm_cluster.write_attributes.call_count == 0
-        assert entity.get_state()["hvac_mode"] == "off"
+        assert entity.state["hvac_mode"] == "off"
 
     # turn off
     thrm_cluster.write_attributes.reset_mock()
     await entity.async_set_hvac_mode("off")
     await zha_gateway.async_block_till_done()
 
-    assert entity.get_state()["hvac_mode"] == "off"
+    assert entity.state["hvac_mode"] == "off"
     assert thrm_cluster.write_attributes.call_count == 1
     assert thrm_cluster.write_attributes.call_args[0][0] == {
         "system_mode": Thermostat.SystemMode.Off
@@ -778,7 +778,7 @@ async def test_preset_setting(
     assert entity is not None
     assert isinstance(entity, ThermostatEntity)
 
-    assert entity.get_state()["preset_mode"] == "none"
+    assert entity.state["preset_mode"] == "none"
 
     # unsuccessful occupancy change
     thrm_cluster.write_attributes.return_value = [
@@ -796,7 +796,7 @@ async def test_preset_setting(
         await entity.async_set_preset_mode("away")
         await zha_gateway.async_block_till_done()
 
-    assert entity.get_state()["preset_mode"] == "none"
+    assert entity.state["preset_mode"] == "none"
     assert thrm_cluster.write_attributes.call_count == 1
     assert thrm_cluster.write_attributes.call_args[0][0] == {"set_occupancy": 0}
 
@@ -808,7 +808,7 @@ async def test_preset_setting(
     await entity.async_set_preset_mode("away")
     await zha_gateway.async_block_till_done()
 
-    assert entity.get_state()["preset_mode"] == "away"
+    assert entity.state["preset_mode"] == "away"
     assert thrm_cluster.write_attributes.call_count == 1
     assert thrm_cluster.write_attributes.call_args[0][0] == {"set_occupancy": 0}
 
@@ -830,7 +830,7 @@ async def test_preset_setting(
         await entity.async_set_preset_mode("none")
         await zha_gateway.async_block_till_done()
 
-    assert entity.get_state()["preset_mode"] == "away"
+    assert entity.state["preset_mode"] == "away"
     assert thrm_cluster.write_attributes.call_count == 1
     assert thrm_cluster.write_attributes.call_args[0][0] == {"set_occupancy": 1}
 
@@ -843,7 +843,7 @@ async def test_preset_setting(
     await entity.async_set_preset_mode("none")
     await zha_gateway.async_block_till_done()
 
-    assert entity.get_state()["preset_mode"] == "none"
+    assert entity.state["preset_mode"] == "none"
     assert thrm_cluster.write_attributes.call_count == 1
     assert thrm_cluster.write_attributes.call_args[0][0] == {"set_occupancy": 1}
 
@@ -862,11 +862,11 @@ async def test_preset_setting_invalid(
     assert entity is not None
     assert isinstance(entity, ThermostatEntity)
 
-    assert entity.get_state()["preset_mode"] == "none"
+    assert entity.state["preset_mode"] == "none"
     await entity.async_set_preset_mode("invalid_preset")
     await zha_gateway.async_block_till_done()
 
-    assert entity.get_state()["preset_mode"] == "none"
+    assert entity.state["preset_mode"] == "none"
     assert thrm_cluster.write_attributes.call_count == 0
 
 
@@ -884,11 +884,11 @@ async def test_set_temperature_hvac_mode(
     assert entity is not None
     assert isinstance(entity, ThermostatEntity)
 
-    assert entity.get_state()["hvac_mode"] == "off"
+    assert entity.state["hvac_mode"] == "off"
     await entity.async_set_temperature(hvac_mode="heat_cool", temperature=20)
     await zha_gateway.async_block_till_done()
 
-    assert entity.get_state()["hvac_mode"] == "heat_cool"
+    assert entity.state["hvac_mode"] == "heat_cool"
     assert thrm_cluster.write_attributes.await_count == 1
     assert thrm_cluster.write_attributes.call_args[0][0] == {
         "system_mode": Thermostat.SystemMode.Auto
@@ -920,20 +920,20 @@ async def test_set_temperature_heat_cool(
     assert entity is not None
     assert isinstance(entity, ThermostatEntity)
 
-    assert entity.get_state()["hvac_mode"] == "heat_cool"
+    assert entity.state["hvac_mode"] == "heat_cool"
 
     await entity.async_set_temperature(temperature=20)
     await zha_gateway.async_block_till_done()
 
-    assert entity.get_state()["target_temperature_low"] == 20.0
-    assert entity.get_state()["target_temperature_high"] == 25.0
+    assert entity.state["target_temperature_low"] == 20.0
+    assert entity.state["target_temperature_high"] == 25.0
     assert thrm_cluster.write_attributes.await_count == 0
 
     await entity.async_set_temperature(target_temp_high=26, target_temp_low=19)
     await zha_gateway.async_block_till_done()
 
-    assert entity.get_state()["target_temperature_low"] == 19.0
-    assert entity.get_state()["target_temperature_high"] == 26.0
+    assert entity.state["target_temperature_low"] == 19.0
+    assert entity.state["target_temperature_high"] == 26.0
     assert thrm_cluster.write_attributes.await_count == 2
     assert thrm_cluster.write_attributes.call_args_list[0][0][0] == {
         "occupied_heating_setpoint": 1900
@@ -949,8 +949,8 @@ async def test_set_temperature_heat_cool(
     await entity.async_set_temperature(target_temp_high=30, target_temp_low=15)
     await zha_gateway.async_block_till_done()
 
-    assert entity.get_state()["target_temperature_low"] == 15.0
-    assert entity.get_state()["target_temperature_high"] == 30.0
+    assert entity.state["target_temperature_low"] == 15.0
+    assert entity.state["target_temperature_high"] == 30.0
     assert thrm_cluster.write_attributes.await_count == 2
     assert thrm_cluster.write_attributes.call_args_list[0][0][0] == {
         "unoccupied_heating_setpoint": 1500
@@ -985,22 +985,22 @@ async def test_set_temperature_heat(
     assert entity is not None
     assert isinstance(entity, ThermostatEntity)
 
-    assert entity.get_state()["hvac_mode"] == "heat"
+    assert entity.state["hvac_mode"] == "heat"
 
     await entity.async_set_temperature(target_temp_high=30, target_temp_low=15)
     await zha_gateway.async_block_till_done()
 
-    assert entity.get_state()["target_temperature_low"] is None
-    assert entity.get_state()["target_temperature_high"] is None
-    assert entity.get_state()["target_temperature"] == 20.0
+    assert entity.state["target_temperature_low"] is None
+    assert entity.state["target_temperature_high"] is None
+    assert entity.state["target_temperature"] == 20.0
     assert thrm_cluster.write_attributes.await_count == 0
 
     await entity.async_set_temperature(temperature=21)
     await zha_gateway.async_block_till_done()
 
-    assert entity.get_state()["target_temperature_low"] is None
-    assert entity.get_state()["target_temperature_high"] is None
-    assert entity.get_state()["target_temperature"] == 21.0
+    assert entity.state["target_temperature_low"] is None
+    assert entity.state["target_temperature_high"] is None
+    assert entity.state["target_temperature"] == 21.0
     assert thrm_cluster.write_attributes.await_count == 1
     assert thrm_cluster.write_attributes.call_args_list[0][0][0] == {
         "occupied_heating_setpoint": 2100
@@ -1013,9 +1013,9 @@ async def test_set_temperature_heat(
     await entity.async_set_temperature(temperature=22)
     await zha_gateway.async_block_till_done()
 
-    assert entity.get_state()["target_temperature_low"] is None
-    assert entity.get_state()["target_temperature_high"] is None
-    assert entity.get_state()["target_temperature"] == 22.0
+    assert entity.state["target_temperature_low"] is None
+    assert entity.state["target_temperature_high"] is None
+    assert entity.state["target_temperature"] == 22.0
     assert thrm_cluster.write_attributes.await_count == 1
     assert thrm_cluster.write_attributes.call_args_list[0][0][0] == {
         "unoccupied_heating_setpoint": 2200
@@ -1047,22 +1047,22 @@ async def test_set_temperature_cool(
     assert entity is not None
     assert isinstance(entity, ThermostatEntity)
 
-    assert entity.get_state()["hvac_mode"] == "cool"
+    assert entity.state["hvac_mode"] == "cool"
 
     await entity.async_set_temperature(target_temp_high=30, target_temp_low=15)
     await zha_gateway.async_block_till_done()
 
-    assert entity.get_state()["target_temperature_low"] is None
-    assert entity.get_state()["target_temperature_high"] is None
-    assert entity.get_state()["target_temperature"] == 25.0
+    assert entity.state["target_temperature_low"] is None
+    assert entity.state["target_temperature_high"] is None
+    assert entity.state["target_temperature"] == 25.0
     assert thrm_cluster.write_attributes.await_count == 0
 
     await entity.async_set_temperature(temperature=21)
     await zha_gateway.async_block_till_done()
 
-    assert entity.get_state()["target_temperature_low"] is None
-    assert entity.get_state()["target_temperature_high"] is None
-    assert entity.get_state()["target_temperature"] == 21.0
+    assert entity.state["target_temperature_low"] is None
+    assert entity.state["target_temperature_high"] is None
+    assert entity.state["target_temperature"] == 21.0
     assert thrm_cluster.write_attributes.await_count == 1
     assert thrm_cluster.write_attributes.call_args_list[0][0][0] == {
         "occupied_cooling_setpoint": 2100
@@ -1075,9 +1075,9 @@ async def test_set_temperature_cool(
     await entity.async_set_temperature(temperature=22)
     await zha_gateway.async_block_till_done()
 
-    assert entity.get_state()["target_temperature_low"] is None
-    assert entity.get_state()["target_temperature_high"] is None
-    assert entity.get_state()["target_temperature"] == 22.0
+    assert entity.state["target_temperature_low"] is None
+    assert entity.state["target_temperature_high"] is None
+    assert entity.state["target_temperature"] == 22.0
     assert thrm_cluster.write_attributes.await_count == 1
     assert thrm_cluster.write_attributes.call_args_list[0][0][0] == {
         "unoccupied_cooling_setpoint": 2200
@@ -1113,14 +1113,14 @@ async def test_set_temperature_wrong_mode(
     assert entity is not None
     assert isinstance(entity, ThermostatEntity)
 
-    assert entity.get_state()["hvac_mode"] == "dry"
+    assert entity.state["hvac_mode"] == "dry"
 
     await entity.async_set_temperature(temperature=24)
     await zha_gateway.async_block_till_done()
 
-    assert entity.get_state()["target_temperature_low"] is None
-    assert entity.get_state()["target_temperature_high"] is None
-    assert entity.get_state()["target_temperature"] is None
+    assert entity.state["target_temperature_low"] is None
+    assert entity.state["target_temperature_high"] is None
+    assert entity.state["target_temperature"] is None
     assert thrm_cluster.write_attributes.await_count == 0
 
 
@@ -1137,20 +1137,20 @@ async def test_occupancy_reset(
     assert entity is not None
     assert isinstance(entity, ThermostatEntity)
 
-    assert entity.get_state()["preset_mode"] == "none"
+    assert entity.state["preset_mode"] == "none"
 
     await entity.async_set_preset_mode("away")
     await zha_gateway.async_block_till_done()
     thrm_cluster.write_attributes.reset_mock()
 
-    assert entity.get_state()["preset_mode"] == "away"
+    assert entity.state["preset_mode"] == "away"
 
     await send_attributes_report(
         zha_gateway,
         thrm_cluster,
         {"occupied_heating_setpoint": zigpy.types.uint16_t(1950)},
     )
-    assert entity.get_state()["preset_mode"] == "none"
+    assert entity.state["preset_mode"] == "none"
 
 
 async def test_fan_mode(
@@ -1167,26 +1167,26 @@ async def test_fan_mode(
     assert isinstance(entity, ThermostatEntity)
 
     assert set(entity.fan_modes) == {FanState.AUTO, FanState.ON}
-    assert entity.get_state()["fan_mode"] == FanState.AUTO
+    assert entity.state["fan_mode"] == FanState.AUTO
 
     await send_attributes_report(
         zha_gateway,
         thrm_cluster,
         {"running_state": Thermostat.RunningState.Fan_State_On},
     )
-    assert entity.get_state()["fan_mode"] == FanState.ON
+    assert entity.state["fan_mode"] == FanState.ON
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {"running_state": Thermostat.RunningState.Idle}
     )
-    assert entity.get_state()["fan_mode"] == FanState.AUTO
+    assert entity.state["fan_mode"] == FanState.AUTO
 
     await send_attributes_report(
         zha_gateway,
         thrm_cluster,
         {"running_state": Thermostat.RunningState.Fan_2nd_Stage_On},
     )
-    assert entity.get_state()["fan_mode"] == FanState.ON
+    assert entity.state["fan_mode"] == FanState.ON
 
 
 async def test_set_fan_mode_not_supported(
@@ -1220,7 +1220,7 @@ async def test_set_fan_mode(
     assert entity is not None
     assert isinstance(entity, ThermostatEntity)
 
-    assert entity.get_state()["fan_mode"] == FanState.AUTO
+    assert entity.state["fan_mode"] == FanState.AUTO
 
     await entity.async_set_fan_mode(FanState.ON)
     await zha_gateway.async_block_till_done()
@@ -1245,7 +1245,7 @@ async def test_set_moes_preset(device_climate_moes: Device, zha_gateway: Gateway
     assert entity is not None
     assert isinstance(entity, ThermostatEntity)
 
-    assert entity.get_state()["preset_mode"] == "none"
+    assert entity.state["preset_mode"] == "none"
 
     await entity.async_set_preset_mode("away")
     await zha_gateway.async_block_till_done()
@@ -1339,31 +1339,31 @@ async def test_set_moes_operation_mode(
 
     await send_attributes_report(zha_gateway, thrm_cluster, {"operation_preset": 0})
 
-    assert entity.get_state()["preset_mode"] == "away"
+    assert entity.state["preset_mode"] == "away"
 
     await send_attributes_report(zha_gateway, thrm_cluster, {"operation_preset": 1})
 
-    assert entity.get_state()["preset_mode"] == "Schedule"
+    assert entity.state["preset_mode"] == "Schedule"
 
     await send_attributes_report(zha_gateway, thrm_cluster, {"operation_preset": 2})
 
-    assert entity.get_state()["preset_mode"] == "none"
+    assert entity.state["preset_mode"] == "none"
 
     await send_attributes_report(zha_gateway, thrm_cluster, {"operation_preset": 3})
 
-    assert entity.get_state()["preset_mode"] == "comfort"
+    assert entity.state["preset_mode"] == "comfort"
 
     await send_attributes_report(zha_gateway, thrm_cluster, {"operation_preset": 4})
 
-    assert entity.get_state()["preset_mode"] == "eco"
+    assert entity.state["preset_mode"] == "eco"
 
     await send_attributes_report(zha_gateway, thrm_cluster, {"operation_preset": 5})
 
-    assert entity.get_state()["preset_mode"] == "boost"
+    assert entity.state["preset_mode"] == "boost"
 
     await send_attributes_report(zha_gateway, thrm_cluster, {"operation_preset": 6})
 
-    assert entity.get_state()["preset_mode"] == "Complex"
+    assert entity.state["preset_mode"] == "Complex"
 
 
 # Device is running an energy-saving mode
@@ -1400,7 +1400,7 @@ async def test_beca_operation_mode_update(
         zha_gateway, thrm_cluster, {"operation_preset": preset_attr}
     )
 
-    assert entity.get_state()[ATTR_PRESET_MODE] == preset_mode
+    assert entity.state[ATTR_PRESET_MODE] == preset_mode
 
     await entity.async_set_preset_mode(preset_mode)
     await zha_gateway.async_block_till_done()
@@ -1424,7 +1424,7 @@ async def test_set_zonnsmart_preset(
     assert entity is not None
     assert isinstance(entity, ThermostatEntity)
 
-    assert entity.get_state()[ATTR_PRESET_MODE] == PRESET_NONE
+    assert entity.state[ATTR_PRESET_MODE] == PRESET_NONE
 
     await entity.async_set_preset_mode(PRESET_SCHEDULE)
     await zha_gateway.async_block_till_done()
@@ -1482,20 +1482,20 @@ async def test_set_zonnsmart_operation_mode(
 
     await send_attributes_report(zha_gateway, thrm_cluster, {"operation_preset": 0})
 
-    assert entity.get_state()[ATTR_PRESET_MODE] == PRESET_SCHEDULE
+    assert entity.state[ATTR_PRESET_MODE] == PRESET_SCHEDULE
 
     await send_attributes_report(zha_gateway, thrm_cluster, {"operation_preset": 1})
 
-    assert entity.get_state()[ATTR_PRESET_MODE] == PRESET_NONE
+    assert entity.state[ATTR_PRESET_MODE] == PRESET_NONE
 
     await send_attributes_report(zha_gateway, thrm_cluster, {"operation_preset": 2})
 
-    assert entity.get_state()[ATTR_PRESET_MODE] == "holiday"
+    assert entity.state[ATTR_PRESET_MODE] == "holiday"
 
     await send_attributes_report(zha_gateway, thrm_cluster, {"operation_preset": 3})
 
-    assert entity.get_state()[ATTR_PRESET_MODE] == "holiday"
+    assert entity.state[ATTR_PRESET_MODE] == "holiday"
 
     await send_attributes_report(zha_gateway, thrm_cluster, {"operation_preset": 4})
 
-    assert entity.get_state()[ATTR_PRESET_MODE] == "frost protect"
+    assert entity.state[ATTR_PRESET_MODE] == "frost protect"

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -162,7 +162,7 @@ async def test_cover_non_tilt_initial_state(  # pylint: disable=unused-argument
 
     entity = get_entity(zha_device, entity_id)
     assert entity is not None
-    state = entity.get_state()
+    state = entity.state
     assert state["state"] == STATE_OPEN
     assert state[ATTR_CURRENT_POSITION] == 100
 
@@ -177,8 +177,8 @@ async def test_cover_non_tilt_initial_state(  # pylint: disable=unused-argument
     await entity.async_update()
     assert cluster.read_attributes.call_count == prev_call_count + 1
 
-    assert entity.get_state()["state"] == STATE_CLOSED
-    assert entity.get_state()[ATTR_CURRENT_POSITION] == 0
+    assert entity.state["state"] == STATE_CLOSED
+    assert entity.state[ATTR_CURRENT_POSITION] == 0
 
 
 async def test_cover(
@@ -225,31 +225,31 @@ async def test_cover(
     await send_attributes_report(
         zha_gateway, cluster, {WCAttrs.current_position_lift_percentage.id: 100}
     )
-    assert entity.get_state()["state"] == STATE_CLOSED
+    assert entity.state["state"] == STATE_CLOSED
 
     # test to see if it opens
     await send_attributes_report(
         zha_gateway, cluster, {WCAttrs.current_position_lift_percentage.id: 0}
     )
-    assert entity.get_state()["state"] == STATE_OPEN
+    assert entity.state["state"] == STATE_OPEN
 
     # test that the state remains after tilting to 100%
     await send_attributes_report(
         zha_gateway, cluster, {WCAttrs.current_position_tilt_percentage.id: 100}
     )
-    assert entity.get_state()["state"] == STATE_OPEN
+    assert entity.state["state"] == STATE_OPEN
 
     # test to see the state remains after tilting to 0%
     await send_attributes_report(
         zha_gateway, cluster, {WCAttrs.current_position_tilt_percentage.id: 0}
     )
-    assert entity.get_state()["state"] == STATE_OPEN
+    assert entity.state["state"] == STATE_OPEN
 
     cluster.PLUGGED_ATTR_READS = {1: 100}
     update_attribute_cache(cluster)
     await entity.async_update()
     await zha_gateway.async_block_till_done()
-    assert entity.get_state()["state"] == STATE_OPEN
+    assert entity.state["state"] == STATE_OPEN
 
     # close from client
     with patch("zigpy.zcl.Cluster.request", return_value=[0x1, zcl_f.Status.SUCCESS]):
@@ -261,13 +261,13 @@ async def test_cover(
         assert cluster.request.call_args[0][2].command.name == WCCmds.down_close.name
         assert cluster.request.call_args[1]["expect_reply"] is True
 
-        assert entity.get_state()["state"] == STATE_CLOSING
+        assert entity.state["state"] == STATE_CLOSING
 
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_lift_percentage.id: 100}
         )
 
-        assert entity.get_state()["state"] == STATE_CLOSED
+        assert entity.state["state"] == STATE_CLOSED
 
     # tilt close from client
     with patch("zigpy.zcl.Cluster.request", return_value=[0x1, zcl_f.Status.SUCCESS]):
@@ -283,13 +283,13 @@ async def test_cover(
         assert cluster.request.call_args[0][3] == 100
         assert cluster.request.call_args[1]["expect_reply"] is True
 
-        assert entity.get_state()["state"] == STATE_CLOSING
+        assert entity.state["state"] == STATE_CLOSING
 
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_tilt_percentage.id: 100}
         )
 
-        assert entity.get_state()["state"] == STATE_CLOSED
+        assert entity.state["state"] == STATE_CLOSED
 
     # open from client
     with patch("zigpy.zcl.Cluster.request", return_value=[0x0, zcl_f.Status.SUCCESS]):
@@ -301,13 +301,13 @@ async def test_cover(
         assert cluster.request.call_args[0][2].command.name == WCCmds.up_open.name
         assert cluster.request.call_args[1]["expect_reply"] is True
 
-        assert entity.get_state()["state"] == STATE_OPENING
+        assert entity.state["state"] == STATE_OPENING
 
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_lift_percentage.id: 0}
         )
 
-        assert entity.get_state()["state"] == STATE_OPEN
+        assert entity.state["state"] == STATE_OPEN
 
     # open tilt from client
     with patch("zigpy.zcl.Cluster.request", return_value=[0x0, zcl_f.Status.SUCCESS]):
@@ -323,13 +323,13 @@ async def test_cover(
         assert cluster.request.call_args[0][3] == 0
         assert cluster.request.call_args[1]["expect_reply"] is True
 
-        assert entity.get_state()["state"] == STATE_OPENING
+        assert entity.state["state"] == STATE_OPENING
 
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_tilt_percentage.id: 0}
         )
 
-        assert entity.get_state()["state"] == STATE_OPEN
+        assert entity.state["state"] == STATE_OPEN
 
     # set position UI
     with patch("zigpy.zcl.Cluster.request", return_value=[0x5, zcl_f.Status.SUCCESS]):
@@ -342,19 +342,19 @@ async def test_cover(
         assert cluster.request.call_args[0][3] == 53
         assert cluster.request.call_args[1]["expect_reply"] is True
 
-        assert entity.get_state()["state"] == STATE_CLOSING
+        assert entity.state["state"] == STATE_CLOSING
 
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_lift_percentage.id: 35}
         )
 
-        assert entity.get_state()["state"] == STATE_CLOSING
+        assert entity.state["state"] == STATE_CLOSING
 
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_lift_percentage.id: 53}
         )
 
-        assert entity.get_state()["state"] == STATE_OPEN
+        assert entity.state["state"] == STATE_OPEN
 
     # set tilt position UI
     with patch("zigpy.zcl.Cluster.request", return_value=[0x5, zcl_f.Status.SUCCESS]):
@@ -370,19 +370,19 @@ async def test_cover(
         assert cluster.request.call_args[0][3] == 53
         assert cluster.request.call_args[1]["expect_reply"] is True
 
-        assert entity.get_state()["state"] == STATE_CLOSING
+        assert entity.state["state"] == STATE_CLOSING
 
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_lift_percentage.id: 35}
         )
 
-        assert entity.get_state()["state"] == STATE_CLOSING
+        assert entity.state["state"] == STATE_CLOSING
 
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_lift_percentage.id: 53}
         )
 
-        assert entity.get_state()["state"] == STATE_OPEN
+        assert entity.state["state"] == STATE_OPEN
 
     # stop from client
     with patch("zigpy.zcl.Cluster.request", return_value=[0x2, zcl_f.Status.SUCCESS]):
@@ -429,7 +429,7 @@ async def test_cover_failures(
         zha_gateway, cluster, {WCAttrs.current_position_lift_percentage.id: 0}
     )
 
-    assert entity.get_state()["state"] == STATE_OPEN
+    assert entity.state["state"] == STATE_OPEN
 
     # close from UI
     with patch(
@@ -447,7 +447,7 @@ async def test_cover_failures(
             cluster.request.call_args[0][1]
             == closures.WindowCovering.ServerCommandDefs.down_close.id
         )
-        assert entity.get_state()["state"] == STATE_OPEN
+        assert entity.state["state"] == STATE_OPEN
 
     with patch(
         "zigpy.zcl.Cluster.request",
@@ -587,17 +587,17 @@ async def test_shade(
     await send_attributes_report(
         zha_gateway, cluster_on_off, {cluster_on_off.AttributeDefs.on_off.id: 0}
     )
-    assert entity.get_state()["state"] == STATE_CLOSED
+    assert entity.state["state"] == STATE_CLOSED
 
     # test to see if it opens
     await send_attributes_report(
         zha_gateway, cluster_on_off, {cluster_on_off.AttributeDefs.on_off.id: 1}
     )
-    assert entity.get_state()["state"] == STATE_OPEN
+    assert entity.state["state"] == STATE_OPEN
 
     await entity.async_update()
     await zha_gateway.async_block_till_done()
-    assert entity.get_state()["state"] == STATE_OPEN
+    assert entity.state["state"] == STATE_OPEN
 
     # close from client command fails
     with (
@@ -615,7 +615,7 @@ async def test_shade(
         assert cluster_on_off.request.call_count == 1
         assert cluster_on_off.request.call_args[0][0] is False
         assert cluster_on_off.request.call_args[0][1] == 0x0000
-        assert entity.get_state()["state"] == STATE_OPEN
+        assert entity.state["state"] == STATE_OPEN
 
     with patch(
         "zigpy.zcl.Cluster.request", AsyncMock(return_value=[0x1, zcl_f.Status.SUCCESS])
@@ -625,11 +625,11 @@ async def test_shade(
         assert cluster_on_off.request.call_count == 1
         assert cluster_on_off.request.call_args[0][0] is False
         assert cluster_on_off.request.call_args[0][1] == 0x0000
-        assert entity.get_state()["state"] == STATE_CLOSED
+        assert entity.state["state"] == STATE_CLOSED
 
     # open from client command fails
     await send_attributes_report(zha_gateway, cluster_level, {0: 0})
-    assert entity.get_state()["state"] == STATE_CLOSED
+    assert entity.state["state"] == STATE_CLOSED
 
     with (
         patch(
@@ -646,7 +646,7 @@ async def test_shade(
         assert cluster_on_off.request.call_count == 1
         assert cluster_on_off.request.call_args[0][0] is False
         assert cluster_on_off.request.call_args[0][1] == 0x0001
-        assert entity.get_state()["state"] == STATE_CLOSED
+        assert entity.state["state"] == STATE_CLOSED
 
     # open from client succeeds
     with patch(
@@ -657,7 +657,7 @@ async def test_shade(
         assert cluster_on_off.request.call_count == 1
         assert cluster_on_off.request.call_args[0][0] is False
         assert cluster_on_off.request.call_args[0][1] == 0x0001
-        assert entity.get_state()["state"] == STATE_OPEN
+        assert entity.state["state"] == STATE_OPEN
 
     # set position UI command fails
     with (
@@ -676,7 +676,7 @@ async def test_shade(
         assert cluster_level.request.call_args[0][0] is False
         assert cluster_level.request.call_args[0][1] == 0x0004
         assert int(cluster_level.request.call_args[0][3] * 100 / 255) == 47
-        assert entity.get_state()["current_position"] == 0
+        assert entity.state["current_position"] == 0
 
     # set position UI success
     with patch(
@@ -688,11 +688,11 @@ async def test_shade(
         assert cluster_level.request.call_args[0][0] is False
         assert cluster_level.request.call_args[0][1] == 0x0004
         assert int(cluster_level.request.call_args[0][3] * 100 / 255) == 47
-        assert entity.get_state()["current_position"] == 47
+        assert entity.state["current_position"] == 47
 
     # report position change
     await send_attributes_report(zha_gateway, cluster_level, {8: 0, 0: 100, 1: 1})
-    assert entity.get_state()["current_position"] == int(100 * 100 / 255)
+    assert entity.state["current_position"] == int(100 * 100 / 255)
 
     # stop command fails
     with (
@@ -740,11 +740,11 @@ async def test_keen_vent(
 
     # test that the state has changed from unavailable to off
     await send_attributes_report(zha_gateway, cluster_on_off, {8: 0, 0: False, 1: 1})
-    assert entity.get_state()["state"] == STATE_CLOSED
+    assert entity.state["state"] == STATE_CLOSED
 
     await entity.async_update()
     await zha_gateway.async_block_till_done()
-    assert entity.get_state()["state"] == STATE_CLOSED
+    assert entity.state["state"] == STATE_CLOSED
 
     # open from client command fails
     p1 = patch.object(cluster_on_off, "request", side_effect=asyncio.TimeoutError)
@@ -760,7 +760,7 @@ async def test_keen_vent(
         assert cluster_on_off.request.call_args[0][0] is False
         assert cluster_on_off.request.call_args[0][1] == 0x0001
         assert cluster_level.request.call_count == 1
-        assert entity.get_state()["state"] == STATE_CLOSED
+        assert entity.state["state"] == STATE_CLOSED
 
     # open from client command success
     p1 = patch.object(cluster_on_off, "request", AsyncMock(return_value=[1, 0]))
@@ -773,8 +773,8 @@ async def test_keen_vent(
         assert cluster_on_off.request.call_args[0][0] is False
         assert cluster_on_off.request.call_args[0][1] == 0x0001
         assert cluster_level.request.call_count == 1
-        assert entity.get_state()["state"] == STATE_OPEN
-        assert entity.get_state()["current_position"] == 100
+        assert entity.state["state"] == STATE_OPEN
+        assert entity.state["current_position"] == 100
 
 
 async def test_cover_remote(

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -37,7 +37,7 @@ async def test_immediate_works(zha_gateway: Gateway) -> None:
     assert len(calls) == 1
     assert debouncer._timer_task is not None
     assert debouncer._execute_at_end_of_timer is True
-    assert debouncer._job.target == debouncer.function  # type: ignore[unreachable]
+    assert debouncer._job.target == debouncer.function
 
     # Canceling debounce in cooldown
     debouncer.async_cancel()
@@ -94,7 +94,7 @@ async def test_immediate_works_with_schedule_call(zha_gateway: Gateway) -> None:
     assert len(calls) == 1
     assert debouncer._timer_task is not None
     assert debouncer._execute_at_end_of_timer is True
-    assert debouncer._job.target == debouncer.function  # type: ignore[unreachable]
+    assert debouncer._job.target == debouncer.function
 
     # Canceling debounce in cooldown
     debouncer.async_cancel()
@@ -202,7 +202,7 @@ async def test_immediate_works_with_passed_callback_function_raises(
     assert len(calls) == 1
     assert debouncer._timer_task is not None
     assert debouncer._execute_at_end_of_timer is True
-    assert debouncer._job.target == debouncer.function  # type: ignore[unreachable]
+    assert debouncer._job.target == debouncer.function
 
     # Canceling debounce in cooldown
     debouncer.async_cancel()
@@ -266,7 +266,7 @@ async def test_immediate_works_with_passed_coroutine_raises(
     assert len(calls) == 1
     assert debouncer._timer_task is not None
     assert debouncer._execute_at_end_of_timer is True
-    assert debouncer._job.target == debouncer.function  # type: ignore[unreachable]
+    assert debouncer._job.target == debouncer.function
 
     # Canceling debounce in cooldown
     debouncer.async_cancel()
@@ -325,7 +325,7 @@ async def test_not_immediate_works(zha_gateway: Gateway) -> None:
     # Canceling while on cooldown
     debouncer.async_cancel()
     assert debouncer._timer_task is None
-    assert debouncer._execute_at_end_of_timer is False  # type: ignore[unreachable]
+    assert debouncer._execute_at_end_of_timer is False
 
     # Call and let timer run out
     await debouncer.async_call()
@@ -379,7 +379,7 @@ async def test_not_immediate_works_schedule_call(zha_gateway: Gateway) -> None:
     # Canceling while on cooldown
     debouncer.async_cancel()
     assert debouncer._timer_task is None
-    assert debouncer._execute_at_end_of_timer is False  # type: ignore[unreachable]
+    assert debouncer._execute_at_end_of_timer is False
 
     # Call and let timer run out
     debouncer.async_schedule_call()
@@ -434,7 +434,7 @@ async def test_immediate_works_with_function_swapped(zha_gateway: Gateway) -> No
     assert len(calls) == 1
     assert debouncer._timer_task is not None
     assert debouncer._execute_at_end_of_timer is True
-    assert debouncer._job.target == debouncer.function  # type: ignore[unreachable]
+    assert debouncer._job.target == debouncer.function
 
     # Canceling debounce in cooldown
     debouncer.async_cancel()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -142,7 +142,7 @@ async def test_check_available_success(
     assert zha_device.available is True
     await _send_time_changed(zha_gateway, zha_device.consider_unavailable_time + 2)
     assert zha_device.available is False
-    assert basic_ch.read_attributes.await_count == 0  # type: ignore[unreachable]
+    assert basic_ch.read_attributes.await_count == 0
 
     device_with_basic_cluster_handler.last_seen = (
         time.time() - zha_device.consider_unavailable_time - 100
@@ -244,7 +244,7 @@ async def test_check_available_no_basic_cluster_handler(
     await _send_time_changed(zha_gateway, zha_device.__polling_interval + 1)
 
     assert zha_device.available is False
-    assert "does not have a mandatory basic cluster" in caplog.text  # type: ignore[unreachable]
+    assert "does not have a mandatory basic cluster" in caplog.text
 
 
 async def test_device_is_active_coordinator(

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -63,7 +63,7 @@ async def test_device_tracker(
     entity = get_entity(zha_device, entity_id)
     assert entity is not None
 
-    assert entity.get_state()["connected"] is False
+    assert entity.state["connected"] is False
 
     # turn state flip
     await send_attributes_report(
@@ -76,7 +76,7 @@ async def test_device_tracker(
     await zha_gateway.async_block_till_done()
     assert entity.async_update.await_count == 1
 
-    assert entity.get_state()["connected"] is True
+    assert entity.state["connected"] is True
     assert entity.is_connected is True
     assert entity.source_type == SourceType.ROUTER
     assert entity.battery_level == 100
@@ -85,19 +85,19 @@ async def test_device_tracker(
     zigpy_device_dt.last_seen = time.time() - 90
     await entity.async_update()
     await zha_gateway.async_block_till_done()
-    assert entity.get_state()["connected"] is False
+    assert entity.state["connected"] is False
     assert entity.is_connected is False
 
     # bring it back
-    zigpy_device_dt.last_seen = time.time()  # type: ignore[unreachable]
+    zigpy_device_dt.last_seen = time.time()
     await entity.async_update()
     await zha_gateway.async_block_till_done()
-    assert entity.get_state()["connected"] is True
+    assert entity.state["connected"] is True
     assert entity.is_connected is True
 
     # knock it offline by setting last seen None
     zigpy_device_dt.last_seen = None
     await entity.async_update()
     await zha_gateway.async_block_till_done()
-    assert entity.get_state()["connected"] is False
+    assert entity.state["connected"] is False
     assert entity.is_connected is False

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -678,7 +678,7 @@ async def test_quirks_v2_entity_discovery_e1_curtain(
     power_source_entity = get_entity(zha_device, power_source_entity_id)
     assert power_source_entity is not None
     assert (
-        power_source_entity.get_state()["state"]
+        power_source_entity.state["state"]
         == BasicCluster.PowerSource.Mains_single_phase.name
     )
 
@@ -690,7 +690,7 @@ async def test_quirks_v2_entity_discovery_e1_curtain(
     assert hook_state_entity_id is not None
     hook_state_entity = get_entity(zha_device, hook_state_entity_id)
     assert hook_state_entity is not None
-    assert hook_state_entity.get_state()["state"] == AqaraE1HookState.Unlocked.name
+    assert hook_state_entity.state["state"] == AqaraE1HookState.Unlocked.name
 
     error_detected_entity_id = find_entity_id(
         Platform.BINARY_SENSOR,
@@ -699,7 +699,7 @@ async def test_quirks_v2_entity_discovery_e1_curtain(
     assert error_detected_entity_id is not None
     error_detected_entity = get_entity(zha_device, error_detected_entity_id)
     assert error_detected_entity is not None
-    assert error_detected_entity.get_state()["state"] is False
+    assert error_detected_entity.state["state"] is False
 
 
 def _get_test_device(

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -21,7 +21,6 @@ from zha.application.gateway import Gateway
 from zha.application.platforms import GroupEntity, PlatformEntity
 from zha.application.platforms.fan.const import (
     ATTR_PERCENTAGE,
-    ATTR_PERCENTAGE_STEP,
     ATTR_PRESET_MODE,
     PRESET_MODE_AUTO,
     PRESET_MODE_ON,
@@ -656,7 +655,7 @@ async def test_fan_ikea_update_entity(
     assert entity.get_state()["is_on"] is False
     assert entity.get_state()[ATTR_PERCENTAGE] == 0
     assert entity.get_state()[ATTR_PRESET_MODE] is None
-    assert entity.to_json()[ATTR_PERCENTAGE_STEP] == 100 / 10
+    assert entity.percentage_step == 100 / 10
 
     cluster.PLUGGED_ATTR_READS = {"fan_mode": 1}
 
@@ -666,7 +665,7 @@ async def test_fan_ikea_update_entity(
     assert entity.get_state()["is_on"] is True
     assert entity.get_state()[ATTR_PERCENTAGE] == 10
     assert entity.get_state()[ATTR_PRESET_MODE] is PRESET_MODE_AUTO
-    assert entity.to_json()[ATTR_PERCENTAGE_STEP] == 100 / 10
+    assert entity.percentage_step == 100 / 10
 
 
 @pytest.fixture
@@ -808,7 +807,7 @@ async def test_fan_kof_update_entity(
     assert entity.get_state()["is_on"] is False
     assert entity.get_state()[ATTR_PERCENTAGE] == 0
     assert entity.get_state()[ATTR_PRESET_MODE] is None
-    assert entity.to_json()[ATTR_PERCENTAGE_STEP] == 100 / 4
+    assert entity.percentage_step == 100 / 4
 
     cluster.PLUGGED_ATTR_READS = {"fan_mode": 1}
 
@@ -818,4 +817,4 @@ async def test_fan_kof_update_entity(
     assert entity.get_state()["is_on"] is True
     assert entity.get_state()[ATTR_PERCENTAGE] == 25
     assert entity.get_state()[ATTR_PRESET_MODE] is None
-    assert entity.to_json()[ATTR_PERCENTAGE_STEP] == 100 / 4
+    assert entity.percentage_step == 100 / 4

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -150,15 +150,15 @@ async def test_fan(
 
     entity = get_entity(zha_device, entity_id)
     assert entity is not None
-    assert entity.get_state()["is_on"] is False
+    assert entity.state["is_on"] is False
 
     # turn on at fan
     await send_attributes_report(zha_gateway, cluster, {1: 2, 0: 1, 2: 3})
-    assert entity.get_state()["is_on"] is True
+    assert entity.state["is_on"] is True
 
     # turn off at fan
     await send_attributes_report(zha_gateway, cluster, {1: 1, 0: 0, 2: 2})
-    assert entity.get_state()["is_on"] is False
+    assert entity.state["is_on"] is False
 
     # turn on from client
     cluster.write_attributes.reset_mock()
@@ -167,7 +167,7 @@ async def test_fan(
     assert cluster.write_attributes.call_args == call(
         {"fan_mode": 2}, manufacturer=None
     )
-    assert entity.get_state()["is_on"] is True
+    assert entity.state["is_on"] is True
 
     # turn off from client
     cluster.write_attributes.reset_mock()
@@ -176,7 +176,7 @@ async def test_fan(
     assert cluster.write_attributes.call_args == call(
         {"fan_mode": 0}, manufacturer=None
     )
-    assert entity.get_state()["is_on"] is False
+    assert entity.state["is_on"] is False
 
     # change speed from client
     cluster.write_attributes.reset_mock()
@@ -185,8 +185,8 @@ async def test_fan(
     assert cluster.write_attributes.call_args == call(
         {"fan_mode": 3}, manufacturer=None
     )
-    assert entity.get_state()["is_on"] is True
-    assert entity.get_state()["speed"] == SPEED_HIGH
+    assert entity.state["is_on"] is True
+    assert entity.state["speed"] == SPEED_HIGH
 
     # change preset_mode from client
     cluster.write_attributes.reset_mock()
@@ -195,8 +195,8 @@ async def test_fan(
     assert cluster.write_attributes.call_args == call(
         {"fan_mode": 4}, manufacturer=None
     )
-    assert entity.get_state()["is_on"] is True
-    assert entity.get_state()["preset_mode"] == PRESET_MODE_ON
+    assert entity.state["is_on"] is True
+    assert entity.state["preset_mode"] == PRESET_MODE_ON
 
     # test set percentage from client
     cluster.write_attributes.reset_mock()
@@ -207,8 +207,8 @@ async def test_fan(
         {"fan_mode": 2}, manufacturer=None
     )
     # this is converted to a ranged value
-    assert entity.get_state()["percentage"] == 66
-    assert entity.get_state()["is_on"] is True
+    assert entity.state["percentage"] == 66
+    assert entity.state["is_on"] is True
 
     # set invalid preset_mode from client
     cluster.write_attributes.reset_mock()
@@ -220,14 +220,14 @@ async def test_fan(
     # test percentage in turn on command
     await entity.async_turn_on(percentage=25)
     await zha_gateway.async_block_till_done()
-    assert entity.get_state()["percentage"] == 33  # this is converted to a ranged value
-    assert entity.get_state()["speed"] == SPEED_LOW
+    assert entity.state["percentage"] == 33  # this is converted to a ranged value
+    assert entity.state["speed"] == SPEED_LOW
 
     # test speed in turn on command
     await entity.async_turn_on(speed=SPEED_HIGH)
     await zha_gateway.async_block_till_done()
-    assert entity.get_state()["percentage"] == 100
-    assert entity.get_state()["speed"] == SPEED_HIGH
+    assert entity.state["percentage"] == 100
+    assert entity.state["speed"] == SPEED_HIGH
 
 
 async def async_turn_on(
@@ -317,7 +317,7 @@ async def test_zha_group_fan_entity(
     dev2_fan_cluster = device_fan_2.device.endpoints[1].fan
 
     # test that the fan group entity was created and is off
-    assert entity.get_state()["is_on"] is False
+    assert entity.state["is_on"] is False
 
     # turn on from client
     group_fan_cluster.write_attributes.reset_mock()
@@ -361,19 +361,19 @@ async def test_zha_group_fan_entity(
     await send_attributes_report(zha_gateway, dev2_fan_cluster, {0: 0})
 
     # test that group fan is off
-    assert entity.get_state()["is_on"] is False
+    assert entity.state["is_on"] is False
 
     await send_attributes_report(zha_gateway, dev2_fan_cluster, {0: 2})
     await zha_gateway.async_block_till_done()
 
     # test that group fan is speed medium
-    assert entity.get_state()["is_on"] is True
+    assert entity.state["is_on"] is True
 
     await send_attributes_report(zha_gateway, dev2_fan_cluster, {0: 0})
     await zha_gateway.async_block_till_done()
 
     # test that group fan is now off
-    assert entity.get_state()["is_on"] is False
+    assert entity.state["is_on"] is False
 
 
 @patch(
@@ -417,7 +417,7 @@ async def test_zha_group_fan_entity_failure_state(
     group_fan_cluster = zha_group.zigpy_group.endpoint[hvac.Fan.cluster_id]
 
     # test that the fan group entity was created and is off
-    assert entity.get_state()["is_on"] is False
+    assert entity.state["is_on"] is False
 
     # turn on from client
     group_fan_cluster.write_attributes.reset_mock()
@@ -459,10 +459,10 @@ async def test_fan_init(
     entity = get_entity(zha_device, entity_id)
     assert entity is not None
 
-    assert entity.get_state()["is_on"] == expected_state
-    assert entity.get_state()["speed"] == expected_speed
-    assert entity.get_state()["percentage"] == expected_percentage
-    assert entity.get_state()["preset_mode"] is None
+    assert entity.state["is_on"] == expected_state
+    assert entity.state["speed"] == expected_speed
+    assert entity.state["percentage"] == expected_percentage
+    assert entity.state["preset_mode"] is None
 
 
 async def test_fan_update_entity(
@@ -481,26 +481,26 @@ async def test_fan_update_entity(
     entity = get_entity(zha_device, entity_id)
     assert entity is not None
 
-    assert entity.get_state()["is_on"] is False
-    assert entity.get_state()["speed"] == SPEED_OFF
-    assert entity.get_state()["percentage"] == 0
-    assert entity.get_state()["preset_mode"] is None
+    assert entity.state["is_on"] is False
+    assert entity.state["speed"] == SPEED_OFF
+    assert entity.state["percentage"] == 0
+    assert entity.state["preset_mode"] is None
     assert entity.percentage_step == 100 / 3
     assert cluster.read_attributes.await_count == 2
 
     await entity.async_update()
     await zha_gateway.async_block_till_done()
-    assert entity.get_state()["is_on"] is False
-    assert entity.get_state()["speed"] == SPEED_OFF
+    assert entity.state["is_on"] is False
+    assert entity.state["speed"] == SPEED_OFF
     assert cluster.read_attributes.await_count == 3
 
     cluster.PLUGGED_ATTR_READS = {"fan_mode": 1}
     await entity.async_update()
     await zha_gateway.async_block_till_done()
-    assert entity.get_state()["is_on"] is True
-    assert entity.get_state()["percentage"] == 33
-    assert entity.get_state()["speed"] == SPEED_LOW
-    assert entity.get_state()["preset_mode"] is None
+    assert entity.state["is_on"] is True
+    assert entity.state["percentage"] == 33
+    assert entity.state["speed"] == SPEED_LOW
+    assert entity.state["preset_mode"] is None
     assert entity.percentage_step == 100 / 3
     assert cluster.read_attributes.await_count == 4
 
@@ -544,15 +544,15 @@ async def test_fan_ikea(
     entity = get_entity(zha_device, entity_id)
     assert entity is not None
 
-    assert entity.get_state()["is_on"] is False
+    assert entity.state["is_on"] is False
 
     # turn on at fan
     await send_attributes_report(zha_gateway, cluster, {6: 1})
-    assert entity.get_state()["is_on"] is True
+    assert entity.state["is_on"] is True
 
     # turn off at fan
     await send_attributes_report(zha_gateway, cluster, {6: 0})
-    assert entity.get_state()["is_on"] is False
+    assert entity.state["is_on"] is False
 
     # turn on from HA
     cluster.write_attributes.reset_mock()
@@ -632,9 +632,9 @@ async def test_fan_ikea_init(
     assert entity_id is not None
     entity = get_entity(zha_device, entity_id)
     assert entity is not None
-    assert entity.get_state()["is_on"] == ikea_expected_state
-    assert entity.get_state()["percentage"] == ikea_expected_percentage
-    assert entity.get_state()["preset_mode"] == ikea_preset_mode
+    assert entity.state["is_on"] == ikea_expected_state
+    assert entity.state["percentage"] == ikea_expected_percentage
+    assert entity.state["preset_mode"] == ikea_preset_mode
 
 
 async def test_fan_ikea_update_entity(
@@ -652,9 +652,9 @@ async def test_fan_ikea_update_entity(
     entity = get_entity(zha_device, entity_id)
     assert entity is not None
 
-    assert entity.get_state()["is_on"] is False
-    assert entity.get_state()[ATTR_PERCENTAGE] == 0
-    assert entity.get_state()[ATTR_PRESET_MODE] is None
+    assert entity.state["is_on"] is False
+    assert entity.state[ATTR_PERCENTAGE] == 0
+    assert entity.state[ATTR_PRESET_MODE] is None
     assert entity.percentage_step == 100 / 10
 
     cluster.PLUGGED_ATTR_READS = {"fan_mode": 1}
@@ -662,9 +662,9 @@ async def test_fan_ikea_update_entity(
     await entity.async_update()
     await zha_gateway.async_block_till_done()
 
-    assert entity.get_state()["is_on"] is True
-    assert entity.get_state()[ATTR_PERCENTAGE] == 10
-    assert entity.get_state()[ATTR_PRESET_MODE] is PRESET_MODE_AUTO
+    assert entity.state["is_on"] is True
+    assert entity.state[ATTR_PERCENTAGE] == 10
+    assert entity.state[ATTR_PRESET_MODE] is PRESET_MODE_AUTO
     assert entity.percentage_step == 100 / 10
 
 
@@ -707,15 +707,15 @@ async def test_fan_kof(
     entity = get_entity(zha_device, entity_id)
     assert entity is not None
 
-    assert entity.get_state()["is_on"] is False
+    assert entity.state["is_on"] is False
 
     # turn on at fan
     await send_attributes_report(zha_gateway, cluster, {1: 2, 0: 1, 2: 3})
-    assert entity.get_state()["is_on"] is True
+    assert entity.state["is_on"] is True
 
     # turn off at fan
     await send_attributes_report(zha_gateway, cluster, {1: 1, 0: 0, 2: 2})
-    assert entity.get_state()["is_on"] is False
+    assert entity.state["is_on"] is False
 
     # turn on from HA
     cluster.write_attributes.reset_mock()
@@ -783,9 +783,9 @@ async def test_fan_kof_init(
     entity = get_entity(zha_device, entity_id)
     assert entity is not None
 
-    assert entity.get_state()["is_on"] is expected_state
-    assert entity.get_state()[ATTR_PERCENTAGE] == expected_percentage
-    assert entity.get_state()[ATTR_PRESET_MODE] == expected_preset
+    assert entity.state["is_on"] is expected_state
+    assert entity.state[ATTR_PERCENTAGE] == expected_percentage
+    assert entity.state[ATTR_PRESET_MODE] == expected_preset
 
 
 async def test_fan_kof_update_entity(
@@ -804,9 +804,9 @@ async def test_fan_kof_update_entity(
     entity = get_entity(zha_device, entity_id)
     assert entity is not None
 
-    assert entity.get_state()["is_on"] is False
-    assert entity.get_state()[ATTR_PERCENTAGE] == 0
-    assert entity.get_state()[ATTR_PRESET_MODE] is None
+    assert entity.state["is_on"] is False
+    assert entity.state[ATTR_PERCENTAGE] == 0
+    assert entity.state[ATTR_PRESET_MODE] is None
     assert entity.percentage_step == 100 / 4
 
     cluster.PLUGGED_ATTR_READS = {"fan_mode": 1}
@@ -814,7 +814,7 @@ async def test_fan_kof_update_entity(
     await entity.async_update()
     await zha_gateway.async_block_till_done()
 
-    assert entity.get_state()["is_on"] is True
-    assert entity.get_state()[ATTR_PERCENTAGE] == 25
-    assert entity.get_state()[ATTR_PRESET_MODE] is None
+    assert entity.state["is_on"] is True
+    assert entity.state[ATTR_PERCENTAGE] == 25
+    assert entity.state[ATTR_PRESET_MODE] is None
     assert entity.percentage_step == 100 / 4

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -17,10 +17,14 @@ from zigpy.zdo.types import LogicalType, NodeDescriptor
 from tests.common import async_find_group_entity_id, find_entity_id
 from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 from zha.application import Platform
-from zha.application.gateway import Gateway
+from zha.application.gateway import (
+    Gateway,
+    RawDeviceInitializedDeviceInfo,
+    RawDeviceInitializedEvent,
+)
 from zha.application.helpers import ZHAData
 from zha.application.platforms import GroupEntity, PlatformEntity
-from zha.application.platforms.light.const import ColorMode, LightEntityFeature
+from zha.application.platforms.light.const import LightEntityFeature
 from zha.zigbee.device import Device
 from zha.zigbee.group import Group, GroupMemberReference
 
@@ -211,35 +215,16 @@ async def test_gateway_group_methods(
     assert isinstance(entity, GroupEntity)
     assert entity is not None
 
-    assert entity.to_json() == {
-        "class_name": "LightGroup",
-        "effect_list": None,
-        "group_id": zha_group.group_id,
-        "max_mireds": 500,
-        "min_mireds": 153,
-        "name": "Test Group_0x0002",
-        "platform": Platform.LIGHT,
-        "state": {
-            "brightness": None,
-            "class_name": "LightGroup",
-            "color_mode": ColorMode.UNKNOWN,
-            "color_temp": None,
-            "effect": None,
-            "hs_color": None,
-            "off_brightness": None,
-            "off_with_transition": False,
-            "on": False,
-            "supported_color_modes": {
-                ColorMode.BRIGHTNESS,
-                ColorMode.ONOFF,
-                ColorMode.XY,
-            },
-            "supported_features": LightEntityFeature.TRANSITION,
-            "xy_color": None,
-        },
-        "supported_features": LightEntityFeature.TRANSITION,
-        "unique_id": "light.0x0002",
-    }
+    info = entity.info_object
+    assert info.class_name == "LightGroup"
+    assert info.platform == Platform.LIGHT
+    assert info.unique_id == "light.0x0002"
+    assert info.name == "Test Group_0x0002"
+    assert info.group_id == zha_group.group_id
+    assert info.supported_features == LightEntityFeature.TRANSITION
+    assert info.min_mireds == 153
+    assert info.max_mireds == 500
+    assert info.effect_list is None
 
     device_1_entity_id = find_entity_id(Platform.LIGHT, device_light_1)
     device_2_entity_id = find_entity_id(Platform.LIGHT, device_light_2)
@@ -543,15 +528,14 @@ def test_gateway_raw_device_initialized(
     assert zha_gateway.emit.call_count == 1
     assert zha_gateway.emit.call_args == call(
         "raw_device_initialized",
-        {
-            "type": "zha_gateway_message",
-            "device_info": {
-                "nwk": 0xB79C,
-                "ieee": "00:0d:6f:00:0a:90:69:e7",
-                "pairing_status": "INTERVIEW_COMPLETE",
-                "model": "FakeModel",
-                "manufacturer": "FakeManufacturer",
-                "signature": {
+        RawDeviceInitializedEvent(
+            device_info=RawDeviceInitializedDeviceInfo(
+                ieee="00:0d:6f:00:0a:90:69:e7",
+                nwk=0xB79C,
+                pairing_status="INTERVIEW_COMPLETE",
+                model="FakeModel",
+                manufacturer="FakeManufacturer",
+                signature={
                     "manufacturer": "FakeManufacturer",
                     "model": "FakeModel",
                     "node_desc": {
@@ -578,6 +562,8 @@ def test_gateway_raw_device_initialized(
                         }
                     },
                 },
-            },
-        },
+            ),
+            event_type="zha_gateway_message",
+            event="raw_device_initialized",
+        ),
     )

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -295,7 +295,7 @@ async def test_light_refresh(
 
     entity = get_entity(zha_device, entity_id)
     assert entity is not None
-    assert bool(entity.get_state()["on"]) is False
+    assert bool(entity.state["on"]) is False
 
     on_off_cluster.read_attributes.reset_mock()
 
@@ -304,7 +304,7 @@ async def test_light_refresh(
     await zha_gateway.async_block_till_done()
     assert on_off_cluster.read_attributes.call_count == 0
     assert on_off_cluster.read_attributes.await_count == 0
-    assert bool(entity.get_state()["on"]) is False
+    assert bool(entity.state["on"]) is False
 
     # 1 interval - at least 1 call
     on_off_cluster.PLUGGED_ATTR_READS = {"on_off": 1}
@@ -312,7 +312,7 @@ async def test_light_refresh(
     await zha_gateway.async_block_till_done()
     assert on_off_cluster.read_attributes.call_count >= 1
     assert on_off_cluster.read_attributes.await_count >= 1
-    assert bool(entity.get_state()["on"]) is True
+    assert bool(entity.state["on"]) is True
 
     # 2 intervals - at least 2 calls
     on_off_cluster.PLUGGED_ATTR_READS = {"on_off": 0}
@@ -320,7 +320,7 @@ async def test_light_refresh(
     await zha_gateway.async_block_till_done()
     assert on_off_cluster.read_attributes.call_count >= 2
     assert on_off_cluster.read_attributes.await_count >= 2
-    assert bool(entity.get_state()["on"]) is False
+    assert bool(entity.state["on"]) is False
 
 
 # TODO reporting is not checked
@@ -384,7 +384,7 @@ async def test_light(
     entity = get_entity(zha_device, entity_id)
     assert entity is not None
 
-    assert bool(entity.get_state()["on"]) is False
+    assert bool(entity.state["on"]) is False
 
     # test turning the lights on and off from the light
     await async_test_on_off_from_light(zha_gateway, cluster_on_off, entity)
@@ -429,13 +429,13 @@ async def test_light(
 
     if cluster_color:
         # test color temperature from the client with transition
-        assert entity.get_state()["brightness"] != 50
-        assert entity.get_state()["color_temp"] != 200
+        assert entity.state["brightness"] != 50
+        assert entity.state["color_temp"] != 200
         await entity.async_turn_on(brightness=50, transition=10, color_temp=200)
         await zha_gateway.async_block_till_done()
-        assert entity.get_state()["brightness"] == 50
-        assert entity.get_state()["color_temp"] == 200
-        assert bool(entity.get_state()["on"]) is True
+        assert entity.state["brightness"] == 50
+        assert entity.state["color_temp"] == 200
+        assert bool(entity.state["on"]) is True
         assert cluster_color.request.call_count == 1
         assert cluster_color.request.await_count == 1
         assert cluster_color.request.call_args == call(
@@ -451,11 +451,11 @@ async def test_light(
         cluster_color.request.reset_mock()
 
         # test color xy from the client
-        assert entity.get_state()["xy_color"] != [13369, 18087]
+        assert entity.state["xy_color"] != [13369, 18087]
         await entity.async_turn_on(brightness=50, xy_color=[13369, 18087])
         await zha_gateway.async_block_till_done()
-        assert entity.get_state()["brightness"] == 50
-        assert entity.get_state()["xy_color"] == [13369, 18087]
+        assert entity.state["brightness"] == 50
+        assert entity.state["xy_color"] == [13369, 18087]
         assert cluster_color.request.call_count == 1
         assert cluster_color.request.await_count == 1
         assert cluster_color.request.call_args == call(
@@ -482,12 +482,12 @@ async def async_test_on_off_from_light(
     # turn on at light
     await send_attributes_report(zha_gateway, cluster, {1: 0, 0: 1, 2: 3})
     await zha_gateway.async_block_till_done()
-    assert bool(entity.get_state()["on"]) is True
+    assert bool(entity.state["on"]) is True
 
     # turn off at light
     await send_attributes_report(zha_gateway, cluster, {1: 1, 0: 0, 2: 3})
     await zha_gateway.async_block_till_done()
-    assert bool(entity.get_state()["on"]) is False
+    assert bool(entity.state["on"]) is False
 
 
 async def async_test_on_from_light(
@@ -501,7 +501,7 @@ async def async_test_on_from_light(
         zha_gateway, cluster, {general.OnOff.AttributeDefs.on_off.id: 1}
     )
     await zha_gateway.async_block_till_done()
-    assert bool(entity.get_state()["on"]) is True
+    assert bool(entity.state["on"]) is True
 
 
 async def async_test_on_off_from_client(
@@ -514,7 +514,7 @@ async def async_test_on_off_from_client(
     cluster.request.reset_mock()
     await entity.async_turn_on()
     await zha_gateway.async_block_till_done()
-    assert bool(entity.get_state()["on"]) is True
+    assert bool(entity.state["on"]) is True
     assert cluster.request.call_count == 1
     assert cluster.request.await_count == 1
     assert cluster.request.call_args == call(
@@ -540,7 +540,7 @@ async def async_test_off_from_client(
     cluster.request.reset_mock()
     await entity.async_turn_off()
     await zha_gateway.async_block_till_done()
-    assert bool(entity.get_state()["on"]) is False
+    assert bool(entity.state["on"]) is False
     assert cluster.request.call_count == 1
     assert cluster.request.await_count == 1
     assert cluster.request.call_args == call(
@@ -575,7 +575,7 @@ async def async_test_level_on_off_from_client(
         await zha_gateway.async_block_till_done()
         on_off_cluster.request.reset_mock()
         level_cluster.request.reset_mock()
-        assert bool(entity.get_state()["on"]) is False
+        assert bool(entity.state["on"]) is False
 
     await _reset_light()
     await _async_shift_time(zha_gateway)
@@ -583,7 +583,7 @@ async def async_test_level_on_off_from_client(
     # turn on via UI
     await entity.async_turn_on()
     await zha_gateway.async_block_till_done()
-    assert bool(entity.get_state()["on"]) is True
+    assert bool(entity.state["on"]) is True
     assert on_off_cluster.request.call_count == 1
     assert on_off_cluster.request.await_count == 1
     assert level_cluster.request.call_count == 0
@@ -602,7 +602,7 @@ async def async_test_level_on_off_from_client(
 
     await entity.async_turn_on(transition=10)
     await zha_gateway.async_block_till_done()
-    assert bool(entity.get_state()["on"]) is True
+    assert bool(entity.state["on"]) is True
     assert on_off_cluster.request.call_count == 0
     assert on_off_cluster.request.await_count == 0
     assert level_cluster.request.call_count == 1
@@ -622,7 +622,7 @@ async def async_test_level_on_off_from_client(
 
     await entity.async_turn_on(brightness=10)
     await zha_gateway.async_block_till_done()
-    assert bool(entity.get_state()["on"]) is True
+    assert bool(entity.state["on"]) is True
     # the onoff cluster is now not used when brightness is present by default
     assert on_off_cluster.request.call_count == 0
     assert on_off_cluster.request.await_count == 0
@@ -657,12 +657,12 @@ async def async_test_dimmer_from_light(
         zha_gateway, cluster, {1: level + 10, 0: level, 2: level - 10 or 22}
     )
     await zha_gateway.async_block_till_done()
-    assert entity.get_state()["on"] == expected_state
+    assert entity.state["on"] == expected_state
     # hass uses None for brightness of 0 in state attributes
     if level == 0:
-        assert entity.get_state()["brightness"] is None
+        assert entity.state["brightness"] is None
     else:
-        assert entity.get_state()["brightness"] == level
+        assert entity.state["brightness"] == level
 
 
 async def async_test_flash_from_client(
@@ -676,7 +676,7 @@ async def async_test_flash_from_client(
     cluster.request.reset_mock()
     await entity.async_turn_on(flash=flash)
     await zha_gateway.async_block_till_done()
-    assert bool(entity.get_state()["on"]) is True
+    assert bool(entity.state["on"]) is True
     assert cluster.request.call_count == 1
     assert cluster.request.await_count == 1
     assert cluster.request.call_args == call(
@@ -785,7 +785,7 @@ async def test_zha_group_light_entity(
     dev1_cluster_level = device_light_1.device.endpoints[1].level
 
     # test that the lights were created and are off
-    assert bool(entity.get_state()["on"]) is False
+    assert bool(entity.state["on"]) is False
 
     # test turning the lights on and off from the client
     await async_test_on_off_from_client(zha_gateway, group_cluster_on_off, entity)
@@ -829,40 +829,40 @@ async def test_zha_group_light_entity(
     await zha_gateway.async_block_till_done()
 
     # test that group light is on
-    assert device_1_light_entity.get_state()["on"] is True
-    assert device_2_light_entity.get_state()["on"] is True
-    assert bool(entity.get_state()["on"]) is True
+    assert device_1_light_entity.state["on"] is True
+    assert device_2_light_entity.state["on"] is True
+    assert bool(entity.state["on"]) is True
 
     await send_attributes_report(zha_gateway, dev1_cluster_on_off, {0: 0})
     await zha_gateway.async_block_till_done()
 
     # test that group light is still on
-    assert device_1_light_entity.get_state()["on"] is False
-    assert device_2_light_entity.get_state()["on"] is True
-    assert bool(entity.get_state()["on"]) is True
+    assert device_1_light_entity.state["on"] is False
+    assert device_2_light_entity.state["on"] is True
+    assert bool(entity.state["on"]) is True
 
     await send_attributes_report(zha_gateway, dev2_cluster_on_off, {0: 0})
     await zha_gateway.async_block_till_done()
 
     # test that group light is now off
-    assert device_1_light_entity.get_state()["on"] is False
-    assert device_2_light_entity.get_state()["on"] is False
-    assert bool(entity.get_state()["on"]) is False
+    assert device_1_light_entity.state["on"] is False
+    assert device_2_light_entity.state["on"] is False
+    assert bool(entity.state["on"]) is False
 
     await send_attributes_report(zha_gateway, dev1_cluster_on_off, {0: 1})
     await zha_gateway.async_block_till_done()
 
     # test that group light is now back on
-    assert device_1_light_entity.get_state()["on"] is True
-    assert device_2_light_entity.get_state()["on"] is False
-    assert bool(entity.get_state()["on"]) is True
+    assert device_1_light_entity.state["on"] is True
+    assert device_2_light_entity.state["on"] is False
+    assert bool(entity.state["on"]) is True
 
     # turn it off to test a new member add being tracked
     await send_attributes_report(zha_gateway, dev1_cluster_on_off, {0: 0})
     await zha_gateway.async_block_till_done()
-    assert device_1_light_entity.get_state()["on"] is False
-    assert device_2_light_entity.get_state()["on"] is False
-    assert bool(entity.get_state()["on"]) is False
+    assert device_1_light_entity.state["on"] is False
+    assert device_2_light_entity.state["on"] is False
+    assert bool(entity.state["on"]) is False
 
     # add a new member and test that his state is also tracked
     await zha_group.async_add_members(
@@ -876,10 +876,10 @@ async def test_zha_group_light_entity(
     await send_attributes_report(zha_gateway, dev3_cluster_on_off, {0: 1})
     await zha_gateway.async_block_till_done()
 
-    assert device_1_light_entity.get_state()["on"] is False
-    assert device_2_light_entity.get_state()["on"] is False
-    assert device_3_light_entity.get_state()["on"] is True
-    assert bool(entity.get_state()["on"]) is True
+    assert device_1_light_entity.state["on"] is False
+    assert device_2_light_entity.state["on"] is False
+    assert device_3_light_entity.state["on"] is True
+    assert bool(entity.state["on"]) is True
 
     # make the group have only 1 member and now there should be no entity
     await zha_group.async_remove_members(
@@ -908,14 +908,14 @@ async def test_zha_group_light_entity(
     assert entity is not None
     await send_attributes_report(zha_gateway, dev3_cluster_on_off, {0: 1})
     await zha_gateway.async_block_till_done()
-    assert bool(entity.get_state()["on"]) is True
+    assert bool(entity.state["on"]) is True
 
     # add a 3rd member and ensure we still have an entity and we track the new member
     # First we turn the lights currently in the group off
     await send_attributes_report(zha_gateway, dev1_cluster_on_off, {0: 0})
     await send_attributes_report(zha_gateway, dev3_cluster_on_off, {0: 0})
     await zha_gateway.async_block_till_done()
-    assert bool(entity.get_state()["on"]) is False
+    assert bool(entity.state["on"]) is False
 
     # this will test that _reprobe_group is used correctly
     await zha_group.async_add_members(
@@ -930,7 +930,7 @@ async def test_zha_group_light_entity(
     assert entity is not None
     await send_attributes_report(zha_gateway, dev2_cluster_on_off, {0: 1})
     await zha_gateway.async_block_till_done()
-    assert bool(entity.get_state()["on"]) is True
+    assert bool(entity.state["on"]) is True
 
     await zha_group.async_remove_members(
         [GroupMemberReference(ieee=coordinator.ieee, endpoint_id=1)]
@@ -938,7 +938,7 @@ async def test_zha_group_light_entity(
     await zha_gateway.async_block_till_done()
     entity = get_group_entity(zha_group, group_entity_id)
     assert entity is not None
-    assert bool(entity.get_state()["on"]) is True
+    assert bool(entity.state["on"]) is True
     assert len(zha_group.members) == 3
 
     # remove the group and ensure that there is no entity and that the entity registry is cleaned up
@@ -1116,9 +1116,9 @@ async def test_transitions(
     eWeLink_cluster_color = eWeLink_light.device.endpoints[1].light_color
 
     # test that the lights were created and are off
-    assert bool(entity.get_state()["on"]) is False
-    assert bool(device_1_light_entity.get_state()["on"]) is False
-    assert bool(device_2_light_entity.get_state()["on"]) is False
+    assert bool(entity.state["on"]) is False
+    assert bool(device_1_light_entity.state["on"]) is False
+    assert bool(device_2_light_entity.state["on"]) is False
 
     # first test 0 length transition with no color and no brightness provided
     dev1_cluster_on_off.request.reset_mock()
@@ -1142,8 +1142,8 @@ async def test_transitions(
         tsn=None,
     )
 
-    assert bool(device_1_light_entity.get_state()["on"]) is True
-    assert device_1_light_entity.get_state()["brightness"] == 254
+    assert bool(device_1_light_entity.state["on"]) is True
+    assert device_1_light_entity.state["brightness"] == 254
 
     # test 0 length transition with no color and no brightness provided again, but for "force on" lights
     eWeLink_cluster_on_off.request.reset_mock()
@@ -1176,8 +1176,8 @@ async def test_transitions(
         tsn=None,
     )
 
-    assert bool(eWeLink_light_entity.get_state()["on"]) is True
-    assert eWeLink_light_entity.get_state()["brightness"] == 254
+    assert bool(eWeLink_light_entity.state["on"]) is True
+    assert eWeLink_light_entity.state["brightness"] == 254
 
     eWeLink_cluster_on_off.request.reset_mock()
     eWeLink_cluster_level.request.reset_mock()
@@ -1204,8 +1204,8 @@ async def test_transitions(
         tsn=None,
     )
 
-    assert bool(device_1_light_entity.get_state()["on"]) is True
-    assert device_1_light_entity.get_state()["brightness"] == 50
+    assert bool(device_1_light_entity.state["on"]) is True
+    assert device_1_light_entity.state["brightness"] == 50
 
     dev1_cluster_level.request.reset_mock()
 
@@ -1241,10 +1241,10 @@ async def test_transitions(
         tsn=None,
     )
 
-    assert bool(device_1_light_entity.get_state()["on"]) is True
-    assert device_1_light_entity.get_state()["brightness"] == 18
-    assert device_1_light_entity.get_state()["color_temp"] == 432
-    assert device_1_light_entity.get_state()["color_mode"] == ColorMode.COLOR_TEMP
+    assert bool(device_1_light_entity.state["on"]) is True
+    assert device_1_light_entity.state["brightness"] == 18
+    assert device_1_light_entity.state["color_temp"] == 432
+    assert device_1_light_entity.state["color_mode"] == ColorMode.COLOR_TEMP
 
     dev1_cluster_level.request.reset_mock()
     dev1_cluster_color.request.reset_mock()
@@ -1269,7 +1269,7 @@ async def test_transitions(
         tsn=None,
     )
 
-    assert bool(device_1_light_entity.get_state()["on"]) is False
+    assert bool(device_1_light_entity.state["on"]) is False
 
     dev1_cluster_level.request.reset_mock()
 
@@ -1317,10 +1317,10 @@ async def test_transitions(
         tsn=None,
     )
 
-    assert bool(device_1_light_entity.get_state()["on"]) is True
-    assert device_1_light_entity.get_state()["brightness"] == 25
-    assert device_1_light_entity.get_state()["color_temp"] == 235
-    assert device_1_light_entity.get_state()["color_mode"] == ColorMode.COLOR_TEMP
+    assert bool(device_1_light_entity.state["on"]) is True
+    assert device_1_light_entity.state["brightness"] == 25
+    assert device_1_light_entity.state["color_temp"] == 235
+    assert device_1_light_entity.state["color_mode"] == ColorMode.COLOR_TEMP
 
     dev1_cluster_level.request.reset_mock()
     dev1_cluster_color.request.reset_mock()
@@ -1335,7 +1335,7 @@ async def test_transitions(
     assert dev1_cluster_level.request.call_count == 0
     assert dev1_cluster_level.request.await_count == 0
 
-    assert bool(entity.get_state()["on"]) is False
+    assert bool(entity.state["on"]) is False
 
     dev1_cluster_on_off.request.reset_mock()
     dev1_cluster_color.request.reset_mock()
@@ -1383,10 +1383,10 @@ async def test_transitions(
         tsn=None,
     )
 
-    assert bool(device_1_light_entity.get_state()["on"]) is True
-    assert device_1_light_entity.get_state()["brightness"] == 25
-    assert device_1_light_entity.get_state()["color_temp"] == 236
-    assert device_1_light_entity.get_state()["color_mode"] == ColorMode.COLOR_TEMP
+    assert bool(device_1_light_entity.state["on"]) is True
+    assert device_1_light_entity.state["brightness"] == 25
+    assert device_1_light_entity.state["color_temp"] == 236
+    assert device_1_light_entity.state["color_mode"] == ColorMode.COLOR_TEMP
 
     dev1_cluster_level.request.reset_mock()
     dev1_cluster_color.request.reset_mock()
@@ -1400,7 +1400,7 @@ async def test_transitions(
     assert dev1_cluster_color.request.await_count == 0
     assert dev1_cluster_level.request.call_count == 0
     assert dev1_cluster_level.request.await_count == 0
-    assert bool(entity.get_state()["on"]) is False
+    assert bool(entity.state["on"]) is False
 
     dev1_cluster_on_off.request.reset_mock()
     dev1_cluster_color.request.reset_mock()
@@ -1436,10 +1436,10 @@ async def test_transitions(
         tsn=None,
     )
 
-    assert bool(device_1_light_entity.get_state()["on"]) is True
-    assert device_1_light_entity.get_state()["brightness"] == 25
-    assert device_1_light_entity.get_state()["color_temp"] == 236
-    assert device_1_light_entity.get_state()["color_mode"] == ColorMode.COLOR_TEMP
+    assert bool(device_1_light_entity.state["on"]) is True
+    assert device_1_light_entity.state["brightness"] == 25
+    assert device_1_light_entity.state["color_temp"] == 236
+    assert device_1_light_entity.state["color_mode"] == ColorMode.COLOR_TEMP
 
     dev1_cluster_on_off.request.reset_mock()
     dev1_cluster_color.request.reset_mock()
@@ -1453,7 +1453,7 @@ async def test_transitions(
     assert dev1_cluster_color.request.await_count == 0
     assert dev1_cluster_level.request.call_count == 0
     assert dev1_cluster_level.request.await_count == 0
-    assert bool(entity.get_state()["on"]) is False
+    assert bool(entity.state["on"]) is False
 
     dev1_cluster_on_off.request.reset_mock()
     dev1_cluster_color.request.reset_mock()
@@ -1483,8 +1483,8 @@ async def test_transitions(
         tsn=None,
     )
 
-    assert bool(device_2_light_entity.get_state()["on"]) is True
-    assert device_2_light_entity.get_state()["brightness"] == 100
+    assert bool(device_2_light_entity.state["on"]) is True
+    assert device_2_light_entity.state["brightness"] == 100
 
     dev2_cluster_level.request.reset_mock()
 
@@ -1497,7 +1497,7 @@ async def test_transitions(
     assert dev2_cluster_color.request.await_count == 0
     assert dev2_cluster_level.request.call_count == 0
     assert dev2_cluster_level.request.await_count == 0
-    assert bool(device_2_light_entity.get_state()["on"]) is False
+    assert bool(device_2_light_entity.state["on"]) is False
 
     dev2_cluster_on_off.request.reset_mock()
 
@@ -1545,10 +1545,10 @@ async def test_transitions(
         tsn=None,
     )
 
-    assert bool(device_2_light_entity.get_state()["on"]) is True
-    assert device_2_light_entity.get_state()["brightness"] == 25
-    assert device_2_light_entity.get_state()["color_temp"] == 235
-    assert device_2_light_entity.get_state()["color_mode"] == ColorMode.COLOR_TEMP
+    assert bool(device_2_light_entity.state["on"]) is True
+    assert device_2_light_entity.state["brightness"] == 25
+    assert device_2_light_entity.state["color_temp"] == 235
+    assert device_2_light_entity.state["color_mode"] == ColorMode.COLOR_TEMP
 
     dev2_cluster_level.request.reset_mock()
     dev2_cluster_color.request.reset_mock()
@@ -1562,7 +1562,7 @@ async def test_transitions(
     assert dev2_cluster_color.request.await_count == 0
     assert dev2_cluster_level.request.call_count == 0
     assert dev2_cluster_level.request.await_count == 0
-    assert bool(device_2_light_entity.get_state()["on"]) is False
+    assert bool(device_2_light_entity.state["on"]) is False
 
     dev2_cluster_on_off.request.reset_mock()
 
@@ -1602,10 +1602,10 @@ async def test_transitions(
         tsn=None,
     )
 
-    assert bool(entity.get_state()["on"]) is True
-    assert entity.get_state()["brightness"] == 25
-    assert entity.get_state()["color_temp"] == 235
-    assert entity.get_state()["color_mode"] == ColorMode.COLOR_TEMP
+    assert bool(entity.state["on"]) is True
+    assert entity.state["brightness"] == 25
+    assert entity.state["color_temp"] == 235
+    assert entity.state["color_mode"] == ColorMode.COLOR_TEMP
 
     group_on_off_cluster_handler.request.reset_mock()
     group_color_cluster_handler.request.reset_mock()
@@ -1620,7 +1620,7 @@ async def test_transitions(
     assert dev2_cluster_color.request.await_count == 0
     assert dev2_cluster_level.request.call_count == 0
     assert dev2_cluster_level.request.await_count == 0
-    assert bool(device_2_light_entity.get_state()["on"]) is True
+    assert bool(device_2_light_entity.state["on"]) is True
 
     dev2_cluster_on_off.request.reset_mock()
 
@@ -1644,7 +1644,7 @@ async def test_transitions(
         tsn=None,
     )
 
-    assert bool(device_2_light_entity.get_state()["on"]) is False
+    assert bool(device_2_light_entity.state["on"]) is False
 
     dev2_cluster_level.request.reset_mock()
 
@@ -1668,7 +1668,7 @@ async def test_transitions(
         tsn=None,
     )
 
-    assert bool(device_2_light_entity.get_state()["on"]) is True
+    assert bool(device_2_light_entity.state["on"]) is True
 
     dev2_cluster_level.request.reset_mock()
     eWeLink_cluster_on_off.request.reset_mock()
@@ -1705,9 +1705,9 @@ async def test_transitions(
         tsn=None,
     )
 
-    assert bool(eWeLink_light_entity.get_state()["on"]) is True
-    assert eWeLink_light_entity.get_state()["color_temp"] == 235
-    assert eWeLink_light_entity.get_state()["color_mode"] == ColorMode.COLOR_TEMP
+    assert bool(eWeLink_light_entity.state["on"]) is True
+    assert eWeLink_light_entity.state["color_temp"] == 235
+    assert eWeLink_light_entity.state["color_mode"] == ColorMode.COLOR_TEMP
     assert eWeLink_light_entity.min_mireds == 153
     assert eWeLink_light_entity.max_mireds == 500
 
@@ -1777,9 +1777,9 @@ async def test_on_with_off_color(
         tsn=None,
     )
 
-    assert bool(entity.get_state()["on"]) is True
-    assert entity.get_state()["color_temp"] == 235
-    assert entity.get_state()["color_mode"] == ColorMode.COLOR_TEMP
+    assert bool(entity.state["on"]) is True
+    assert entity.state["color_temp"] == 235
+    assert entity.state["color_mode"] == ColorMode.COLOR_TEMP
 
     # now let's turn off the Execute_if_off option and see if the old behavior is restored
     dev1_cluster_color.PLUGGED_ATTR_READS = {"options": 0}
@@ -1834,10 +1834,10 @@ async def test_on_with_off_color(
         tsn=None,
     )
 
-    assert bool(entity.get_state()["on"]) is True
-    assert entity.get_state()["color_temp"] == 240
-    assert entity.get_state()["brightness"] == 254
-    assert entity.get_state()["color_mode"] == ColorMode.COLOR_TEMP
+    assert bool(entity.state["on"]) is True
+    assert entity.state["color_temp"] == 240
+    assert entity.state["brightness"] == 254
+    assert entity.state["color_mode"] == ColorMode.COLOR_TEMP
 
 
 @patch(
@@ -1906,7 +1906,7 @@ async def test_group_member_assume_state(
     group_cluster_on_off = zha_group.endpoint[general.OnOff.cluster_id]
 
     # test that the lights were created and are off
-    assert bool(entity.get_state()["on"]) is False
+    assert bool(entity.state["on"]) is False
 
     group_cluster_on_off.request.reset_mock()
     await asyncio.sleep(11)
@@ -1916,15 +1916,15 @@ async def test_group_member_assume_state(
     await zha_gateway.async_block_till_done()
 
     # members also instantly assume STATE_ON
-    assert bool(device_1_light_entity.get_state()["on"]) is True
-    assert bool(device_2_light_entity.get_state()["on"]) is True
-    assert bool(entity.get_state()["on"]) is True
+    assert bool(device_1_light_entity.state["on"]) is True
+    assert bool(device_2_light_entity.state["on"]) is True
+    assert bool(entity.state["on"]) is True
 
     # turn off via UI
     await entity.async_turn_off()
     await zha_gateway.async_block_till_done()
 
     # members also instantly assume STATE_OFF
-    assert bool(device_1_light_entity.get_state()["on"]) is False
-    assert bool(device_2_light_entity.get_state()["on"]) is False
-    assert bool(entity.get_state()["on"]) is False
+    assert bool(device_1_light_entity.state["on"]) is False
+    assert bool(device_2_light_entity.state["on"]) is False
+    assert bool(entity.state["on"]) is False

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -1708,8 +1708,8 @@ async def test_transitions(
     assert bool(eWeLink_light_entity.get_state()["on"]) is True
     assert eWeLink_light_entity.get_state()["color_temp"] == 235
     assert eWeLink_light_entity.get_state()["color_mode"] == ColorMode.COLOR_TEMP
-    assert eWeLink_light_entity.to_json()["min_mireds"] == 153
-    assert eWeLink_light_entity.to_json()["max_mireds"] == 500
+    assert eWeLink_light_entity.min_mireds == 153
+    assert eWeLink_light_entity.max_mireds == 500
 
 
 @patch(

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -69,15 +69,15 @@ async def test_lock(
     entity = get_entity(zha_device, entity_id)
     assert entity is not None
 
-    assert entity.get_state()["is_locked"] is False
+    assert entity.state["is_locked"] is False
 
     # set state to locked
     await send_attributes_report(zha_gateway, cluster, {1: 0, 0: 1, 2: 2})
-    assert entity.get_state()["is_locked"] is True
+    assert entity.state["is_locked"] is True
 
     # set state to unlocked
     await send_attributes_report(zha_gateway, cluster, {1: 0, 0: 2, 2: 3})
-    assert entity.get_state()["is_locked"] is False
+    assert entity.state["is_locked"] is False
 
     # lock from HA
     await async_lock(zha_gateway, cluster, entity)
@@ -99,13 +99,13 @@ async def test_lock(
 
     # test updating entity state from client
     cluster.read_attributes.reset_mock()
-    assert entity.get_state()["is_locked"] is False
+    assert entity.state["is_locked"] is False
     cluster.PLUGGED_ATTR_READS = {"lock_state": 1}
     update_attribute_cache(cluster)
     await entity.async_update()
     await zha_gateway.async_block_till_done()
     assert cluster.read_attributes.call_count == 1
-    assert entity.get_state()["is_locked"] is True
+    assert entity.state["is_locked"] is True
 
 
 async def async_lock(
@@ -117,7 +117,7 @@ async def async_lock(
     with patch("zigpy.zcl.Cluster.request", return_value=[zcl_f.Status.SUCCESS]):
         await entity.async_lock()
         await zha_gateway.async_block_till_done()
-        assert entity.get_state()["is_locked"] is True
+        assert entity.state["is_locked"] is True
         assert cluster.request.call_count == 1
         assert cluster.request.call_args[0][0] is False
         assert cluster.request.call_args[0][1] == LOCK_DOOR
@@ -127,7 +127,7 @@ async def async_lock(
     with patch("zigpy.zcl.Cluster.request", return_value=[zcl_f.Status.FAILURE]):
         await entity.async_unlock()
         await zha_gateway.async_block_till_done()
-        assert entity.get_state()["is_locked"] is True
+        assert entity.state["is_locked"] is True
         assert cluster.request.call_count == 1
         assert cluster.request.call_args[0][0] is False
         assert cluster.request.call_args[0][1] == UNLOCK_DOOR
@@ -143,7 +143,7 @@ async def async_unlock(
     with patch("zigpy.zcl.Cluster.request", return_value=[zcl_f.Status.SUCCESS]):
         await entity.async_unlock()
         await zha_gateway.async_block_till_done()
-        assert entity.get_state()["is_locked"] is False
+        assert entity.state["is_locked"] is False
         assert cluster.request.call_count == 1
         assert cluster.request.call_args[0][0] is False
         assert cluster.request.call_args[0][1] == UNLOCK_DOOR
@@ -153,7 +153,7 @@ async def async_unlock(
     with patch("zigpy.zcl.Cluster.request", return_value=[zcl_f.Status.FAILURE]):
         await entity.async_lock()
         await zha_gateway.async_block_till_done()
-        assert entity.get_state()["is_locked"] is False
+        assert entity.state["is_locked"] is False
         assert cluster.request.call_count == 1
         assert cluster.request.call_args[0][0] is False
         assert cluster.request.call_args[0][1] == LOCK_DOOR

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -110,7 +110,7 @@ async def test_number(
     assert cluster.read_attributes.call_count == 3
 
     # test that the state is 15.0
-    assert entity.get_state()["state"] == 15.0
+    assert entity.state["state"] == 15.0
 
     # test attributes
     assert entity.info_object.min_value == 1.0
@@ -121,12 +121,12 @@ async def test_number(
     assert cluster.read_attributes.call_count == 3
     await send_attributes_report(zha_gateway, cluster, {0x0055: 15})
     await zha_gateway.async_block_till_done()
-    assert entity.get_state()["state"] == 15.0
+    assert entity.state["state"] == 15.0
 
     # update value from device
     await send_attributes_report(zha_gateway, cluster, {0x0055: 20})
     await zha_gateway.async_block_till_done()
-    assert entity.get_state()["state"] == 20.0
+    assert entity.state["state"] == 20.0
 
     # change value from client
     await entity.async_set_value(30.0)
@@ -136,11 +136,11 @@ async def test_number(
     assert cluster.write_attributes.call_args == call(
         {"present_value": 30.0}, manufacturer=None
     )
-    assert entity.get_state()["state"] == 30.0
+    assert entity.state["state"] == 30.0
 
     # test updating entity state from client
     cluster.read_attributes.reset_mock()
-    assert entity.get_state()["state"] == 30.0
+    assert entity.state["state"] == 30.0
     cluster.PLUGGED_ATTR_READS = {"present_value": 20}
     await entity.async_update()
     await zha_gateway.async_block_till_done()
@@ -148,7 +148,7 @@ async def test_number(
     assert cluster.read_attributes.await_args == call(
         ["present_value"], allow_cache=False, only_cache=False, manufacturer=None
     )
-    assert entity.get_state()["state"] == 20.0
+    assert entity.state["state"] == 20.0
 
 
 def get_entity(zha_dev: Device, entity_id: str) -> PlatformEntity:
@@ -225,7 +225,7 @@ async def test_level_control_number(
 
     entity = get_entity(zha_device, entity_id)
     assert entity
-    assert entity.get_state()["state"] == initial_value
+    assert entity.state["state"] == initial_value
     assert entity._attr_entity_category == EntityCategory.CONFIG
 
     await entity.async_set_native_value(new_value)
@@ -233,12 +233,12 @@ async def test_level_control_number(
         call({attr: new_value}, manufacturer=None)
     ]
 
-    assert entity.get_state()["state"] == new_value
+    assert entity.state["state"] == new_value
 
     level_control_cluster.read_attributes.reset_mock()
     await entity.async_update()
     # the mocking doesn't update the attr cache so this flips back to initial value
-    assert entity.get_state()["state"] == initial_value
+    assert entity.state["state"] == initial_value
     assert level_control_cluster.read_attributes.mock_calls == [
         call(
             [attr],
@@ -259,11 +259,11 @@ async def test_level_control_number(
         call({attr: new_value}, manufacturer=None),
         call({attr: new_value}, manufacturer=None),
     ]
-    assert entity.get_state()["state"] == initial_value
+    assert entity.state["state"] == initial_value
 
     # test updating entity state from client
     level_control_cluster.read_attributes.reset_mock()
-    assert entity.get_state()["state"] == initial_value
+    assert entity.state["state"] == initial_value
     level_control_cluster.PLUGGED_ATTR_READS = {attr: new_value}
     await entity.async_update()
     await zha_gateway.async_block_till_done()
@@ -278,7 +278,7 @@ async def test_level_control_number(
             manufacturer=None,
         ),
     ]
-    assert entity.get_state()["state"] == new_value
+    assert entity.state["state"] == new_value
 
 
 @pytest.mark.parametrize(
@@ -328,7 +328,7 @@ async def test_color_number(
     entity = get_entity(zha_device, entity_id)
     assert entity
 
-    assert entity.get_state()["state"] == initial_value
+    assert entity.state["state"] == initial_value
     assert entity._attr_entity_category == EntityCategory.CONFIG
 
     await entity.async_set_native_value(new_value)
@@ -337,12 +337,12 @@ async def test_color_number(
         attr: new_value,
     }
 
-    assert entity.get_state()["state"] == new_value
+    assert entity.state["state"] == new_value
 
     color_cluster.read_attributes.reset_mock()
     await entity.async_update()
     # the mocking doesn't update the attr cache so this flips back to initial value
-    assert entity.get_state()["state"] == initial_value
+    assert entity.state["state"] == initial_value
     assert color_cluster.read_attributes.call_count == 1
     assert (
         call(
@@ -365,11 +365,11 @@ async def test_color_number(
         call({attr: new_value}, manufacturer=None),
         call({attr: new_value}, manufacturer=None),
     ]
-    assert entity.get_state()["state"] == initial_value
+    assert entity.state["state"] == initial_value
 
     # test updating entity state from client
     color_cluster.read_attributes.reset_mock()
-    assert entity.get_state()["state"] == initial_value
+    assert entity.state["state"] == initial_value
     color_cluster.PLUGGED_ATTR_READS = {attr: new_value}
     await entity.async_update()
     await zha_gateway.async_block_till_done()
@@ -384,4 +384,4 @@ async def test_color_number(
             manufacturer=None,
         ),
     ]
-    assert entity.get_state()["state"] == new_value
+    assert entity.state["state"] == new_value

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -113,9 +113,9 @@ async def test_number(
     assert entity.get_state()["state"] == 15.0
 
     # test attributes
-    assert entity.to_json()["min_value"] == 1.0
-    assert entity.to_json()["max_value"] == 100.0
-    assert entity.to_json()["step"] == 1.1
+    assert entity.info_object.min_value == 1.0
+    assert entity.info_object.max_value == 100.0
+    assert entity.info_object.step == 1.1
 
     # change value from device
     assert cluster.read_attributes.call_count == 3

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -80,7 +80,7 @@ async def test_select(
     entity = get_entity(zha_device, entity_id)
     assert entity is not None
     assert entity.get_state()["state"] is None  # unknown in HA
-    assert entity.to_json()["options"] == [
+    assert entity.info_object.options == [
         "Stop",
         "Burglar",
         "Fire",

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -79,7 +79,7 @@ async def test_select(
 
     entity = get_entity(zha_device, entity_id)
     assert entity is not None
-    assert entity.get_state()["state"] is None  # unknown in HA
+    assert entity.state["state"] is None  # unknown in HA
     assert entity.info_object.options == [
         "Stop",
         "Burglar",
@@ -94,9 +94,7 @@ async def test_select(
     # change value from client
     await entity.async_select_option(security.IasWd.Warning.WarningMode.Burglar.name)
     await zha_gateway.async_block_till_done()
-    assert (
-        entity.get_state()["state"] == security.IasWd.Warning.WarningMode.Burglar.name
-    )
+    assert entity.state["state"] == security.IasWd.Warning.WarningMode.Burglar.name
 
 
 class MotionSensitivityQuirk(CustomDevice):
@@ -176,13 +174,13 @@ async def test_on_off_select_attribute_report(
     entity = get_entity(zha_device, entity_id)
     assert entity is not None
 
-    assert entity.get_state()["state"] == AqaraMotionSensitivities.Medium.name
+    assert entity.state["state"] == AqaraMotionSensitivities.Medium.name
 
     # send attribute report from device
     await send_attributes_report(
         zha_gateway, cluster, {"motion_sensitivity": AqaraMotionSensitivities.Low}
     )
-    assert entity.get_state()["state"] == AqaraMotionSensitivities.Low.name
+    assert entity.state["state"] == AqaraMotionSensitivities.Low.name
 
 
 (
@@ -248,13 +246,13 @@ async def test_on_off_select_attribute_report_v2(
     assert entity is not None
 
     # test that the state is in default medium state
-    assert entity.get_state()["state"] == AqaraMotionSensitivities.Medium.name
+    assert entity.state["state"] == AqaraMotionSensitivities.Medium.name
 
     # send attribute report from device
     await send_attributes_report(
         zha_gateway, cluster, {"motion_sensitivity": AqaraMotionSensitivities.Low}
     )
-    assert entity.get_state()["state"] == AqaraMotionSensitivities.Low.name
+    assert entity.state["state"] == AqaraMotionSensitivities.Low.name
 
     assert entity._attr_entity_category == EntityCategory.CONFIG
     # TODO assert entity._attr_entity_registry_enabled_default is True
@@ -262,7 +260,7 @@ async def test_on_off_select_attribute_report_v2(
 
     await entity.async_select_option(AqaraMotionSensitivities.Medium.name)
     await zha_gateway.async_block_till_done()
-    assert entity.get_state()["state"] == AqaraMotionSensitivities.Medium.name
+    assert entity.state["state"] == AqaraMotionSensitivities.Medium.name
     assert cluster.write_attributes.call_count == 1
     assert cluster.write_attributes.call_args == call(
         {"motion_sensitivity": AqaraMotionSensitivities.Medium}, manufacturer=None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -125,12 +125,12 @@ async def async_test_metering(
         zha_gateway, cluster, {1025: 1, 1024: 12345, 1026: 100}
     )
     assert_state(entity, 12345.0, None)
-    assert entity.get_state()["status"] == "NO_ALARMS"
-    assert entity.get_state()["device_type"] == "Electric Metering"
+    assert entity.state["status"] == "NO_ALARMS"
+    assert entity.state["device_type"] == "Electric Metering"
 
     await send_attributes_report(zha_gateway, cluster, {1024: 12346, "status": 64 + 8})
     assert_state(entity, 12346.0, None)
-    assert entity.get_state()["status"] in (
+    assert entity.state["status"] in (
         "SERVICE_DISCONNECT|POWER_FAILURE",
         "POWER_FAILURE|SERVICE_DISCONNECT",
     )
@@ -138,7 +138,7 @@ async def async_test_metering(
     await send_attributes_report(
         zha_gateway, cluster, {"status": 64 + 8, "metering_device_type": 1}
     )
-    assert entity.get_state()["status"] in (
+    assert entity.state["status"] in (
         "SERVICE_DISCONNECT|NOT_DEFINED",
         "NOT_DEFINED|SERVICE_DISCONNECT",
     )
@@ -146,7 +146,7 @@ async def async_test_metering(
     await send_attributes_report(
         zha_gateway, cluster, {"status": 64 + 8, "metering_device_type": 2}
     )
-    assert entity.get_state()["status"] in (
+    assert entity.state["status"] in (
         "SERVICE_DISCONNECT|PIPE_EMPTY",
         "PIPE_EMPTY|SERVICE_DISCONNECT",
     )
@@ -154,7 +154,7 @@ async def async_test_metering(
     await send_attributes_report(
         zha_gateway, cluster, {"status": 64 + 8, "metering_device_type": 5}
     )
-    assert entity.get_state()["status"] in (
+    assert entity.state["status"] in (
         "SERVICE_DISCONNECT|TEMPERATURE_SENSOR",
         "TEMPERATURE_SENSOR|SERVICE_DISCONNECT",
     )
@@ -163,7 +163,7 @@ async def async_test_metering(
     await send_attributes_report(
         zha_gateway, cluster, {"status": 32, "metering_device_type": 4}
     )
-    assert entity.get_state()["status"] in ("<bitmap8.32: 32>", "32")
+    assert entity.state["status"] in ("<bitmap8.32: 32>", "32")
 
 
 async def async_test_smart_energy_summation_delivered(
@@ -175,8 +175,8 @@ async def async_test_smart_energy_summation_delivered(
         zha_gateway, cluster, {1025: 1, "current_summ_delivered": 12321, 1026: 100}
     )
     assert_state(entity, 12.321, UnitOfEnergy.KILO_WATT_HOUR)
-    assert entity.get_state()["status"] == "NO_ALARMS"
-    assert entity.get_state()["device_type"] == "Electric Metering"
+    assert entity.state["status"] == "NO_ALARMS"
+    assert entity.state["device_type"] == "Electric Metering"
     assert entity.info_object.device_class == SensorDeviceClass.ENERGY
 
 
@@ -189,8 +189,8 @@ async def async_test_smart_energy_summation_received(
         zha_gateway, cluster, {1025: 1, "current_summ_received": 12321, 1026: 100}
     )
     assert_state(entity, 12.321, UnitOfEnergy.KILO_WATT_HOUR)
-    assert entity.get_state()["status"] == "NO_ALARMS"
-    assert entity.get_state()["device_type"] == "Electric Metering"
+    assert entity.state["status"] == "NO_ALARMS"
+    assert entity.state["device_type"] == "Electric Metering"
     assert entity.info_object.device_class == SensorDeviceClass.ENERGY
 
 
@@ -203,8 +203,8 @@ async def async_test_smart_energy_summation(
         zha_gateway, cluster, {1025: 1, "current_summ_delivered": 12321, 1026: 100}
     )
     assert_state(entity, 12.32, "m³")
-    assert entity.get_state()["status"] == "NO_ALARMS"
-    assert entity.get_state()["device_type"] == "Electric Metering"
+    assert entity.state["status"] == "NO_ALARMS"
+    assert entity.state["device_type"] == "Electric Metering"
 
 
 async def async_test_electrical_measurement(
@@ -235,7 +235,7 @@ async def async_test_electrical_measurement(
     assert_state(entity, 9.9, "W")
 
     await send_attributes_report(zha_gateway, cluster, {0: 1, 0x050D: 88})
-    assert entity.get_state()["active_power_max"] == 8.8
+    assert entity.state["active_power_max"] == 8.8
 
 
 async def async_test_em_apparent_power(
@@ -294,7 +294,7 @@ async def async_test_em_rms_current(
     assert_state(entity, 124, "A")
 
     await send_attributes_report(zha_gateway, cluster, {0: 1, 0x050A: 88})
-    assert entity.get_state()["rms_current_max"] == 8.8
+    assert entity.state["rms_current_max"] == 8.8
 
 
 async def async_test_em_rms_voltage(
@@ -313,7 +313,7 @@ async def async_test_em_rms_voltage(
     assert_state(entity, 22.4, "V")
 
     await send_attributes_report(zha_gateway, cluster, {0: 1, 0x0507: 888})
-    assert entity.get_state()["rms_voltage_max"] == 8.9
+    assert entity.state["rms_voltage_max"] == 8.9
 
 
 async def async_test_powerconfiguration(
@@ -322,11 +322,11 @@ async def async_test_powerconfiguration(
     """Test powerconfiguration/battery sensor."""
     await send_attributes_report(zha_gateway, cluster, {33: 98})
     assert_state(entity, 49, "%")
-    assert entity.get_state()["battery_voltage"] == 2.9
-    assert entity.get_state()["battery_quantity"] == 3
-    assert entity.get_state()["battery_size"] == "AAA"
+    assert entity.state["battery_voltage"] == 2.9
+    assert entity.state["battery_quantity"] == 3
+    assert entity.state["battery_size"] == "AAA"
     await send_attributes_report(zha_gateway, cluster, {32: 20})
-    assert entity.get_state()["battery_voltage"] == 2.0
+    assert entity.state["battery_voltage"] == 2.0
 
 
 async def async_test_powerconfiguration2(
@@ -360,7 +360,7 @@ async def async_test_setpoint_change_source(
         cluster,
         {hvac.Thermostat.AttributeDefs.setpoint_change_source.id: 0x01},
     )
-    assert entity.get_state()["state"] == "Schedule"
+    assert entity.state["state"] == "Schedule"
 
 
 async def async_test_pi_heating_demand(
@@ -587,7 +587,7 @@ def assert_state(entity: PlatformEntity, state: Any, unit_of_measurement: str) -
     This is used to ensure that the logic in each sensor class handled the
     attribute report it received correctly.
     """
-    assert entity.get_state()["state"] == state
+    assert entity.state["state"] == state
     # TODO assert entity._attr_native_unit_of_measurement == unit_of_measurement
 
 
@@ -625,7 +625,7 @@ async def test_electrical_measurement_init(
         cluster,
         {EMAttrs.active_power.id: 100},
     )
-    assert entity.get_state()["state"] == 100
+    assert entity.state["state"] == 100
 
     cluster_handler = list(zha_device._endpoints.values())[0].all_cluster_handlers[
         "1:0x0b04"
@@ -641,7 +641,7 @@ async def test_electrical_measurement_init(
     )
     assert cluster_handler.ac_power_divisor == 5
     assert cluster_handler.ac_power_multiplier == 1
-    assert entity.get_state()["state"] == 4.0
+    assert entity.state["state"] == 4.0
 
     zha_device.available = False
 
@@ -660,7 +660,7 @@ async def test_electrical_measurement_init(
     )
     assert cluster_handler.ac_power_divisor == 10
     assert cluster_handler.ac_power_multiplier == 1
-    assert entity.get_state()["state"] == 3.0
+    assert entity.state["state"] == 3.0
 
     # update power multiplier
     await send_attributes_report(
@@ -670,7 +670,7 @@ async def test_electrical_measurement_init(
     )
     assert cluster_handler.ac_power_divisor == 10
     assert cluster_handler.ac_power_multiplier == 6
-    assert entity.get_state()["state"] == 12.0
+    assert entity.state["state"] == 12.0
 
     await send_attributes_report(
         zha_gateway,
@@ -679,7 +679,7 @@ async def test_electrical_measurement_init(
     )
     assert cluster_handler.ac_power_divisor == 10
     assert cluster_handler.ac_power_multiplier == 20
-    assert entity.get_state()["state"] == 60.0
+    assert entity.state["state"] == 60.0
 
 
 @pytest.mark.parametrize(
@@ -960,7 +960,7 @@ async def test_elec_measurement_sensor_type(
 
     entity = get_entity(zha_dev, entity_id)
     assert entity is not None
-    assert entity.get_state()["measurement_type"] == expected_type
+    assert entity.state["measurement_type"] == expected_type
 
 
 @pytest.mark.looptime
@@ -981,7 +981,7 @@ async def test_elec_measurement_sensor_polling(  # pylint: disable=redefined-out
 
     # test that the sensor has an initial state of 2.0
     entity = get_entity(zha_dev, entity_id)
-    assert entity.get_state()["state"] == 2.0
+    assert entity.state["state"] == 2.0
 
     # update the value for the power reading
     zigpy_dev.endpoints[1].electrical_measurement.PLUGGED_ATTR_READS["active_power"] = (
@@ -989,14 +989,14 @@ async def test_elec_measurement_sensor_polling(  # pylint: disable=redefined-out
     )
 
     # ensure the state is still 2.0
-    assert entity.get_state()["state"] == 2.0
+    assert entity.state["state"] == 2.0
 
     # let the polling happen
     await asyncio.sleep(90)
     await zha_gateway.async_block_till_done(wait_background_tasks=True)
 
     # ensure the state has been updated to 6.0
-    assert entity.get_state()["state"] == 6.0
+    assert entity.state["state"] == 6.0
 
 
 @pytest.mark.parametrize(
@@ -1166,7 +1166,7 @@ async def test_device_counter_sensors(
     entity = get_entity(coordinator, entity_id)
     assert entity is not None
 
-    assert entity.get_state()["state"] == 1
+    assert entity.state["state"] == 1
 
     # simulate counter increment on application
     coordinator.device.application.state.counters["ezsp_counters"][
@@ -1176,7 +1176,7 @@ async def test_device_counter_sensors(
     await entity.async_update()
     await zha_gateway.async_block_till_done()
 
-    assert entity.get_state()["state"] == 2
+    assert entity.state["state"] == 2
 
     coordinator.available = False
     await asyncio.sleep(120)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -17,7 +17,7 @@ from zigpy.zcl.clusters import general, homeautomation, hvac, measurement, smart
 from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
 
 from zha.application import Platform
-from zha.application.const import ATTR_DEVICE_CLASS, ZHA_CLUSTER_HANDLER_READS_PER_REQ
+from zha.application.const import ZHA_CLUSTER_HANDLER_READS_PER_REQ
 from zha.application.gateway import Gateway
 from zha.application.platforms import PlatformEntity
 from zha.application.platforms.sensor import UnitOfMass
@@ -177,7 +177,7 @@ async def async_test_smart_energy_summation_delivered(
     assert_state(entity, 12.321, UnitOfEnergy.KILO_WATT_HOUR)
     assert entity.get_state()["status"] == "NO_ALARMS"
     assert entity.get_state()["device_type"] == "Electric Metering"
-    assert entity.to_json()[ATTR_DEVICE_CLASS] == SensorDeviceClass.ENERGY
+    assert entity.info_object.device_class == SensorDeviceClass.ENERGY
 
 
 async def async_test_smart_energy_summation_received(
@@ -191,7 +191,7 @@ async def async_test_smart_energy_summation_received(
     assert_state(entity, 12.321, UnitOfEnergy.KILO_WATT_HOUR)
     assert entity.get_state()["status"] == "NO_ALARMS"
     assert entity.get_state()["device_type"] == "Electric Metering"
-    assert entity.to_json()[ATTR_DEVICE_CLASS] == SensorDeviceClass.ENERGY
+    assert entity.info_object.device_class == SensorDeviceClass.ENERGY
 
 
 async def async_test_smart_energy_summation(

--- a/tests/test_siren.py
+++ b/tests/test_siren.py
@@ -66,7 +66,7 @@ async def test_siren(
     entity = get_entity(zha_device, entity_id)
     assert entity is not None
 
-    assert entity.get_state()["state"] is False
+    assert entity.state["state"] is False
 
     # turn on from client
     with patch(
@@ -85,7 +85,7 @@ async def test_siren(
         cluster.request.reset_mock()
 
     # test that the state has changed to on
-    assert entity.get_state()["state"] is True
+    assert entity.state["state"] is True
 
     # turn off from client
     with patch(
@@ -104,7 +104,7 @@ async def test_siren(
         cluster.request.reset_mock()
 
     # test that the state has changed to off
-    assert entity.get_state()["state"] is False
+    assert entity.state["state"] is False
 
     # turn on from client with options
     with patch(
@@ -123,7 +123,7 @@ async def test_siren(
         cluster.request.reset_mock()
 
     # test that the state has changed to on
-    assert entity.get_state()["state"] is True
+    assert entity.state["state"] is True
 
 
 @pytest.mark.looptime
@@ -141,7 +141,7 @@ async def test_siren_timed_off(
     entity = get_entity(zha_device, entity_id)
     assert entity is not None
 
-    assert entity.get_state()["state"] is False
+    assert entity.state["state"] is False
 
     # turn on from client
     with patch(
@@ -160,9 +160,9 @@ async def test_siren_timed_off(
         cluster.request.reset_mock()
 
     # test that the state has changed to on
-    assert entity.get_state()["state"] is True
+    assert entity.state["state"] is True
 
     await asyncio.sleep(6)
 
     # test that the state has changed to off from the timer
-    assert entity.get_state()["state"] is False
+    assert entity.state["state"] is False

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -141,15 +141,15 @@ async def test_switch(
     entity: PlatformEntity = get_entity(zha_device, entity_id)
     assert entity is not None
 
-    assert bool(bool(entity.get_state()["state"])) is False
+    assert bool(bool(entity.state["state"])) is False
 
     # turn on at switch
     await send_attributes_report(zha_gateway, cluster, {1: 0, 0: 1, 2: 2})
-    assert bool(entity.get_state()["state"]) is True
+    assert bool(entity.state["state"]) is True
 
     # turn off at switch
     await send_attributes_report(zha_gateway, cluster, {1: 1, 0: 0, 2: 2})
-    assert bool(entity.get_state()["state"]) is False
+    assert bool(entity.state["state"]) is False
 
     # turn on from client
     with patch(
@@ -158,7 +158,7 @@ async def test_switch(
     ):
         await entity.async_turn_on()
         await zha_gateway.async_block_till_done()
-        assert bool(entity.get_state()["state"]) is True
+        assert bool(entity.state["state"]) is True
         assert len(cluster.request.mock_calls) == 1
         assert cluster.request.call_args == call(
             False,
@@ -179,7 +179,7 @@ async def test_switch(
     ):
         await entity.async_turn_off()
         await zha_gateway.async_block_till_done()
-        assert bool(entity.get_state()["state"]) is True
+        assert bool(entity.state["state"]) is True
         assert len(cluster.request.mock_calls) == 1
         assert cluster.request.call_args == call(
             False,
@@ -197,7 +197,7 @@ async def test_switch(
     ):
         await entity.async_turn_off()
         await zha_gateway.async_block_till_done()
-        assert bool(entity.get_state()["state"]) is False
+        assert bool(entity.state["state"]) is False
         assert len(cluster.request.mock_calls) == 1
         assert cluster.request.call_args == call(
             False,
@@ -218,7 +218,7 @@ async def test_switch(
     ):
         await entity.async_turn_on()
         await zha_gateway.async_block_till_done()
-        assert bool(entity.get_state()["state"]) is False
+        assert bool(entity.state["state"]) is False
         assert len(cluster.request.mock_calls) == 1
         assert cluster.request.call_args == call(
             False,
@@ -231,7 +231,7 @@ async def test_switch(
 
     # test updating entity state from client
     cluster.read_attributes.reset_mock()
-    assert bool(entity.get_state()["state"]) is False
+    assert bool(entity.state["state"]) is False
     cluster.PLUGGED_ATTR_READS = {"on_off": True}
     await entity.async_update()
     await zha_gateway.async_block_till_done()
@@ -239,7 +239,7 @@ async def test_switch(
     assert cluster.read_attributes.await_args == call(
         ["on_off"], allow_cache=False, only_cache=False, manufacturer=None
     )
-    assert bool(entity.get_state()["state"]) is True
+    assert bool(entity.state["state"]) is True
 
 
 async def test_zha_group_switch_entity(
@@ -279,7 +279,7 @@ async def test_zha_group_switch_entity(
     dev2_cluster_on_off = device_switch_2.device.endpoints[1].on_off
 
     # test that the lights were created and are off
-    assert bool(entity.get_state()["state"]) is False
+    assert bool(entity.state["state"]) is False
 
     # turn on from HA
     with patch(
@@ -298,7 +298,7 @@ async def test_zha_group_switch_entity(
             manufacturer=None,
             tsn=None,
         )
-    assert bool(entity.get_state()["state"]) is True
+    assert bool(entity.state["state"]) is True
 
     # turn off from HA
     with patch(
@@ -317,7 +317,7 @@ async def test_zha_group_switch_entity(
             manufacturer=None,
             tsn=None,
         )
-    assert bool(entity.get_state()["state"]) is False
+    assert bool(entity.state["state"]) is False
 
     # test some of the group logic to make sure we key off states correctly
     await send_attributes_report(zha_gateway, dev1_cluster_on_off, {0: 1})
@@ -325,25 +325,25 @@ async def test_zha_group_switch_entity(
     await zha_gateway.async_block_till_done()
 
     # test that group light is on
-    assert bool(entity.get_state()["state"]) is True
+    assert bool(entity.state["state"]) is True
 
     await send_attributes_report(zha_gateway, dev1_cluster_on_off, {0: 0})
     await zha_gateway.async_block_till_done()
 
     # test that group light is still on
-    assert bool(entity.get_state()["state"]) is True
+    assert bool(entity.state["state"]) is True
 
     await send_attributes_report(zha_gateway, dev2_cluster_on_off, {0: 0})
     await zha_gateway.async_block_till_done()
 
     # test that group light is now off
-    assert bool(entity.get_state()["state"]) is False
+    assert bool(entity.state["state"]) is False
 
     await send_attributes_report(zha_gateway, dev1_cluster_on_off, {0: 1})
     await zha_gateway.async_block_till_done()
 
     # test that group light is now back on
-    assert bool(entity.get_state()["state"]) is True
+    assert bool(entity.state["state"]) is True
 
 
 def get_entity(zha_dev: Device, entity_id: str) -> PlatformEntity:
@@ -434,19 +434,19 @@ async def test_switch_configurable(
     assert entity is not None
 
     # test that the state has changed from unavailable to off
-    assert bool(entity.get_state()["state"]) is False
+    assert bool(entity.state["state"]) is False
 
     # turn on at switch
     await send_attributes_report(
         zha_gateway, cluster, {"window_detection_function": True}
     )
-    assert bool(entity.get_state()["state"]) is True
+    assert bool(entity.state["state"]) is True
 
     # turn off at switch
     await send_attributes_report(
         zha_gateway, cluster, {"window_detection_function": False}
     )
-    assert bool(entity.get_state()["state"]) is False
+    assert bool(entity.state["state"]) is False
 
     # turn on from HA
     with patch(
@@ -566,15 +566,15 @@ async def test_switch_configurable_custom_on_off_values(
     entity = get_entity(zha_device, entity_id)
     assert entity is not None
 
-    assert bool(entity.get_state()["state"]) is False
+    assert bool(entity.state["state"]) is False
 
     # turn on at switch
     await send_attributes_report(zha_gateway, cluster, {"window_detection_function": 3})
-    assert bool(entity.get_state()["state"]) is True
+    assert bool(entity.state["state"]) is True
 
     # turn off at switch
     await send_attributes_report(zha_gateway, cluster, {"window_detection_function": 5})
-    assert bool(entity.get_state()["state"]) is False
+    assert bool(entity.state["state"]) is False
 
     # turn on from HA
     with patch(
@@ -645,15 +645,15 @@ async def test_switch_configurable_custom_on_off_values_force_inverted(
     entity = get_entity(zha_device, entity_id)
     assert entity is not None
 
-    assert bool(entity.get_state()["state"]) is True
+    assert bool(entity.state["state"]) is True
 
     # turn on at switch
     await send_attributes_report(zha_gateway, cluster, {"window_detection_function": 3})
-    assert bool(entity.get_state()["state"]) is False
+    assert bool(entity.state["state"]) is False
 
     # turn off at switch
     await send_attributes_report(zha_gateway, cluster, {"window_detection_function": 5})
-    assert bool(entity.get_state()["state"]) is True
+    assert bool(entity.state["state"]) is True
 
     # turn on from HA
     with patch(
@@ -727,15 +727,15 @@ async def test_switch_configurable_custom_on_off_values_inverter_attribute(
     entity = get_entity(zha_device, entity_id)
     assert entity is not None
 
-    assert bool(entity.get_state()["state"]) is True
+    assert bool(entity.state["state"]) is True
 
     # turn on at switch
     await send_attributes_report(zha_gateway, cluster, {"window_detection_function": 3})
-    assert bool(entity.get_state()["state"]) is False
+    assert bool(entity.state["state"]) is False
 
     # turn off at switch
     await send_attributes_report(zha_gateway, cluster, {"window_detection_function": 5})
-    assert bool(entity.get_state()["state"]) is True
+    assert bool(entity.state["state"]) is True
 
     # turn on from HA
     with patch(
@@ -812,13 +812,13 @@ async def test_cover_inversion_switch(
     await entity.async_update()
     await zha_gateway.async_block_till_done()
     assert cluster.read_attributes.call_count == prev_call_count + 1
-    assert bool(entity.get_state()["state"]) is False
+    assert bool(entity.state["state"]) is False
 
     # test to see the state remains after tilting to 0%
     await send_attributes_report(
         zha_gateway, cluster, {WCAttrs.current_position_tilt_percentage.id: 0}
     )
-    assert bool(entity.get_state()["state"]) is False
+    assert bool(entity.state["state"]) is False
 
     with patch(
         "zigpy.zcl.Cluster.write_attributes", return_value=[0x1, zcl_f.Status.SUCCESS]
@@ -839,7 +839,7 @@ async def test_cover_inversion_switch(
             manufacturer=None,
         )
 
-        assert bool(entity.get_state()["state"]) is True
+        assert bool(entity.state["state"]) is True
 
         cluster.write_attributes.reset_mock()
 
@@ -855,7 +855,7 @@ async def test_cover_inversion_switch(
             manufacturer=None,
         )
 
-        assert bool(entity.get_state()["state"]) is False
+        assert bool(entity.state["state"]) is False
 
         cluster.write_attributes.reset_mock()
 
@@ -864,7 +864,7 @@ async def test_cover_inversion_switch(
         await zha_gateway.async_block_till_done()
         assert cluster.write_attributes.call_count == 0
 
-        assert bool(entity.get_state()["state"]) is False
+        assert bool(entity.state["state"]) is False
 
 
 async def test_cover_inversion_switch_not_created(

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -120,7 +120,7 @@ async def test_firmware_update_notification_from_zigpy(
 
     entity = get_entity(zha_device, entity_id)
     assert entity is not None
-    assert entity.state is False
+    assert entity.state["state"] is False
 
     # simulate an image available notification
     await cluster._handle_query_next_image(
@@ -137,11 +137,11 @@ async def test_firmware_update_notification_from_zigpy(
     )
 
     await zha_gateway.async_block_till_done()
-    assert entity.state is True
-    assert entity.get_state()[ATTR_INSTALLED_VERSION] == f"0x{installed_fw_version:08x}"  # type: ignore[unreachable]
-    assert not entity.get_state()[ATTR_IN_PROGRESS]
+    assert entity.state["state"] is True
+    assert entity.state[ATTR_INSTALLED_VERSION] == f"0x{installed_fw_version:08x}"
+    assert not entity.state[ATTR_IN_PROGRESS]
     assert (
-        entity.get_state()[ATTR_LATEST_VERSION]
+        entity.state[ATTR_LATEST_VERSION]
         == f"0x{fw_image.firmware.header.file_version:08x}"
     )
 
@@ -161,7 +161,7 @@ async def test_firmware_update_notification_from_service_call(
 
     entity = get_entity(zha_device, entity_id)
     assert entity is not None
-    assert entity.state is False
+    assert entity.state["state"] is False
 
     # pylint: disable=pointless-string-statement
     """TODO
@@ -189,7 +189,7 @@ async def test_firmware_update_notification_from_service_call(
     )
 
     await zha_gateway.async_block_till_done()
-    assert entity.state is True
+    assert entity.state["state"] is True
     assert entity.get_state()[ATTR_INSTALLED_VERSION] == f"0x{installed_fw_version:08x}"
     assert not entity.get_state()[ATTR_IN_PROGRESS]
     assert (
@@ -250,7 +250,7 @@ async def test_firmware_update_success(
 
     entity = get_entity(zha_device, entity_id)
     assert entity is not None
-    assert entity.state is False
+    assert entity.state["state"] is False
 
     # simulate an image available notification
     await cluster._handle_query_next_image(
@@ -266,11 +266,11 @@ async def test_firmware_update_success(
     )
 
     await zha_gateway.async_block_till_done()
-    assert entity.state is True
-    assert entity.get_state()[ATTR_INSTALLED_VERSION] == f"0x{installed_fw_version:08x}"  # type: ignore[unreachable]
-    assert not entity.get_state()[ATTR_IN_PROGRESS]
+    assert entity.state["state"] is True
+    assert entity.state[ATTR_INSTALLED_VERSION] == f"0x{installed_fw_version:08x}"
+    assert not entity.state[ATTR_IN_PROGRESS]
     assert (
-        entity.get_state()[ATTR_LATEST_VERSION]
+        entity.state[ATTR_LATEST_VERSION]
         == f"0x{fw_image.firmware.header.file_version:08x}"
     )
 
@@ -351,14 +351,14 @@ async def test_firmware_update_success(
                     assert cmd.image_data == fw_image.firmware.serialize()[40:70]
 
                     # make sure the state machine gets progress reports
-                    assert entity.state is True
+                    assert entity.state["state"] is True
                     assert (
-                        entity.get_state()[ATTR_INSTALLED_VERSION]
+                        entity.state[ATTR_INSTALLED_VERSION]
                         == f"0x{installed_fw_version:08x}"
                     )
-                    assert entity.get_state()[ATTR_IN_PROGRESS] == 58
+                    assert entity.state[ATTR_IN_PROGRESS] == 58
                     assert (
-                        entity.get_state()[ATTR_LATEST_VERSION]
+                        entity.state[ATTR_LATEST_VERSION]
                         == f"0x{fw_image.firmware.header.file_version:08x}"
                     )
 
@@ -404,23 +404,20 @@ async def test_firmware_update_success(
     await entity.async_install(fw_image.firmware.header.file_version, False)
     await zha_gateway.async_block_till_done()
 
-    assert entity.state is False
+    assert entity.state["state"] is False
 
     assert (
-        entity.get_state()[ATTR_INSTALLED_VERSION]
+        entity.state[ATTR_INSTALLED_VERSION]
         == f"0x{fw_image.firmware.header.file_version:08x}"
     )
-    assert not entity.get_state()[ATTR_IN_PROGRESS]
-    assert (
-        entity.get_state()[ATTR_LATEST_VERSION]
-        == entity.get_state()[ATTR_INSTALLED_VERSION]
-    )
+    assert not entity.state[ATTR_IN_PROGRESS]
+    assert entity.state[ATTR_LATEST_VERSION] == entity.state[ATTR_INSTALLED_VERSION]
 
     # If we send a progress notification incorrectly, it won't be handled
     entity._update_progress(50, 100, 0.50)
 
-    assert not entity.get_state()[ATTR_IN_PROGRESS]
-    assert entity.state is False
+    assert not entity.state[ATTR_IN_PROGRESS]
+    assert entity.state["state"] is False
 
 
 async def test_firmware_update_raises(
@@ -438,7 +435,7 @@ async def test_firmware_update_raises(
 
     entity = get_entity(zha_device, entity_id)
     assert entity is not None
-    assert entity.state is False
+    assert entity.state["state"] is False
 
     # simulate an image available notification
     await cluster._handle_query_next_image(
@@ -455,11 +452,11 @@ async def test_firmware_update_raises(
     )
 
     await zha_gateway.async_block_till_done()
-    assert entity.state is True
-    assert entity.get_state()[ATTR_INSTALLED_VERSION] == f"0x{installed_fw_version:08x}"  # type: ignore[unreachable]
-    assert not entity.get_state()[ATTR_IN_PROGRESS]
+    assert entity.state["state"] is True
+    assert entity.state[ATTR_INSTALLED_VERSION] == f"0x{installed_fw_version:08x}"
+    assert not entity.state[ATTR_IN_PROGRESS]
     assert (
-        entity.get_state()[ATTR_LATEST_VERSION]
+        entity.state[ATTR_LATEST_VERSION]
         == f"0x{fw_image.firmware.header.file_version:08x}"
     )
 
@@ -520,7 +517,7 @@ async def test_firmware_update_no_longer_compatible(
 
     entity = get_entity(zha_device, entity_id)
     assert entity is not None
-    assert entity.state is False
+    assert entity.state["state"] is False
 
     # simulate an image available notification
     await cluster._handle_query_next_image(
@@ -537,11 +534,11 @@ async def test_firmware_update_no_longer_compatible(
     )
 
     await zha_gateway.async_block_till_done()
-    assert entity.state is True
-    assert entity.get_state()[ATTR_INSTALLED_VERSION] == f"0x{installed_fw_version:08x}"  # type: ignore[unreachable]
-    assert not entity.get_state()[ATTR_IN_PROGRESS]
+    assert entity.state["state"] is True
+    assert entity.state[ATTR_INSTALLED_VERSION] == f"0x{installed_fw_version:08x}"
+    assert not entity.state[ATTR_IN_PROGRESS]
     assert (
-        entity.get_state()[ATTR_LATEST_VERSION]
+        entity.state[ATTR_LATEST_VERSION]
         == f"0x{fw_image.firmware.header.file_version:08x}"
     )
 
@@ -571,7 +568,7 @@ async def test_firmware_update_no_longer_compatible(
         await zha_gateway.async_block_till_done()
 
     # We updated the currently installed firmware version, as it is no longer valid
-    assert entity.state is False
-    assert entity.get_state()[ATTR_INSTALLED_VERSION] == f"0x{new_version:08x}"
-    assert not entity.get_state()[ATTR_IN_PROGRESS]
-    assert entity.get_state()[ATTR_LATEST_VERSION] == f"0x{new_version:08x}"
+    assert entity.state["state"] is False
+    assert entity.state[ATTR_INSTALLED_VERSION] == f"0x{new_version:08x}"
+    assert not entity.state[ATTR_IN_PROGRESS]
+    assert entity.state[ATTR_LATEST_VERSION] == f"0x{new_version:08x}"

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -8,6 +8,7 @@ from contextlib import suppress
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum
+from functools import cached_property
 import logging
 import time
 from typing import Any, Final, Self, TypeVar, cast
@@ -301,7 +302,7 @@ class Gateway(AsyncUtilMixin, EventBase):
                     )
             self.config.platforms[platform].clear()
 
-    @property
+    @cached_property
     def radio_concurrency(self) -> int:
         """Maximum configured radio concurrency."""
         return self.application_controller._concurrent_requests_semaphore.max_value  # pylint: disable=protected-access

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Iterable
 from contextlib import suppress
+from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum
 import logging
 import time
-from typing import Final, Self, TypeVar, cast
+from typing import Any, Final, Self, TypeVar, cast
 
 from zhaquirks import setup as setup_quirks
 from zigpy.application import ControllerApplication
@@ -22,27 +23,18 @@ from zigpy.types.named import EUI64
 
 from zha.application import discovery
 from zha.application.const import (
-    ATTR_IEEE,
-    ATTR_MANUFACTURER,
-    ATTR_MODEL,
-    ATTR_NWK,
-    ATTR_SIGNATURE,
-    ATTR_TYPE,
     CONF_CUSTOM_QUIRKS_PATH,
     CONF_ENABLE_QUIRKS,
     CONF_RADIO_TYPE,
     CONF_USE_THREAD,
     CONF_ZIGPY,
-    DEVICE_PAIRING_STATUS,
     UNKNOWN_MANUFACTURER,
     UNKNOWN_MODEL,
     ZHA_GW_MSG,
     ZHA_GW_MSG_DEVICE_FULL_INIT,
-    ZHA_GW_MSG_DEVICE_INFO,
     ZHA_GW_MSG_DEVICE_JOINED,
     ZHA_GW_MSG_DEVICE_REMOVED,
     ZHA_GW_MSG_GROUP_ADDED,
-    ZHA_GW_MSG_GROUP_INFO,
     ZHA_GW_MSG_GROUP_MEMBER_ADDED,
     ZHA_GW_MSG_GROUP_MEMBER_REMOVED,
     ZHA_GW_MSG_GROUP_REMOVED,
@@ -56,8 +48,8 @@ from zha.async_ import (
     gather_with_limited_concurrency,
 )
 from zha.event import EventBase
-from zha.zigbee.device import Device, DeviceStatus
-from zha.zigbee.group import Group, GroupMemberReference
+from zha.zigbee.device import Device, DeviceInfo, DeviceStatus, ExtendedDeviceInfo
+from zha.zigbee.group import Group, GroupInfo, GroupMemberReference
 
 BLOCK_LOG_TIMEOUT: Final[int] = 60
 _R = TypeVar("_R")
@@ -71,6 +63,83 @@ class DevicePairingStatus(Enum):
     INTERVIEW_COMPLETE = 2
     CONFIGURED = 3
     INITIALIZED = 4
+
+
+@dataclass(kw_only=True, frozen=True)
+class DeviceInfoWithPairingStatus(DeviceInfo):
+    """Information about a device with pairing status."""
+
+    pairing_status: DevicePairingStatus
+
+
+@dataclass(kw_only=True, frozen=True)
+class ExtendedDeviceInfoWithPairingStatus(ExtendedDeviceInfo):
+    """Information about a device with pairing status."""
+
+    pairing_status: DevicePairingStatus
+
+
+@dataclass(kw_only=True, frozen=True)
+class DeviceJoinedDeviceInfo:
+    """Information about a device."""
+
+    ieee: str
+    nwk: int
+    pairing_status: DevicePairingStatus
+
+
+@dataclass(kw_only=True, frozen=True)
+class DeviceJoinedEvent:
+    """Event to signal that a device has joined the network."""
+
+    device_info: DeviceJoinedDeviceInfo
+    event_type: Final[str] = ZHA_GW_MSG
+    event: Final[str] = ZHA_GW_MSG_DEVICE_JOINED
+
+
+@dataclass(kw_only=True, frozen=True)
+class RawDeviceInitializedDeviceInfo(DeviceJoinedDeviceInfo):
+    """Information about a device that has been initialized without quirks loaded."""
+
+    model: str
+    manufacturer: str
+    signature: dict[str, Any]
+
+
+@dataclass(kw_only=True, frozen=True)
+class RawDeviceInitializedEvent:
+    """Event to signal that a device has been initialized without quirks loaded."""
+
+    device_info: RawDeviceInitializedDeviceInfo
+    event_type: Final[str] = ZHA_GW_MSG
+    event: Final[str] = ZHA_GW_MSG_RAW_INIT
+
+
+@dataclass(kw_only=True, frozen=True)
+class DeviceFullInitEvent:
+    """Event to signal that a device has been fully initialized."""
+
+    device_info: ExtendedDeviceInfoWithPairingStatus
+    event_type: Final[str] = ZHA_GW_MSG
+    event: Final[str] = ZHA_GW_MSG_DEVICE_FULL_INIT
+
+
+@dataclass(kw_only=True, frozen=True)
+class GroupEvent:
+    """Event to signal a group event."""
+
+    event: str
+    group_info: GroupInfo
+    event_type: Final[str] = ZHA_GW_MSG
+
+
+@dataclass(kw_only=True, frozen=True)
+class DeviceRemovedEvent:
+    """Event to signal that a device has been removed."""
+
+    device_info: ExtendedDeviceInfo
+    event_type: Final[str] = ZHA_GW_MSG
+    event: Final[str] = ZHA_GW_MSG_DEVICE_REMOVED
 
 
 class Gateway(AsyncUtilMixin, EventBase):
@@ -227,7 +296,9 @@ class Gateway(AsyncUtilMixin, EventBase):
                     *args, **kw_args
                 )
                 if platform_entity:
-                    _LOGGER.debug("Platform entity data: %s", platform_entity.to_json())
+                    _LOGGER.debug(
+                        "Platform entity data: %s", platform_entity.info_object
+                    )
             self.config.platforms[platform].clear()
 
     @property
@@ -291,14 +362,13 @@ class Gateway(AsyncUtilMixin, EventBase):
 
         self.emit(
             ZHA_GW_MSG_DEVICE_JOINED,
-            {
-                ATTR_TYPE: ZHA_GW_MSG,
-                ZHA_GW_MSG_DEVICE_INFO: {
-                    ATTR_NWK: device.nwk,
-                    ATTR_IEEE: str(device.ieee),
-                    DEVICE_PAIRING_STATUS: DevicePairingStatus.PAIRED.name,
-                },
-            },
+            DeviceJoinedEvent(
+                device_info=DeviceJoinedDeviceInfo(
+                    ieee=str(device.ieee),
+                    nwk=device.nwk,
+                    pairing_status=DevicePairingStatus.PAIRED.name,
+                )
+            ),
         )
 
     def raw_device_initialized(self, device: zigpy.device.Device) -> None:  # pylint: disable=unused-argument
@@ -306,19 +376,18 @@ class Gateway(AsyncUtilMixin, EventBase):
 
         self.emit(
             ZHA_GW_MSG_RAW_INIT,
-            {
-                ATTR_TYPE: ZHA_GW_MSG,
-                ZHA_GW_MSG_DEVICE_INFO: {
-                    ATTR_NWK: device.nwk,
-                    ATTR_IEEE: str(device.ieee),
-                    DEVICE_PAIRING_STATUS: DevicePairingStatus.INTERVIEW_COMPLETE.name,
-                    ATTR_MODEL: device.model if device.model else UNKNOWN_MODEL,
-                    ATTR_MANUFACTURER: device.manufacturer
+            RawDeviceInitializedEvent(
+                device_info=RawDeviceInitializedDeviceInfo(
+                    ieee=str(device.ieee),
+                    nwk=device.nwk,
+                    pairing_status=DevicePairingStatus.INTERVIEW_COMPLETE.name,
+                    model=device.model if device.model else UNKNOWN_MODEL,
+                    manufacturer=device.manufacturer
                     if device.manufacturer
                     else UNKNOWN_MANUFACTURER,
-                    ATTR_SIGNATURE: device.get_signature(),
-                },
-            },
+                    signature=device.get_signature(),
+                )
+            ),
         )
 
     def device_initialized(self, device: zigpy.device.Device) -> None:
@@ -346,6 +415,7 @@ class Gateway(AsyncUtilMixin, EventBase):
         """Handle zigpy group member removed event."""
         # need to handle endpoint correctly on groups
         zha_group = self.get_or_create_group(zigpy_group)
+        zha_group.clear_caches()
         discovery.GROUP_PROBE.discover_group_entities(zha_group)
         zha_group.info("group_member_removed - endpoint: %s", endpoint)
         self._emit_group_gateway_message(zigpy_group, ZHA_GW_MSG_GROUP_MEMBER_REMOVED)
@@ -356,6 +426,7 @@ class Gateway(AsyncUtilMixin, EventBase):
         """Handle zigpy group member added event."""
         # need to handle endpoint correctly on groups
         zha_group = self.get_or_create_group(zigpy_group)
+        zha_group.clear_caches()
         discovery.GROUP_PROBE.discover_group_entities(zha_group)
         zha_group.info("group_member_added - endpoint: %s", endpoint)
         self._emit_group_gateway_message(zigpy_group, ZHA_GW_MSG_GROUP_MEMBER_ADDED)
@@ -383,10 +454,10 @@ class Gateway(AsyncUtilMixin, EventBase):
         if zha_group is not None:
             self.emit(
                 gateway_message_type,
-                {
-                    ATTR_TYPE: ZHA_GW_MSG,
-                    ZHA_GW_MSG_GROUP_INFO: zha_group.group_info,
-                },
+                GroupEvent(
+                    event=gateway_message_type,
+                    group_info=zha_group.info_object,
+                ),
             )
 
     def device_removed(self, device: zigpy.device.Device) -> None:
@@ -394,7 +465,7 @@ class Gateway(AsyncUtilMixin, EventBase):
         _LOGGER.info("Removing device %s - %s", device.ieee, f"0x{device.nwk:04x}")
         zha_device = self._devices.pop(device.ieee, None)
         if zha_device is not None:
-            device_info = zha_device.zha_device_info
+            device_info = zha_device.extended_device_info
             self.track_task(
                 create_eager_task(
                     zha_device.on_remove(), name="Gateway._async_remove_device"
@@ -403,10 +474,7 @@ class Gateway(AsyncUtilMixin, EventBase):
             if device_info is not None:
                 self.emit(
                     ZHA_GW_MSG_DEVICE_REMOVED,
-                    {
-                        ATTR_TYPE: ZHA_GW_MSG,
-                        ZHA_GW_MSG_DEVICE_INFO: device_info,
-                    },
+                    DeviceRemovedEvent(device_info=device_info),
                 )
 
     def get_device(self, ieee: EUI64) -> Device | None:
@@ -489,27 +557,25 @@ class Gateway(AsyncUtilMixin, EventBase):
             )
             await self._async_device_joined(zha_device)
 
-        device_info = zha_device.zha_device_info
-        device_info[DEVICE_PAIRING_STATUS] = DevicePairingStatus.INITIALIZED.name
+        device_info = ExtendedDeviceInfoWithPairingStatus(
+            pairing_status=DevicePairingStatus.INITIALIZED.name,
+            **zha_device.extended_device_info.__dict__,
+        )
         self.emit(
             ZHA_GW_MSG_DEVICE_FULL_INIT,
-            {
-                ATTR_TYPE: ZHA_GW_MSG,
-                ZHA_GW_MSG_DEVICE_INFO: device_info,
-            },
+            DeviceFullInitEvent(device_info=device_info),
         )
 
     async def _async_device_joined(self, zha_device: Device) -> None:
         zha_device.available = True
-        device_info = zha_device.device_info
         await zha_device.async_configure()
-        device_info[DEVICE_PAIRING_STATUS] = DevicePairingStatus.CONFIGURED.name
+        device_info = ExtendedDeviceInfoWithPairingStatus(
+            pairing_status=DevicePairingStatus.CONFIGURED.name,
+            **zha_device.extended_device_info.__dict__,
+        )
         self.emit(
             ZHA_GW_MSG_DEVICE_FULL_INIT,
-            {
-                ATTR_TYPE: ZHA_GW_MSG,
-                ZHA_GW_MSG_DEVICE_INFO: device_info,
-            },
+            DeviceFullInitEvent(device_info=device_info),
         )
         await zha_device.async_initialize(from_cache=False)
         self.create_platform_entities()
@@ -523,14 +589,13 @@ class Gateway(AsyncUtilMixin, EventBase):
         # we don't have to do this on a nwk swap
         # but we don't have a way to tell currently
         await zha_device.async_configure()
-        device_info = zha_device.device_info
-        device_info[DEVICE_PAIRING_STATUS] = DevicePairingStatus.CONFIGURED.name
+        device_info = ExtendedDeviceInfoWithPairingStatus(
+            pairing_status=DevicePairingStatus.CONFIGURED.name,
+            **zha_device.extended_device_info.__dict__,
+        )
         self.emit(
             ZHA_GW_MSG_DEVICE_FULL_INIT,
-            {
-                ATTR_TYPE: ZHA_GW_MSG,
-                ZHA_GW_MSG_DEVICE_INFO: device_info,
-            },
+            DeviceFullInitEvent(device_info=device_info),
         )
         # force async_initialize() to fire so don't explicitly call it
         zha_device.available = False

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 from functools import cached_property
 import logging
-from typing import TYPE_CHECKING, Any, Final, Optional
+from typing import TYPE_CHECKING, Any, Final, Optional, final
 
 from zigpy.quirks.v2 import EntityMetadata, EntityType
 from zigpy.types.named import EUI64
@@ -123,7 +123,8 @@ class BaseEntity(LogMixin, EventBase):
         self.__previous_state: Any = None
         self._tracked_tasks: list[asyncio.Task] = []
 
-    @property
+    @final
+    @cached_property
     def unique_id(self) -> str:
         """Return the unique id."""
         return self._unique_id
@@ -253,31 +254,6 @@ class PlatformEntity(BaseEntity):
         else:
             self._attr_entity_category = None
 
-    @property
-    def device(self) -> Device:
-        """Return the device."""
-        return self._device
-
-    @property
-    def endpoint(self) -> Endpoint:
-        """Return the endpoint."""
-        return self._endpoint
-
-    @property
-    def should_poll(self) -> bool:
-        """Return True if we need to poll for state changes."""
-        return False
-
-    @property
-    def available(self) -> bool:
-        """Return true if the device this entity belongs to is available."""
-        return self.device.available
-
-    @property
-    def name(self) -> str:
-        """Return the name of the platform entity."""
-        return self._name
-
     @cached_property
     def identifiers(self) -> PlatformEntityIdentifiers:
         """Return a dict with the information necessary to identify this entity."""
@@ -301,6 +277,31 @@ class PlatformEntity(BaseEntity):
             endpoint_id=self._endpoint.id,
             available=self.available,
         )
+
+    @cached_property
+    def device(self) -> Device:
+        """Return the device."""
+        return self._device
+
+    @cached_property
+    def endpoint(self) -> Endpoint:
+        """Return the endpoint."""
+        return self._endpoint
+
+    @cached_property
+    def should_poll(self) -> bool:
+        """Return True if we need to poll for state changes."""
+        return False
+
+    @property
+    def available(self) -> bool:
+        """Return true if the device this entity belongs to is available."""
+        return self.device.available
+
+    @property
+    def name(self) -> str:
+        """Return the name of the platform entity."""
+        return self._name
 
     @property
     def state(self) -> dict[str, Any]:
@@ -335,21 +336,6 @@ class GroupEntity(BaseEntity):
         self._group: Group = group
         self._group.register_group_entity(self)
 
-    @property
-    def name(self) -> str:
-        """Return the name of the group entity."""
-        return self._name
-
-    @property
-    def group_id(self) -> int:
-        """Return the group id."""
-        return self._group.group_id
-
-    @property
-    def group(self) -> Group:
-        """Return the group."""
-        return self._group
-
     @cached_property
     def identifiers(self) -> GroupEntityIdentifiers:
         """Return a dict with the information necessary to identify this entity."""
@@ -358,10 +344,6 @@ class GroupEntity(BaseEntity):
             platform=self.PLATFORM,
             group_id=self.group_id,
         )
-
-    @abstractmethod
-    def update(self, _: Any | None = None) -> None:
-        """Update the state of this group entity."""
 
     @cached_property
     def info_object(self) -> GroupEntityInfo:
@@ -373,3 +355,22 @@ class GroupEntity(BaseEntity):
             name=self._name,
             group_id=self.group_id,
         )
+
+    @property
+    def name(self) -> str:
+        """Return the name of the group entity."""
+        return self._name
+
+    @property
+    def group_id(self) -> int:
+        """Return the group id."""
+        return self._group.group_id
+
+    @cached_property
+    def group(self) -> Group:
+        """Return the group."""
+        return self._group
+
+    @abstractmethod
+    def update(self, _: Any | None = None) -> None:
+        """Update the state of this group entity."""

--- a/zha/application/platforms/alarm_control_panel/__init__.py
+++ b/zha/application/platforms/alarm_control_panel/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import functools
 import logging
 from typing import TYPE_CHECKING
@@ -16,7 +17,7 @@ from zha.application.const import (
     ZHA_ALARM_OPTIONS,
 )
 from zha.application.helpers import async_get_zha_config_value
-from zha.application.platforms import PlatformEntity
+from zha.application.platforms import PlatformEntity, PlatformEntityInfo
 from zha.application.platforms.alarm_control_panel.const import (
     IAS_ACE_STATE_MAP,
     SUPPORT_ALARM_ARM_AWAY,
@@ -46,6 +47,16 @@ STRICT_MATCH = functools.partial(
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class AlarmControlPanelEntityInfo(PlatformEntityInfo):
+    """Alarm control panel entity info."""
+
+    code_arm_required: bool
+    code_format: CodeFormat
+    supported_features: int
+    translation_key: str
 
 
 @STRICT_MATCH(cluster_handler_names=CLUSTER_HANDLER_IAS_ACE)
@@ -80,13 +91,6 @@ class AlarmControlPanel(PlatformEntity):
             CLUSTER_HANDLER_STATE_CHANGED, self._handle_event_protocol
         )
 
-    def handle_cluster_handler_state_changed(
-        self,
-        event: ClusterHandlerStateChangedEvent,  # pylint: disable=unused-argument
-    ) -> None:
-        """Handle state changed on cluster."""
-        self.maybe_emit_state_changed_event()
-
     @property
     def code_arm_required(self) -> bool:
         """Whether the code is required for arm actions."""
@@ -101,6 +105,41 @@ class AlarmControlPanel(PlatformEntity):
     def translation_key(self) -> str:
         """Return the translation key."""
         return self._attr_translation_key
+
+    @property
+    def supported_features(self) -> int:
+        """Return the list of supported features."""
+        return (
+            SUPPORT_ALARM_ARM_HOME
+            | SUPPORT_ALARM_ARM_AWAY
+            | SUPPORT_ALARM_ARM_NIGHT
+            | SUPPORT_ALARM_TRIGGER
+        )
+
+    @property
+    def state(self) -> str:
+        """Return the state of the entity."""
+        return IAS_ACE_STATE_MAP.get(
+            self._cluster_handler.armed_state, AlarmState.UNKNOWN
+        )
+
+    @functools.cached_property
+    def info_object(self) -> AlarmControlPanelEntityInfo:
+        """Return a representation of the alarm control panel."""
+        return AlarmControlPanelEntityInfo(
+            **super().info_object.__dict__,
+            code_arm_required=self.code_arm_required,
+            code_format=self.code_format,
+            supported_features=self.supported_features,
+            translation_key=self.translation_key,
+        )
+
+    def handle_cluster_handler_state_changed(
+        self,
+        event: ClusterHandlerStateChangedEvent,  # pylint: disable=unused-argument
+    ) -> None:
+        """Handle state changed on cluster."""
+        self.maybe_emit_state_changed_event()
 
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
@@ -126,32 +165,6 @@ class AlarmControlPanel(PlatformEntity):
         """Send alarm trigger command."""
         self._cluster_handler.panic()
         self.maybe_emit_state_changed_event()
-
-    @property
-    def supported_features(self) -> int:
-        """Return the list of supported features."""
-        return (
-            SUPPORT_ALARM_ARM_HOME
-            | SUPPORT_ALARM_ARM_AWAY
-            | SUPPORT_ALARM_ARM_NIGHT
-            | SUPPORT_ALARM_TRIGGER
-        )
-
-    def to_json(self) -> dict:
-        """Return a JSON representation of the alarm control panel."""
-        json = super().to_json()
-        json["supported_features"] = self.supported_features
-        json["code_arm_required"] = self.code_arm_required
-        json["code_format"] = self.code_format
-        json["translation_key"] = self.translation_key
-        return json
-
-    @property
-    def state(self) -> str:
-        """Return the state of the entity."""
-        return IAS_ACE_STATE_MAP.get(
-            self._cluster_handler.armed_state, AlarmState.UNKNOWN
-        )
 
     def get_state(self) -> dict:
         """Get the state of the alarm control panel."""

--- a/zha/application/platforms/alarm_control_panel/__init__.py
+++ b/zha/application/platforms/alarm_control_panel/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import functools
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from zigpy.zcl.clusters.security import IasAce
 
@@ -117,11 +117,13 @@ class AlarmControlPanel(PlatformEntity):
         )
 
     @property
-    def state(self) -> str:
-        """Return the state of the entity."""
-        return IAS_ACE_STATE_MAP.get(
+    def state(self) -> dict[str, Any]:
+        """Get the state of the alarm control panel."""
+        response = super().state
+        response["state"] = IAS_ACE_STATE_MAP.get(
             self._cluster_handler.armed_state, AlarmState.UNKNOWN
         )
+        return response
 
     @functools.cached_property
     def info_object(self) -> AlarmControlPanelEntityInfo:
@@ -165,9 +167,3 @@ class AlarmControlPanel(PlatformEntity):
         """Send alarm trigger command."""
         self._cluster_handler.panic()
         self.maybe_emit_state_changed_event()
-
-    def get_state(self) -> dict:
-        """Get the state of the alarm control panel."""
-        response = super().get_state()
-        response["state"] = self.state
-        return response

--- a/zha/application/platforms/alarm_control_panel/__init__.py
+++ b/zha/application/platforms/alarm_control_panel/__init__.py
@@ -91,29 +91,15 @@ class AlarmControlPanel(PlatformEntity):
             CLUSTER_HANDLER_STATE_CHANGED, self._handle_event_protocol
         )
 
-    @property
-    def code_arm_required(self) -> bool:
-        """Whether the code is required for arm actions."""
-        return self._cluster_handler.code_required_arm_actions
-
-    @property
-    def code_format(self) -> CodeFormat:
-        """Code format or None if no code is required."""
-        return CodeFormat.NUMBER
-
-    @property
-    def translation_key(self) -> str:
-        """Return the translation key."""
-        return self._attr_translation_key
-
-    @property
-    def supported_features(self) -> int:
-        """Return the list of supported features."""
-        return (
-            SUPPORT_ALARM_ARM_HOME
-            | SUPPORT_ALARM_ARM_AWAY
-            | SUPPORT_ALARM_ARM_NIGHT
-            | SUPPORT_ALARM_TRIGGER
+    @functools.cached_property
+    def info_object(self) -> AlarmControlPanelEntityInfo:
+        """Return a representation of the alarm control panel."""
+        return AlarmControlPanelEntityInfo(
+            **super().info_object.__dict__,
+            code_arm_required=self.code_arm_required,
+            code_format=self.code_format,
+            supported_features=self.supported_features,
+            translation_key=self.translation_key,
         )
 
     @property
@@ -125,15 +111,29 @@ class AlarmControlPanel(PlatformEntity):
         )
         return response
 
+    @property
+    def code_arm_required(self) -> bool:
+        """Whether the code is required for arm actions."""
+        return self._cluster_handler.code_required_arm_actions
+
     @functools.cached_property
-    def info_object(self) -> AlarmControlPanelEntityInfo:
-        """Return a representation of the alarm control panel."""
-        return AlarmControlPanelEntityInfo(
-            **super().info_object.__dict__,
-            code_arm_required=self.code_arm_required,
-            code_format=self.code_format,
-            supported_features=self.supported_features,
-            translation_key=self.translation_key,
+    def code_format(self) -> CodeFormat:
+        """Code format or None if no code is required."""
+        return CodeFormat.NUMBER
+
+    @functools.cached_property
+    def translation_key(self) -> str:
+        """Return the translation key."""
+        return self._attr_translation_key
+
+    @functools.cached_property
+    def supported_features(self) -> int:
+        """Return the list of supported features."""
+        return (
+            SUPPORT_ALARM_ARM_HOME
+            | SUPPORT_ALARM_ARM_AWAY
+            | SUPPORT_ALARM_ARM_NIGHT
+            | SUPPORT_ALARM_TRIGGER
         )
 
     def handle_cluster_handler_state_changed(

--- a/zha/application/platforms/binary_sensor/__init__.py
+++ b/zha/application/platforms/binary_sensor/__init__.py
@@ -73,6 +73,7 @@ class BinarySensor(PlatformEntity):
         if ENTITY_METADATA in kwargs:
             self._init_from_quirks_metadata(kwargs[ENTITY_METADATA])
         super().__init__(unique_id, cluster_handlers, endpoint, device, **kwargs)
+        self._state: bool = self.is_on
         self._cluster_handler.on_event(
             CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
             self.handle_cluster_handler_attribute_updated,
@@ -93,7 +94,9 @@ class BinarySensor(PlatformEntity):
     @property
     def is_on(self) -> bool:
         """Return True if the switch is on based on the state machine."""
-        raw_state = self._cluster_handler.cluster.get(self._attribute_name)
+        self._state = raw_state = self._cluster_handler.cluster.get(
+            self._attribute_name
+        )
         if raw_state is None:
             return False
         return self.parse(raw_state)
@@ -114,9 +117,10 @@ class BinarySensor(PlatformEntity):
             else None,
         )
 
-    def get_state(self) -> dict:
+    @property
+    def state(self) -> dict:
         """Return the state of the binary sensor."""
-        response = super().get_state()
+        response = super().state
         response["state"] = self.is_on
         return response
 

--- a/zha/application/platforms/binary_sensor/__init__.py
+++ b/zha/application/platforms/binary_sensor/__init__.py
@@ -91,21 +91,6 @@ class BinarySensor(PlatformEntity):
                 _LOGGER,
             )
 
-    @property
-    def is_on(self) -> bool:
-        """Return True if the switch is on based on the state machine."""
-        self._state = raw_state = self._cluster_handler.cluster.get(
-            self._attribute_name
-        )
-        if raw_state is None:
-            return False
-        return self.parse(raw_state)
-
-    @functools.cached_property
-    def device_class(self) -> BinarySensorDeviceClass | None:
-        """Return the class of this entity."""
-        return self._attr_device_class
-
     @functools.cached_property
     def info_object(self) -> dict:
         """Return a representation of the binary sensor."""
@@ -123,6 +108,21 @@ class BinarySensor(PlatformEntity):
         response = super().state
         response["state"] = self.is_on
         return response
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if the switch is on based on the state machine."""
+        self._state = raw_state = self._cluster_handler.cluster.get(
+            self._attribute_name
+        )
+        if raw_state is None:
+            return False
+        return self.parse(raw_state)
+
+    @functools.cached_property
+    def device_class(self) -> BinarySensorDeviceClass | None:
+        """Return the class of this entity."""
+        return self._attr_device_class
 
     def handle_cluster_handler_attribute_updated(
         self, event: ClusterAttributeUpdatedEvent
@@ -239,7 +239,7 @@ class IASZone(BinarySensor):
         self._attr_device_class = self.device_class
         self._attr_translation_key = self.translation_key
 
-    @property
+    @functools.cached_property
     def translation_key(self) -> str | None:
         """Return the name of the sensor."""
         zone_type = self._cluster_handler.cluster.get("zone_type")
@@ -247,7 +247,7 @@ class IASZone(BinarySensor):
             return None
         return "ias_zone"
 
-    @property
+    @functools.cached_property
     def device_class(self) -> BinarySensorDeviceClass | None:
         """Return device class from platform DEVICE_CLASSES."""
         zone_type = self._cluster_handler.cluster.get("zone_type")

--- a/zha/application/platforms/climate/__init__.py
+++ b/zha/application/platforms/climate/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import datetime as dt
 import functools
 from typing import TYPE_CHECKING, Any
@@ -9,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 from zigpy.zcl.clusters.hvac import FanMode, RunningState, SystemMode
 
 from zha.application import Platform
-from zha.application.platforms import PlatformEntity
+from zha.application.platforms import PlatformEntity, PlatformEntityInfo
 from zha.application.platforms.climate.const import (
     ATTR_HVAC_MODE,
     ATTR_OCCP_COOL_SETPT,
@@ -52,6 +53,18 @@ if TYPE_CHECKING:
 
 STRICT_MATCH = functools.partial(PLATFORM_ENTITIES.strict_match, Platform.CLIMATE)
 MULTI_MATCH = functools.partial(PLATFORM_ENTITIES.multipass_match, Platform.CLIMATE)
+
+
+@dataclass(frozen=True, kw_only=True)
+class ThermostatEntityInfo(PlatformEntityInfo):
+    """Thermostat entity info."""
+
+    max_temp: float
+    min_temp: float
+    supported_features: ClimateEntityFeature
+    fan_modes: list[str] | None
+    preset_modes: list[str] | None
+    hvac_modes: list[HVACMode]
 
 
 @MULTI_MATCH(
@@ -97,6 +110,19 @@ class Thermostat(PlatformEntity):
         self._thermostat_cluster_handler.on_event(
             CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
             self.handle_cluster_handler_attribute_updated,
+        )
+
+    @functools.cached_property
+    def info_object(self) -> ThermostatEntityInfo:
+        """Return a representation of the thermostat."""
+        return ThermostatEntityInfo(
+            **super().info_object.__dict__,
+            max_temp=self.max_temp,
+            min_temp=self.min_temp,
+            supported_features=self.supported_features,
+            fan_modes=self.fan_modes,
+            preset_modes=self.preset_modes,
+            hvac_modes=self.hvac_modes,
         )
 
     @property
@@ -163,7 +189,7 @@ class Thermostat(PlatformEntity):
             return FAN_ON
         return FAN_AUTO
 
-    @property
+    @functools.cached_property
     def fan_modes(self) -> list[str] | None:
         """Return supported FAN modes."""
         if not self._fan_cluster_handler:
@@ -226,7 +252,7 @@ class Thermostat(PlatformEntity):
         """Return HVAC operation mode."""
         return SYSTEM_MODE_2_HVAC.get(self._thermostat_cluster_handler.system_mode)
 
-    @property
+    @functools.cached_property
     def hvac_modes(self) -> list[HVACMode]:
         """Return the list of available HVAC operation modes."""
         return SEQ_OF_OPERATION.get(
@@ -238,12 +264,12 @@ class Thermostat(PlatformEntity):
         """Return current preset mode."""
         return self._preset
 
-    @property
+    @functools.cached_property
     def preset_modes(self) -> list[str] | None:
         """Return supported preset modes."""
         return self._presets
 
-    @property
+    @functools.cached_property
     def supported_features(self) -> ClimateEntityFeature:
         """Return the list of supported features."""
         features = self._supported_flags
@@ -437,17 +463,6 @@ class Thermostat(PlatformEntity):
         handler = getattr(self, f"async_preset_handler_{preset}")
         await handler(enable)
 
-    def to_json(self) -> dict:
-        """Return a JSON representation of the thermostat."""
-        json = super().to_json()
-        json["hvac_modes"] = self.hvac_modes
-        json["fan_modes"] = self.fan_modes
-        json["preset_modes"] = self.preset_modes
-        json["supported_features"] = self.supported_features
-        json["max_temp"] = self.max_temp
-        json["min_temp"] = self.min_temp
-        return json
-
     def get_state(self) -> dict:
         """Get the state of the lock."""
         response = super().get_state()
@@ -610,7 +625,7 @@ class MoesThermostat(Thermostat):
         ]
         self._supported_flags |= ClimateEntityFeature.PRESET_MODE
 
-    @property
+    @functools.cached_property
     def hvac_modes(self) -> list[HVACMode]:
         """Return only the heat mode, because the device can't be turned off."""
         return [HVACMode.HEAT]
@@ -698,7 +713,7 @@ class BecaThermostat(Thermostat):
         ]
         self._supported_flags |= ClimateEntityFeature.PRESET_MODE
 
-    @property
+    @functools.cached_property
     def hvac_modes(self) -> list[HVACMode]:
         """Return only the heat mode, because the device can't be turned off."""
         return [HVACMode.HEAT]

--- a/zha/application/platforms/climate/__init__.py
+++ b/zha/application/platforms/climate/__init__.py
@@ -126,6 +126,21 @@ class Thermostat(PlatformEntity):
         )
 
     @property
+    def state(self) -> dict[str, Any]:
+        """Get the state of the lock."""
+        response = super().state
+        response["current_temperature"] = self.current_temperature
+        response["target_temperature"] = self.target_temperature
+        response["target_temperature_high"] = self.target_temperature_high
+        response["target_temperature_low"] = self.target_temperature_low
+        response["hvac_action"] = self.hvac_action
+        response["hvac_mode"] = self.hvac_mode
+        response["preset_mode"] = self.preset_mode
+        response["fan_mode"] = self.fan_mode
+        response.update(self.extra_state_attributes)
+        return response
+
+    @property
     def current_temperature(self):
         """Return the current temperature."""
         if self._thermostat_cluster_handler.local_temperature is None:
@@ -462,20 +477,6 @@ class Thermostat(PlatformEntity):
 
         handler = getattr(self, f"async_preset_handler_{preset}")
         await handler(enable)
-
-    def get_state(self) -> dict:
-        """Get the state of the lock."""
-        response = super().get_state()
-        response["current_temperature"] = self.current_temperature
-        response["target_temperature"] = self.target_temperature
-        response["target_temperature_high"] = self.target_temperature_high
-        response["target_temperature_low"] = self.target_temperature_low
-        response["hvac_action"] = self.hvac_action
-        response["hvac_mode"] = self.hvac_mode
-        response["preset_mode"] = self.preset_mode
-        response["fan_mode"] = self.fan_mode
-        response.update(self.extra_state_attributes)
-        return response
 
 
 @MULTI_MATCH(

--- a/zha/application/platforms/climate/__init__.py
+++ b/zha/application/platforms/climate/__init__.py
@@ -776,7 +776,7 @@ class BecaThermostat(Thermostat):
 class StelproFanHeater(Thermostat):
     """Stelpro Fan Heater implementation."""
 
-    @property
+    @functools.cached_property
     def hvac_modes(self) -> list[HVACMode]:
         """Return only the heat mode, because the device can't be turned off."""
         return [HVACMode.HEAT]

--- a/zha/application/platforms/device_tracker.py
+++ b/zha/application/platforms/device_tracker.py
@@ -100,7 +100,7 @@ class DeviceScannerEntity(PlatformEntity):
         """Return true if the device is connected to the network."""
         return self._connected
 
-    @property
+    @functools.cached_property
     def source_type(self) -> SourceType:
         """Return the source type, eg gps or router, of the device."""
         return SourceType.ROUTER

--- a/zha/application/platforms/fan/__init__.py
+++ b/zha/application/platforms/fan/__init__.py
@@ -244,6 +244,20 @@ class Fan(PlatformEntity, BaseFan):
         )
 
     @property
+    def state(self) -> dict:
+        """Return the state of the fan."""
+        response = super().state
+        response.update(
+            {
+                "preset_mode": self.preset_mode,
+                "percentage": self.percentage,
+                "is_on": self.is_on,
+                "speed": self.speed,
+            }
+        )
+        return response
+
+    @property
     def percentage(self) -> int | None:
         """Return the current speed percentage."""
         if (
@@ -270,19 +284,6 @@ class Fan(PlatformEntity, BaseFan):
         if (percentage := self.percentage) is None:
             return None
         return self.percentage_to_speed(percentage)
-
-    def get_state(self) -> dict:
-        """Return the state of the fan."""
-        response = super().get_state()
-        response.update(
-            {
-                "preset_mode": self.preset_mode,
-                "percentage": self.percentage,
-                "is_on": self.is_on,
-                "speed": self.speed,
-            }
-        )
-        return response
 
     async def _async_set_fan_mode(self, fan_mode: int) -> None:
         """Set the fan mode for the fan."""
@@ -319,6 +320,20 @@ class FanGroup(GroupEntity, BaseFan):
         )
 
     @property
+    def state(self) -> dict[str, Any]:
+        """Return the state of the fan."""
+        response = super().state
+        response.update(
+            {
+                "preset_mode": self.preset_mode,
+                "percentage": self.percentage,
+                "is_on": self.is_on,
+                "speed": self.speed,
+            }
+        )
+        return response
+
+    @property
     def percentage(self) -> int | None:
         """Return the current speed percentage."""
         return self._percentage
@@ -337,19 +352,6 @@ class FanGroup(GroupEntity, BaseFan):
             return None
         return self.percentage_to_speed(percentage)
 
-    def get_state(self) -> dict:
-        """Return the state of the fan."""
-        response = super().get_state()
-        response.update(
-            {
-                "preset_mode": self.preset_mode,
-                "percentage": self.percentage,
-                "is_on": self.is_on,
-                "speed": self.speed,
-            }
-        )
-        return response
-
     async def _async_set_fan_mode(self, fan_mode: int) -> None:
         """Set the fan mode for the group."""
 
@@ -362,7 +364,7 @@ class FanGroup(GroupEntity, BaseFan):
         """Attempt to retrieve on off state from the fan."""
         self.debug("Updating fan group entity state")
         platform_entities = self._group.get_platform_entities(self.PLATFORM)
-        all_states = [entity.get_state() for entity in platform_entities]
+        all_states = [entity.state for entity in platform_entities]
         self.debug(
             "All platform entity states for group entity members: %s", all_states
         )

--- a/zha/application/platforms/fan/__init__.py
+++ b/zha/application/platforms/fan/__init__.py
@@ -93,37 +93,37 @@ class BaseFan(BaseEntity):
     _attr_supported_features = FanEntityFeature.SET_SPEED
     _attr_translation_key: str = "fan"
 
-    @property
+    @functools.cached_property
     def preset_modes(self) -> list[str]:
         """Return the available preset modes."""
         return list(self.preset_modes_to_name.values())
 
-    @property
+    @functools.cached_property
     def preset_modes_to_name(self) -> dict[int, str]:
         """Return a dict from preset mode to name."""
         return PRESET_MODES_TO_NAME
 
-    @property
+    @functools.cached_property
     def preset_name_to_mode(self) -> dict[str, int]:
         """Return a dict from preset name to mode."""
         return {v: k for k, v in self.preset_modes_to_name.items()}
 
-    @property
+    @functools.cached_property
     def default_on_percentage(self) -> int:
         """Return the default on percentage."""
         return DEFAULT_ON_PERCENTAGE
 
-    @property
+    @functools.cached_property
     def speed_range(self) -> tuple[int, int]:
         """Return the range of speeds the fan supports. Off is not included."""
         return SPEED_RANGE
 
-    @property
+    @functools.cached_property
     def speed_count(self) -> int:
         """Return the number of speeds the fan supports."""
         return int_states_in_range(self.speed_range)
 
-    @property
+    @functools.cached_property
     def supported_features(self) -> int:
         """Flag supported features."""
         return SUPPORT_SET_SPEED
@@ -133,12 +133,12 @@ class BaseFan(BaseEntity):
         """Return true if the entity is on."""
         return self.speed not in [SPEED_OFF, None]  # pylint: disable=no-member
 
-    @property
+    @functools.cached_property
     def percentage_step(self) -> float:
         """Return the step size for percentage."""
         return 100 / self.speed_count
 
-    @property
+    @functools.cached_property
     def speed_list(self) -> list[str]:
         """Get the list of available speeds."""
         speeds = [SPEED_OFF, *LEGACY_SPEED_LIST]
@@ -430,12 +430,12 @@ class IkeaFan(Fan):
             self.handle_cluster_handler_attribute_updated,
         )
 
-    @property
+    @functools.cached_property
     def preset_modes_to_name(self) -> dict[int, str]:
         """Return a dict from preset mode to name."""
         return IKEA_PRESET_MODES_TO_NAME
 
-    @property
+    @functools.cached_property
     def speed_range(self) -> tuple[int, int]:
         """Return the range of speeds the fan supports. Off is not included."""
         return IKEA_SPEED_RANGE
@@ -457,12 +457,12 @@ class KofFan(Fan):
 
     _attr_supported_features = FanEntityFeature.SET_SPEED | FanEntityFeature.PRESET_MODE
 
-    @property
+    @functools.cached_property
     def speed_range(self) -> tuple[int, int]:
         """Return the range of speeds the fan supports. Off is not included."""
         return (1, 4)
 
-    @property
+    @functools.cached_property
     def preset_modes_to_name(self) -> dict[int, str]:
         """Return a dict from preset mode to name."""
         return {6: PRESET_MODE_SMART}

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -157,6 +157,23 @@ class BaseLight(BaseEntity, ABC):
         self._transition_listener: Callable[[], None] | None = None
 
     @property
+    def state(self) -> dict[str, Any]:
+        """Return the state of the light."""
+        response = super().state
+        response["on"] = self.is_on
+        response["brightness"] = self.brightness
+        response["hs_color"] = self.hs_color
+        response["xy_color"] = self.xy_color
+        response["color_temp"] = self.color_temp
+        response["effect"] = self.effect
+        response["off_brightness"] = self._off_brightness
+        response["off_with_transition"] = self._off_with_transition
+        response["supported_features"] = self.supported_features
+        response["color_mode"] = self.color_mode
+        response["supported_color_modes"] = self._supported_color_modes
+        return response
+
+    @property
     def hs_color(self) -> tuple[float, float] | None:
         """Return the hs color value [int, int]."""
         return self._hs_color
@@ -217,22 +234,6 @@ class BaseLight(BaseEntity, ABC):
     def max_mireds(self) -> int | None:
         """Return the warmest color_temp that this light supports."""
         return self._max_mireds
-
-    def get_state(self) -> dict[str, Any]:
-        """Return the state of the light."""
-        response = super().get_state()
-        response["on"] = self.is_on
-        response["brightness"] = self.brightness
-        response["hs_color"] = self.hs_color
-        response["xy_color"] = self.xy_color
-        response["color_temp"] = self.color_temp
-        response["effect"] = self.effect
-        response["off_brightness"] = self._off_brightness
-        response["off_with_transition"] = self._off_with_transition
-        response["supported_features"] = self.supported_features
-        response["color_mode"] = self.color_mode
-        response["supported_color_modes"] = self._supported_color_modes
-        return response
 
     def handle_cluster_handler_set_level(self, event: LevelChangeEvent) -> None:
         """Set the brightness of this light between 0..254.
@@ -1263,7 +1264,7 @@ class LightGroup(GroupEntity, BaseLight):
         """Query all members and determine the light group state."""
         self.debug("Updating light group entity state")
         platform_entities = self._group.get_platform_entities(self.PLATFORM)
-        all_states = [entity.get_state() for entity in platform_entities]
+        all_states = [entity.state for entity in platform_entities]
         states: list = list(filter(None, all_states))
         self.debug(
             "All platform entity states for group entity members: %s", all_states

--- a/zha/application/platforms/lock/__init__.py
+++ b/zha/application/platforms/lock/__init__.py
@@ -50,13 +50,20 @@ class DoorLock(PlatformEntity):
         self._doorlock_cluster_handler: ClusterHandler = self.cluster_handlers.get(
             CLUSTER_HANDLER_DOORLOCK
         )
-        self._state = VALUE_TO_STATE.get(
+        self._state: str | None = VALUE_TO_STATE.get(
             self._doorlock_cluster_handler.cluster.get("lock_state"), None
         )
         self._doorlock_cluster_handler.on_event(
             CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
             self.handle_cluster_handler_attribute_updated,
         )
+
+    @property
+    def state(self) -> dict[str, Any]:
+        """Get the state of the lock."""
+        response = super().state
+        response["is_locked"] = self.is_locked
+        return response
 
     @property
     def is_locked(self) -> bool:
@@ -117,9 +124,3 @@ class DoorLock(PlatformEntity):
             return
         self._state = VALUE_TO_STATE.get(event.attribute_value, self._state)
         self.maybe_emit_state_changed_event()
-
-    def get_state(self) -> dict:
-        """Get the state of the lock."""
-        response = super().get_state()
-        response["is_locked"] = self.is_locked
-        return response

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -95,6 +95,18 @@ class Number(PlatformEntity):
             self.handle_cluster_handler_attribute_updated,
         )
 
+    @functools.cached_property
+    def info_object(self) -> NumberEntityInfo:
+        """Return a representation of the number entity."""
+        return NumberEntityInfo(
+            **super().info_object.__dict__,
+            engineering_units=self._analog_output_cluster_handler.engineering_units,
+            application_type=self._analog_output_cluster_handler.application_type,
+            min_value=self.native_min_value,
+            max_value=self.native_max_value,
+            step=self.native_step,
+        )
+
     @property
     def state(self) -> dict[str, Any]:
         """Return the state of the entity."""
@@ -128,7 +140,7 @@ class Number(PlatformEntity):
         """Return the value step."""
         return self._analog_output_cluster_handler.resolution
 
-    @property
+    @functools.cached_property
     def name(self) -> str | None:
         """Return the name of the number entity."""
         description = self._analog_output_cluster_handler.description
@@ -136,7 +148,7 @@ class Number(PlatformEntity):
             return f"{super().name} {description}"
         return super().name
 
-    @property
+    @functools.cached_property
     def icon(self) -> str | None:
         """Return the icon to be used for this entity."""
         application_type = self._analog_output_cluster_handler.application_type
@@ -144,13 +156,13 @@ class Number(PlatformEntity):
             return ICONS.get(application_type >> 16, None)
         return None
 
-    @property
+    @functools.cached_property
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit the value is expressed in."""
         engineering_units = self._analog_output_cluster_handler.engineering_units
         return UNITS.get(engineering_units)
 
-    @property
+    @functools.cached_property
     def mode(self) -> NumberMode:
         """Return the mode of the entity."""
         return self._attr_mode
@@ -172,18 +184,6 @@ class Number(PlatformEntity):
         num_value = float(value)
         if await self._analog_output_cluster_handler.async_set_present_value(num_value):
             self.maybe_emit_state_changed_event()
-
-    @functools.cached_property
-    def info_object(self) -> NumberEntityInfo:
-        """Return a representation of the number entity."""
-        return NumberEntityInfo(
-            **super().info_object.__dict__,
-            engineering_units=self._analog_output_cluster_handler.engineering_units,
-            application_type=self._analog_output_cluster_handler.application_type,
-            min_value=self.native_min_value,
-            max_value=self.native_max_value,
-            step=self.native_step,
-        )
 
 
 class NumberConfigurationEntity(PlatformEntity):
@@ -314,19 +314,19 @@ class NumberConfigurationEntity(PlatformEntity):
         """Return the value step."""
         return self._attr_native_step
 
-    @property
+    @functools.cached_property
     def icon(self) -> str | None:
         """Return the icon to be used for this entity."""
         return self._attr_icon
 
-    @property
+    @functools.cached_property
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit the value is expressed in."""
         if hasattr(self, "_attr_native_unit_of_measurement"):
             return self._attr_native_unit_of_measurement
         return None
 
-    @property
+    @functools.cached_property
     def mode(self) -> NumberMode:
         """Return the mode of the entity."""
         return self._attr_mode

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import functools
 import logging
 from typing import TYPE_CHECKING, Any, Self
@@ -11,7 +12,7 @@ from zigpy.zcl.clusters.hvac import Thermostat
 
 from zha.application import Platform
 from zha.application.const import ENTITY_METADATA
-from zha.application.platforms import EntityCategory, PlatformEntity
+from zha.application.platforms import EntityCategory, PlatformEntity, PlatformEntityInfo
 from zha.application.platforms.helpers import validate_device_class
 from zha.application.platforms.number.const import (
     ICONS,
@@ -44,6 +45,28 @@ STRICT_MATCH = functools.partial(PLATFORM_ENTITIES.strict_match, Platform.NUMBER
 CONFIG_DIAGNOSTIC_MATCH = functools.partial(
     PLATFORM_ENTITIES.config_diagnostic_match, Platform.NUMBER
 )
+
+
+@dataclass(frozen=True, kw_only=True)
+class NumberEntityInfo(PlatformEntityInfo):
+    """Number entity info."""
+
+    engineering_units: int
+    application_type: int
+    min_value: float | None
+    max_value: float | None
+    step: float | None
+
+
+@dataclass(frozen=True, kw_only=True)
+class NumberConfigurationEntityInfo(PlatformEntityInfo):
+    """Number configuration entity info."""
+
+    min_value: float | None
+    max_value: float | None
+    step: float | None
+    multiplier: float | None
+    device_class: str | None
 
 
 @STRICT_MATCH(cluster_handler_names=CLUSTER_HANDLER_ANALOG_OUTPUT)
@@ -143,16 +166,17 @@ class Number(PlatformEntity):
         if await self._analog_output_cluster_handler.async_set_present_value(num_value):
             self.maybe_emit_state_changed_event()
 
-    def to_json(self) -> dict:
-        """Return the JSON representation of the number entity."""
-        json = super().to_json()
-        json["engineer_units"] = self._analog_output_cluster_handler.engineering_units
-        json["application_type"] = self._analog_output_cluster_handler.application_type
-        json["step"] = self.native_step
-        json["min_value"] = self.native_min_value
-        json["max_value"] = self.native_max_value
-        json["name"] = self.name
-        return json
+    @functools.cached_property
+    def info_object(self) -> NumberEntityInfo:
+        """Return a representation of the number entity."""
+        return NumberEntityInfo(
+            **super().info_object.__dict__,
+            engineering_units=self._analog_output_cluster_handler.engineering_units,
+            application_type=self._analog_output_cluster_handler.application_type,
+            min_value=self.native_min_value,
+            max_value=self.native_max_value,
+            step=self.native_step,
+        )
 
     def get_state(self) -> dict:
         """Return the state of the entity."""
@@ -247,6 +271,18 @@ class NumberConfigurationEntity(PlatformEntity):
             self.handle_cluster_handler_attribute_updated,
         )
 
+    @functools.cached_property
+    def info_object(self) -> NumberConfigurationEntityInfo:
+        """Return a representation of the number entity."""
+        return NumberConfigurationEntityInfo(
+            **super().info_object.__dict__,
+            min_value=self._attr_native_min_value,
+            max_value=self._attr_native_max_value,
+            step=self._attr_native_step,
+            multiplier=self._attr_multiplier,
+            device_class=self._attr_device_class,
+        )
+
     @property
     def native_value(self) -> float:
         """Return the current value."""
@@ -311,17 +347,6 @@ class NumberConfigurationEntity(PlatformEntity):
         """Handle value update from cluster handler."""
         if event.attribute_name == self._attribute_name:
             self.maybe_emit_state_changed_event()
-
-    def to_json(self) -> dict:
-        """Return the JSON representation of the number entity."""
-        json = super().to_json()
-        json["multiplier"] = self._attr_multiplier
-        json["device_class"] = self._attr_device_class
-        json["step"] = self._attr_native_step
-        json["min_value"] = self._attr_native_min_value
-        json["max_value"] = self._attr_native_max_value
-        json["name"] = self.name
-        return json
 
     def get_state(self) -> dict:
         """Return the state of the entity."""

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -96,6 +96,13 @@ class Number(PlatformEntity):
         )
 
     @property
+    def state(self) -> dict[str, Any]:
+        """Return the state of the entity."""
+        response = super().state
+        response["state"] = self.native_value
+        return response
+
+    @property
     def native_value(self) -> float | None:
         """Return the current value."""
         return self._analog_output_cluster_handler.present_value
@@ -177,12 +184,6 @@ class Number(PlatformEntity):
             max_value=self.native_max_value,
             step=self.native_step,
         )
-
-    def get_state(self) -> dict:
-        """Return the state of the entity."""
-        response = super().get_state()
-        response["state"] = self.native_value
-        return response
 
 
 class NumberConfigurationEntity(PlatformEntity):
@@ -284,6 +285,13 @@ class NumberConfigurationEntity(PlatformEntity):
         )
 
     @property
+    def state(self) -> dict[str, Any]:
+        """Return the state of the entity."""
+        response = super().state
+        response["state"] = self.native_value
+        return response
+
+    @property
     def native_value(self) -> float:
         """Return the current value."""
         value = self._cluster_handler.cluster.get(self._attribute_name)
@@ -347,12 +355,6 @@ class NumberConfigurationEntity(PlatformEntity):
         """Handle value update from cluster handler."""
         if event.attribute_name == self._attribute_name:
             self.maybe_emit_state_changed_event()
-
-    def get_state(self) -> dict:
-        """Return the state of the entity."""
-        response = super().get_state()
-        response["state"] = self.native_value
-        return response
 
 
 @CONFIG_DIAGNOSTIC_MATCH(

--- a/zha/application/platforms/siren.py
+++ b/zha/application/platforms/siren.py
@@ -108,6 +108,13 @@ class Siren(PlatformEntity):
             supported_features=self._attr_supported_features,
         )
 
+    @property
+    def state(self) -> dict[str, Any]:
+        """Get the state of the siren."""
+        response = super().state
+        response["state"] = self._attr_is_on
+        return response
+
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on siren."""
         if self._off_listener:
@@ -175,9 +182,3 @@ class Siren(PlatformEntity):
             self._off_listener.cancel()
             self._off_listener = None
         self.maybe_emit_state_changed_event()
-
-    def get_state(self) -> dict:
-        """Get the state of the siren."""
-        response = super().get_state()
-        response["state"] = self._attr_is_on
-        return response

--- a/zha/application/platforms/siren.py
+++ b/zha/application/platforms/siren.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 from enum import IntFlag
 import functools
 from typing import TYPE_CHECKING, Any, Final, cast
@@ -23,7 +24,7 @@ from zha.application.const import (
     WARNING_DEVICE_STROBE_NO,
     Strobe,
 )
-from zha.application.platforms import PlatformEntity
+from zha.application.platforms import PlatformEntity, PlatformEntityInfo
 from zha.application.registries import PLATFORM_ENTITIES
 from zha.zigbee.cluster_handlers.const import CLUSTER_HANDLER_IAS_WD
 from zha.zigbee.cluster_handlers.security import IasWdClusterHandler
@@ -52,6 +53,14 @@ class SirenEntityFeature(IntFlag):
     DURATION = 16
 
 
+@dataclass(frozen=True, kw_only=True)
+class SirenEntityInfo(PlatformEntityInfo):
+    """Siren entity info."""
+
+    available_tones: dict[int, str]
+    supported_features: SirenEntityFeature
+
+
 @MULTI_MATCH(cluster_handler_names=CLUSTER_HANDLER_IAS_WD)
 class Siren(PlatformEntity):
     """Representation of a ZHA siren."""
@@ -75,7 +84,7 @@ class Siren(PlatformEntity):
             | SirenEntityFeature.VOLUME_SET
             | SirenEntityFeature.TONES
         )
-        self._attr_available_tones: list[int | str] | dict[int, str] | None = {
+        self._attr_available_tones: dict[int, str] = {
             WARNING_DEVICE_MODE_BURGLAR: "Burglar",
             WARNING_DEVICE_MODE_FIRE: "Fire",
             WARNING_DEVICE_MODE_EMERGENCY: "Emergency",
@@ -89,6 +98,15 @@ class Siren(PlatformEntity):
         super().__init__(unique_id, cluster_handlers, endpoint, device, **kwargs)
         self._attr_is_on: bool = False
         self._off_listener: asyncio.TimerHandle | None = None
+
+    @functools.cached_property
+    def info_object(self) -> SirenEntityInfo:
+        """Return representation of the siren."""
+        return SirenEntityInfo(
+            **super().info_object.__dict__,
+            available_tones=self._attr_available_tones,
+            supported_features=self._attr_supported_features,
+        )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on siren."""
@@ -157,13 +175,6 @@ class Siren(PlatformEntity):
             self._off_listener.cancel()
             self._off_listener = None
         self.maybe_emit_state_changed_event()
-
-    def to_json(self) -> dict:
-        """Return JSON representation of the siren."""
-        json = super().to_json()
-        json[ATTR_AVAILABLE_TONES] = self._attr_available_tones
-        json["supported_features"] = self._attr_supported_features
-        return json
 
     def get_state(self) -> dict:
         """Get the state of the siren."""

--- a/zha/application/platforms/update.py
+++ b/zha/application/platforms/update.py
@@ -166,6 +166,14 @@ class FirmwareUpdateEntity(PlatformEntity):
         )
 
     @property
+    def state(self):
+        """Get the state for the entity."""
+        response = super().state
+        response["state"] = self._state
+        response.update(self.state_attributes)
+        return response
+
+    @property
     def installed_version(self) -> str | None:
         """Version installed and in use."""
         return self._attr_installed_version
@@ -207,7 +215,7 @@ class FirmwareUpdateEntity(PlatformEntity):
 
     @property
     @final
-    def state(self) -> bool | None:
+    def _state(self) -> bool | None:
         """Return the entity state."""
         if (installed_version := self.installed_version) is None or (
             latest_version := self.latest_version
@@ -357,13 +365,6 @@ class FirmwareUpdateEntity(PlatformEntity):
         """Update the entity."""
         # await CoordinatorEntity.async_update(self)
         await super().async_update()
-
-    def get_state(self):
-        """Get the state for the entity."""
-        response = super().get_state()
-        response["state"] = self.state
-        response.update(self.state_attributes)
-        return response
 
 
 @functools.lru_cache(maxsize=256)

--- a/zha/zigbee/cluster_handlers/__init__.py
+++ b/zha/zigbee/cluster_handlers/__init__.py
@@ -216,36 +216,6 @@ class ClusterHandler(LogMixin, EventBase):
         """Filter the cluster match for specific devices."""
         return True
 
-    @property
-    def id(self) -> str:
-        """Return cluster handler id unique for this device only."""
-        return self._id
-
-    @property
-    def generic_id(self) -> str:
-        """Return the generic id for this cluster handler."""
-        return self._generic_id
-
-    @property
-    def unique_id(self) -> str:
-        """Return the unique id for this cluster handler."""
-        return self._unique_id
-
-    @property
-    def cluster(self) -> zigpy.zcl.Cluster:
-        """Return the zigpy cluster for this cluster handler."""
-        return self._cluster
-
-    @property
-    def name(self) -> str:
-        """Return friendly name."""
-        return self.cluster.ep_attribute or self._generic_id
-
-    @property
-    def status(self) -> ClusterHandlerStatus:
-        """Return the status of the cluster handler."""
-        return self._status
-
     @functools.cached_property
     def info_object(self) -> ClusterHandlerInfo:
         """Return info about this cluster handler."""
@@ -264,6 +234,36 @@ class ClusterHandler(LogMixin, EventBase):
             status=self._status.name,
             value_attribute=getattr(self, "value_attribute", None),
         )
+
+    @functools.cached_property
+    def id(self) -> str:
+        """Return cluster handler id unique for this device only."""
+        return self._id
+
+    @functools.cached_property
+    def generic_id(self) -> str:
+        """Return the generic id for this cluster handler."""
+        return self._generic_id
+
+    @functools.cached_property
+    def unique_id(self) -> str:
+        """Return the unique id for this cluster handler."""
+        return self._unique_id
+
+    @functools.cached_property
+    def cluster(self) -> zigpy.zcl.Cluster:
+        """Return the zigpy cluster for this cluster handler."""
+        return self._cluster
+
+    @functools.cached_property
+    def name(self) -> str:
+        """Return friendly name."""
+        return self.cluster.ep_attribute or self._generic_id
+
+    @property
+    def status(self) -> ClusterHandlerStatus:
+        """Return the status of the cluster handler."""
+        return self._status
 
     def __hash__(self) -> int:
         """Make this a hashable."""

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -270,36 +270,36 @@ class Device(LogMixin, EventBase):
                 getattr(self, "__polling_interval"),
             )
 
-    @property
+    @cached_property
     def device(self) -> zigpy.device.Device:
         """Return underlying Zigpy device."""
         return self._zigpy_device
 
-    @property
+    @cached_property
     def name(self) -> str:
         """Return device name."""
         return f"{self.manufacturer} {self.model}"
 
-    @property
+    @cached_property
     def ieee(self) -> EUI64:
         """Return ieee address for device."""
         return self._zigpy_device.ieee
 
-    @property
+    @cached_property
     def manufacturer(self) -> str:
         """Return manufacturer for device."""
         if self._zigpy_device.manufacturer is None:
             return UNKNOWN_MANUFACTURER
         return self._zigpy_device.manufacturer
 
-    @property
+    @cached_property
     def model(self) -> str:
         """Return model for device."""
         if self._zigpy_device.model is None:
             return UNKNOWN_MODEL
         return self._zigpy_device.model
 
-    @property
+    @cached_property
     def manufacturer_code(self) -> int | None:
         """Return the manufacturer code for the device."""
         if self._zigpy_device.node_desc is None:
@@ -307,7 +307,7 @@ class Device(LogMixin, EventBase):
 
         return self._zigpy_device.node_desc.manufacturer_code
 
-    @property
+    @cached_property
     def nwk(self) -> NWK:
         """Return nwk for device."""
         return self._zigpy_device.nwk
@@ -327,7 +327,7 @@ class Device(LogMixin, EventBase):
         """Return last_seen for device."""
         return self._zigpy_device.last_seen
 
-    @property
+    @cached_property
     def is_mains_powered(self) -> bool | None:
         """Return true if device is mains powered."""
         if self._zigpy_device.node_desc is None:
@@ -335,7 +335,7 @@ class Device(LogMixin, EventBase):
 
         return self._zigpy_device.node_desc.is_mains_powered
 
-    @property
+    @cached_property
     def device_type(self) -> str:
         """Return the logical device type for the device."""
         if self._zigpy_device.node_desc is None:
@@ -350,7 +350,7 @@ class Device(LogMixin, EventBase):
             POWER_MAINS_POWERED if self.is_mains_powered else POWER_BATTERY_OR_UNKNOWN
         )
 
-    @property
+    @cached_property
     def is_router(self) -> bool | None:
         """Return true if this is a routing capable device."""
         if self._zigpy_device.node_desc is None:
@@ -358,7 +358,7 @@ class Device(LogMixin, EventBase):
 
         return self._zigpy_device.node_desc.is_router
 
-    @property
+    @cached_property
     def is_coordinator(self) -> bool | None:
         """Return true if this device represents a coordinator."""
         if self._zigpy_device.node_desc is None:
@@ -374,7 +374,7 @@ class Device(LogMixin, EventBase):
 
         return self.ieee == self.gateway.state.node_info.ieee
 
-    @property
+    @cached_property
     def is_end_device(self) -> bool | None:
         """Return true if this device is an end device."""
         if self._zigpy_device.node_desc is None:
@@ -389,12 +389,12 @@ class Device(LogMixin, EventBase):
             self.available and bool(self.async_get_groupable_endpoints())
         )
 
-    @property
+    @cached_property
     def skip_configuration(self) -> bool:
         """Return true if the device should not issue configuration related commands."""
         return self._zigpy_device.skip_configuration or bool(self.is_coordinator)
 
-    @property
+    @cached_property
     def gateway(self):
         """Return the gateway for this device."""
         return self._gateway
@@ -456,7 +456,7 @@ class Device(LogMixin, EventBase):
         if self._identify_ch is None:
             self._identify_ch = cluster_handler
 
-    @property
+    @cached_property
     def zdo_cluster_handler(self) -> ZDOClusterHandler:
         """Return ZDO cluster handler."""
         return self._zdo_handler
@@ -466,7 +466,7 @@ class Device(LogMixin, EventBase):
         """Return the endpoints for this device."""
         return self._endpoints
 
-    @property
+    @cached_property
     def zigbee_signature(self) -> dict[str, Any]:
         """Get zigbee signature for this device."""
         return {

--- a/zha/zigbee/endpoint.py
+++ b/zha/zigbee/endpoint.py
@@ -50,7 +50,7 @@ class Endpoint:
         self._client_cluster_handlers: dict[str, ClientClusterHandler] = {}
         self._unique_id: str = f"{str(device.ieee)}-{zigpy_endpoint.endpoint_id}"
 
-    @property
+    @functools.cached_property
     def device(self) -> Device:
         """Return the device this endpoint belongs to."""
         return self._device
@@ -70,17 +70,17 @@ class Endpoint:
         """Return a dict of client cluster handlers."""
         return self._client_cluster_handlers
 
-    @property
+    @functools.cached_property
     def zigpy_endpoint(self) -> ZigpyEndpoint:
         """Return endpoint of zigpy device."""
         return self._zigpy_endpoint
 
-    @property
+    @functools.cached_property
     def id(self) -> int:
         """Return endpoint id."""
         return self._zigpy_endpoint.endpoint_id
 
-    @property
+    @functools.cached_property
     def unique_id(self) -> str:
         """Return the unique id for this endpoint."""
         return self._unique_id


### PR DESCRIPTION
This PR:

- converts remaining events to dataclasses
- converts to_json -> info_object and makes it a property
- converts get_state -> state and makes it a property
- leverages cached_property where it makes sense to / is safe to. There are probably more that can be converted
- rearranged code so properties come before methods for consistency (init, init_from_quirks are left before props)

fixes #7 by disabling the error globally for tests as there are a ton of false positives
