### PR TITLE
Reduce the number of polling tasks

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -178,6 +178,7 @@ async def test_check_available_success(
     assert basic_ch.read_attributes.await_count == 2
     assert basic_ch.read_attributes.await_args[0][0] == ["manufacturer"]
     assert zha_device.available is True
+    assert zha_device.on_network is True
 
 
 @patch(

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -596,3 +596,30 @@ async def test_pollers_skip(
 
     assert "Global updater interval skipped" in caplog.text
     assert "Device availability checker interval skipped" in caplog.text
+
+
+async def test_gateway_handle_message(
+    zha_gateway: Gateway,
+    zha_dev_basic: Device,  # pylint: disable=redefined-outer-name
+) -> None:
+    """Test handle message."""
+
+    assert zha_dev_basic.available is True
+    assert zha_dev_basic.on_network is True
+
+    zha_dev_basic.on_network = False
+
+    assert zha_dev_basic.available is False
+    assert zha_dev_basic.on_network is False
+
+    zha_gateway.handle_message(
+        zha_dev_basic.device,
+        zha.PROFILE_ID,
+        general.Basic.cluster_id,
+        1,
+        1,
+        b"",
+    )
+
+    assert zha_dev_basic.available is True
+    assert zha_dev_basic.on_network is True

--- a/zha/application/helpers.py
+++ b/zha/application/helpers.py
@@ -337,7 +337,7 @@ class GlobalUpdater:
                 _LOGGER.debug("Global updater running update callback")
                 listener()
         else:
-            _LOGGER.debug("Global updater pass skipped")
+            _LOGGER.debug("Global updater interval skipped")
         _LOGGER.debug("Global updater interval finished")
 
 
@@ -378,9 +378,9 @@ class DeviceAvailabilityChecker:
     @periodic(_REFRESH_INTERVAL)
     async def check_device_availability(self):
         """Check device availability."""
-        _LOGGER.debug("Global updater device availability checker starting")
+        _LOGGER.debug("Device availability checker interval starting")
         if self._gateway.config.allow_polling:
-            _LOGGER.debug("Global updater checking device availability")
+            _LOGGER.debug("Checking device availability")
             # 20 because most devices will not make remote calls
             await gather_with_limited_concurrency(
                 20,
@@ -390,6 +390,6 @@ class DeviceAvailabilityChecker:
                     if not dev.is_coordinator
                 ),
             )
-            _LOGGER.debug("Global updater device availability checker finished")
+            _LOGGER.debug("Device availability checker interval finished")
         else:
-            _LOGGER.debug("Global updater device availability checker skipped")
+            _LOGGER.debug("Device availability checker interval skipped")


### PR DESCRIPTION
This PR creates 2 helpers that are used to reduce the overhead needed to refresh polling things. 

`GlobalUpdater` is added to refresh things that need to update from local state (non async). DeviceCounterSensor, RSSISensor and LQISensor are currently using this. These should be updated to leverage events or callbacks once zigpy provides the appropriate feedback mechanism.

`DeviceAvailabilityChecker` is added to periodically check the available state of a device

a new flag was also added to `Device` that tracks whether or not a device is on the network

fixes #9 
fixes #10