### PR TITLE
Fix group unique id

### DIFF
--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -220,7 +220,7 @@ async def test_gateway_group_methods(
     info = entity.info_object
     assert info.class_name == "LightGroup"
     assert info.platform == Platform.LIGHT
-    assert info.unique_id == "light.0x0002"
+    assert info.unique_id == "light_zha_group_0x0002"
     assert info.name == "Test Group_0x0002"
     assert info.group_id == zha_group.group_id
     assert info.supported_features == LightEntityFeature.TRANSITION

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -331,7 +331,7 @@ class GroupEntity(BaseEntity):
         group: Group,
     ) -> None:
         """Initialize a group."""
-        super().__init__(f"{self.PLATFORM}.{group.group_id}")
+        super().__init__(f"{self.PLATFORM}_zha_group_0x{group.group_id:04x}")
         self._name: str = f"{group.name}_0x{group.group_id:04x}"
         self._group: Group = group
         self._group.register_group_entity(self)


### PR DESCRIPTION
## Proposed change
This changes the unique id for groups to align with the unique id from current HA ZHA, so we don't create a new entity.
The test is also changed to check for the new unique id. (The tests in HA never check the unique id)

There's still an issue left with the default name not using the group name and always being "Light group" that's explained below. That should be addressed in a future PR.

### Issue left: default name

There still seems to be an issue with the default name shown in HA.
This might be because HA expects the `_attr_name` attribute for a custom name, but the ZHA library never sets that. It uses `_name` and exposes it as the `name` property.
An example of old/new entity registry entries follows below.

#### Entity registry entries

I've created a ZHA group called "ZHA Group ID 3". The entity in the registry is regenerated on the current HA ZHA integration and afterwards with the ZHA library. A custom name is not set (as seen by `name = null`), so the `original_name` is used.
By default, this should be the ZHA group name, so "ZHA Group ID 3". It's also used for the entity id suffix then.
With the ZHA library, this always seems to be "Light group" for now (also resulting in the less descriptive entity id). That should be fixed in a future PR.

<details><summary>Current HA ZHA (good)</summary>
<p>

```json
{
  "aliases": [],
  "area_id": null,
  "categories": {},
  "capabilities": {
    "min_color_temp_kelvin": 2000,
    "max_color_temp_kelvin": 6535,
    "min_mireds": 153,
    "max_mireds": 500,
    "effect_list": [
      "colorloop"
    ],
    "supported_color_modes": [
      "color_temp",
      "xy"
    ]
  },
  "config_entry_id": "9afa7813c02240642802443599f8f31b",
  "device_class": null,
  "device_id": "930dc2f5f2c48a5fa552c20c27af7e57",
  "disabled_by": null,
  "entity_category": null,
  "entity_id": "light.silicon_labs_ezsp_zha_group_id_3",
  "hidden_by": null,
  "icon": null,
  "id": "7b76a1842a3a279b08ba7a29e1c89bdf",
  "has_entity_name": true,
  "labels": [],
  "name": null,
  "options": {
    "conversation": {
      "should_expose": true
    }
  },
  "original_device_class": null,
  "original_icon": null,
  "original_name": "ZHA Group ID 3",
  "platform": "zha",
  "supported_features": 44,
  "translation_key": "light_group",
  "unique_id": "light_zha_group_0x0003",
  "previous_unique_id": null,
  "unit_of_measurement": null
}
```

</p>
</details> 

<details><summary>Generated with this PR (unique id is good now, name not)</summary>
<p>

```json
{
  "aliases": [],
  "area_id": null,
  "categories": {},
  "capabilities": {
    "min_color_temp_kelvin": 2000,
    "max_color_temp_kelvin": 6535,
    "min_mireds": 153,
    "max_mireds": 500,
    "effect_list": null,
    "supported_color_modes": [
      "color_temp",
      "xy"
    ]
  },
  "config_entry_id": "9afa7813c02240642802443599f8f31b",
  "device_class": null,
  "device_id": "930dc2f5f2c48a5fa552c20c27af7e57",
  "disabled_by": null,
  "entity_category": null,
  "entity_id": "light.silicon_labs_ezsp_light_group",
  "hidden_by": null,
  "icon": null,
  "id": "d4fa6c91250a492a5f574371f43634ce",
  "has_entity_name": true,
  "labels": [],
  "name": null,
  "options": {
    "conversation": {
      "should_expose": true
    }
  },
  "original_device_class": null,
  "original_icon": null,
  "original_name": "Light group",
  "platform": "zha",
  "supported_features": 44,
  "translation_key": "light_group",
  "unique_id": "light_zha_group_0x0003",
  "previous_unique_id": null,
  "unit_of_measurement": null
}
```

</p>
</details> 