### PR TITLE
Support Codecov v4 changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,5 @@ jobs:
       PRE_COMMIT_CACHE_PATH: ~/.cache/pre-commit
       MINIMUM_COVERAGE_PERCENTAGE: 95
       PYTHON_MATRIX: "3.12"
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### ~~IMPORTANT: workflows branch `dm/update-ci-03272024` also needs to be updated for this repo.~~

### ~~DRAFT -- do not merge yet (needs below workflow PR merged first, CI will fail for now)~~

Passes the `CODECOV_TOKEN` GH secret to the shared workflow.
Related PR with more information:
- https://github.com/zigpy/workflows/pull/17