### PR TITLE
Provide metadata for the calculation of extra_state_attributes

### DIFF
--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -87,6 +87,7 @@ async def async_test_temperature(
     zha_gateway: Gateway, cluster: Cluster, entity: PlatformEntity
 ) -> None:
     """Test temperature sensor."""
+    assert entity.extra_state_attribute_names is None
     await send_attributes_report(zha_gateway, cluster, {1: 1, 0: 2900, 2: 100})
     assert_state(entity, 29.0, "°C")
 
@@ -117,6 +118,11 @@ async def async_test_metering(
     zha_gateway: Gateway, cluster: Cluster, entity: PlatformEntity
 ) -> None:
     """Test Smart Energy metering sensor."""
+    assert entity.extra_state_attribute_names == {
+        "status",
+        "device_type",
+        "zcl_unit_of_measurement",
+    }
     await send_attributes_report(
         zha_gateway, cluster, {1025: 1, 1024: 12345, 1026: 100}
     )
@@ -166,7 +172,11 @@ async def async_test_smart_energy_summation_delivered(
     zha_gateway: Gateway, cluster, entity
 ):
     """Test SmartEnergy Summation delivered sensor."""
-
+    assert entity.extra_state_attribute_names == {
+        "status",
+        "device_type",
+        "zcl_unit_of_measurement",
+    }
     await send_attributes_report(
         zha_gateway, cluster, {1025: 1, "current_summ_delivered": 12321, 1026: 100}
     )
@@ -316,6 +326,12 @@ async def async_test_powerconfiguration(
     zha_gateway: Gateway, cluster: Cluster, entity: PlatformEntity
 ) -> None:
     """Test powerconfiguration/battery sensor."""
+    assert entity.extra_state_attribute_names == {
+        "battery_voltage",
+        "battery_quantity",
+        "battery_size",
+        "battery_voltage",
+    }
     await send_attributes_report(zha_gateway, cluster, {33: 98})
     assert_state(entity, 49, "%")
     assert entity.state["battery_voltage"] == 2.9

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -213,6 +213,17 @@ class BaseEntity(LogMixin, EventBase):
             "class_name": self.__class__.__name__,
         }
 
+    @cached_property
+    def extra_state_attribute_names(self) -> set[str] | None:
+        """Return entity specific state attribute names.
+
+        Implemented by platform classes. Convention for attribute names
+        is lowercase snake_case.
+        """
+        if hasattr(self, "_attr_extra_state_attribute_names"):
+            return self._attr_extra_state_attribute_names
+        return None
+
     async def on_remove(self) -> None:
         """Cancel tasks and timers this entity owns."""
         for handle in self._tracked_handles:

--- a/zha/application/platforms/climate/__init__.py
+++ b/zha/application/platforms/climate/__init__.py
@@ -83,6 +83,16 @@ class Thermostat(PlatformEntity):
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_translation_key: str = "thermostat"
     _enable_turn_on_off_backwards_compatibility = False
+    _attr_extra_state_attribute_names: set[str] = {
+        ATTR_SYS_MODE,
+        ATTR_OCCUPANCY,
+        ATTR_OCCP_COOL_SETPT,
+        ATTR_OCCP_HEAT_SETPT,
+        ATTR_PI_HEATING_DEMAND,
+        ATTR_PI_COOLING_DEMAND,
+        ATTR_UNOCCP_COOL_SETPT,
+        ATTR_UNOCCP_HEAT_SETPT,
+    }
 
     def __init__(
         self,

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -117,6 +117,10 @@ class BaseLight(BaseEntity, ABC):
     PLATFORM = Platform.LIGHT
     _FORCE_ON = False
     _DEFAULT_MIN_TRANSITION_TIME: float = 0
+    _attr_extra_state_attribute_names: set[str] = {
+        "off_with_transition",
+        "off_brightness",
+    }
 
     def __init__(self, *args, **kwargs):
         """Initialize the light."""


### PR DESCRIPTION
Usage in HA. Done this way to account for the potential future where properties are removed and we only have dicts shared from the lib to HA. 


```python
    @property
    def extra_state_attributes(self) -> Mapping[str, Any] | None:
        """Return entity specific state attributes."""
        if self.entity_data.entity.extra_state_attribute_names is not None:
            state_data = self.entity_data.entity.state
            extra_state_attributes = {}
            for name in self.entity_data.entity.extra_state_attribute_names:
                if name in state_data and state_data[name] is not None:
                    extra_state_attributes[name] = state_data[name]
            return extra_state_attributes
        return None
```