### PR TITLE
Remove some mypy excludes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,13 +63,13 @@ install_types = true
 non_interactive = true
 
 disable_error_code = [
-    "no-untyped-def",   # 348
-    "attr-defined",     # 172
-    "no-any-return",    # 99
-    "no-untyped-call",  # 81
-    "assignment",       # 73
-    "arg-type",         # 42
-    "union-attr",       # 41
+    "no-untyped-def",
+    "attr-defined",
+    "no-any-return",
+    "no-untyped-call",
+    "assignment",
+    "arg-type",
+    "union-attr",
 ]
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ dependencies = [
 [tool.setuptools.packages.find]
 exclude = ["tests", "tests.*"]
 
+[tool.setuptools.package-data]
+"*" = ["py.typed"]
+
 [project.optional-dependencies]
 testing = [
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,10 +77,6 @@ disable_error_code = [
     "misc",             # 31
     "var-annotated",    # 15
     "override",         # 13
-    "return-value",     # 11
-    "method-assign",    # 9
-    "index",            # 6
-    "dict-item",        # 1
 ]
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,6 @@ disable_error_code = [
     "assignment",       # 73
     "arg-type",         # 42
     "union-attr",       # 41
-    "misc",             # 31
 ]
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,20 +66,21 @@ install_types = true
 non_interactive = true
 
 disable_error_code = [
-    "arg-type",
-    "assignment",
-    "attr-defined",
-    "call-arg",
-    "dict-item",
-    "index",
-    "misc",
-    "no-any-return",
-    "no-untyped-call",
-    "no-untyped-def",
-    "override",
-    "return-value",
-    "union-attr",
-    "var-annotated",
+    "no-untyped-def",   # 348
+    "attr-defined",     # 172
+    "call-arg",         # 112
+    "no-any-return",    # 99
+    "no-untyped-call",  # 81
+    "assignment",       # 73
+    "arg-type",         # 42
+    "union-attr",       # 41
+    "misc",             # 31
+    "var-annotated",    # 15
+    "override",         # 13
+    "return-value",     # 11
+    "method-assign",    # 9
+    "index",            # 6
+    "dict-item",        # 1
 ]
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,6 @@ disable_error_code = [
     "arg-type",         # 42
     "union-attr",       # 41
     "misc",             # 31
-    "var-annotated",    # 15
     "override",         # 13
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,6 @@ disable_error_code = [
     "arg-type",         # 42
     "union-attr",       # 41
     "misc",             # 31
-    "override",         # 13
 ]
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ non_interactive = true
 disable_error_code = [
     "no-untyped-def",   # 348
     "attr-defined",     # 172
-    "call-arg",         # 112
     "no-any-return",    # 99
     "no-untyped-call",  # 81
     "assignment",       # 73

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,6 @@ dependencies = [
 [tool.setuptools.packages.find]
 exclude = ["tests", "tests.*"]
 
-[tool.setuptools.package-data]
-"*" = ["py.typed"]
-
 [project.optional-dependencies]
 testing = [
     "pytest",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 """Test configuration for the ZHA component."""
 
 import asyncio
-from collections.abc import Callable, Generator
+from collections.abc import Awaitable, Callable, Generator
 from contextlib import contextmanager
 import itertools
 import logging
@@ -44,7 +44,7 @@ from zha.zigbee.device import Device
 FIXTURE_GRP_ID = 0x1001
 FIXTURE_GRP_NAME = "fixture group"
 COUNTER_NAMES = ["counter_1", "counter_2", "counter_3"]
-INSTANCES = []
+INSTANCES: list[Gateway] = []
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -381,13 +381,16 @@ def globally_load_quirks():
 @pytest.fixture
 def device_joined(
     zha_gateway: Gateway,  # pylint: disable=redefined-outer-name
-) -> Callable[[zigpy.device.Device], Device]:
+) -> Callable[[zigpy.device.Device], Awaitable[Device]]:
     """Return a newly joined ZHAWS device."""
 
     async def _zha_device(zigpy_dev: zigpy.device.Device) -> Device:
         await zha_gateway.async_device_initialized(zigpy_dev)
         await zha_gateway.async_block_till_done()
-        return zha_gateway.get_device(zigpy_dev.ieee)
+
+        device = zha_gateway.get_device(zigpy_dev.ieee)
+        assert device is not None
+        return device
 
     return _zha_device
 

--- a/tests/test_async_.py
+++ b/tests/test_async_.py
@@ -378,53 +378,6 @@ async def test_async_run_zha_job_delegates_non_async() -> None:
     assert len(zha_gateway.async_add_zha_job.mock_calls) == 1
 
 
-async def test_pending_scheduler(zha_gateway: Gateway) -> None:
-    """Add a coro to pending tasks."""
-    call_count = []
-
-    async def test_coro():
-        """Test Coro."""
-        call_count.append("call")
-
-    for _ in range(3):
-        zha_gateway.async_add_job(test_coro())
-
-    await asyncio.wait(zha_gateway._tracked_completable_tasks)
-
-    assert len(zha_gateway._tracked_completable_tasks) == 0
-    assert len(call_count) == 3
-
-
-def test_add_job_pending_tasks_coro(zha_gateway: Gateway) -> None:
-    """Add a coro to pending tasks."""
-
-    async def test_coro():
-        """Test Coro."""
-
-    for _ in range(2):
-        zha_gateway.add_job(test_coro())
-
-    # Ensure add_job does not run immediately
-    assert len(zha_gateway._tracked_completable_tasks) == 0
-
-
-async def test_async_add_job_pending_tasks_coro(zha_gateway: Gateway) -> None:
-    """Add a coro to pending tasks."""
-    call_count = []
-
-    async def test_coro():
-        """Test Coro."""
-        call_count.append("call")
-
-    for _ in range(2):
-        zha_gateway.async_add_job(test_coro())
-
-    assert len(zha_gateway._tracked_completable_tasks) == 2
-    await zha_gateway.async_block_till_done()
-    assert len(call_count) == 2
-    assert len(zha_gateway._tracked_completable_tasks) == 0
-
-
 async def test_async_create_task_pending_tasks_coro(zha_gateway: Gateway) -> None:
     """Add a coro to pending tasks."""
     call_count = []
@@ -440,78 +393,6 @@ async def test_async_create_task_pending_tasks_coro(zha_gateway: Gateway) -> Non
     await zha_gateway.async_block_till_done()
     assert len(call_count) == 2
     assert len(zha_gateway._tracked_completable_tasks) == 0
-
-
-async def test_async_add_job_pending_tasks_executor(zha_gateway: Gateway) -> None:
-    """Run an executor in pending tasks."""
-    call_count = []
-
-    def test_executor():
-        """Test executor."""
-        call_count.append("call")
-
-    async def wait_finish_callback():
-        """Wait until all stuff is scheduled."""
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-
-    for _ in range(2):
-        zha_gateway.async_add_job(test_executor)
-
-    await wait_finish_callback()
-
-    await zha_gateway.async_block_till_done()
-    assert len(call_count) == 2
-
-
-async def test_async_add_job_pending_tasks_callback(zha_gateway: Gateway) -> None:
-    """Run a callback in pending tasks."""
-    call_count = []
-
-    @callback
-    def test_callback():
-        """Test callback."""
-        call_count.append("call")
-
-    async def wait_finish_callback():
-        """Wait until all stuff is scheduled."""
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-
-    for _ in range(2):
-        zha_gateway.async_add_job(test_callback)
-
-    await wait_finish_callback()
-
-    await zha_gateway.async_block_till_done()
-
-    assert len(zha_gateway._tracked_completable_tasks) == 0
-    assert len(call_count) == 2
-
-
-async def test_add_job_with_none(zha_gateway: Gateway) -> None:
-    """Try to add a job with None as function."""
-    with pytest.raises(ValueError):
-        zha_gateway.async_add_job(None, "test_arg")
-
-    with pytest.raises(ValueError):
-        zha_gateway.add_job(None, "test_arg")
-
-
-async def test_async_functions_with_callback(zha_gateway: Gateway) -> None:
-    """Test we deal with async functions accidentally marked as callback."""
-    runs = []
-
-    @callback
-    async def test():
-        runs.append(True)
-
-    await zha_gateway.async_add_job(test)
-    assert len(runs) == 1
-
-    zha_gateway.async_run_job(test)
-    await zha_gateway.async_block_till_done()
-    assert len(runs) == 2
 
 
 async def test_async_run_job_starts_tasks_eagerly(zha_gateway: Gateway) -> None:

--- a/tests/test_async_.py
+++ b/tests/test_async_.py
@@ -545,7 +545,7 @@ async def test_async_run_job_starts_coro_eagerly(zha_gateway: Gateway) -> None:
 @pytest.mark.parametrize("eager_start", [True, False])
 async def test_background_task(zha_gateway: Gateway, eager_start: bool) -> None:
     """Test background tasks being quit."""
-    result = asyncio.Future()
+    result = asyncio.get_running_loop().create_future()
 
     async def test_task():
         try:

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -16,7 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 @pytest.mark.looptime
 async def test_immediate_works(zha_gateway: Gateway) -> None:
     """Test immediate works."""
-    calls = []
+    calls: list[None] = []
     debouncer = Debouncer(
         zha_gateway,
         _LOGGER,
@@ -71,7 +71,7 @@ async def test_immediate_works(zha_gateway: Gateway) -> None:
 @pytest.mark.looptime
 async def test_immediate_works_with_schedule_call(zha_gateway: Gateway) -> None:
     """Test immediate works with scheduled calls."""
-    calls = []
+    calls: list[None] = []
     debouncer = Debouncer(
         zha_gateway,
         _LOGGER,
@@ -129,7 +129,7 @@ async def test_immediate_works_with_schedule_call(zha_gateway: Gateway) -> None:
 
 async def test_immediate_works_with_callback_function(zha_gateway: Gateway) -> None:
     """Test immediate works with callback function."""
-    calls = []
+    calls: list[None] = []
     debouncer = Debouncer(
         zha_gateway,
         _LOGGER,
@@ -150,7 +150,7 @@ async def test_immediate_works_with_callback_function(zha_gateway: Gateway) -> N
 
 async def test_immediate_works_with_executor_function(zha_gateway: Gateway) -> None:
     """Test immediate works with executor function."""
-    calls = []
+    calls: list[None] = []
     debouncer = Debouncer(
         zha_gateway,
         _LOGGER,
@@ -174,7 +174,7 @@ async def test_immediate_works_with_passed_callback_function_raises(
     zha_gateway: Gateway,
 ) -> None:
     """Test immediate works with a callback function that raises."""
-    calls = []
+    calls: list[None] = []
 
     @callback
     def _append_and_raise() -> None:
@@ -239,7 +239,7 @@ async def test_immediate_works_with_passed_coroutine_raises(
     zha_gateway: Gateway,
 ) -> None:
     """Test immediate works with a coroutine that raises."""
-    calls = []
+    calls: list[None] = []
 
     async def _append_and_raise() -> None:
         calls.append(None)
@@ -301,7 +301,7 @@ async def test_immediate_works_with_passed_coroutine_raises(
 @pytest.mark.looptime
 async def test_not_immediate_works(zha_gateway: Gateway) -> None:
     """Test immediate works."""
-    calls = []
+    calls: list[None] = []
     debouncer = Debouncer(
         zha_gateway,
         _LOGGER,
@@ -353,7 +353,7 @@ async def test_not_immediate_works(zha_gateway: Gateway) -> None:
 @pytest.mark.looptime
 async def test_not_immediate_works_schedule_call(zha_gateway: Gateway) -> None:
     """Test immediate works with schedule call."""
-    calls = []
+    calls: list[None] = []
     debouncer = Debouncer(
         zha_gateway,
         _LOGGER,
@@ -409,7 +409,7 @@ async def test_not_immediate_works_schedule_call(zha_gateway: Gateway) -> None:
 @pytest.mark.looptime
 async def test_immediate_works_with_function_swapped(zha_gateway: Gateway) -> None:
     """Test immediate works and we can change out the function."""
-    calls = []
+    calls: list[None] = []
 
     one_function = AsyncMock(side_effect=lambda: calls.append(1))
     two_function = AsyncMock(side_effect=lambda: calls.append(2))
@@ -471,8 +471,8 @@ async def test_immediate_works_with_function_swapped(zha_gateway: Gateway) -> No
 
 async def test_shutdown(zha_gateway: Gateway, caplog: pytest.LogCaptureFixture) -> None:
     """Test shutdown."""
-    calls = []
-    future = asyncio.Future()
+    calls: list[None] = []
+    future = asyncio.get_running_loop().create_future()
 
     async def _func() -> None:
         await future
@@ -506,7 +506,7 @@ async def test_shutdown(zha_gateway: Gateway, caplog: pytest.LogCaptureFixture) 
 @pytest.mark.looptime
 async def test_background(zha_gateway: Gateway) -> None:
     """Test background tasks are created when background is True."""
-    calls = []
+    calls: list[None] = []
 
     async def _func() -> None:
         await asyncio.sleep(0.5)

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -901,7 +901,7 @@ def validate_metadata(validator: Callable) -> None:
     all_v2_quirks = itertools.chain.from_iterable(
         zigpy.quirks._DEVICE_REGISTRY._registry_v2.values()
     )
-    translations = {}
+    translations: dict[str, dict[str, str]] = {}
     for quirk in all_v2_quirks:
         for entity_metadata in quirk.entity_metadata:
             platform = Platform(entity_metadata.entity_platform.value)

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -1,6 +1,6 @@
 """Test ZHA device discovery."""
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable, Coroutine
 import enum
 import itertools
 import re
@@ -20,6 +20,7 @@ from zhaquirks.xiaomi.aqara.driver_curtain_e1 import (
     XiaomiAqaraDriverE1,
 )
 from zigpy.const import SIG_ENDPOINTS, SIG_MANUFACTURER, SIG_MODEL, SIG_NODE_DESC
+import zigpy.device
 import zigpy.profiles.zha
 import zigpy.quirks
 from zigpy.quirks.v2 import (
@@ -89,8 +90,8 @@ def contains_ignored_suffix(unique_id: str) -> bool:
 @pytest.fixture
 def zha_device_mock(
     zigpy_device_mock: Callable[..., zigpy.device.Device],
-    device_joined: Callable[..., Device],
-) -> Callable[..., Device]:
+    device_joined: Callable[[zigpy.device.Device], Awaitable[Device]],
+) -> Callable[..., Coroutine[Any, Any, Device]]:
     """Mock device factory."""
 
     async def _mock(
@@ -124,7 +125,7 @@ async def test_devices(
     device,
     zha_gateway: Gateway,
     zigpy_device_mock,
-    device_joined,
+    device_joined: Callable[[zigpy.device.Device], Awaitable[Device]],
 ) -> None:
     """Test device discovery."""
     zigpy_device = zigpy_device_mock(
@@ -317,7 +318,7 @@ def test_discover_probe_single_cluster() -> None:
 @pytest.mark.parametrize("device_info", DEVICES)
 async def test_discover_endpoint(
     device_info: dict[str, Any],
-    zha_device_mock: Callable[..., Device],  # pylint: disable=redefined-outer-name
+    zha_device_mock: Callable[..., Coroutine[Any, Any, Device]],  # pylint: disable=redefined-outer-name
     zha_gateway: Gateway,  # pylint: disable=unused-argument
 ) -> None:
     """Test device discovery."""
@@ -479,7 +480,7 @@ async def test_device_override(
 async def test_quirks_v2_entity_discovery(
     zha_gateway: Gateway,  # pylint: disable=unused-argument
     zigpy_device_mock,
-    device_joined,
+    device_joined: Callable[[zigpy.device.Device], Awaitable[Device]],
 ) -> None:
     """Test quirks v2 discovery."""
 
@@ -538,7 +539,7 @@ async def test_quirks_v2_entity_discovery(
 async def test_quirks_v2_entity_discovery_e1_curtain(
     zha_gateway: Gateway,  # pylint: disable=unused-argument
     zigpy_device_mock,
-    device_joined,
+    device_joined: Callable[[zigpy.device.Device], Awaitable[Device]],
 ) -> None:
     """Test quirks v2 discovery for e1 curtain motor."""
 
@@ -744,7 +745,7 @@ def _get_test_device(
 async def test_quirks_v2_entity_no_metadata(
     zha_gateway: Gateway,  # pylint: disable=unused-argument
     zigpy_device_mock,
-    device_joined,
+    device_joined: Callable[[zigpy.device.Device], Awaitable[Device]],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test quirks v2 discovery skipped - no metadata."""
@@ -763,7 +764,7 @@ async def test_quirks_v2_entity_no_metadata(
 async def test_quirks_v2_entity_discovery_errors(
     zha_gateway: Gateway,  # pylint: disable=unused-argument
     zigpy_device_mock,
-    device_joined,
+    device_joined: Callable[[zigpy.device.Device], Awaitable[Device]],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test quirks v2 discovery skipped - errors."""
@@ -926,7 +927,7 @@ def validate_metadata(validator: Callable) -> None:
 async def test_quirks_v2_metadata_errors(
     zha_gateway: Gateway,  # pylint: disable=unused-argument
     zigpy_device_mock,
-    device_joined,
+    device_joined: Callable[[zigpy.device.Device], Awaitable[Device]],
     augment_method: Callable[[QuirksV2RegistryEntry], QuirksV2RegistryEntry],
     validate_method: Callable,
     expected_exception_string: str,
@@ -1029,7 +1030,7 @@ ERROR_ROOT = "Quirks provided an invalid device class"
 async def test_quirks_v2_metadata_bad_device_classes(
     zha_gateway: Gateway,  # pylint: disable=unused-argument
     zigpy_device_mock,
-    device_joined,
+    device_joined: Callable[[zigpy.device.Device], Awaitable[Device]],
     caplog: pytest.LogCaptureFixture,
     augment_method: Callable[[QuirksV2RegistryEntry], QuirksV2RegistryEntry],
     expected_exception_string: str,

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 
@@ -131,7 +131,7 @@ async def test_event_base_emit_coro():
     await asyncio.gather(*event._event_tasks)
 
     assert callback.await_count == 1
-    assert callback.await_args[0] == ("data",)
+    assert callback.mock_calls == [call("data")]
     assert not event._event_tasks
 
     callback.reset_mock()
@@ -142,7 +142,7 @@ async def test_event_base_emit_coro():
     await asyncio.gather(*event._event_tasks)
 
     assert callback.await_count == 1
-    assert callback.await_args[0] == ("data",)
+    assert callback.mock_calls == [call("data")]
     unsub()
     assert not event._event_tasks
 
@@ -154,7 +154,7 @@ async def test_event_base_emit_coro():
     await asyncio.gather(*event._event_tasks)
 
     assert callback.await_count == 1
-    assert callback.await_args[0] == ("data",)
+    assert callback.mock_calls == [call("data")]
     unsub()
     assert not event._event_tasks
 
@@ -167,7 +167,7 @@ async def test_event_base_emit_coro():
     await asyncio.gather(*event._event_tasks)
 
     assert event.handle_test.await_count == 1
-    assert event.handle_test.await_args[0] == (test_event,)
+    assert event.handle_test.mock_calls == [call(test_event)]
     assert not event._event_tasks
 
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -546,7 +546,7 @@ async def test_sensor(
     zha_gateway: Gateway,
     cluster_id: int,
     entity_type: type[PlatformEntity],
-    test_func: Callable[[Cluster, PlatformEntity], Awaitable[None]],
+    test_func: Callable[[Cluster, Cluster, PlatformEntity], Awaitable[None]],
     read_plug: Optional[dict],
     unsupported_attrs: Optional[set],
 ) -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1235,7 +1235,7 @@ async def test_device_unavailable_skips_entity_polling(
 async def zigpy_device_danfoss_thermostat(
     zigpy_device_mock: Callable[..., ZigpyDevice],  # pylint: disable=redefined-outer-name
     device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
-) -> Device:
+) -> tuple[Device, zigpy.device.Device]:
     """Danfoss thermostat device."""
 
     zigpy_device = zigpy_device_mock(

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -163,14 +163,14 @@ class BaseEntity(LogMixin, EventBase):
         return self._attr_entity_registry_enabled_default
 
     @property
-    def device_class(self) -> EntityCategory | None:
+    def device_class(self) -> str | None:
         """Return the device class."""
         if hasattr(self, "_attr_device_class"):
             return self._attr_device_class
         return None
 
     @property
-    def state_class(self) -> EntityCategory | None:
+    def state_class(self) -> str | None:
         """Return the state class."""
         if hasattr(self, "_attr_state_class"):
             return self._attr_state_class

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from abc import abstractmethod
 import asyncio
 from contextlib import suppress
-from dataclasses import dataclass
+import dataclasses
 from enum import StrEnum
 from functools import cached_property
 import logging
@@ -41,7 +41,7 @@ class EntityCategory(StrEnum):
     DIAGNOSTIC = "diagnostic"
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class BaseEntityInfo:
     """Information about a base entity."""
 
@@ -55,8 +55,17 @@ class BaseEntityInfo:
     entity_category: str | None
     entity_registry_enabled_default: bool
 
+    # For platform entities
+    cluster_handlers: list[ClusterHandlerInfo]
+    device_ieee: EUI64 | None
+    endpoint_id: int | None
+    available: bool | None
 
-@dataclass(frozen=True, kw_only=True)
+    # For group entities
+    group_id: int | None
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class BaseIdentifiers:
     """Identifiers for the base entity."""
 
@@ -64,7 +73,7 @@ class BaseIdentifiers:
     platform: str
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class PlatformEntityIdentifiers(BaseIdentifiers):
     """Identifiers for the platform entity."""
 
@@ -72,31 +81,14 @@ class PlatformEntityIdentifiers(BaseIdentifiers):
     endpoint_id: int
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class GroupEntityIdentifiers(BaseIdentifiers):
     """Identifiers for the group entity."""
 
     group_id: int
 
 
-@dataclass(frozen=True, kw_only=True)
-class PlatformEntityInfo(BaseEntityInfo):
-    """Information about a platform entity."""
-
-    cluster_handlers: list[ClusterHandlerInfo]
-    device_ieee: EUI64
-    endpoint_id: int
-    available: bool
-
-
-@dataclass(frozen=True, kw_only=True)
-class GroupEntityInfo(BaseEntityInfo):
-    """Information about a group entity."""
-
-    group_id: int
-
-
-@dataclass(frozen=True, kw_only=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class EntityStateChangedEvent:
     """Event for when an entity state changes."""
 
@@ -204,6 +196,13 @@ class BaseEntity(LogMixin, EventBase):
             state_class=self.state_class,
             entity_category=self.entity_category,
             entity_registry_enabled_default=self.entity_registry_enabled_default,
+            # Set by platform entities
+            cluster_handlers=[],
+            device_ieee=None,
+            endpoint_id=None,
+            available=None,
+            # Set by group entities
+            group_id=None,
         )
 
     @property
@@ -223,13 +222,6 @@ class BaseEntity(LogMixin, EventBase):
         if hasattr(self, "_attr_extra_state_attribute_names"):
             return self._attr_extra_state_attribute_names
         return None
-
-    def restore_external_state_attributes(self, **kwargs: Any) -> None:
-        """Restore entity specific state attributes from an external source.
-
-        Entities implementing this must accept a keyword argument for each attribute.
-        """
-        raise NotImplementedError
 
     async def on_remove(self) -> None:
         """Cancel tasks and timers this entity owns."""
@@ -359,10 +351,10 @@ class PlatformEntity(BaseEntity):
         )
 
     @cached_property
-    def info_object(self) -> PlatformEntityInfo:
+    def info_object(self) -> BaseEntityInfo:
         """Return a representation of the platform entity."""
-        return PlatformEntityInfo(
-            **super().info_object.__dict__,
+        return dataclasses.replace(
+            super().info_object,
             cluster_handlers=[ch.info_object for ch in self._cluster_handlers],
             device_ieee=self._device.ieee,
             endpoint_id=self._endpoint.id,
@@ -429,10 +421,10 @@ class GroupEntity(BaseEntity):
         )
 
     @cached_property
-    def info_object(self) -> GroupEntityInfo:
+    def info_object(self) -> BaseEntityInfo:
         """Return a representation of the group."""
-        return GroupEntityInfo(
-            **super().info_object.__dict__,
+        return dataclasses.replace(
+            super().info_object,
             group_id=self.group_id,
         )
 

--- a/zha/application/platforms/alarm_control_panel/__init__.py
+++ b/zha/application/platforms/alarm_control_panel/__init__.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 from zigpy.zcl.clusters.security import IasAce
 
 from zha.application import Platform
-from zha.application.platforms import PlatformEntity, PlatformEntityInfo
+from zha.application.platforms import BaseEntityInfo, PlatformEntity
 from zha.application.platforms.alarm_control_panel.const import (
     IAS_ACE_STATE_MAP,
     SUPPORT_ALARM_ARM_AWAY,
@@ -43,7 +43,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, kw_only=True)
-class AlarmControlPanelEntityInfo(PlatformEntityInfo):
+class AlarmControlPanelEntityInfo(BaseEntityInfo):
     """Alarm control panel entity info."""
 
     code_arm_required: bool

--- a/zha/application/platforms/binary_sensor/__init__.py
+++ b/zha/application/platforms/binary_sensor/__init__.py
@@ -91,7 +91,7 @@ class BinarySensor(PlatformEntity):
             )
 
     @functools.cached_property
-    def info_object(self) -> dict:
+    def info_object(self) -> BinarySensorEntityInfo:
         """Return a representation of the binary sensor."""
         return BinarySensorEntityInfo(
             **super().info_object.__dict__,

--- a/zha/application/platforms/binary_sensor/__init__.py
+++ b/zha/application/platforms/binary_sensor/__init__.py
@@ -11,7 +11,7 @@ from zhaquirks.quirk_ids import DANFOSS_ALLY_THERMOSTAT
 from zigpy.quirks.v2 import BinarySensorMetadata
 
 from zha.application import Platform
-from zha.application.platforms import EntityCategory, PlatformEntity, PlatformEntityInfo
+from zha.application.platforms import BaseEntityInfo, EntityCategory, PlatformEntity
 from zha.application.platforms.binary_sensor.const import (
     IAS_ZONE_CLASS_MAPPING,
     BinarySensorDeviceClass,
@@ -47,7 +47,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, kw_only=True)
-class BinarySensorEntityInfo(PlatformEntityInfo):
+class BinarySensorEntityInfo(BaseEntityInfo):
     """Binary sensor entity info."""
 
     attribute_name: str

--- a/zha/application/platforms/button/__init__.py
+++ b/zha/application/platforms/button/__init__.py
@@ -11,7 +11,7 @@ from zigpy.quirks.v2 import WriteAttributeButtonMetadata, ZCLCommandButtonMetada
 
 from zha.application import Platform
 from zha.application.const import ENTITY_METADATA
-from zha.application.platforms import EntityCategory, PlatformEntity, PlatformEntityInfo
+from zha.application.platforms import BaseEntityInfo, EntityCategory, PlatformEntity
 from zha.application.platforms.button.const import DEFAULT_DURATION, ButtonDeviceClass
 from zha.application.registries import PLATFORM_ENTITIES
 from zha.zigbee.cluster_handlers.const import CLUSTER_HANDLER_IDENTIFY
@@ -31,7 +31,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, kw_only=True)
-class CommandButtonEntityInfo(PlatformEntityInfo):
+class CommandButtonEntityInfo(BaseEntityInfo):
     """Command button entity info."""
 
     command: str
@@ -40,7 +40,7 @@ class CommandButtonEntityInfo(PlatformEntityInfo):
 
 
 @dataclass(frozen=True, kw_only=True)
-class WriteAttributeButtonEntityInfo(PlatformEntityInfo):
+class WriteAttributeButtonEntityInfo(BaseEntityInfo):
     """Write attribute button entity info."""
 
     attribute_name: str

--- a/zha/application/platforms/climate/__init__.py
+++ b/zha/application/platforms/climate/__init__.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 from zigpy.zcl.clusters.hvac import FanMode, RunningState, SystemMode
 
 from zha.application import Platform
-from zha.application.platforms import PlatformEntity, PlatformEntityInfo
+from zha.application.platforms import BaseEntityInfo, PlatformEntity
 from zha.application.platforms.climate.const import (
     ATTR_HVAC_MODE,
     ATTR_OCCP_COOL_SETPT,
@@ -56,7 +56,7 @@ MULTI_MATCH = functools.partial(PLATFORM_ENTITIES.multipass_match, Platform.CLIM
 
 
 @dataclass(frozen=True, kw_only=True)
-class ThermostatEntityInfo(PlatformEntityInfo):
+class ThermostatEntityInfo(BaseEntityInfo):
     """Thermostat entity info."""
 
     max_temp: float

--- a/zha/application/platforms/climate/__init__.py
+++ b/zha/application/platforms/climate/__init__.py
@@ -105,7 +105,7 @@ class Thermostat(PlatformEntity):
         """Initialize ZHA Thermostat instance."""
         super().__init__(unique_id, cluster_handlers, endpoint, device, **kwargs)
         self._preset = Preset.NONE
-        self._presets = []
+        self._presets: list[Preset | str] = []
 
         self._thermostat_cluster_handler: ClusterHandler = self.cluster_handlers.get(
             CLUSTER_HANDLER_THERMOSTAT

--- a/zha/application/platforms/fan/__init__.py
+++ b/zha/application/platforms/fan/__init__.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-import dataclasses
 from dataclasses import dataclass
 import functools
 import math
 from typing import TYPE_CHECKING, Any
 
-from zigpy.types import EUI64
 from zigpy.zcl.clusters import hvac
 
 from zha.application import Platform
@@ -44,7 +42,6 @@ from zha.application.platforms.fan.helpers import (
 from zha.application.registries import PLATFORM_ENTITIES
 from zha.zigbee.cluster_handlers import (
     ClusterAttributeUpdatedEvent,
-    ClusterHandlerInfo,
     wrap_zigpy_exceptions,
 )
 from zha.zigbee.cluster_handlers.const import (
@@ -66,18 +63,6 @@ MULTI_MATCH = functools.partial(PLATFORM_ENTITIES.multipass_match, Platform.FAN)
 @dataclass(frozen=True, kw_only=True)
 class FanEntityInfo(BaseEntityInfo):
     """Fan entity info."""
-
-    # combination of PlatformEntityInfo and GroupEntityInfo
-    unique_id: str
-    platform: str
-    class_name: str
-
-    cluster_handlers: list[ClusterHandlerInfo] | None = dataclasses.field(default=None)
-    device_ieee: EUI64 | None = dataclasses.field(default=None)
-    endpoint_id: int | None = dataclasses.field(default=None)
-    group_id: int | None = dataclasses.field(default=None)
-    name: str | None = dataclasses.field(default=None)
-    available: bool | None = dataclasses.field(default=None)
 
     preset_modes: list[str]
     supported_features: int

--- a/zha/application/platforms/helpers.py
+++ b/zha/application/platforms/helpers.py
@@ -54,7 +54,7 @@ def reduce_attribute(
 @overload
 def validate_device_class(
     device_class_enum: type[BinarySensorDeviceClass],
-    metadata_value,
+    metadata_value: enum.Enum,
     platform: str,
     logger: logging.Logger,
 ) -> BinarySensorDeviceClass | None: ...
@@ -63,7 +63,7 @@ def validate_device_class(
 @overload
 def validate_device_class(
     device_class_enum: type[SensorDeviceClass],
-    metadata_value,
+    metadata_value: enum.Enum,
     platform: str,
     logger: logging.Logger,
 ) -> SensorDeviceClass | None: ...
@@ -72,16 +72,18 @@ def validate_device_class(
 @overload
 def validate_device_class(
     device_class_enum: type[NumberDeviceClass],
-    metadata_value,
+    metadata_value: enum.Enum,
     platform: str,
     logger: logging.Logger,
 ) -> NumberDeviceClass | None: ...
 
 
 def validate_device_class(
-    device_class_enum: type[BinarySensorDeviceClass]
-    | type[SensorDeviceClass]
-    | type[NumberDeviceClass],
+    device_class_enum: (
+        type[BinarySensorDeviceClass]
+        | type[SensorDeviceClass]
+        | type[NumberDeviceClass]
+    ),
     metadata_value: enum.Enum,
     platform: str,
     logger: logging.Logger,

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -16,7 +16,6 @@ import itertools
 import logging
 from typing import TYPE_CHECKING, Any
 
-from zigpy.types import EUI64
 from zigpy.zcl.clusters.general import Identify, LevelControl, OnOff
 from zigpy.zcl.clusters.lighting import Color
 from zigpy.zcl.foundation import Status
@@ -67,7 +66,7 @@ from zha.application.platforms.light.helpers import (
 from zha.application.registries import PLATFORM_ENTITIES
 from zha.debounce import Debouncer
 from zha.decorators import periodic
-from zha.zigbee.cluster_handlers import ClusterAttributeUpdatedEvent, ClusterHandlerInfo
+from zha.zigbee.cluster_handlers import ClusterAttributeUpdatedEvent
 from zha.zigbee.cluster_handlers.const import (
     CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
     CLUSTER_HANDLER_COLOR,
@@ -92,18 +91,6 @@ GROUP_MATCH = functools.partial(PLATFORM_ENTITIES.group_match, Platform.LIGHT)
 @dataclass(frozen=True, kw_only=True)
 class LightEntityInfo(BaseEntityInfo):
     """Light entity info."""
-
-    # combination of PlatformEntityInfo and GroupEntityInfo
-    unique_id: str
-    platform: str
-    class_name: str
-
-    cluster_handlers: list[ClusterHandlerInfo] | None = dataclasses.field(default=None)
-    device_ieee: EUI64 | None = dataclasses.field(default=None)
-    endpoint_id: int | None = dataclasses.field(default=None)
-    group_id: int | None = dataclasses.field(default=None)
-    name: str | None = dataclasses.field(default=None)
-    available: bool | None = dataclasses.field(default=None)
 
     effect_list: list[str] | None = dataclasses.field(default=None)
     supported_features: LightEntityFeature

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -187,7 +187,7 @@ class BaseLight(BaseEntity, ABC):
         return self._color_temp
 
     @property
-    def color_mode(self) -> int | None:
+    def color_mode(self) -> ColorMode | None:
         """Return the color mode."""
         return self._color_mode
 

--- a/zha/application/platforms/light/const.py
+++ b/zha/application/platforms/light/const.py
@@ -103,14 +103,12 @@ SUPPORT_COLOR: Final[int] = 16  # Deprecated, replaced by color modes
 SUPPORT_TRANSITION: Final[int] = 32
 SUPPORT_WHITE_VALUE: Final[int] = 128  # Deprecated, replaced by color modes
 
-EFFECT_BLINK: Final[int] = 0x00
-EFFECT_BREATHE: Final[int] = 0x01
 EFFECT_OKAY: Final[int] = 0x02
 EFFECT_DEFAULT_VARIANT: Final[int] = 0x00
 
 FLASH_EFFECTS: Final[dict[str, int]] = {
-    FLASH_SHORT: EFFECT_BLINK,
-    FLASH_LONG: EFFECT_BREATHE,
+    FLASH_SHORT: Identify.EffectIdentifier.Blink,
+    FLASH_LONG: Identify.EffectIdentifier.Breathe,
 }
 
 SUPPORT_GROUP_LIGHT = (
@@ -121,11 +119,6 @@ SUPPORT_GROUP_LIGHT = (
     | SUPPORT_COLOR
     | SUPPORT_TRANSITION
 )
-
-FLASH_EFFECTS = {
-    FLASH_SHORT: Identify.EffectIdentifier.Blink,
-    FLASH_LONG: Identify.EffectIdentifier.Breathe,
-}
 
 VALID_COLOR_MODES = {
     ColorMode.ONOFF,

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -13,7 +13,7 @@ from zigpy.zcl.clusters.hvac import Thermostat
 
 from zha.application import Platform
 from zha.application.const import ENTITY_METADATA
-from zha.application.platforms import EntityCategory, PlatformEntity, PlatformEntityInfo
+from zha.application.platforms import BaseEntityInfo, EntityCategory, PlatformEntity
 from zha.application.platforms.helpers import validate_device_class
 from zha.application.platforms.number.const import (
     ICONS,
@@ -49,7 +49,7 @@ CONFIG_DIAGNOSTIC_MATCH = functools.partial(
 
 
 @dataclass(frozen=True, kw_only=True)
-class NumberEntityInfo(PlatformEntityInfo):
+class NumberEntityInfo(BaseEntityInfo):
     """Number entity info."""
 
     engineering_units: int
@@ -60,7 +60,7 @@ class NumberEntityInfo(PlatformEntityInfo):
 
 
 @dataclass(frozen=True, kw_only=True)
-class NumberConfigurationEntityInfo(PlatformEntityInfo):
+class NumberConfigurationEntityInfo(BaseEntityInfo):
     """Number configuration entity info."""
 
     min_value: float | None

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -289,7 +289,7 @@ class NumberConfigurationEntity(PlatformEntity):
         return response
 
     @property
-    def native_value(self) -> float:
+    def native_value(self) -> float | None:
         """Return the current value."""
         value = self._cluster_handler.cluster.get(self._attribute_name)
         if value is None:

--- a/zha/application/platforms/select.py
+++ b/zha/application/platforms/select.py
@@ -23,7 +23,7 @@ from zigpy.zcl.clusters.security import IasWd
 
 from zha.application import Platform
 from zha.application.const import ENTITY_METADATA, Strobe
-from zha.application.platforms import EntityCategory, PlatformEntity, PlatformEntityInfo
+from zha.application.platforms import BaseEntityInfo, EntityCategory, PlatformEntity
 from zha.application.registries import PLATFORM_ENTITIES
 from zha.zigbee.cluster_handlers import ClusterAttributeUpdatedEvent
 from zha.zigbee.cluster_handlers.const import (
@@ -49,7 +49,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, kw_only=True)
-class EnumSelectInfo(PlatformEntityInfo):
+class EnumSelectInfo(BaseEntityInfo):
     """Enum select entity info."""
 
     enum: str

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -26,7 +26,6 @@ from zha.application.platforms import (
     BaseIdentifiers,
     EntityCategory,
     PlatformEntity,
-    PlatformEntityInfo,
 )
 from zha.application.platforms.climate.const import HVACAction
 from zha.application.platforms.helpers import validate_device_class
@@ -109,7 +108,7 @@ CONFIG_DIAGNOSTIC_MATCH = functools.partial(
 
 
 @dataclass(frozen=True, kw_only=True)
-class SensorEntityInfo(PlatformEntityInfo):
+class SensorEntityInfo(BaseEntityInfo):
     """Sensor entity info."""
 
     attribute: str
@@ -397,8 +396,6 @@ class DeviceCounterSensor(BaseEntity):
         """Return a representation of the platform entity."""
         return DeviceCounterEntityInfo(
             **super().info_object.__dict__,
-            device_ieee=str(self._device.ieee),
-            available=self.available,
             counter=self._zigpy_counter.name,
             counter_value=self._zigpy_counter.value,
             counter_groups=self._zigpy_counter_groups,

--- a/zha/application/platforms/siren.py
+++ b/zha/application/platforms/siren.py
@@ -25,7 +25,7 @@ from zha.application.const import (
     WARNING_DEVICE_STROBE_NO,
     Strobe,
 )
-from zha.application.platforms import PlatformEntity, PlatformEntityInfo
+from zha.application.platforms import BaseEntityInfo, PlatformEntity
 from zha.application.registries import PLATFORM_ENTITIES
 from zha.zigbee.cluster_handlers.const import CLUSTER_HANDLER_IAS_WD
 from zha.zigbee.cluster_handlers.security import IasWdClusterHandler
@@ -55,7 +55,7 @@ class SirenEntityFeature(IntFlag):
 
 
 @dataclass(frozen=True, kw_only=True)
-class SirenEntityInfo(PlatformEntityInfo):
+class SirenEntityInfo(BaseEntityInfo):
     """Siren entity info."""
 
     available_tones: dict[int, str]

--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -18,10 +18,10 @@ from zha.application import Platform
 from zha.application.const import ENTITY_METADATA
 from zha.application.platforms import (
     BaseEntity,
+    BaseEntityInfo,
     EntityCategory,
     GroupEntity,
     PlatformEntity,
-    PlatformEntityInfo,
 )
 from zha.application.registries import PLATFORM_ENTITIES
 from zha.zigbee.cluster_handlers import ClusterAttributeUpdatedEvent
@@ -51,7 +51,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, kw_only=True)
-class SwitchConfigurationEntityInfo(PlatformEntityInfo):
+class SwitchConfigurationEntityInfo(BaseEntityInfo):
     """Switch configuration entity info."""
 
     attribute_name: str

--- a/zha/application/platforms/update.py
+++ b/zha/application/platforms/update.py
@@ -78,7 +78,7 @@ class UpdateEntityInfo(BaseEntityInfo):
 class FirmwareUpdateEntity(PlatformEntity):
     """Representation of a ZHA firmware update entity."""
 
-    PLATFORM: Final = Platform.UPDATE
+    PLATFORM = Platform.UPDATE
 
     _unique_id_suffix = "firmware_update"
     _attr_entity_category = EntityCategory.CONFIG

--- a/zha/application/platforms/update.py
+++ b/zha/application/platforms/update.py
@@ -13,7 +13,7 @@ from zigpy.zcl.clusters.general import Ota
 from zigpy.zcl.foundation import Status
 
 from zha.application import Platform
-from zha.application.platforms import EntityCategory, PlatformEntity, PlatformEntityInfo
+from zha.application.platforms import BaseEntityInfo, EntityCategory, PlatformEntity
 from zha.application.registries import PLATFORM_ENTITIES
 from zha.decorators import callback
 from zha.exceptions import ZHAException
@@ -66,7 +66,7 @@ ATTR_VERSION: Final = "version"
 
 
 @dataclass(frozen=True, kw_only=True)
-class UpdateEntityInfo(PlatformEntityInfo):
+class UpdateEntityInfo(BaseEntityInfo):
     """Update entity info."""
 
     supported_features: UpdateEntityFeature

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -466,12 +466,12 @@ class Device(LogMixin, EventBase):
         }
 
     @property
-    def sw_version(self) -> str | None:
+    def sw_version(self) -> int | None:
         """Return the software version for this device."""
         return self._sw_build_id
 
     @sw_version.setter
-    def sw_version(self, sw_build_id) -> None:
+    def sw_version(self, sw_build_id: int) -> None:
         """Set the software version for this device."""
         self._sw_build_id = sw_build_id
 

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -60,7 +60,7 @@ from zha.application.const import (
     ZHA_EVENT,
 )
 from zha.application.helpers import convert_to_zcl_values
-from zha.application.platforms import PlatformEntity, PlatformEntityInfo
+from zha.application.platforms import BaseEntityInfo, PlatformEntity
 from zha.event import EventBase
 from zha.exceptions import ZHAException
 from zha.mixins import LogMixin
@@ -183,7 +183,7 @@ class ExtendedDeviceInfo(DeviceInfo):
     """Describes a ZHA device."""
 
     active_coordinator: bool
-    entities: dict[str, PlatformEntityInfo]
+    entities: dict[str, BaseEntityInfo]
     neighbors: list[NeighborInfo]
     routes: list[RouteInfo]
     endpoint_names: list[EndpointNameInfo]

--- a/zha/zigbee/group.py
+++ b/zha/zigbee/group.py
@@ -13,9 +13,9 @@ import zigpy.exceptions
 from zigpy.types.named import EUI64
 
 from zha.application.platforms import (
+    BaseEntityInfo,
     EntityStateChangedEvent,
     PlatformEntity,
-    PlatformEntityInfo,
 )
 from zha.const import STATE_CHANGED
 from zha.mixins import LogMixin
@@ -55,7 +55,7 @@ class GroupMemberInfo:
     ieee: EUI64
     endpoint_id: int
     device_info: ExtendedDeviceInfo
-    entities: dict[str, PlatformEntityInfo]
+    entities: dict[str, BaseEntityInfo]
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -65,7 +65,7 @@ class GroupInfo:
     group_id: int
     name: str
     members: list[GroupMemberInfo]
-    entities: dict[str, PlatformEntityInfo]
+    entities: dict[str, BaseEntityInfo]
 
 
 class GroupMember(LogMixin):


### PR DESCRIPTION
Typing is not actually enabled because we do not expose `py.typed`.

Progress:

- [ ] `arg-type`
- [ ] `assignment`
- [ ] `attr-defined`
- [x] `call-arg`
- [x] `dict-item`
- [x] `index`
- [x] `misc`
- [ ] `no-any-return`
- [ ] `no-untyped-call`
- [ ] `no-untyped-def`
- [x] `override`
- [x] `return-value`
- [ ] `union-attr`
- [x] `var-annotated`
