### PR TITLE
Emit state change events for sensors not tied to an attribute

### DIFF
--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -5,7 +5,7 @@
 import asyncio
 from collections.abc import Awaitable, Callable
 import logging
-from unittest.mock import AsyncMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 import zhaquirks.sinope.thermostat
@@ -39,6 +39,7 @@ from zha.application.platforms.sensor import (
     SinopeHVACAction,
     ThermostatHVACAction,
 )
+from zha.const import STATE_CHANGED
 from zha.exceptions import ZHAException
 from zha.zigbee.device import Device
 
@@ -313,6 +314,10 @@ async def test_climate_hvac_action_running_state(
         device_climate_sinope, platform=Platform.SENSOR, entity_type=SinopeHVACAction
     )
 
+    subscriber = MagicMock()
+    entity.on_event(STATE_CHANGED, subscriber)
+    sensor_entity.on_event(STATE_CHANGED, subscriber)
+
     assert entity.state["hvac_action"] == "off"
     assert sensor_entity.state["state"] == "off"
 
@@ -351,6 +356,9 @@ async def test_climate_hvac_action_running_state(
     )
     assert entity.state["hvac_action"] == "fan"
     assert sensor_entity.state["state"] == "fan"
+
+    # Both entities are updated!
+    assert len(subscriber.mock_calls) == 2 * 6
 
 
 @pytest.mark.looptime

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -253,10 +253,14 @@ class Sensor(PlatformEntity):
         event: ClusterAttributeUpdatedEvent,  # pylint: disable=unused-argument
     ) -> None:
         """Handle attribute updates from the cluster handler."""
-        if event.attribute_name == self._attribute_name or (
-            hasattr(self, "_attr_extra_state_attribute_names")
-            and event.attribute_name
-            in getattr(self, "_attr_extra_state_attribute_names")
+        if (
+            event.attribute_name == self._attribute_name
+            or (
+                hasattr(self, "_attr_extra_state_attribute_names")
+                and event.attribute_name
+                in getattr(self, "_attr_extra_state_attribute_names")
+            )
+            or self._attribute_name is None
         ):
             self.maybe_emit_state_changed_event()
 


### PR DESCRIPTION
Sensors not tied to an attribute (such as the Sinope thermostat HVAC mode) did not emit an update event when their state changed.

This fixes all commented out ZHA unit tests.