### PR TITLE
Add `is_on` property to siren

### DIFF
--- a/zha/application/platforms/siren.py
+++ b/zha/application/platforms/siren.py
@@ -113,8 +113,13 @@ class Siren(PlatformEntity):
     def state(self) -> dict[str, Any]:
         """Get the state of the siren."""
         response = super().state
-        response["state"] = self._attr_is_on
+        response["state"] = self.is_on
         return response
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the entity is on."""
+        return self._attr_is_on
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on siren."""


### PR DESCRIPTION
This adds a `is_on` property to the siren platform to align it with the rest of the on/off platforms we have.
The change will allow us to address this comment: https://github.com/home-assistant/core/pull/120190#discussion_r1667428899

The added property is used in the `state` property, like done by other platforms (and thus covered by tests already).