### PR TITLE
Fix `number` platform not having a consistent API

### DIFF
--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -102,7 +102,7 @@ async def test_number(
 
     assert cluster.read_attributes.call_count == 3
 
-    assert entity.name == "PWM1"
+    assert entity.description == "PWM1"
 
     # test that the state is 15.0
     assert entity.state["state"] == 15.0

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -224,6 +224,7 @@ async def test_level_control_number(
     assert entity._attr_entity_category == EntityCategory.CONFIG
 
     assert entity.icon is None
+    assert entity.description is None
     assert entity.native_unit_of_measurement is None
     assert entity.mode == NumberMode.AUTO
     assert entity.native_min_value == 0

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -142,8 +142,8 @@ class Number(PlatformEntity):
         return self._analog_output_cluster_handler.resolution
 
     @functools.cached_property
-    def name(self) -> str | None:
-        """Return the name of the number entity."""
+    def description(self) -> str | None:
+        """Return the description of the number entity."""
         description = self._analog_output_cluster_handler.description
         if not description:
             return None

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -312,6 +312,12 @@ class NumberConfigurationEntity(PlatformEntity):
         return self._attr_native_step
 
     @functools.cached_property
+    def description(self) -> str | None:
+        """Return the description of the number entity."""
+        # To maintain parity with `Number`
+        return None
+
+    @functools.cached_property
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit the value is expressed in."""
         if hasattr(self, "_attr_native_unit_of_measurement"):


### PR DESCRIPTION
We have two independent platform implementations: one for `Number` and one for `NumberConfigurationEntity`. The latter did not have a `name` attribute. I've renamed it to `description` for clarity and implemented it on both.