### PR TITLE
Expose `supported_features` as a property

### DIFF
--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -205,6 +205,16 @@ async def test_cover(
     )
 
     entity = get_entity(zha_device, platform=Platform.COVER)
+    assert entity.supported_features == (
+        CoverEntityFeature.OPEN
+        | CoverEntityFeature.CLOSE
+        | CoverEntityFeature.SET_POSITION
+        | CoverEntityFeature.STOP
+        | CoverEntityFeature.OPEN_TILT
+        | CoverEntityFeature.CLOSE_TILT
+        | CoverEntityFeature.STOP_TILT
+        | CoverEntityFeature.SET_TILT_POSITION
+    )
 
     # test that the state has changed from unavailable to off
     await send_attributes_report(

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -561,7 +561,7 @@ async def test_shade(
     cluster_level = zigpy_shade_device.endpoints.get(1).level
     entity = get_entity(zha_device, platform=Platform.COVER)
 
-    assert entity._attr_supported_features == (
+    assert entity.supported_features == (
         CoverEntityFeature.OPEN
         | CoverEntityFeature.CLOSE
         | CoverEntityFeature.STOP
@@ -719,7 +719,7 @@ async def test_keen_vent(
     cluster_level = zigpy_keen_vent.endpoints.get(1).level
     entity = get_entity(zha_device, platform=Platform.COVER)
 
-    assert entity._attr_supported_features == (
+    assert entity.supported_features == (
         CoverEntityFeature.OPEN
         | CoverEntityFeature.CLOSE
         | CoverEntityFeature.STOP

--- a/tests/test_siren.py
+++ b/tests/test_siren.py
@@ -15,6 +15,7 @@ from tests.common import get_entity, mock_coro
 from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_TYPE
 from zha.application import Platform
 from zha.application.gateway import Gateway
+from zha.platforms.siren import SirenEntityFeature
 from zha.zigbee.device import Device
 
 
@@ -50,6 +51,13 @@ async def test_siren(
     assert cluster is not None
 
     entity = get_entity(zha_device, platform=Platform.SIREN)
+    assert entity.supported_features == (
+        SirenEntityFeature.TURN_ON
+        | SirenEntityFeature.TURN_OFF
+        | SirenEntityFeature.TONES
+        | SirenEntityFeature.VOLUME_SET
+        | SirenEntityFeature.DURATION
+    )
 
     assert entity.state["state"] is False
 

--- a/tests/test_siren.py
+++ b/tests/test_siren.py
@@ -15,7 +15,7 @@ from tests.common import get_entity, mock_coro
 from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_TYPE
 from zha.application import Platform
 from zha.application.gateway import Gateway
-from zha.platforms.siren import SirenEntityFeature
+from zha.application.platforms.siren import SirenEntityFeature
 from zha.zigbee.device import Device
 
 

--- a/zha/application/platforms/cover/__init__.py
+++ b/zha/application/platforms/cover/__init__.py
@@ -96,6 +96,11 @@ class Cover(PlatformEntity):
         )
 
     @property
+    def supported_features(self) -> CoverEntityFeature:
+        """Return supported features."""
+        return self._attr_supported_features
+
+    @property
     def state(self) -> dict[str, Any]:
         """Get the state of the cover."""
         response = super().state

--- a/zha/application/platforms/cover/__init__.py
+++ b/zha/application/platforms/cover/__init__.py
@@ -423,6 +423,11 @@ class Shade(PlatformEntity):
         return response
 
     @property
+    def supported_features(self) -> CoverEntityFeature:
+        """Return supported features."""
+        return self._attr_supported_features
+
+    @property
     def current_cover_position(self) -> int | None:
         """Return current position of cover.
 

--- a/zha/application/platforms/siren.py
+++ b/zha/application/platforms/siren.py
@@ -117,6 +117,11 @@ class Siren(PlatformEntity):
         return response
 
     @property
+    def supported_features(self) -> SirenEntityFeature:
+        """Return supported features."""
+        return self._attr_supported_features
+
+    @property
     def is_on(self) -> bool:
         """Return true if the entity is on."""
         return self._attr_is_on


### PR DESCRIPTION
Fixes internal attribute access in ZHA:

```diff
diff --git a/homeassistant/components/zha/cover.py b/homeassistant/components/zha/cover.py
index 066cb6524a8..c3e4890fcc1 100644
--- a/homeassistant/components/zha/cover.py
+++ b/homeassistant/components/zha/cover.py
@@ -68,9 +68,8 @@ class ZhaCover(ZHAEntity, CoverEntity):
             )
 
         features = CoverEntityFeature(0)
-        zha_features: ZHACoverEntityFeature = (
-            self.entity_data.entity._attr_supported_features  # noqa: SLF001
-        )
+        zha_features: ZHACoverEntityFeature = self.entity_data.entity.supported_features
+
         if ZHACoverEntityFeature.OPEN in zha_features:
             features |= CoverEntityFeature.OPEN
         if ZHACoverEntityFeature.CLOSE in zha_features:
diff --git a/homeassistant/components/zha/siren.py b/homeassistant/components/zha/siren.py
index bed90ef8f22..9d876d9ca4d 100644
--- a/homeassistant/components/zha/siren.py
+++ b/homeassistant/components/zha/siren.py
@@ -74,9 +74,7 @@ class ZHASiren(ZHAEntity, SirenEntity):
         super().__init__(entity_data, **kwargs)
 
         features: SirenEntityFeature = SirenEntityFeature(0)
-        zha_features: ZHASirenEntityFeature = (
-            self.entity_data.entity._attr_supported_features  # noqa: SLF001
-        )
+        zha_features: ZHASirenEntityFeature = self.entity_data.entity.supported_features
 
         if ZHASirenEntityFeature.TURN_ON in zha_features:
             features |= SirenEntityFeature.TURN_ON
```