### PR TITLE
Do not restore light group external state attributes

### DIFF
--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -798,6 +798,21 @@ async def test_zha_group_light_entity(
     # test that the lights were created and are off
     assert bool(entity.state["on"]) is False
 
+    # Group entities do not support state restoration
+    entity.restore_external_state_attributes(
+        state=True,
+        off_with_transition=False,
+        off_brightness=12,
+        brightness=34,
+        color_temp=500,
+        xy_color=(1, 2),
+        hs_color=(3, 4),
+        color_mode=ColorMode.XY,
+        effect="colorloop",
+    )
+
+    assert bool(entity.state["on"]) is False
+
     # test turning the lights on and off from the client
     await async_test_on_off_from_client(zha_gateway, group_cluster_on_off, entity)
     await _async_shift_time(zha_gateway)

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -1394,3 +1394,19 @@ class LightGroup(GroupEntity, BaseLight):
 
         for platform_entity in self.group.get_platform_entities(Light.PLATFORM):
             platform_entity._assume_group_state(update_params)
+
+    def restore_external_state_attributes(
+        self,
+        *,
+        state: bool | None,
+        off_with_transition: bool | None,
+        off_brightness: int | None,
+        brightness: int | None,
+        color_temp: int | None,
+        xy_color: tuple[float, float] | None,
+        hs_color: tuple[float, float] | None,
+        color_mode: ColorMode | None,
+        effect: str | None,
+    ) -> None:
+        """Restore extra state attributes."""
+        # Groups do not restore external state attributes


### PR DESCRIPTION
Without this, state restoration fails for groups and the entities are not added.