### PR TITLE
Expose functionality shared only by all members of a light group

### DIFF
--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -134,12 +134,10 @@ async def device_light_2(
             1: {
                 SIG_EP_INPUT: [
                     general.OnOff.cluster_id,
-                    general.LevelControl.cluster_id,
-                    lighting.Color.cluster_id,
                     general.Groups.cluster_id,
                 ],
                 SIG_EP_OUTPUT: [],
-                SIG_EP_TYPE: zha.DeviceType.COLOR_DIMMABLE_LIGHT,
+                SIG_EP_TYPE: zha.DeviceType.ON_OFF_LIGHT,
                 SIG_EP_PROFILE: zha.PROFILE_ID,
             }
         },
@@ -197,6 +195,17 @@ async def test_gateway_group_methods(
         assert member.group == zha_group
         assert member.endpoint is not None
 
+    device_1_light_entity = get_entity(device_light_1, platform=Platform.LIGHT)
+    assert (
+        device_1_light_entity.info_object.supported_features
+        == LightEntityFeature.TRANSITION
+    )
+
+    device_2_light_entity = get_entity(device_light_2, platform=Platform.LIGHT)
+    assert device_2_light_entity.info_object.supported_features == LightEntityFeature(0)
+
+    assert device_1_light_entity != device_2_light_entity
+
     entity: GroupEntity | None = get_group_entity(zha_group, platform=Platform.LIGHT)
     assert entity is not None
 
@@ -206,17 +215,10 @@ async def test_gateway_group_methods(
     assert info.unique_id == "light_zha_group_0x0002"
     assert info.fallback_name == "Test Group"
     assert info.group_id == zha_group.group_id
-    assert info.supported_features == LightEntityFeature.TRANSITION
+    assert info.supported_features == LightEntityFeature(0)
     assert info.min_mireds == 153
     assert info.max_mireds == 500
     assert info.effect_list is None
-
-    device_1_light_entity = get_entity(device_light_1, platform=Platform.LIGHT)
-    device_2_light_entity = get_entity(device_light_2, platform=Platform.LIGHT)
-    assert device_1_light_entity != device_2_light_entity
-
-    assert device_1_light_entity is not None
-    assert device_2_light_entity is not None
 
     # test get group by name
     assert zha_group == zha_gateway.get_group(zha_group.name)

--- a/zha/application/platforms/helpers.py
+++ b/zha/application/platforms/helpers.py
@@ -2,53 +2,14 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator
 import enum
 import logging
-from typing import TYPE_CHECKING, Any, overload
+from typing import TYPE_CHECKING, overload
 
 if TYPE_CHECKING:
     from zha.application.platforms.binary_sensor.const import BinarySensorDeviceClass
     from zha.application.platforms.number.const import NumberDeviceClass
     from zha.application.platforms.sensor.const import SensorDeviceClass
-
-
-def find_state_attributes(states: list[dict], key: str) -> Iterator[Any]:
-    """Find attributes with matching key from states."""
-    for state in states:
-        if (value := state.get(key)) is not None:
-            yield value
-
-
-def mean_int(*args: Any) -> int:
-    """Return the mean of the supplied values."""
-    return int(sum(args) / len(args))
-
-
-def mean_tuple(*args: Any) -> tuple:
-    """Return the mean values along the columns of the supplied values."""
-    return tuple(sum(x) / len(x) for x in zip(*args))
-
-
-def reduce_attribute(
-    states: list[dict],
-    key: str,
-    default: Any | None = None,
-    reduce: Callable[..., Any] = mean_int,
-) -> Any:
-    """Find the first attribute matching key from states.
-
-    If none are found, return default.
-    """
-    attrs = list(find_state_attributes(states, key))
-
-    if not attrs:
-        return default
-
-    if len(attrs) == 1:
-        return attrs[0]
-
-    return reduce(*attrs)
 
 
 @overload

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -28,11 +28,6 @@ from zha.application.platforms import (
     GroupEntity,
     PlatformEntity,
 )
-from zha.application.platforms.helpers import (
-    find_state_attributes,
-    mean_tuple,
-    reduce_attribute,
-)
 from zha.application.platforms.light.const import (
     ASSUME_UPDATE_GROUP_FROM_CHILD_DELAY,
     ATTR_BRIGHTNESS,
@@ -63,6 +58,9 @@ from zha.application.platforms.light.const import (
 from zha.application.platforms.light.helpers import (
     brightness_supported,
     filter_supported_color_modes,
+    find_state_attributes,
+    mean_tuple,
+    reduce_attribute,
 )
 from zha.application.registries import PLATFORM_ENTITIES
 from zha.debounce import Debouncer

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -1343,9 +1343,8 @@ class LightGroup(GroupEntity, BaseLight):
 
         self._supported_features = LightEntityFeature(0)
         for support in find_state_attributes(states, ATTR_SUPPORTED_FEATURES):
-            # Merge supported features by emulating support for every feature
-            # we find.
-            self._supported_features |= support
+            # Support only the intersection of all supported features
+            self._supported_features &= support
         self.maybe_emit_state_changed_event()
 
     async def _force_member_updates(self) -> None:

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -51,7 +51,6 @@ from zha.application.platforms.light.const import (
     DEFAULT_ON_OFF_TRANSITION,
     EFFECT_COLORLOOP,
     FLASH_EFFECTS,
-    SUPPORT_GROUP_LIGHT,
     ColorMode,
     LightEntityFeature,
 )
@@ -1347,9 +1346,6 @@ class LightGroup(GroupEntity, BaseLight):
             # Merge supported features by emulating support for every feature
             # we find.
             self._supported_features |= support
-        # Bitwise-and the supported features with the GroupedLight's features
-        # so that we don't break in the future when a new feature is added.
-        self._supported_features &= SUPPORT_GROUP_LIGHT
         self.maybe_emit_state_changed_event()
 
     async def _force_member_updates(self) -> None:

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 import functools
 import itertools
 import logging
+import operator
 from typing import TYPE_CHECKING, Any
 
 from zigpy.types import EUI64
@@ -1341,10 +1342,11 @@ class LightGroup(GroupEntity, BaseLight):
             ):  # switch to XY if all members do not support HS
                 self._color_mode = ColorMode.XY
 
-        self._supported_features = LightEntityFeature(0)
-        for support in find_state_attributes(states, ATTR_SUPPORTED_FEATURES):
-            # Support only the intersection of all supported features
-            self._supported_features &= support
+        # Support the intersection of all supported features
+        self._supported_features = functools.reduce(
+            operator.and_,
+            find_state_attributes(states, ATTR_SUPPORTED_FEATURES),
+        )
         self.maybe_emit_state_changed_event()
 
     async def _force_member_updates(self) -> None:

--- a/zha/application/platforms/light/const.py
+++ b/zha/application/platforms/light/const.py
@@ -44,11 +44,6 @@ class ColorMode(StrEnum):
     """Must *NOT* be the only supported mode"""
 
 
-COLOR_MODES_GROUP_LIGHT = {ColorMode.COLOR_TEMP, ColorMode.XY}
-SUPPORT_GROUP_LIGHT = (
-    LightEntityFeature.EFFECT | LightEntityFeature.FLASH | LightEntityFeature.TRANSITION
-)
-
 # Float that represents transition time in seconds to make change.
 ATTR_TRANSITION: Final[str] = "transition"
 
@@ -93,34 +88,6 @@ EFFECT_RANDOM: Final[str] = "random"
 EFFECT_WHITE: Final[str] = "white"
 
 ATTR_SUPPORTED_FEATURES: Final[str] = "supported_features"
-
-# Bitfield of features supported by the light entity
-SUPPORT_BRIGHTNESS: Final[int] = 1  # Deprecated, replaced by color modes
-SUPPORT_COLOR_TEMP: Final[int] = 2  # Deprecated, replaced by color modes
-SUPPORT_EFFECT: Final[int] = 4
-SUPPORT_FLASH: Final[int] = 8
-SUPPORT_COLOR: Final[int] = 16  # Deprecated, replaced by color modes
-SUPPORT_TRANSITION: Final[int] = 32
-SUPPORT_WHITE_VALUE: Final[int] = 128  # Deprecated, replaced by color modes
-
-EFFECT_BLINK: Final[int] = 0x00
-EFFECT_BREATHE: Final[int] = 0x01
-EFFECT_OKAY: Final[int] = 0x02
-EFFECT_DEFAULT_VARIANT: Final[int] = 0x00
-
-FLASH_EFFECTS: Final[dict[str, int]] = {
-    FLASH_SHORT: EFFECT_BLINK,
-    FLASH_LONG: EFFECT_BREATHE,
-}
-
-SUPPORT_GROUP_LIGHT = (
-    SUPPORT_BRIGHTNESS
-    | SUPPORT_COLOR_TEMP
-    | SUPPORT_EFFECT
-    | SUPPORT_FLASH
-    | SUPPORT_COLOR
-    | SUPPORT_TRANSITION
-)
 
 FLASH_EFFECTS = {
     FLASH_SHORT: Identify.EffectIdentifier.Blink,

--- a/zha/application/platforms/light/helpers.py
+++ b/zha/application/platforms/light/helpers.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable, Iterator
+from typing import Any
 
 from zha.application.platforms.light.const import COLOR_MODES_BRIGHTNESS, ColorMode
 from zha.exceptions import ZHAException
@@ -26,3 +27,41 @@ def brightness_supported(color_modes: Iterable[ColorMode | str] | None) -> bool:
     if not color_modes:
         return False
     return not COLOR_MODES_BRIGHTNESS.isdisjoint(color_modes)
+
+
+def find_state_attributes(states: list[dict], key: str) -> Iterator[Any]:
+    """Find attributes with matching key from states."""
+    for state in states:
+        if (value := state.get(key)) is not None:
+            yield value
+
+
+def mean_int(*args: Any) -> int:
+    """Return the mean of the supplied values."""
+    return int(sum(args) / len(args))
+
+
+def mean_tuple(*args: Any) -> tuple:
+    """Return the mean values along the columns of the supplied values."""
+    return tuple(sum(x) / len(x) for x in zip(*args))
+
+
+def reduce_attribute(
+    states: list[dict],
+    key: str,
+    default: Any | None = None,
+    reduce: Callable[..., Any] = mean_int,
+) -> Any:
+    """Find the first attribute matching key from states.
+
+    If none are found, return default.
+    """
+    attrs = list(find_state_attributes(states, key))
+
+    if not attrs:
+        return default
+
+    if len(attrs) == 1:
+        return attrs[0]
+
+    return reduce(*attrs)


### PR DESCRIPTION
The main change is intersecting the features instead of unioning them: a light group should expose only the common functionality.