### PR TITLE
Debounce group entity update when member state changes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -295,7 +295,7 @@ def zha_data() -> ZHAData:
             ),
             light_options=LightOptions(
                 enable_enhanced_light_transition=True,
-                group_members_assume_state=False,
+                group_members_assume_state=True,
             ),
             alarm_control_panel_options=AlarmControlPanelOptions(
                 arm_requires_code=False,

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -519,7 +519,7 @@ async def async_test_on_off_from_light(
     # group member updates are debounced
     if isinstance(entity, GroupEntity):
         assert bool(entity.state["on"]) is False
-        await asyncio.sleep(1)
+        await asyncio.sleep(0.1)
         await zha_gateway.async_block_till_done()
 
     assert bool(entity.state["on"]) is True
@@ -531,7 +531,7 @@ async def async_test_on_off_from_light(
     # group member updates are debounced
     if isinstance(entity, GroupEntity):
         assert bool(entity.state["on"]) is True
-        await asyncio.sleep(1)
+        await asyncio.sleep(0.1)
         await zha_gateway.async_block_till_done()
 
     assert bool(entity.state["on"]) is False
@@ -552,7 +552,7 @@ async def async_test_on_from_light(
     # group member updates are debounced
     if isinstance(entity, GroupEntity):
         assert bool(entity.state["on"]) is False
-        await asyncio.sleep(1)
+        await asyncio.sleep(0.1)
         await zha_gateway.async_block_till_done()
 
     assert bool(entity.state["on"]) is True
@@ -718,7 +718,7 @@ async def async_test_dimmer_from_light(
     else:
         # group member updates are debounced
         if isinstance(entity, GroupEntity):
-            await asyncio.sleep(1)
+            await asyncio.sleep(0.1)
             await zha_gateway.async_block_till_done()
         assert entity.state["brightness"] == level
 
@@ -901,7 +901,7 @@ async def test_zha_group_light_entity(
 
     # group member updates are debounced
     assert bool(entity.state["on"]) is True
-    await asyncio.sleep(1)
+    await asyncio.sleep(0.1)
     await zha_gateway.async_block_till_done()
     assert bool(entity.state["on"]) is False
 
@@ -913,7 +913,7 @@ async def test_zha_group_light_entity(
     assert device_2_light_entity.state["on"] is False
     # group member updates are debounced
     assert bool(entity.state["on"]) is False
-    await asyncio.sleep(1)
+    await asyncio.sleep(0.1)
     await zha_gateway.async_block_till_done()
     assert bool(entity.state["on"]) is True
 
@@ -924,7 +924,7 @@ async def test_zha_group_light_entity(
     assert device_2_light_entity.state["on"] is False
     # group member updates are debounced
     assert bool(entity.state["on"]) is True
-    await asyncio.sleep(1)
+    await asyncio.sleep(0.1)
     await zha_gateway.async_block_till_done()
     assert bool(entity.state["on"]) is False
 
@@ -945,7 +945,7 @@ async def test_zha_group_light_entity(
     assert device_3_light_entity.state["on"] is True
     # group member updates are debounced
     assert bool(entity.state["on"]) is False
-    await asyncio.sleep(1)
+    await asyncio.sleep(0.1)
     await zha_gateway.async_block_till_done()
     assert bool(entity.state["on"]) is True
 
@@ -985,7 +985,7 @@ async def test_zha_group_light_entity(
     await zha_gateway.async_block_till_done()
     # group member updates are debounced
     assert bool(entity.state["on"]) is True
-    await asyncio.sleep(1)
+    await asyncio.sleep(0.1)
     await zha_gateway.async_block_till_done()
     assert bool(entity.state["on"]) is False
 
@@ -1004,7 +1004,7 @@ async def test_zha_group_light_entity(
     await zha_gateway.async_block_till_done()
     # group member updates are debounced
     assert bool(entity.state["on"]) is False
-    await asyncio.sleep(1)
+    await asyncio.sleep(0.1)
     await zha_gateway.async_block_till_done()
     assert bool(entity.state["on"]) is True
 

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -16,6 +16,8 @@ from zigpy.types.named import EUI64
 
 from zha.application import Platform
 from zha.const import STATE_CHANGED
+from zha.debounce import Debouncer
+from zha.decorators import callback
 from zha.event import EventBase
 from zha.mixins import LogMixin
 from zha.zigbee.cluster_handlers import ClusterHandlerInfo
@@ -409,6 +411,13 @@ class GroupEntity(BaseEntity):
         super().__init__(unique_id=f"{self.PLATFORM}_zha_group_0x{group.group_id:04x}")
         self._attr_fallback_name: str = group.name
         self._group: Group = group
+        self._change_listener_debouncer = Debouncer(
+            group.gateway,
+            _LOGGER,
+            cooldown=0.5,
+            immediate=False,
+            function=self.update,
+        )
         self._group.register_group_entity(self)
 
     @cached_property
@@ -437,6 +446,19 @@ class GroupEntity(BaseEntity):
     def group(self) -> Group:
         """Return the group."""
         return self._group
+
+    @callback
+    def debounced_update(self, _: Any | None = None) -> None:
+        """Debounce updating group entity from member entity updates."""
+        # Delay to ensure that we get updates from all members before updating the group entity
+        assert self._change_listener_debouncer
+        self.group.gateway.create_task(self._change_listener_debouncer.async_call())
+
+    async def on_remove(self) -> None:
+        """Cancel tasks this entity owns."""
+        await super().on_remove()
+        if self._change_listener_debouncer:
+            self._change_listener_debouncer.async_cancel()
 
     @abstractmethod
     def update(self, _: Any | None = None) -> None:

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -406,7 +406,9 @@ class PlatformEntity(BaseEntity):
 class GroupEntity(BaseEntity):
     """A base class for group entities."""
 
-    def __init__(self, group: Group) -> None:
+    def __init__(
+        self, group: Group, update_group_from_member_delay: float = 0.5
+    ) -> None:
         """Initialize a group."""
         super().__init__(unique_id=f"{self.PLATFORM}_zha_group_0x{group.group_id:04x}")
         self._attr_fallback_name: str = group.name
@@ -414,7 +416,7 @@ class GroupEntity(BaseEntity):
         self._change_listener_debouncer = Debouncer(
             group.gateway,
             _LOGGER,
-            cooldown=0.5,
+            cooldown=update_group_from_member_delay,
             immediate=False,
             function=self.update,
         )

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -31,6 +31,8 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+DEFAULT_UPDATE_GROUP_FROM_CHILD_DELAY: float = 0.5
+
 
 class EntityCategory(StrEnum):
     """Category of an entity."""
@@ -407,7 +409,9 @@ class GroupEntity(BaseEntity):
     """A base class for group entities."""
 
     def __init__(
-        self, group: Group, update_group_from_member_delay: float = 0.5
+        self,
+        group: Group,
+        update_group_from_member_delay: float = DEFAULT_UPDATE_GROUP_FROM_CHILD_DELAY,
     ) -> None:
         """Initialize a group."""
         super().__init__(unique_id=f"{self.PLATFORM}_zha_group_0x{group.group_id:04x}")

--- a/zha/application/platforms/fan/__init__.py
+++ b/zha/application/platforms/fan/__init__.py
@@ -40,6 +40,7 @@ from zha.application.platforms.fan.helpers import (
     ranged_value_to_percentage,
 )
 from zha.application.registries import PLATFORM_ENTITIES
+from zha.decorators import callback
 from zha.zigbee.cluster_handlers import (
     ClusterAttributeUpdatedEvent,
     wrap_zigpy_exceptions,
@@ -345,6 +346,7 @@ class FanGroup(GroupEntity, BaseFan):
 
         self.maybe_emit_state_changed_event()
 
+    @callback
     def update(self, _: Any = None) -> None:
         """Attempt to retrieve on off state from the fan."""
         self.debug("Updating fan group entity state")

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -1141,16 +1141,14 @@ class LightGroup(GroupEntity, BaseLight):
         self._zha_config_group_members_assume_state = (
             light_options.group_members_assume_state
         )
+        kwargs = {}
         if self._zha_config_group_members_assume_state:
-            update_group_from_member_delay = ASSUME_UPDATE_GROUP_FROM_CHILD_DELAY
-        else:
-            update_group_from_member_delay = 0.5
-
+            kwargs["update_group_from_member_delay"] = (
+                ASSUME_UPDATE_GROUP_FROM_CHILD_DELAY
+            )
         self._zha_config_enhanced_light_transition = False
 
-        super().__init__(
-            group, update_group_from_member_delay=update_group_from_member_delay
-        )
+        super().__init__(group, **kwargs)
         self._GROUP_SUPPORTS_EXECUTE_IF_OFF: bool = True
 
         for member in group.members:

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -65,7 +65,7 @@ from zha.application.platforms.light.helpers import (
 )
 from zha.application.registries import PLATFORM_ENTITIES
 from zha.debounce import Debouncer
-from zha.decorators import periodic
+from zha.decorators import callback, periodic
 from zha.zigbee.cluster_handlers import ClusterAttributeUpdatedEvent
 from zha.zigbee.cluster_handlers.const import (
     CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
@@ -1246,6 +1246,7 @@ class LightGroup(GroupEntity, BaseLight):
         if self._debounced_member_refresh:
             await self._debounced_member_refresh.async_call()
 
+    @callback
     def update(self, _: Any = None) -> None:
         """Query all members and determine the light group state."""
         self.debug("Updating light group entity state")

--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -24,6 +24,7 @@ from zha.application.platforms import (
     PlatformEntity,
 )
 from zha.application.registries import PLATFORM_ENTITIES
+from zha.decorators import callback
 from zha.zigbee.cluster_handlers import ClusterAttributeUpdatedEvent
 from zha.zigbee.cluster_handlers.const import (
     CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
@@ -168,6 +169,7 @@ class SwitchGroup(GroupEntity, BaseSwitch):
         self._state = False
         self.maybe_emit_state_changed_event()
 
+    @callback
     def update(self, _: Any | None = None) -> None:
         """Query all members and determine the light group state."""
         self.debug("Updating switch group entity state")

--- a/zha/zigbee/group.py
+++ b/zha/zigbee/group.py
@@ -277,7 +277,7 @@ class Group(LogMixin):
                     self._entity_unsubs[platform_entity.unique_id] = (
                         platform_entity.on_event(
                             STATE_CHANGED,
-                            group_entity.update,
+                            group_entity.debounced_update,
                         )
                     )
         all_ids = group_entity_ids + processed_platform_entity_ids


### PR DESCRIPTION
This pull request primarily focuses on implementing debouncing for group member updates. Debouncing is used to ensure that updates are not processed immediately but are delayed to accumulate all updates from members before updating the group entity. 

Here are the most significant changes:

Debouncing implementation:
* [`zha/application/platforms/__init__.py`](diffhunk://#diff-c4edc2553efc413d939914b63e742dda91ce6170c26eaed97094f6adc5551fafR414-R420): Introduced a `Debouncer` for group member updates and created a `debounced_update` method to delay updates from member entities. Also, added a cleanup step in the `on_remove` method to cancel any tasks owned by the entity. [[1]](diffhunk://#diff-c4edc2553efc413d939914b63e742dda91ce6170c26eaed97094f6adc5551fafR414-R420) [[2]](diffhunk://#diff-c4edc2553efc413d939914b63e742dda91ce6170c26eaed97094f6adc5551fafR450-R462)
* [`zha/zigbee/group.py`](diffhunk://#diff-d5423fa7077d6d919af44e8b9c876daca8b6ad8ad4e665a424187537a068b61bL280-R280): Updated the `update_entity_subscriptions` method to use the `debounced_update` method instead of the `update` method.

Test file updates:
* [`tests/test_fan.py`](diffhunk://#diff-056dbf9cf7f7b95c2fee5d6278d51bf4c46fe329606df872b433ad436e1df882R5): Imported `asyncio` and added a delay after member updates to account for debouncing. Also added a `pytest.mark.looptime` decorator to the `test_zha_group_fan_entity` method. [[1]](diffhunk://#diff-056dbf9cf7f7b95c2fee5d6278d51bf4c46fe329606df872b433ad436e1df882R5) [[2]](diffhunk://#diff-056dbf9cf7f7b95c2fee5d6278d51bf4c46fe329606df872b433ad436e1df882R259) [[3]](diffhunk://#diff-056dbf9cf7f7b95c2fee5d6278d51bf4c46fe329606df872b433ad436e1df882L341-R361)
* `tests/test_light.py`, `tests/test_switch.py`: Similar changes were made as in `test_fan.py`, adding delays after member updates and importing `asyncio`. [[1]](diffhunk://#diff-ad7c24ffe99d48361fc1258e8558ca561503bb4e76e913c6cd1aaeeb8a87582cR518-R536) [[2]](diffhunk://#diff-76626654c1bd499421e4d9ef3c15f7a650cbf2ea5adfb74f35f5db687bea115bR3) [[3]](diffhunk://#diff-76626654c1bd499421e4d9ef3c15f7a650cbf2ea5adfb74f35f5db687bea115bR239)
* Multiple changes were made in the `tests/test_light.py` file to add delays after member updates in various test methods. [[1]](diffhunk://#diff-ad7c24ffe99d48361fc1258e8558ca561503bb4e76e913c6cd1aaeeb8a87582cR551-R557) [[2]](diffhunk://#diff-ad7c24ffe99d48361fc1258e8558ca561503bb4e76e913c6cd1aaeeb8a87582cR719-R722) [[3]](diffhunk://#diff-ad7c24ffe99d48361fc1258e8558ca561503bb4e76e913c6cd1aaeeb8a87582cR901-R905) [[4]](diffhunk://#diff-ad7c24ffe99d48361fc1258e8558ca561503bb4e76e913c6cd1aaeeb8a87582cR914-R928) [[5]](diffhunk://#diff-ad7c24ffe99d48361fc1258e8558ca561503bb4e76e913c6cd1aaeeb8a87582cR946-R949) [[6]](diffhunk://#diff-ad7c24ffe99d48361fc1258e8558ca561503bb4e76e913c6cd1aaeeb8a87582cR986-R989) [[7]](diffhunk://#diff-ad7c24ffe99d48361fc1258e8558ca561503bb4e76e913c6cd1aaeeb8a87582cR1005-R1008)
* Similar changes were made in the `tests/test_switch.py` file to add delays after member updates in the `test_zha_group_switch_entity` method. [[1]](diffhunk://#diff-76626654c1bd499421e4d9ef3c15f7a650cbf2ea5adfb74f35f5db687bea115bR317-R321) [[2]](diffhunk://#diff-76626654c1bd499421e4d9ef3c15f7a650cbf2ea5adfb74f35f5db687bea115bR334-R349)