### PR TITLE
Drop `@callback` and other unused async helpers

### DIFF
--- a/tests/test_async_.py
+++ b/tests/test_async_.py
@@ -343,36 +343,6 @@ async def test_async_create_task_pending_tasks_coro(zha_gateway: Gateway) -> Non
     assert len(zha_gateway._tracked_completable_tasks) == 0
 
 
-async def test_async_run_job_starts_tasks_eagerly(zha_gateway: Gateway) -> None:
-    """Test async_run_job starts tasks eagerly."""
-    runs = []
-
-    async def _test():
-        runs.append(True)
-
-    task = zha_gateway.async_run_job(_test)
-    assert task is not None
-    # No call to zha_gateway.async_block_till_done to ensure the task is run eagerly
-    assert len(runs) == 1
-    assert task.done()
-    await task
-
-
-async def test_async_run_job_starts_coro_eagerly(zha_gateway: Gateway) -> None:
-    """Test async_run_job starts coros eagerly."""
-    runs = []
-
-    async def _test():
-        runs.append(True)
-
-    task = zha_gateway.async_run_job(_test())
-    assert task is not None
-    # No call to zha_gateway.async_block_till_done to ensure the task is run eagerly
-    assert len(runs) == 1
-    assert task.done()
-    await task
-
-
 @pytest.mark.parametrize("eager_start", [True, False])
 async def test_background_task(zha_gateway: Gateway, eager_start: bool) -> None:
     """Test background tasks being quit."""

--- a/tests/test_async_.py
+++ b/tests/test_async_.py
@@ -3,7 +3,7 @@
 import asyncio
 import functools
 import time
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -425,31 +425,6 @@ async def test_async_add_executor_job(zha_gateway: Gateway) -> None:
     await task
 
 
-@patch("concurrent.futures.Future")
-@patch("threading.get_ident")
-def test_run_callback_threadsafe_from_inside_event_loop(mock_ident, _) -> None:
-    """Testing calling run_callback_threadsafe from inside an event loop."""
-    callback_fn = MagicMock()
-
-    loop = Mock(spec=["call_soon_threadsafe"])
-
-    loop._thread_ident = None
-    mock_ident.return_value = 5
-    zha_async.run_callback_threadsafe(loop, callback_fn)
-    assert len(loop.call_soon_threadsafe.mock_calls) == 1
-
-    loop._thread_ident = 5
-    mock_ident.return_value = 5
-    with pytest.raises(RuntimeError):
-        zha_async.run_callback_threadsafe(loop, callback_fn)
-    assert len(loop.call_soon_threadsafe.mock_calls) == 1
-
-    loop._thread_ident = 1
-    mock_ident.return_value = 5
-    zha_async.run_callback_threadsafe(loop, callback_fn)
-    assert len(loop.call_soon_threadsafe.mock_calls) == 2
-
-
 async def test_gather_with_limited_concurrency() -> None:
     """Test gather_with_limited_concurrency limits the number of running tasks."""
 
@@ -470,74 +445,6 @@ async def test_gather_with_limited_concurrency() -> None:
     )
 
     assert results == [2, 2, -1, -1]
-
-
-async def test_shutdown_run_callback_threadsafe(zha_gateway: Gateway) -> None:
-    """Test we can shutdown run_callback_threadsafe."""
-    zha_async.shutdown_run_callback_threadsafe(zha_gateway.loop)
-    callback_fn = MagicMock()
-
-    with pytest.raises(RuntimeError):
-        zha_async.run_callback_threadsafe(zha_gateway.loop, callback_fn)
-
-
-async def test_run_callback_threadsafe(zha_gateway: Gateway) -> None:
-    """Test run_callback_threadsafe runs code in the event loop."""
-    it_ran = False
-
-    def callback_fn():
-        nonlocal it_ran
-        it_ran = True
-
-    assert zha_async.run_callback_threadsafe(zha_gateway.loop, callback_fn)
-    assert it_ran is False
-
-    # Verify that async_block_till_done will flush
-    # out the callback
-    await zha_gateway.async_block_till_done()
-    assert it_ran is True
-
-
-async def test_run_callback_threadsafe_exception(zha_gateway: Gateway) -> None:
-    """Test run_callback_threadsafe runs code in the event loop."""
-    it_ran = False
-
-    def callback_fn():
-        nonlocal it_ran
-        it_ran = True
-        raise ValueError("Test")
-
-    future = zha_async.run_callback_threadsafe(zha_gateway.loop, callback_fn)
-    assert future
-    assert it_ran is False
-
-    # Verify that async_block_till_done will flush
-    # out the callback
-    await zha_gateway.async_block_till_done()
-    assert it_ran is True
-
-    with pytest.raises(ValueError):
-        future.result()
-
-
-async def test_callback_is_always_scheduled(zha_gateway: Gateway) -> None:
-    """Test run_callback_threadsafe always calls call_soon_threadsafe before checking for shutdown."""
-    # We have to check the shutdown state AFTER the callback is scheduled otherwise
-    # the function could continue on and the caller call `future.result()` after
-    # the point in the main thread where callbacks are no longer run.
-
-    callback_fn = MagicMock()
-    zha_async.shutdown_run_callback_threadsafe(zha_gateway.loop)
-
-    with (
-        patch.object(
-            zha_gateway.loop, "call_soon_threadsafe"
-        ) as mock_call_soon_threadsafe,
-        pytest.raises(RuntimeError),
-    ):
-        zha_async.run_callback_threadsafe(zha_gateway.loop, callback_fn)
-
-    mock_call_soon_threadsafe.assert_called_once()
 
 
 async def test_create_eager_task_312(zha_gateway: Gateway) -> None:  # pylint: disable=unused-argument

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -8,7 +8,6 @@ import pytest
 
 from zha.application.gateway import Gateway
 from zha.debounce import Debouncer
-from zha.decorators import callback
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -135,7 +134,7 @@ async def test_immediate_works_with_callback_function(zha_gateway: Gateway) -> N
         _LOGGER,
         cooldown=0.01,
         immediate=True,
-        function=callback(Mock(side_effect=lambda: calls.append(None))),
+        function=Mock(side_effect=lambda: calls.append(None)),
     )
 
     # Call when nothing happening
@@ -176,7 +175,6 @@ async def test_immediate_works_with_passed_callback_function_raises(
     """Test immediate works with a callback function that raises."""
     calls: list[None] = []
 
-    @callback
     def _append_and_raise() -> None:
         calls.append(None)
         raise RuntimeError("forced_raise")

--- a/zha/application/helpers.py
+++ b/zha/application/helpers.py
@@ -29,7 +29,7 @@ from zha.application.const import (
     CONF_DEFAULT_CONSIDER_UNAVAILABLE_MAINS,
 )
 from zha.async_ import gather_with_limited_concurrency
-from zha.decorators import SetRegistry, callback, periodic
+from zha.decorators import SetRegistry, periodic
 
 # from zha.zigbee.cluster_handlers.registries import BINDABLE_CLUSTERS
 BINDABLE_CLUSTERS = SetRegistry()
@@ -394,7 +394,6 @@ class GlobalUpdater:
         """Remove an update listener."""
         self._update_listeners.remove(listener)
 
-    @callback
     @periodic(_REFRESH_INTERVAL)
     async def update_listeners(self):
         """Update all listeners."""

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -17,7 +17,6 @@ from zigpy.types.named import EUI64
 from zha.application import Platform
 from zha.const import STATE_CHANGED
 from zha.debounce import Debouncer
-from zha.decorators import callback
 from zha.event import EventBase
 from zha.mixins import LogMixin
 from zha.zigbee.cluster_handlers import ClusterHandlerInfo
@@ -453,7 +452,6 @@ class GroupEntity(BaseEntity):
         """Return the group."""
         return self._group
 
-    @callback
     def debounced_update(self, _: Any | None = None) -> None:
         """Debounce updating group entity from member entity updates."""
         # Delay to ensure that we get updates from all members before updating the group entity

--- a/zha/application/platforms/fan/__init__.py
+++ b/zha/application/platforms/fan/__init__.py
@@ -40,7 +40,6 @@ from zha.application.platforms.fan.helpers import (
     ranged_value_to_percentage,
 )
 from zha.application.registries import PLATFORM_ENTITIES
-from zha.decorators import callback
 from zha.zigbee.cluster_handlers import (
     ClusterAttributeUpdatedEvent,
     wrap_zigpy_exceptions,
@@ -346,7 +345,6 @@ class FanGroup(GroupEntity, BaseFan):
 
         self.maybe_emit_state_changed_event()
 
-    @callback
     def update(self, _: Any = None) -> None:
         """Attempt to retrieve on off state from the fan."""
         self.debug("Updating fan group entity state")

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -65,7 +65,7 @@ from zha.application.platforms.light.helpers import (
 )
 from zha.application.registries import PLATFORM_ENTITIES
 from zha.debounce import Debouncer
-from zha.decorators import callback, periodic
+from zha.decorators import periodic
 from zha.zigbee.cluster_handlers import ClusterAttributeUpdatedEvent
 from zha.zigbee.cluster_handlers.const import (
     CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
@@ -1246,7 +1246,6 @@ class LightGroup(GroupEntity, BaseLight):
         if self._debounced_member_refresh:
             await self._debounced_member_refresh.async_call()
 
-    @callback
     def update(self, _: Any = None) -> None:
         """Query all members and determine the light group state."""
         self.debug("Updating light group entity state")

--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -24,7 +24,6 @@ from zha.application.platforms import (
     PlatformEntity,
 )
 from zha.application.registries import PLATFORM_ENTITIES
-from zha.decorators import callback
 from zha.zigbee.cluster_handlers import ClusterAttributeUpdatedEvent
 from zha.zigbee.cluster_handlers.const import (
     CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
@@ -169,7 +168,6 @@ class SwitchGroup(GroupEntity, BaseSwitch):
         self._state = False
         self.maybe_emit_state_changed_event()
 
-    @callback
     def update(self, _: Any | None = None) -> None:
         """Query all members and determine the light group state."""
         self.debug("Updating switch group entity state")

--- a/zha/application/platforms/update.py
+++ b/zha/application/platforms/update.py
@@ -15,7 +15,6 @@ from zigpy.zcl.foundation import Status
 from zha.application import Platform
 from zha.application.platforms import BaseEntityInfo, EntityCategory, PlatformEntity
 from zha.application.registries import PLATFORM_ENTITIES
-from zha.decorators import callback
 from zha.exceptions import ZHAException
 from zha.zigbee.cluster_handlers import ClusterAttributeUpdatedEvent
 from zha.zigbee.cluster_handlers.const import (
@@ -232,7 +231,6 @@ class FirmwareUpdateEntity(PlatformEntity):
             self._attr_installed_version = f"0x{event.attribute_value:08x}"
             self.maybe_emit_state_changed_event()
 
-    @callback
     def device_ota_update_available(
         self, image: OtaImageWithMetadata, current_file_version: int
     ) -> None:

--- a/zha/async_.py
+++ b/zha/async_.py
@@ -5,14 +5,12 @@ from __future__ import annotations
 import asyncio
 from asyncio import AbstractEventLoop, Future, Semaphore, Task, gather, get_running_loop
 from collections.abc import Awaitable, Callable, Collection, Coroutine, Iterable
-import concurrent.futures
 import contextlib
 from dataclasses import dataclass
 import enum
 import functools
 from functools import cached_property
 import logging
-import threading
 import time
 from typing import (
     TYPE_CHECKING,
@@ -33,8 +31,6 @@ _R_co = TypeVar("_R_co", covariant=True)
 _P = ParamSpec("_P")
 _Ts = TypeVarTuple("_Ts")
 BLOCK_LOG_TIMEOUT: Final[int] = 60
-
-_SHUTDOWN_RUN_CALLBACK_THREADSAFE = "_zha_shutdown_run_callback_threadsafe"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -71,72 +67,6 @@ async def gather_with_limited_concurrency(
         *(create_eager_task(sem_task(task)) for task in tasks),
         return_exceptions=return_exceptions,
     )
-
-
-def run_callback_threadsafe(
-    loop: AbstractEventLoop, callback_fn: Callable[[*_Ts], _T], *args: *_Ts
-) -> concurrent.futures.Future[_T]:
-    """Submit a callback object to a given event loop.
-
-    Return a concurrent.futures.Future to access the result.
-    """
-    ident = loop.__dict__.get("_thread_ident")
-    if ident is not None and ident == threading.get_ident():
-        raise RuntimeError("Cannot be called from within the event loop")
-
-    future: concurrent.futures.Future[_T] = concurrent.futures.Future()
-
-    def run_callback() -> None:
-        """Run callback and store result."""
-        try:
-            future.set_result(callback_fn(*args))
-        except Exception as exc:  # pylint: disable=broad-except
-            if future.set_running_or_notify_cancel():
-                future.set_exception(exc)
-            else:
-                _LOGGER.warning("Exception on lost future: ", exc_info=True)
-
-    loop.call_soon_threadsafe(run_callback)
-
-    if hasattr(loop, _SHUTDOWN_RUN_CALLBACK_THREADSAFE):
-        #
-        # If the final `Gateway.async_block_till_done` in
-        # `Gateway.shutdown` has already been called, the callback
-        # will never run and, `future.result()` will block forever which
-        # will prevent the thread running this code from shutting down which
-        # will result in a deadlock when the main thread attempts to shutdown
-        # the executor and `.join()` the thread running this code.
-        #
-        # To prevent this deadlock we do the following on shutdown:
-        #
-        # 1. Set the _SHUTDOWN_RUN_CALLBACK_THREADSAFE attr on this function
-        #    by calling `shutdown_run_callback_threadsafe`
-        # 2. Call `zha_gateway.async_block_till_done` at least once after shutdown
-        #    to ensure all callbacks have run
-        # 3. Raise an exception here to ensure `future.result()` can never be
-        #    called and hit the deadlock since once `shutdown_run_callback_threadsafe`
-        #    we cannot promise the callback will be executed.
-        #
-        raise RuntimeError("The event loop is in the process of shutting down.")
-
-    return future
-
-
-def shutdown_run_callback_threadsafe(loop: AbstractEventLoop) -> None:
-    """Call when run_callback_threadsafe should prevent creating new futures.
-
-    We must finish all callbacks before the executor is shutdown
-    or we can end up in a deadlock state where:
-
-    `executor.result()` is waiting for its `._condition`
-    and the executor shutdown is trying to `.join()` the
-    executor thread.
-
-    This function is considered irreversible and should only ever
-    be called when ZHA is going to shutdown and
-    python is going to exit.
-    """
-    setattr(loop, _SHUTDOWN_RUN_CALLBACK_THREADSAFE, True)
 
 
 def cancelling(task: Future[Any]) -> bool:
@@ -223,13 +153,6 @@ class AsyncUtilMixin:
 
     async def shutdown(self) -> None:
         """Shutdown the executor."""
-
-        # Prevent run_callback_threadsafe from scheduling any additional
-        # callbacks in the event loop as callbacks created on the futures
-        # it returns will never run after the final `self.async_block_till_done`
-        # which will cause the futures to block forever when waiting for
-        # the `result()` which will cause a deadlock when shutting down the executor.
-        shutdown_run_callback_threadsafe(self.loop)
 
         async def _cancel_tasks(tasks_to_cancel: Iterable) -> None:
             tasks = [t for t in tasks_to_cancel if not (t.done() or t.cancelled())]

--- a/zha/async_.py
+++ b/zha/async_.py
@@ -479,26 +479,3 @@ class AsyncUtilMixin:
             eager_start=eager_start,
             background=background,
         )
-
-    def async_run_job(
-        self,
-        target: Callable[..., Coroutine[Any, Any, _R] | _R] | Coroutine[Any, Any, _R],
-        *args: Any,
-    ) -> asyncio.Future[_R] | asyncio.Task[_R] | None:
-        """Run a job from within the event loop.
-
-        This method must be run in the event loop.
-
-        target: target to call.
-        args: parameters for method to call.
-        """
-        if asyncio.iscoroutine(target):
-            return self.async_create_task(target, eager_start=True)
-
-        # This code path is performance sensitive and uses
-        # if TYPE_CHECKING to avoid the overhead of constructing
-        # the type used for the cast. For history see:
-        # https://github.com/home-assistant/core/pull/71960
-        if TYPE_CHECKING:
-            target = cast(Callable[..., Coroutine[Any, Any, _R] | _R], target)
-        return self.async_run_zha_job(ZHAJob(target), *args)

--- a/zha/decorators.py
+++ b/zha/decorators.py
@@ -100,9 +100,3 @@ def periodic(refresh_interval: tuple, run_immediately=False) -> Callable:
         return wrapper
 
     return scheduler
-
-
-def callback(func: Callable[..., Any]) -> Callable[..., Any]:
-    """Annotation to mark method as safe to call from within the event loop."""
-    setattr(func, "_zha_callback", True)
-    return func


### PR DESCRIPTION
ZHA does not really run truly synchronous code in the event loop and doesn't need to worry about `@callback`.