### PR TITLE
Fix light groups not restoring `off_brightness`

### DIFF
--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -823,7 +823,8 @@ async def test_zha_group_light_entity(
     # test that the lights were created and are off
     assert bool(entity.state["on"]) is False
 
-    # Group entities do not support state restoration
+    # Group entities do not support state restoration,
+    # except for off_brightness and off_with_transition
     entity.restore_external_state_attributes(
         state=True,
         off_with_transition=False,
@@ -837,6 +838,8 @@ async def test_zha_group_light_entity(
     )
 
     assert bool(entity.state["on"]) is False
+    assert bool(entity.state["off_with_transition"]) is False
+    assert entity.state["off_brightness"] == 12
 
     # test turning the lights on and off from the client
     await async_test_on_off_from_client(zha_gateway, group_cluster_on_off, entity)

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -1401,4 +1401,9 @@ class LightGroup(GroupEntity, BaseLight):
         effect: str | None,
     ) -> None:
         """Restore extra state attributes."""
-        # Groups do not restore external state attributes
+        # Group state is calculated from the members,
+        # except for off_with_transition and off_brightness
+        if off_with_transition is not None:
+            self._off_with_transition = off_with_transition
+        if off_brightness is not None:
+            self._off_brightness = off_brightness


### PR DESCRIPTION
### Background info

At the moment, we do not restore light group state at all, which is fine generally.
However, `off_brightness` and `off_with_transition` are not calculated from the member state at the moment.
So, we need to restore them to make sure that a group light turned off with a transition still turns on to the correct brightness after a restart (and not completely dim).

(yet to this PR in the "real-world", but it should be fine and is unit-tested at least)

### Change

For that reason, this PR restores `off_brightness` and `off_with_transition` for light groups.
The test is also modified to test for the restored `off_brightness` and verifies `off_with_transition` is still `False` after the restore.