### PR TITLE
Fix light group assume behavior

### DIFF
--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -1361,27 +1361,27 @@ class LightGroup(GroupEntity, BaseLight):
 
         # check if the parameters were actually updated
         # in the service call before updating members
-        if ATTR_BRIGHTNESS in service_kwargs:  # or off brightness
+        if service_kwargs.get(ATTR_BRIGHTNESS) is not None:  # or off brightness
             update_params[ATTR_BRIGHTNESS] = self._brightness
         elif off_brightness is not None:
             # if we turn on the group light with "off brightness",
             # pass that to the members
             update_params[ATTR_BRIGHTNESS] = off_brightness
 
-        if ATTR_COLOR_TEMP in service_kwargs:
+        if service_kwargs.get(ATTR_COLOR_TEMP) is not None:
             update_params[ATTR_COLOR_MODE] = self._color_mode
             update_params[ATTR_COLOR_TEMP] = self._color_temp
 
-        if ATTR_XY_COLOR in service_kwargs:
+        if service_kwargs.get(ATTR_XY_COLOR) is not None:
             update_params[ATTR_COLOR_MODE] = self._color_mode
             update_params[ATTR_XY_COLOR] = self._xy_color
 
-        if ATTR_HS_COLOR in service_kwargs:
+        if service_kwargs.get(ATTR_HS_COLOR) is not None:
             update_params[ATTR_COLOR_MODE] = self._color_mode
             update_params[ATTR_HS_COLOR] = self._hs_color
 
-        if ATTR_EFFECT in service_kwargs:
-            update_params[ATTR_EFFECT] = self._effect
+        # we always update effect for now, as we don't know if it was set or not
+        update_params[ATTR_EFFECT] = self._effect
 
         for platform_entity in self.group.get_platform_entities(Light.PLATFORM):
             platform_entity._assume_group_state(update_params)


### PR DESCRIPTION
### Change
This fixes the assume option for light groups always setting unchanged members attributes to the average of the group.
HA currently sends `None` for the unchanged options: [homeassistant/components/zha/light.py#L181-L189](https://github.com/home-assistant/core/blob/3111951757c8b5b13fe83e6ae530f3f8dcbf66f2/homeassistant/components/zha/light.py#L181-L189)
Previously, we just didn't add it to the `kwargs`. Tests also still use the latter behavior.

This PR just fixes the behavior and adds a regression test.

We also update `effect` every time now, which isn't ideal, but it should be fine for 99% of use-cases. In the future, we should migrate to use `EFFECT_OFF` from HA.
Right now, we can't differentiate if `None` means that the effect was turned off OR if the effect was untouched.

#### Future
In the future, we likely just want to change `async_turn_on` (and `off`) to explicitly describe all parameters and default them to `None`. That should be done in a separate PR though, as all platforms should be changed then.

### Tests

The `ASSUME_UPDATE_GROUP_FROM_CHILD_DELAY` patch also didn't seem to work anyway and since we use `looptime` now, we can just sleep a second to wait for the assume members debounce.

A regression test that provides `brightness=None` is also added to make sure this doesn't fail again. It would fail in lines 2001 and 2002 (so at the end of the test) with the old light group assume code.
If wanted, I can separate this out into another test too.