### PR TITLE
Prefer loading the coordinator information from `node_info`

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -317,6 +317,29 @@ async def test_device_is_active_coordinator(
     assert not stale_coordinator.is_active_coordinator
 
 
+async def test_coordinator_info_uses_node_info(
+    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
+    zigpy_device: Callable[..., ZigpyDevice],  # pylint: disable=redefined-outer-name
+) -> None:
+    """Test that the current coordinator uses strings from `node_info`."""
+
+    current_coord_dev = zigpy_device(ieee="aa:bb:cc:dd:ee:ff:00:11", nwk=0x0000)
+    current_coord_dev.node_desc = current_coord_dev.node_desc.replace(
+        logical_type=zdo_t.LogicalType.Coordinator
+    )
+
+    app = current_coord_dev.application
+    app.state.node_info.ieee = current_coord_dev.ieee
+    app.state.node_info.model = "Real Coordinator Model"
+    app.state.node_info.manufacturer = "Real Coordinator Manufacturer"
+
+    current_coordinator = await device_joined(current_coord_dev)
+    assert current_coordinator.is_active_coordinator
+
+    assert current_coordinator.model == "Real Coordinator Model"
+    assert current_coordinator.manufacturer == "Real Coordinator Manufacturer"
+
+
 async def test_async_get_clusters(
     device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device: Callable[..., ZigpyDevice],  # pylint: disable=redefined-outer-name

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -261,6 +261,8 @@ class Device(LogMixin, EventBase):
     @cached_property
     def manufacturer(self) -> str:
         """Return manufacturer for device."""
+        if self.is_active_coordinator:
+            return self.gateway.application_controller.state.node_info.manufacturer
         if self._zigpy_device.manufacturer is None:
             return UNKNOWN_MANUFACTURER
         return self._zigpy_device.manufacturer
@@ -268,6 +270,8 @@ class Device(LogMixin, EventBase):
     @cached_property
     def model(self) -> str:
         """Return model for device."""
+        if self.is_active_coordinator:
+            return self.gateway.application_controller.state.node_info.model
         if self._zigpy_device.model is None:
             return UNKNOWN_MODEL
         return self._zigpy_device.model


### PR DESCRIPTION
The information in the zigpy device is wrong. We load the current node information into `state.node_info` and it should be used instead.

Not sure if we should also remove setting `name` to `{model} {manufacturer}`?

<img width="258" alt="image" src="https://github.com/user-attachments/assets/dddd9c50-896d-4691-b075-8ee8d0094e3e">