### PR TITLE
Clean up when removing a device from the network

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -385,6 +385,7 @@ def device_joined(
     """Return a newly joined ZHAWS device."""
 
     async def _zha_device(zigpy_dev: zigpy.device.Device) -> Device:
+        zha_gateway.application_controller.devices[zigpy_dev.ieee] = zigpy_dev
         await zha_gateway.async_device_initialized(zigpy_dev)
         await zha_gateway.async_block_till_done()
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -355,6 +355,7 @@ async def test_remove_device_cleans_up_group_membership(
 
     assert len(zha_group.members) == 1
     assert zha_group.members[0].device.ieee == device_light_2.ieee
+    assert device_light_1.ieee not in zha_gateway.devices
 
 
 @patch(


### PR DESCRIPTION
This PR adds `async_remove_device` to the gateway object. This is done so that we can clean up anything referencing a device when we remove the device from the network. Currently it will remove the device from any groups that it is a member of. In the future we should handle cleaning up bindings to groups and other devices as well (once we are keeping tabs on those).

fixes: #90


HA needs an update here: 

https://github.com/home-assistant/core/blob/570725293ca455083677f14c170c60f32a609f7c/homeassistant/components/zha/websocket_api.py#L1319

to change the remove call to this new method. 

https://github.com/home-assistant/core/compare/dev...dmulcahey:home-assistant:dm/zha-device-removal-enhancement