### PR TITLE
Add ability to enable and disable entities

### DIFF
--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -397,6 +397,24 @@ async def test_sinope_time(
     assert mfg_cluster.write_attributes.await_count == 1
     assert "secs_since_2k" in mfg_cluster.write_attributes.await_args_list[0][0][0]
 
+    entity.disable()
+
+    assert entity.enabled is False
+
+    await asyncio.sleep(4600)
+
+    assert entity._async_update_time.await_count == 1
+    assert mfg_cluster.write_attributes.await_count == 1
+
+    entity.enable()
+
+    assert entity.enabled is True
+
+    await asyncio.sleep(4600)
+
+    assert entity._async_update_time.await_count == 2
+    assert mfg_cluster.write_attributes.await_count == 2
+
 
 async def test_climate_hvac_action_running_state_zen(
     device_climate_zen: Device,

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -303,6 +303,9 @@ async def test_light_refresh(
     assert on_off_cluster.read_attributes.await_count >= 2
     assert bool(entity.state["on"]) is False
 
+    read_call_count = on_off_cluster.read_attributes.call_count
+    read_await_count = on_off_cluster.read_attributes.await_count
+
     entity.disable()
 
     assert entity.enabled is False
@@ -310,8 +313,8 @@ async def test_light_refresh(
     on_off_cluster.PLUGGED_ATTR_READS = {"on_off": 1}
     await asyncio.sleep(4800)  # 80 minutes
     await zha_gateway.async_block_till_done()
-    assert not on_off_cluster.read_attributes.call_count >= 3
-    assert not on_off_cluster.read_attributes.await_count >= 3
+    assert on_off_cluster.read_attributes.call_count == read_call_count
+    assert on_off_cluster.read_attributes.await_count == read_await_count
     assert bool(entity.state["on"]) is False
 
     entity.enable()
@@ -320,8 +323,8 @@ async def test_light_refresh(
 
     await asyncio.sleep(4800)  # 80 minutes
     await zha_gateway.async_block_till_done()
-    assert on_off_cluster.read_attributes.call_count >= 3
-    assert on_off_cluster.read_attributes.await_count >= 3
+    assert on_off_cluster.read_attributes.call_count > read_call_count
+    assert on_off_cluster.read_attributes.await_count > read_await_count
     assert bool(entity.state["on"]) is True
 
 

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -303,6 +303,27 @@ async def test_light_refresh(
     assert on_off_cluster.read_attributes.await_count >= 2
     assert bool(entity.state["on"]) is False
 
+    entity.disable()
+
+    assert entity.enabled is False
+
+    on_off_cluster.PLUGGED_ATTR_READS = {"on_off": 1}
+    await asyncio.sleep(4800)  # 80 minutes
+    await zha_gateway.async_block_till_done()
+    assert not on_off_cluster.read_attributes.call_count >= 3
+    assert not on_off_cluster.read_attributes.await_count >= 3
+    assert bool(entity.state["on"]) is False
+
+    entity.enable()
+
+    assert entity.enabled is True
+
+    await asyncio.sleep(4800)  # 80 minutes
+    await zha_gateway.async_block_till_done()
+    assert on_off_cluster.read_attributes.call_count >= 3
+    assert on_off_cluster.read_attributes.await_count >= 3
+    assert bool(entity.state["on"]) is True
+
 
 # TODO reporting is not checked
 @patch(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1272,12 +1272,14 @@ async def test_device_unavailable_or_disabled_skips_entity_polling(
     assert entity.enabled is False
     assert len(zha_gateway.global_updater._update_listeners) == 4
 
+    # wrap the update method so we can count how many times it was called
     entity.update = MagicMock(wraps=entity.update)
     await asyncio.sleep(zha_gateway.global_updater.__polling_interval + 2)
     await zha_gateway.async_block_till_done(wait_background_tasks=True)
 
     assert entity.update.call_count == 0
 
+    # re-enable the entity and ensure it is back in the updater and that update is called
     entity.enable()
     assert len(zha_gateway.global_updater._update_listeners) == 5
     assert entity.enabled is True
@@ -1287,6 +1289,7 @@ async def test_device_unavailable_or_disabled_skips_entity_polling(
 
     assert entity.update.call_count == 1
 
+    # knock it off the network and ensure the polling is skipped
     assert (
         "00:0d:6f:00:0a:90:69:e7-1-0-rssi: skipping polling for updated state, "
         "available: False, allow polled requests: True" not in caplog.text

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -4,7 +4,7 @@ import asyncio
 from collections.abc import Awaitable, Callable
 import math
 from typing import Any, Optional
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from zhaquirks.danfoss import thermostat as danfoss_thermostat
@@ -1240,7 +1240,7 @@ async def test_device_counter_sensors(zha_gateway: Gateway) -> None:
 
 
 @pytest.mark.looptime
-async def test_device_unavailable_skips_entity_polling(
+async def test_device_unavailable_or_disabled_skips_entity_polling(
     zha_gateway: Gateway,
     elec_measurement_zha_dev: Device,  # pylint: disable=redefined-outer-name
     caplog: pytest.LogCaptureFixture,
@@ -1263,10 +1263,40 @@ async def test_device_unavailable_skips_entity_polling(
     await zha_gateway.async_block_till_done(wait_background_tasks=True)
 
     assert entity.state["state"] == 60
+    assert entity.enabled is True
+    assert len(zha_gateway.global_updater._update_listeners) == 5
+
+    # let's drop the normal update method from the updater
+    entity.disable()
+
+    assert entity.enabled is False
+    assert len(zha_gateway.global_updater._update_listeners) == 4
+
+    entity.update = MagicMock(wraps=entity.update)
+    await asyncio.sleep(zha_gateway.global_updater.__polling_interval + 2)
+    await zha_gateway.async_block_till_done(wait_background_tasks=True)
+
+    assert entity.update.call_count == 0
+
+    entity.enable()
+    assert len(zha_gateway.global_updater._update_listeners) == 5
+    assert entity.enabled is True
+
+    await asyncio.sleep(zha_gateway.global_updater.__polling_interval + 2)
+    await zha_gateway.async_block_till_done(wait_background_tasks=True)
+
+    assert entity.update.call_count == 1
+
+    assert (
+        "00:0d:6f:00:0a:90:69:e7-1-0-rssi: skipping polling for updated state, "
+        "available: False, allow polled requests: True" not in caplog.text
+    )
 
     elec_measurement_zha_dev.on_network = False
-    await asyncio.sleep(zha_gateway.global_updater.__polling_interval * 2)
+    await asyncio.sleep(zha_gateway.global_updater.__polling_interval + 2)
     await zha_gateway.async_block_till_done(wait_background_tasks=True)
+
+    assert entity.update.call_count == 2
 
     assert (
         "00:0d:6f:00:0a:90:69:e7-1-0-rssi: skipping polling for updated state, "

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1195,6 +1195,26 @@ async def test_device_counter_sensors(zha_gateway: Gateway) -> None:
 
     assert entity.state["state"] == 2
 
+    # test disabling the entity disables it and removes it from the updater
+    assert len(zha_gateway.global_updater._update_listeners) == 3
+    assert entity.enabled is True
+
+    entity.disable()
+
+    assert entity.enabled is False
+    assert len(zha_gateway.global_updater._update_listeners) == 2
+
+    # test enabling the entity enables it and adds it to the updater
+    entity.enable()
+
+    assert entity.enabled is True
+    assert len(zha_gateway.global_updater._update_listeners) == 3
+
+    # make sure we don't get multiple listeners for the same entity in the updater
+    entity.enable()
+
+    assert len(zha_gateway.global_updater._update_listeners) == 3
+
 
 @pytest.mark.looptime
 async def test_device_unavailable_skips_entity_polling(

--- a/zha/application/helpers.py
+++ b/zha/application/helpers.py
@@ -393,6 +393,8 @@ class GlobalUpdater:
 
     def register_update_listener(self, listener: Callable):
         """Register an update listener."""
+        if listener in self._update_listeners:
+            return
         self._update_listeners.append(listener)
 
     def remove_update_listener(self, listener: Callable):

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -57,6 +57,7 @@ class BaseEntityInfo:
     state_class: str | None
     entity_category: str | None
     entity_registry_enabled_default: bool
+    enabled: bool = True
 
     # For platform entities
     cluster_handlers: list[ClusterHandlerInfo]
@@ -115,6 +116,7 @@ class BaseEntity(LogMixin, EventBase):
     _attr_entity_registry_enabled_default: bool = True
     _attr_device_class: str | None
     _attr_state_class: str | None
+    _attr_enabled: bool = True
 
     def __init__(self, unique_id: str) -> None:
         """Initialize the platform entity."""
@@ -125,6 +127,16 @@ class BaseEntity(LogMixin, EventBase):
         self.__previous_state: Any = None
         self._tracked_tasks: list[asyncio.Task] = []
         self._tracked_handles: list[asyncio.Handle] = []
+
+    @property
+    def enabled(self) -> bool:
+        """Return the entity enabled state."""
+        return self._attr_enabled
+
+    @enabled.setter
+    def enabled(self, value: bool) -> None:
+        """Set the entity enabled state."""
+        self._attr_enabled = value
 
     @property
     def fallback_name(self) -> str | None:
@@ -199,6 +211,7 @@ class BaseEntity(LogMixin, EventBase):
             state_class=self.state_class,
             entity_category=self.entity_category,
             entity_registry_enabled_default=self.entity_registry_enabled_default,
+            enabled=self.enabled,
             # Set by platform entities
             cluster_handlers=[],
             device_ieee=None,
@@ -225,6 +238,14 @@ class BaseEntity(LogMixin, EventBase):
         if hasattr(self, "_attr_extra_state_attribute_names"):
             return self._attr_extra_state_attribute_names
         return None
+
+    def enable(self) -> None:
+        """Enable the entity."""
+        self.enabled = True
+
+    def disable(self) -> None:
+        """Disable the entity."""
+        self.enabled = False
 
     async def on_remove(self) -> None:
         """Cancel tasks and timers this entity owns."""

--- a/zha/application/platforms/climate/__init__.py
+++ b/zha/application/platforms/climate/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from asyncio import Task
 from dataclasses import dataclass
 import datetime as dt
 import functools
@@ -494,19 +495,35 @@ class SinopeTechnologiesThermostat(Thermostat):
         self._presets = [Preset.AWAY, Preset.NONE]
         self._supported_features |= ClimateEntityFeature.PRESET_MODE
         self._manufacturer_ch = self.cluster_handlers["sinope_manufacturer_specific"]
+        self._time_update_task: Task | None = None
+        self.start_polling()
 
-        self._tracked_tasks.append(
-            device.gateway.async_create_background_task(
-                self._update_time(),
-                name=f"sinope_time_updater_{self.unique_id}",
-                eager_start=True,
-                untracked=True,
-            )
+    def start_polling(self) -> None:
+        """Start polling."""
+        self._time_update_task = self.device.gateway.async_create_background_task(
+            self._update_time(),
+            name=f"sinope_time_updater_{self.unique_id}",
+            eager_start=True,
+            untracked=True,
         )
+        self._tracked_tasks.append(self._time_update_task)
         self.debug(
             "started time updating interval of %s",
             getattr(self, "__polling_interval"),
         )
+
+    def enable(self) -> None:
+        """Enable the entity."""
+        super().enable()
+        self.start_polling()
+
+    def disable(self) -> None:
+        """Disable the entity."""
+        super().disable()
+        if self._time_update_task:
+            self._tracked_tasks.remove(self._time_update_task)
+            self._time_update_task.cancel()
+            self._time_update_task = None
 
     @periodic((2700, 4500))
     async def _update_time(self) -> None:


### PR DESCRIPTION
This PR will allow entities to be enabled and disabled. This will allow us to not poll entities that the user has disabled. 

fixes: #92 

HA branch: https://github.com/home-assistant/core/compare/dev...dmulcahey:home-assistant:dm/zha-enable-disable-entities