### PR TITLE
Read out the supported and unsupported attribute of a device at configure

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -19,9 +19,14 @@ from zha.zigbee.group import Group
 _LOGGER = logging.getLogger(__name__)
 
 
-def patch_cluster(cluster: zigpy.zcl.Cluster) -> None:
+def patch_cluster(
+    cluster: zigpy.zcl.Cluster, unsupported_attr: set[str] | None = None
+) -> None:
     """Patch a cluster for testing."""
     cluster.PLUGGED_ATTR_READS = {}
+
+    if unsupported_attr is None:
+        unsupported_attr = set()
 
     async def _read_attribute_raw(attributes: Any, *args: Any, **kwargs: Any) -> Any:
         result = []
@@ -53,6 +58,7 @@ def patch_cluster(cluster: zigpy.zcl.Cluster) -> None:
                 {"attrid": attr.id, "datatype": 0}
             )
             for attr in cluster.attributes.values()
+            if attr.name not in unsupported_attr
         ]
         return schema(discovery_complete=t.Bool.true, attribute_info=records)
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -44,6 +44,18 @@ def patch_cluster(cluster: zigpy.zcl.Cluster) -> None:
                 result.append(zcl_f.ReadAttributeRecord(attr_id, zcl_f.Status.FAILURE))
         return (result,)
 
+    async def _discover_attributes(*args: Any, **kwargs: Any) -> Any:
+        schema = zcl_f.GENERAL_COMMANDS[
+            zcl_f.GeneralCommand.Discover_Attributes_rsp
+        ].schema
+        records = [
+            zcl_f.DiscoverAttributesResponseRecord.from_dict(
+                {"attrid": attr.id, "datatype": 0}
+            )
+            for attr in cluster.attributes.values()
+        ]
+        return schema(discovery_complete=t.Bool.true, attribute_info=records)
+
     cluster.bind = AsyncMock(return_value=[0])
     cluster.configure_reporting = AsyncMock(
         return_value=[
@@ -61,6 +73,7 @@ def patch_cluster(cluster: zigpy.zcl.Cluster) -> None:
     cluster._write_attributes = AsyncMock(
         return_value=[zcl_f.WriteAttributesResponse.deserialize(b"\x00")[0]]
     )
+    cluster.discover_attributes = AsyncMock(side_effect=_discover_attributes)
     if cluster.cluster_id == 4:
         cluster.add = AsyncMock(return_value=[0])
     if cluster.cluster_id == 0x1000:

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -116,10 +116,6 @@ def zha_device_mock(
     return _mock
 
 
-@patch(
-    "zigpy.zcl.clusters.general.Identify.request",
-    new=AsyncMock(return_value=[mock.sentinel.data, zcl_f.Status.SUCCESS]),
-)
 @pytest.mark.parametrize("device", DEVICES)
 async def test_devices(
     device,
@@ -140,7 +136,9 @@ async def test_devices(
 
     cluster_identify = _get_identify_cluster(zigpy_device)
     if cluster_identify:
-        cluster_identify.request.reset_mock()
+        cluster_identify.request = AsyncMock(
+            return_value=[mock.sentinel.data, zcl_f.Status.SUCCESS]
+        )
 
     zha_dev: Device = await device_joined(zigpy_device)
     await zha_gateway.async_block_till_done()

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -146,16 +146,6 @@ async def test_devices(
     if cluster_identify and not zha_dev.skip_configuration:
         assert cluster_identify.request.mock_calls == [
             mock.call(
-                True,
-                zcl_f.GeneralCommand.Discover_Attributes,
-                zcl_f.GENERAL_COMMANDS[zcl_f.GeneralCommand.Discover_Attributes].schema,
-                manufacturer=None,
-                expect_reply=True,
-                tsn=None,
-                start_attribute_id=0,
-                max_attribute_ids=255,
-            ),
-            mock.call(
                 False,
                 cluster_identify.commands_by_name["trigger_effect"].id,
                 cluster_identify.commands_by_name["trigger_effect"].schema,
@@ -166,6 +156,16 @@ async def test_devices(
                 effect_variant=(
                     zigpy.zcl.clusters.general.Identify.EffectVariant.Default
                 ),
+            ),
+            mock.call(
+                True,
+                zcl_f.GeneralCommand.Discover_Attributes,
+                zcl_f.GENERAL_COMMANDS[zcl_f.GeneralCommand.Discover_Attributes].schema,
+                manufacturer=None,
+                expect_reply=True,
+                tsn=None,
+                start_attribute_id=0,
+                max_attribute_ids=255,
             ),
         ]
 

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -148,17 +148,27 @@ async def test_devices(
     if cluster_identify and not zha_dev.skip_configuration:
         assert cluster_identify.request.mock_calls == [
             mock.call(
+                True,
+                zcl_f.GeneralCommand.Discover_Attributes,
+                zcl_f.GENERAL_COMMANDS[zcl_f.GeneralCommand.Discover_Attributes].schema,
+                manufacturer=None,
+                expect_reply=True,
+                tsn=None,
+                start_attribute_id=0,
+                max_attribute_ids=255,
+            ),
+            mock.call(
                 False,
                 cluster_identify.commands_by_name["trigger_effect"].id,
                 cluster_identify.commands_by_name["trigger_effect"].schema,
+                manufacturer=None,
+                expect_reply=True,
+                tsn=None,
                 effect_id=zigpy.zcl.clusters.general.Identify.EffectIdentifier.Okay,
                 effect_variant=(
                     zigpy.zcl.clusters.general.Identify.EffectVariant.Default
                 ),
-                expect_reply=True,
-                manufacturer=None,
-                tsn=None,
-            )
+            ),
         ]
 
     event_cluster_handlers = {

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -6,7 +6,7 @@ import itertools
 import re
 from typing import Any, Final
 from unittest import mock
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 from zhaquirks.ikea import PowerConfig1CRCluster, ScenesCluster

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -798,14 +798,12 @@ async def test_unsupported_attributes_sensor(
                 SIG_EP_TYPE: zigpy.profiles.zha.DeviceType.ON_OFF_SWITCH,
                 SIG_EP_PROFILE: zigpy.profiles.zha.PROFILE_ID,
             }
-        }
+        },
+        unsupported_attr={1: unsupported_attributes},
     )
-    cluster = zigpy_device.endpoints[1].in_clusters[cluster_id]
     if cluster_id == smartenergy.Metering.cluster_id:
         # this one is mains powered
         zigpy_device.node_desc.mac_capability_flags |= 0b_0000_0100
-    for attr in unsupported_attributes:
-        cluster.add_unsupported_attribute(attr)
 
     zha_device = await device_joined(zigpy_device)
 

--- a/zha/zigbee/cluster_handlers/__init__.py
+++ b/zha/zigbee/cluster_handlers/__init__.py
@@ -15,6 +15,7 @@ import zigpy.types
 import zigpy.util
 import zigpy.zcl
 from zigpy.zcl.foundation import (
+    GENERAL_COMMANDS,
     CommandSchema,
     ConfigureReportingResponseRecord,
     DiscoverAttributesResponseRecord,
@@ -642,11 +643,12 @@ class ClusterHandler(LogMixin, EventBase):
             rsp = await cluster.discover_attributes(
                 start_attribute_id=start_attribute_id, max_attribute_ids=0xFF
             )
-            assert rsp, "Must have a response to discover request"
-
-            if rsp.command.id == GeneralCommand.Default_Response:
+            if not isinstance(
+                rsp, GENERAL_COMMANDS[GeneralCommand.Discover_Attributes_rsp].schema
+            ):
                 self.debug(
-                    "Ignoring attribute discovery due to unexpected default response"
+                    "Ignoring attribute discovery due to unexpected default response: %r",
+                    rsp,
                 )
                 return None
 

--- a/zha/zigbee/cluster_handlers/__init__.py
+++ b/zha/zigbee/cluster_handlers/__init__.py
@@ -463,8 +463,9 @@ class ClusterHandler(LogMixin, EventBase):
         uncached = [a for a, cached in self.ZCL_INIT_ATTRS.items() if not cached]
         uncached.extend([cfg["attr"] for cfg in self.REPORT_CONFIG])
 
-        self.debug("discovering unsupported attributes")
-        await self.discover_unsupported_attributes()
+        if not from_cache:
+            self.debug("discovering unsupported attributes")
+            await self.discover_unsupported_attributes()
 
         if cached:
             self.debug("initializing cached cluster handler attributes: %s", cached)

--- a/zha/zigbee/cluster_handlers/__init__.py
+++ b/zha/zigbee/cluster_handlers/__init__.py
@@ -446,9 +446,6 @@ class ClusterHandler(LogMixin, EventBase):
                 self.debug("Performing cluster handler specific configuration")
                 await ch_specific_cfg()
 
-            self.debug("Discovering unsupported attributes")
-            await self.discover_unsupported_attributes()
-
             self.debug("finished cluster handler configuration")
         else:
             self.debug("skipping cluster handler configuration")
@@ -465,6 +462,9 @@ class ClusterHandler(LogMixin, EventBase):
         cached = [a for a, cached in self.ZCL_INIT_ATTRS.items() if cached]
         uncached = [a for a, cached in self.ZCL_INIT_ATTRS.items() if not cached]
         uncached.extend([cfg["attr"] for cfg in self.REPORT_CONFIG])
+
+        self.debug("discovering unsupported attributes")
+        await self.discover_unsupported_attributes()
 
         if cached:
             self.debug("initializing cached cluster handler attributes: %s", cached)

--- a/zha/zigbee/cluster_handlers/__init__.py
+++ b/zha/zigbee/cluster_handlers/__init__.py
@@ -445,7 +445,7 @@ class ClusterHandler(LogMixin, EventBase):
                 self.debug("Performing cluster handler specific configuration")
                 await ch_specific_cfg()
 
-            self.debug("Discovering available attributes")
+            self.debug("Discovering unsupported attributes")
             await self.discover_unsupported_attributes()
 
             self.debug("finished cluster handler configuration")


### PR DESCRIPTION
- Read out the supported and unsupported attribute of a device at configure to be able to only list available attributes in GUI.
- Don't swallow exceptions during configure of clusters in debug logs.
