### PR TITLE
Fix shades and keen vents

### DIFF
--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -578,6 +578,10 @@ async def test_shade(
         | CoverEntityFeature.SET_POSITION
     )
 
+    # coverage (these are always False for now)
+    assert entity.is_opening is False
+    assert entity.is_closing is False
+
     # test that the state has changed from unavailable to off
     await send_attributes_report(
         zha_gateway, cluster_on_off, {cluster_on_off.AttributeDefs.on_off.id: 0}
@@ -735,6 +739,10 @@ async def test_keen_vent(
         | CoverEntityFeature.STOP
         | CoverEntityFeature.SET_POSITION
     )
+
+    # coverage (these are always False for now)
+    assert entity.is_opening is False
+    assert entity.is_closing is False
 
     # test that the state has changed from unavailable to off
     await send_attributes_report(zha_gateway, cluster_on_off, {8: 0, 0: False, 1: 1})

--- a/zha/application/platforms/cover/__init__.py
+++ b/zha/application/platforms/cover/__init__.py
@@ -428,7 +428,7 @@ class Shade(PlatformEntity):
         return response
 
     @functools.cached_property
-    def is_opening(self) -> bool | None:
+    def is_opening(self) -> bool:
         """Return if the cover is opening or not."""
         return False
 

--- a/zha/application/platforms/cover/__init__.py
+++ b/zha/application/platforms/cover/__init__.py
@@ -427,7 +427,17 @@ class Shade(PlatformEntity):
         )
         return response
 
-    @property
+    @functools.cached_property
+    def is_opening(self) -> bool | None:
+        """Return if the cover is opening or not."""
+        return False
+
+    @functools.cached_property
+    def is_closing(self) -> bool | None:
+        """Return if the cover is closing or not."""
+        return False
+
+    @functools.cached_property
     def supported_features(self) -> CoverEntityFeature:
         """Return supported features."""
         return self._attr_supported_features

--- a/zha/application/platforms/cover/__init__.py
+++ b/zha/application/platforms/cover/__init__.py
@@ -433,7 +433,7 @@ class Shade(PlatformEntity):
         return False
 
     @functools.cached_property
-    def is_closing(self) -> bool | None:
+    def is_closing(self) -> bool:
         """Return if the cover is closing or not."""
         return False
 


### PR DESCRIPTION
Finally got around to putting batteries in my Keen vents and found a bug from the lib conversion:

```
Logger: homeassistant
Source: components/zha/cover.py:110
First occurred: 2:30:27 PM (3 occurrences)
Last logged: 2:35:33 PM

Error doing job: Task exception was never retrieved (None)
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/zha/zigbee/device.py", line 606, in _async_became_available
    platform_entity.maybe_emit_state_changed_event()
  File "/usr/local/lib/python3.12/site-packages/zha/application/platforms/__init__.py", line 246, in maybe_emit_state_changed_event
    self.emit(
  File "/usr/local/lib/python3.12/site-packages/zha/event.py", line 101, in emit
    call = listener.callback(data)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/zha/entity.py", line 87, in _handle_entity_events
    self.async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1005, in async_write_ha_state
    self._async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1130, in _async_write_ha_state
    self.__async_calculate_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1067, in __async_calculate_state
    state = self._stringify_state(available)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1011, in _stringify_state
    if (state := self.state) is None:
                 ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/cover/__init__.py", line 304, in state
    if self.is_opening:
       ^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/zha/cover.py", line 110, in is_opening
    return self.entity_data.entity.is_opening
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'KeenVent' object has no attribute 'is_opening'
```

for reference here was the previous implementation: https://github.com/home-assistant/core/blob/c773d57d392dc1062948a5cd935b419587896575/homeassistant/components/zha/cover.py#L361

and here is what the base cover entity supplied: https://github.com/home-assistant/core/blob/f98487ef18978f70ebe5c898efec0916816688c9/homeassistant/components/cover/__init__.py#L268-L269 and https://github.com/home-assistant/core/blob/f98487ef18978f70ebe5c898efec0916816688c9/homeassistant/components/cover/__init__.py#L357-L365

the _attr fields were initialized to None and never touched in the base class or our extensions for `Shade` and `KeenVent`.

This PR adds the properties to the `Shade` class and they always return `False`. In the future we can probably enhance this to use the position information to intelligently return these values. For now I just want to restore what we had before.

Fixes:  #103