### PR TITLE
Don't hide handler exceptions behind debug

### DIFF
--- a/tests/test_cluster_handlers.py
+++ b/tests/test_cluster_handlers.py
@@ -847,8 +847,8 @@ async def test_ep_cluster_handlers_configure(cluster_handler) -> None:
         assert ch.async_configure.call_count == 1
         assert ch.async_configure.await_count == 1
 
-    assert ch_3.debug.call_count == 2
-    assert ch_5.debug.call_count == 2
+    assert ch_3.warning.call_count == 2
+    assert ch_5.warning.call_count == 2
 
 
 async def test_poll_control_configure(

--- a/zha/zigbee/endpoint.py
+++ b/zha/zigbee/endpoint.py
@@ -204,7 +204,7 @@ class Endpoint:
         results = await gather(*tasks, return_exceptions=True)
         for cluster_handler, outcome in zip(cluster_handlers, results):
             if isinstance(outcome, Exception):
-                cluster_handler.debug(
+                cluster_handler.warning(
                     "'%s' stage failed: %s", func_name, str(outcome), exc_info=outcome
                 )
             else:


### PR DESCRIPTION
Don't swallow exceptions during configure of clusters in debug logs.

Catching generic Exceptions will hide programming errors. We could hide specific exceptions if we know their cause, other exceptions should be fixed.