### PR TITLE
Make sure gateway fixture does not reload quirk on each run

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -384,7 +384,7 @@ def globally_load_quirks():
     zhaquirks.setup()
 
     # Disable gateway built in quirks loading
-    with patch("zha.application.gateway.Gateway._async_load_quirks"):
+    with patch("zha.application.gateway.setup_quirks"):
         yield
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -383,6 +383,10 @@ def globally_load_quirks():
 
     zhaquirks.setup()
 
+    # Disable gateway built in quirks loading
+    with patch("zha.application.gateway.Gateway._async_load_quirks"):
+        yield
+
 
 @pytest.fixture
 def device_joined(

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -218,6 +218,12 @@ class Gateway(AsyncUtilMixin, EventBase):
         await instance.async_initialize()
         return instance
 
+    async def _async_load_quirks(self) -> None:
+        """Load quirks for this configuration."""
+        await self.async_add_executor_job(
+            setup_quirks, self.config.config.quirks_configuration.custom_quirks_path
+        )
+
     async def async_initialize(self) -> None:
         """Initialize controller and connect radio."""
         discovery.DEVICE_PROBE.initialize(self)
@@ -225,9 +231,7 @@ class Gateway(AsyncUtilMixin, EventBase):
         discovery.GROUP_PROBE.initialize(self)
 
         if self.config.config.quirks_configuration.enabled:
-            await self.async_add_executor_job(
-                setup_quirks, self.config.config.quirks_configuration.custom_quirks_path
-            )
+            await self._async_load_quirks()
 
         self.shutting_down = False
 

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -218,12 +218,6 @@ class Gateway(AsyncUtilMixin, EventBase):
         await instance.async_initialize()
         return instance
 
-    async def _async_load_quirks(self) -> None:
-        """Load quirks for this configuration."""
-        await self.async_add_executor_job(
-            setup_quirks, self.config.config.quirks_configuration.custom_quirks_path
-        )
-
     async def async_initialize(self) -> None:
         """Initialize controller and connect radio."""
         discovery.DEVICE_PROBE.initialize(self)
@@ -231,7 +225,9 @@ class Gateway(AsyncUtilMixin, EventBase):
         discovery.GROUP_PROBE.initialize(self)
 
         if self.config.config.quirks_configuration.enabled:
-            await self._async_load_quirks()
+            await self.async_add_executor_job(
+                setup_quirks, self.config.config.quirks_configuration.custom_quirks_path
+            )
 
         self.shutting_down = False
 


### PR DESCRIPTION
The code in quirks setup would still run since it does not try to protect for multiple invocations internally.

I can't fully patch out the executor and keep test coverage unless we move this quirks loading out of the gateway object.