### PR TITLE
RFC: Let cluster config/init bubble up exception groups

### DIFF
--- a/tests/test_cluster_handlers.py
+++ b/tests/test_cluster_handlers.py
@@ -837,8 +837,10 @@ async def test_ep_cluster_handlers_configure(cluster_handler) -> None:
         mock.patch.dict(endpoint.claimed_cluster_handlers, claimed, clear=True),
         mock.patch.dict(endpoint.client_cluster_handlers, client_handlers, clear=True),
     ):
-        await endpoint.async_configure()
-        await endpoint.async_initialize(mock.sentinel.from_cache)
+        with pytest.raises(ExceptionGroup):
+            await endpoint.async_configure()
+        with pytest.raises(ExceptionGroup):
+            await endpoint.async_initialize(mock.sentinel.from_cache)
 
     for ch in [*claimed.values(), *client_handlers.values()]:
         assert ch.async_initialize.call_count == 1
@@ -846,9 +848,6 @@ async def test_ep_cluster_handlers_configure(cluster_handler) -> None:
         assert ch.async_initialize.call_args[0][0] is mock.sentinel.from_cache
         assert ch.async_configure.call_count == 1
         assert ch.async_configure.await_count == 1
-
-    assert ch_3.warning.call_count == 2
-    assert ch_5.warning.call_count == 2
 
 
 async def test_poll_control_configure(

--- a/tests/test_cluster_handlers.py
+++ b/tests/test_cluster_handlers.py
@@ -847,8 +847,8 @@ async def test_ep_cluster_handlers_configure(cluster_handler) -> None:
         assert ch.async_configure.call_count == 1
         assert ch.async_configure.await_count == 1
 
-    assert ch_3.debug.call_count == 2
-    assert ch_5.debug.call_count == 2
+    assert ch_3.warning.call_count == 2
+    assert ch_5.warning.call_count == 2
 
 
 async def test_poll_control_configure(

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -616,7 +616,6 @@ async def test_async_add_to_group_remove_from_group(
 async def test_async_bind_to_group(
     device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device: Callable[..., ZigpyDevice],  # pylint: disable=redefined-outer-name
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test async_bind_to_group method."""
     zigpy_dev = zigpy_device(with_basic_cluster_handler=True)
@@ -640,18 +639,11 @@ async def test_async_bind_to_group(
         group.group_id,
         [ClusterBinding(name="on_off", type=CLUSTER_TYPE_OUT, id=6, endpoint_id=3)],
     )
-    assert (
-        "0xb79c: Bind_req 00:0d:7f:00:0a:90:69:e8, ep: 3, cluster: 6 to group: 0x1001 completed: [<Status.SUCCESS: 0>]"
-        in caplog.text
-    )
 
     await zha_device_remote.async_unbind_from_group(
         group.group_id,
         [ClusterBinding(name="on_off", type=CLUSTER_TYPE_OUT, id=6, endpoint_id=3)],
     )
-
-    m1 = "0xb79c: Unbind_req 00:0d:7f:00:0a:90:69:e8, ep: 3, cluster: 6"
-    assert f"{m1} to group: 0x1001 completed: [<Status.SUCCESS: 0>]" in caplog.text
 
 
 async def test_device_automation_triggers(

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -23,6 +23,7 @@ from zigpy.config import (
 )
 import zigpy.device
 import zigpy.endpoint
+from zigpy.exceptions import DeliveryError
 import zigpy.group
 from zigpy.state import State
 from zigpy.types.named import EUI64
@@ -618,7 +619,11 @@ class Gateway(AsyncUtilMixin, EventBase):
         )
         # we don't have to do this on a nwk swap
         # but we don't have a way to tell currently
-        await zha_device.async_configure()
+        try:
+            await zha_device.async_configure()
+        except* (TimeoutError, DeliveryError):
+            zha_device.debug("ignoring error %s during rejoin", exc_info=True)
+
         device_info = ExtendedDeviceInfoWithPairingStatus(
             pairing_status=DevicePairingStatus.CONFIGURED,
             **zha_device.extended_device_info.__dict__,

--- a/zha/zigbee/cluster_handlers/__init__.py
+++ b/zha/zigbee/cluster_handlers/__init__.py
@@ -374,7 +374,7 @@ class ClusterHandler(LogMixin, EventBase):
         event_data: dict[str, dict[str, Any]],
     ) -> None:
         """Parse configure reporting result."""
-        if isinstance(res, (Exception, ConfigureReportingResponseRecord)):
+        if isinstance(res, (Exception, ConfigureReportingResponseRecord, int)):
             # assume default response
             self.debug(
                 "attr reporting for '%s' on '%s': %s",

--- a/zha/zigbee/cluster_handlers/lightlink.py
+++ b/zha/zigbee/cluster_handlers/lightlink.py
@@ -2,7 +2,6 @@
 
 import zigpy.exceptions
 from zigpy.zcl.clusters.lightlink import LightLink
-from zigpy.zcl.foundation import GENERAL_COMMANDS, GeneralCommand
 
 from zha.zigbee.cluster_handlers import ClusterHandler, ClusterHandlerStatus, registries
 

--- a/zha/zigbee/cluster_handlers/lightlink.py
+++ b/zha/zigbee/cluster_handlers/lightlink.py
@@ -44,4 +44,4 @@ class LightLinkClusterHandler(ClusterHandler):
                 self.debug("Adding coordinator to 0x%04x group id", group.group_id)
                 await coordinator.add_to_group(group.group_id)
         else:
-            await coordinator.add_to_group(0x0000, name="Default Lightlink Group")
+            await coordinator.add_to_group(0x0000, name="Lightlink Group")

--- a/zha/zigbee/cluster_handlers/lightlink.py
+++ b/zha/zigbee/cluster_handlers/lightlink.py
@@ -34,10 +34,12 @@ class LightLinkClusterHandler(ClusterHandler):
             self.warning("Couldn't get list of groups: %s", str(exc))
             return
 
-        if isinstance(rsp, GENERAL_COMMANDS[GeneralCommand.Default_Response].schema):
-            groups = []
-        else:
+        if isinstance(
+            rsp, LightLink.ClientCommandDefs.get_group_identifiers_rsp.schema
+        ):
             groups = rsp.group_info_records
+        else:
+            groups = []
 
         if groups:
             for group in groups:


### PR DESCRIPTION
Let cluster config/init bubble up exception groups
 - Only skip errors when re-joining

This shows that we have several faults we currently don't detect properly.