### PR TITLE
Split quirks loading from network and app initialization

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -323,6 +323,7 @@ class TestGateway:
     async def __aenter__(self) -> Gateway:
         """Start the ZHA gateway."""
         self.zha_gateway = await Gateway.async_from_config(self.zha_data)
+        await self.zha_gateway.async_initialize()
         await self.zha_gateway.async_block_till_done()
         await self.zha_gateway.async_initialize_devices_and_entities()
         INSTANCES.append(self.zha_gateway)

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -215,7 +215,13 @@ class Gateway(AsyncUtilMixin, EventBase):
     async def async_from_config(cls, config: ZHAData) -> Self:
         """Create an instance of a gateway from config objects."""
         instance = cls(config)
-        await instance.async_initialize()
+
+        if config.config.quirks_configuration.enabled:
+            await instance.async_add_executor_job(
+                setup_quirks,
+                instance.config.config.quirks_configuration.custom_quirks_path,
+            )
+
         return instance
 
     async def async_initialize(self) -> None:
@@ -223,11 +229,6 @@ class Gateway(AsyncUtilMixin, EventBase):
         discovery.DEVICE_PROBE.initialize(self)
         discovery.ENDPOINT_PROBE.initialize(self)
         discovery.GROUP_PROBE.initialize(self)
-
-        if self.config.config.quirks_configuration.enabled:
-            await self.async_add_executor_job(
-                setup_quirks, self.config.config.quirks_configuration.custom_quirks_path
-            )
 
         self.shutting_down = False
 


### PR DESCRIPTION
This PR moves the loading of quirks so that we can split the quirk loading from the initialization of the network and the application. There are a couple HA users that hit an issue in the beta where device triggers from quirks aren't available early enough and if the integration fails to set up on the first shot (flaky stick, poor nwk conditions etc.) it prevents automations from finding triggers for ZHA devices:

```
Logger: homeassistant.components.automation.drukknop_slaapkamer_noor
Source: components/automation/__init__.py:842
integration: Automation (documentation, issues)
First occurred: 02:53:39 (1 occurrences)
Last logged: 02:53:39

Got error 'Unable to find trigger ('remote_button_short_press', 'remote_button_short_press')' when setting up triggers for Drukknop slaapkamer Noor
```

There is a corresponding HA PR: https://github.com/home-assistant/core/pull/123027