### PR TITLE
Bump dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.12"
 dependencies = [
-    "zigpy==0.65.0",
+    "zigpy==0.65.1",
     "bellows==0.40.2",
     "zigpy-znp==0.12.3",
     "zigpy-deconz==0.23.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "zigpy-deconz==0.23.2",
     "zigpy-xbee==0.20.1",
     "zigpy-zigate==0.13.0",
-    "zha-quirks==0.0.117",
+    "zha-quirks==0.0.118",
     "pyserial==3.5",
     "pyserial-asyncio-fast",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.12"
 dependencies = [
-    "zigpy==0.65.1",
+    "zigpy==0.65.2",
     "bellows==0.40.2",
     "zigpy-znp==0.12.3",
     "zigpy-deconz==0.23.2",

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -9,6 +9,6 @@ pytest-timeout
 pytest-asyncio
 pytest-xdist
 pytest
-zigpy>=0.63.5
+zigpy>=0.65.1
 ruff
 looptime

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -9,6 +9,6 @@ pytest-timeout
 pytest-asyncio
 pytest-xdist
 pytest
-zigpy>=0.65.1
+zigpy>=0.65.2
 ruff
 looptime

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -15,7 +15,7 @@ from zigpy.const import SIG_EP_PROFILE
 from zigpy.device import Device as ZigpyDevice
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice, get_device
-from zigpy.quirks.v2 import CustomDeviceV2, add_to_registry_v2
+from zigpy.quirks.v2 import CustomDeviceV2, QuirkBuilder
 import zigpy.types as t
 from zigpy.zcl.clusters import general, security
 from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
@@ -162,7 +162,7 @@ async def test_on_off_select_attribute_report(
 
 
 (
-    add_to_registry_v2("Fake_Manufacturer", "Fake_Model")
+    QuirkBuilder("Fake_Manufacturer", "Fake_Model")
     .replaces(MotionSensitivityQuirk.OppleCluster)
     .enum(
         "motion_sensitivity",
@@ -176,6 +176,7 @@ async def test_on_off_select_attribute_report(
         translation_key="motion_sensitivity",
         initially_disabled=True,
     )
+    .add_to_registry()
 )
 
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -10,7 +10,7 @@ from zhaquirks.danfoss import thermostat as danfoss_thermostat
 from zigpy.device import Device as ZigpyDevice
 import zigpy.profiles.zha
 from zigpy.quirks import CustomCluster, get_device
-from zigpy.quirks.v2 import CustomDeviceV2, add_to_registry_v2
+from zigpy.quirks.v2 import CustomDeviceV2, QuirkBuilder
 import zigpy.types as t
 from zigpy.zcl import Cluster
 from zigpy.zcl.clusters import general, homeautomation, hvac, measurement, smartenergy
@@ -1115,7 +1115,7 @@ class OppleCluster(CustomCluster, ManufacturerSpecificCluster):
 
 
 (
-    add_to_registry_v2("Fake_Manufacturer_sensor", "Fake_Model_sensor")
+    QuirkBuilder("Fake_Manufacturer_sensor", "Fake_Model_sensor")
     .replaces(OppleCluster)
     .sensor(
         "last_feeding_size",
@@ -1124,6 +1124,7 @@ class OppleCluster(CustomCluster, ManufacturerSpecificCluster):
         multiplier=1,
         unit=UnitOfMass.GRAMS,
     )
+    .add_to_registry()
 )
 
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -17,7 +17,7 @@ from zigpy.device import Device as ZigpyDevice
 from zigpy.exceptions import ZigbeeException
 from zigpy.profiles import zha
 from zigpy.quirks import _DEVICE_REGISTRY, CustomCluster, CustomDevice
-from zigpy.quirks.v2 import CustomDeviceV2, add_to_registry_v2
+from zigpy.quirks.v2 import CustomDeviceV2, QuirkBuilder
 import zigpy.types as t
 from zigpy.zcl.clusters import closures, general
 from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
@@ -525,7 +525,7 @@ async def test_switch_configurable_custom_on_off_values(
     )
 
     (
-        add_to_registry_v2(zigpy_dev.manufacturer, zigpy_dev.model)
+        QuirkBuilder(zigpy_dev.manufacturer, zigpy_dev.model)
         .adds(WindowDetectionFunctionQuirk.TuyaManufCluster)
         .switch(
             "window_detection_function",
@@ -533,6 +533,7 @@ async def test_switch_configurable_custom_on_off_values(
             on_value=3,
             off_value=5,
         )
+        .add_to_registry()
     )
 
     zigpy_device_ = _DEVICE_REGISTRY.get_device(zigpy_dev)
@@ -600,7 +601,7 @@ async def test_switch_configurable_custom_on_off_values_force_inverted(
     )
 
     (
-        add_to_registry_v2(zigpy_dev.manufacturer, zigpy_dev.model)
+        QuirkBuilder(zigpy_dev.manufacturer, zigpy_dev.model)
         .adds(WindowDetectionFunctionQuirk.TuyaManufCluster)
         .switch(
             "window_detection_function",
@@ -609,6 +610,7 @@ async def test_switch_configurable_custom_on_off_values_force_inverted(
             off_value=5,
             force_inverted=True,
         )
+        .add_to_registry()
     )
 
     zigpy_device_ = _DEVICE_REGISTRY.get_device(zigpy_dev)
@@ -676,7 +678,7 @@ async def test_switch_configurable_custom_on_off_values_inverter_attribute(
     )
 
     (
-        add_to_registry_v2(zigpy_dev.manufacturer, zigpy_dev.model)
+        QuirkBuilder(zigpy_dev.manufacturer, zigpy_dev.model)
         .adds(WindowDetectionFunctionQuirk.TuyaManufCluster)
         .switch(
             "window_detection_function",
@@ -685,6 +687,7 @@ async def test_switch_configurable_custom_on_off_values_inverter_attribute(
             off_value=5,
             invert_attribute_name="window_detection_function_inverter",
         )
+        .add_to_registry()
     )
 
     zigpy_device_ = _DEVICE_REGISTRY.get_device(zigpy_dev)

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -24,6 +24,7 @@ from zigpy.config import (
 import zigpy.device
 import zigpy.endpoint
 import zigpy.group
+from zigpy.quirks.v2 import UNBUILT_QUIRK_BUILDERS
 from zigpy.state import State
 from zigpy.types.named import EUI64
 
@@ -217,6 +218,15 @@ class Gateway(AsyncUtilMixin, EventBase):
         instance = cls(config)
 
         if config.config.quirks_configuration.enabled:
+            for quirk in UNBUILT_QUIRK_BUILDERS:
+                _LOGGER.warning(
+                    "Found a quirk that was not added to the registry: %s",
+                    quirk,
+                )
+                quirk.add_to_registry()
+
+            UNBUILT_QUIRK_BUILDERS.clear()
+
             await instance.async_add_executor_job(
                 setup_quirks,
                 instance.config.config.quirks_configuration.custom_quirks_path,

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -220,7 +220,7 @@ class Gateway(AsyncUtilMixin, EventBase):
         if config.config.quirks_configuration.enabled:
             for quirk in UNBUILT_QUIRK_BUILDERS:
                 _LOGGER.warning(
-                    "Found a quirk that was not added to the registry: %s",
+                    "Found a v2 quirk that was not added to the registry: %s",
                     quirk,
                 )
                 quirk.add_to_registry()


### PR DESCRIPTION
This PR bumps the following dependencies:

- Zigpy to 0.65.2: https://github.com/zigpy/zigpy/releases/tag/0.65.2
- zha-quirks to 0.0.118: https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.118