### PR TITLE
Fix IKEA Starkvind attribute reports

### DIFF
--- a/zha/zigbee/cluster_handlers/manufacturerspecific.py
+++ b/zha/zigbee/cluster_handlers/manufacturerspecific.py
@@ -422,24 +422,6 @@ class IkeaAirPurifierClusterHandler(ClusterHandler):
         """Retrieve latest state."""
         await self.get_attribute_value("fan_mode", from_cache=False)
 
-    def attribute_updated(self, attrid: int, value: Any, _: Any) -> None:
-        """Handle attribute update from fan cluster."""
-        attr_name = self._get_attribute_name(attrid)
-        self.debug(
-            "Attribute report '%s'[%s] = %s", self.cluster.name, attr_name, value
-        )
-        if attr_name == "fan_mode":
-            self.emit(
-                CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
-                ClusterAttributeUpdatedEvent(
-                    attribute_id=attrid,
-                    attribute_name=attr_name,
-                    attribute_value=value,
-                    cluster_handler_unique_id=self.unique_id,
-                    cluster_id=self.cluster.cluster_id,
-                ),
-            )
-
 
 @registries.CLUSTER_HANDLER_ONLY_CLUSTERS.register(IKEA_REMOTE_CLUSTER)
 @registries.CLUSTER_HANDLER_REGISTRY.register(IKEA_REMOTE_CLUSTER)

--- a/zha/zigbee/cluster_handlers/manufacturerspecific.py
+++ b/zha/zigbee/cluster_handlers/manufacturerspecific.py
@@ -429,7 +429,16 @@ class IkeaAirPurifierClusterHandler(ClusterHandler):
             "Attribute report '%s'[%s] = %s", self.cluster.name, attr_name, value
         )
         if attr_name == "fan_mode":
-            self.attribute_updated(attrid, attr_name, value)
+            self.emit(
+                CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
+                ClusterAttributeUpdatedEvent(
+                    attribute_id=attrid,
+                    attribute_name=attr_name,
+                    attribute_value=value,
+                    cluster_handler_unique_id=self.unique_id,
+                    cluster_id=self.cluster.cluster_id,
+                ),
+            )
 
 
 @registries.CLUSTER_HANDLER_ONLY_CLUSTERS.register(IKEA_REMOTE_CLUSTER)


### PR DESCRIPTION
### Proposed change

When the `fan_mode` attribute was updated, the `attribute_updated` method was called again. Repeat this.
Eventually, we would reach the maximum recursion depth and error out.

Now, we're completely removing the overridden `attribute_updated` method in the IKEA manufacturer-specific cluster.
Instead, the [super method is now called](https://github.com/zigpy/zha/blob/8c05c9b09891d431dc026485173e5c098d64e681/zha/zigbee/cluster_handlers/__init__.py#L452-L471) which does what we want (emit an event), but for all attributes. This is needed, as the `child_lock` and other config attributes on that cluster would not cause the config switch entities to update if changed from the device.

The change is tested and seems to be working as expected now.

### Additional information

On a side note, the `attribute_updated` stuff in the other cluster handlers also needs be improved. There's some duplicate code that can be avoided and it's one of the last places where the old `_value_attribute` stuff is still used.
It's also a bit confusing if only one attribute change actually emits an "attribute updated" event on a cluster. Maybe we should always emit the events and just check for the attribute in the places where we're subscribing? (the config switches do this already) It shouldn't cause any performance issues really..

Also, it seems like we do have a unit test for this in `test_fan.py`, but it didn't catch the issue, as we're (1) not testing getting a `fan_mode` attribute report from the device and/or (2) because when `fan_mode` is changed from ZHA, we're only checking if the attribute was written correctly. Not if the entity was also updated correctly.
Doing either of those things would have caught the issue.

Further fixes and changes will come with https://github.com/zigpy/zha/pull/87/ in the future.