### PR TITLE
Fix Light Link default group name too long

### DIFF
--- a/zha/zigbee/cluster_handlers/lightlink.py
+++ b/zha/zigbee/cluster_handlers/lightlink.py
@@ -44,4 +44,4 @@ class LightLinkClusterHandler(ClusterHandler):
                 self.debug("Adding coordinator to 0x%04x group id", group.group_id)
                 await coordinator.add_to_group(group.group_id)
         else:
-            await coordinator.add_to_group(0x0000, name="Default Lightlink Group")
+            await coordinator.add_to_group(0x0000, name="Lightlink Group")


### PR DESCRIPTION
This fixes the following error that occurs hidden in debug logs in tests:

```
    | Traceback (most recent call last):
    |   File "/Users/joakim/src/hass/zha/zha/zigbee/endpoint.py", line 200, in caller
    |     await getattr(ch, func_name)(*args)
    |   File "/Users/joakim/src/hass/zha/zha/zigbee/cluster_handlers/lightlink.py", line 48, in async_configure
    |     await coordinator.add_to_group(0x0000, name="Default Lightlink Group")
    |   File "/Users/joakim/src/hass/zigpy/zigpy/device.py", line 294, in add_to_group
    |     await ep.add_to_group(grp_id, name)
    |   File "/Users/joakim/src/hass/zigpy/zigpy/endpoint.py", line 149, in add_to_group
    |     res = await self.groups.add(grp_id, name)
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/joakim/src/hass/zigpy/zigpy/zcl/__init__.py", line 357, in request
    |     hdr, request = self._create_request(
    |                    ^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/joakim/src/hass/zigpy/zigpy/zcl/__init__.py", line 320, in _create_request
    |     request.serialize()  # Throw an error before generating a new TSN
    |     ^^^^^^^^^^^^^^^^^^^
    |   File "/Users/joakim/src/hass/zigpy/zigpy/types/struct.py", line 261, in serialize
    |     chunks.append(value.serialize())
    |                   ^^^^^^^^^^^^^^^^^
    |   File "/Users/joakim/src/hass/zigpy/zigpy/types/basic.py", line 983, in serialize
    |     raise ValueError(f"String is too long (>{self._max_len})")
    | ValueError: String is too long (>16)
```

Source of limitation: https://github.com/zigpy/zigpy/blob/925a112b8f64685164c7cbc89479a3ad76b9b5a1/zigpy/zcl/clusters/general.py#L613