### PR TITLE
Guard `Gateway` shutdown for when `application_controller` is None

### DIFF
--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -728,9 +728,10 @@ class Gateway(AsyncUtilMixin, EventBase):
             await group.on_remove()
 
         _LOGGER.debug("Shutting down ZHA ControllerApplication")
-        await self.application_controller.shutdown()
-        self.application_controller = None
-        await asyncio.sleep(0.1)  # give bellows thread callback a chance to run
+        if self.application_controller is not None:
+            await self.application_controller.shutdown()
+            self.application_controller = None
+            await asyncio.sleep(0.1)  # give bellows thread callback a chance to run
 
         await super().shutdown()
 


### PR DESCRIPTION
Triggered by zigpy `ControllerApplication.__init__` failing due to https://github.com/zigpy/zha/pull/142.