### PR TITLE
Fix yet another config double conversion

### DIFF
--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -409,7 +409,12 @@ async def test_gateway_initialize_bellows_thread(
     ) as mock_new:
         zha_gw = Gateway(zha_data)
         await zha_gw.async_initialize()
-        assert mock_new.mock_calls[-1].kwargs["config"][CONF_USE_THREAD] is thread_state
+
+        if thread_state is False:
+            assert mock_new.mock_calls[-1].kwargs["config"][CONF_USE_THREAD] is False
+        else:
+            assert CONF_USE_THREAD not in mock_new.mock_calls[-1].kwargs["config"]
+
         await zha_gw.shutdown()
 
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -409,12 +409,10 @@ async def test_gateway_initialize_bellows_thread(
     ) as mock_new:
         zha_gw = Gateway(zha_data)
         await zha_gw.async_initialize()
-
-        if thread_state is False:
-            assert mock_new.mock_calls[-1].kwargs["config"][CONF_USE_THREAD] is False
-        else:
-            assert CONF_USE_THREAD not in mock_new.mock_calls[-1].kwargs["config"]
-
+        assert (
+            mock_new.mock_calls[-1].kwargs["config"].get(CONF_USE_THREAD, True)
+            is thread_state
+        )
         await zha_gw.shutdown()
 
 

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -210,7 +210,7 @@ class Gateway(AsyncUtilMixin, EventBase):
         ):
             app_config[CONF_USE_THREAD] = False
 
-        return radio_type.controller, radio_type.controller.SCHEMA(app_config)
+        return radio_type.controller, app_config
 
     @classmethod
     async def async_from_config(cls, config: ZHAData) -> Self:


### PR DESCRIPTION
This should be the final one. At this point, only zigpy will be converting the config dict via the config schema.