### PR TITLE
Add config option to disable polling mains devices at startup

### DIFF
--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -215,6 +215,41 @@ async def test_gateway_starts_entity_exception(
         await zha_gateway.shutdown()
 
 
+@pytest.mark.parametrize(("enabled", "await_count"), [(True, 1), (False, 0)])
+async def test_mains_devices_startup_polling_config(
+    zha_data: ZHAData,
+    zigpy_app_controller: ControllerApplication,
+    enabled: bool,
+    await_count: int,
+) -> None:
+    """Test mains powered device startup polling config is respected."""
+
+    with (
+        patch(
+            "bellows.zigbee.application.ControllerApplication.new",
+            return_value=zigpy_app_controller,
+        ),
+        patch(
+            "bellows.zigbee.application.ControllerApplication",
+            return_value=zigpy_app_controller,
+        ),
+    ):
+        zha_data.config.device_options.enable_mains_startup_polling = enabled
+        zha_gateway = await Gateway.async_from_config(zha_data)
+        zha_gateway.async_fetch_updated_state_mains = AsyncMock(
+            wraps=zha_gateway.async_fetch_updated_state_mains
+        )
+        await zha_gateway.async_initialize()
+        await zha_gateway.async_block_till_done()
+        await zha_gateway.async_initialize_devices_and_entities()
+        await zha_gateway.async_block_till_done()
+
+        assert zha_gateway.async_fetch_updated_state_mains.await_count == await_count
+
+        await zha_gateway.shutdown()
+        await zha_gateway.async_block_till_done()
+
+
 async def test_gateway_group_methods(
     zha_gateway: Gateway,
     device_light_1,  # pylint: disable=redefined-outer-name

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -387,7 +387,7 @@ class Gateway(AsyncUtilMixin, EventBase):
             *(dev.async_initialize(from_cache=True) for dev in self.devices.values())
         )
 
-        if not self.config.config.device_options.allow_startup_polling_mains_devices:
+        if not self.config.config.device_options.allow_mains_startup_polling:
             _LOGGER.debug("Polling of mains powered devices at startup is disabled")
             return
 

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -387,6 +387,10 @@ class Gateway(AsyncUtilMixin, EventBase):
             *(dev.async_initialize(from_cache=True) for dev in self.devices.values())
         )
 
+        if not self.config.config.device_options.allow_startup_polling_mains_devices:
+            _LOGGER.debug("Polling of mains powered devices at startup is disabled")
+            return
+
         async def fetch_updated_state() -> None:
             """Fetch updated state for mains powered devices."""
             await self.async_fetch_updated_state_mains()

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -387,7 +387,7 @@ class Gateway(AsyncUtilMixin, EventBase):
             *(dev.async_initialize(from_cache=True) for dev in self.devices.values())
         )
 
-        if not self.config.config.device_options.allow_mains_startup_polling:
+        if not self.config.config.device_options.enable_mains_startup_polling:
             _LOGGER.debug("Polling of mains powered devices at startup is disabled")
             return
 

--- a/zha/application/helpers.py
+++ b/zha/application/helpers.py
@@ -283,6 +283,7 @@ class DeviceOptions:
     consider_unavailable_battery: int = dataclasses.field(
         default=CONF_DEFAULT_CONSIDER_UNAVAILABLE_BATTERY
     )
+    allow_startup_polling_mains_devices: bool = dataclasses.field(default=True)
 
 
 @dataclass(kw_only=True, slots=True)

--- a/zha/application/helpers.py
+++ b/zha/application/helpers.py
@@ -283,7 +283,7 @@ class DeviceOptions:
     consider_unavailable_battery: int = dataclasses.field(
         default=CONF_DEFAULT_CONSIDER_UNAVAILABLE_BATTERY
     )
-    allow_startup_polling_mains_devices: bool = dataclasses.field(default=True)
+    allow_mains_startup_polling: bool = dataclasses.field(default=True)
 
 
 @dataclass(kw_only=True, slots=True)

--- a/zha/application/helpers.py
+++ b/zha/application/helpers.py
@@ -283,7 +283,7 @@ class DeviceOptions:
     consider_unavailable_battery: int = dataclasses.field(
         default=CONF_DEFAULT_CONSIDER_UNAVAILABLE_BATTERY
     )
-    allow_mains_startup_polling: bool = dataclasses.field(default=True)
+    enable_mains_startup_polling: bool = dataclasses.field(default=True)
 
 
 @dataclass(kw_only=True, slots=True)


### PR DESCRIPTION
This pull request introduces a new configuration option to control the polling behavior of mains-powered devices during startup. 

Fixes: #140 