### PR TITLE
Avoid creating binary sensor for unsupported attributes

### DIFF
--- a/zha/application/platforms/binary_sensor/__init__.py
+++ b/zha/application/platforms/binary_sensor/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import functools
 import logging
-from typing import TYPE_CHECKING, Self, Any
+from typing import TYPE_CHECKING, Any, Self
 
 from zhaquirks.quirk_ids import DANFOSS_ALLY_THERMOSTAT
 from zigpy.quirks.v2 import BinarySensorMetadata


### PR DESCRIPTION
Some of these are virtual attributes updated but "toggle" events the the OnOffClusterHandler, but not really supported by the device itself.