### PR TITLE
Remove group translation keys

### DIFF
--- a/zha/application/platforms/fan/__init__.py
+++ b/zha/application/platforms/fan/__init__.py
@@ -283,8 +283,6 @@ class Fan(PlatformEntity, BaseFan):
 class FanGroup(GroupEntity, BaseFan):
     """Representation of a fan group."""
 
-    _attr_translation_key: str = "fan_group"
-
     def __init__(self, group: Group):
         """Initialize a fan group."""
         self._fan_cluster_handler: ClusterHandler = group.endpoint[hvac.Fan.cluster_id]

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -1124,8 +1124,6 @@ class MinTransitionLight(Light):
 class LightGroup(GroupEntity, BaseLight):
     """Representation of a light group."""
 
-    _attr_translation_key: str = "light_group"
-
     def __init__(self, group: Group):
         """Initialize a light group."""
         # light groups change the update_group_from_child_delay so we need to do this


### PR DESCRIPTION
Groups shouldn't use translation keys to begin with, as groups (even without names) will always have a string name.

Before:
<img width="288" alt="image" src="https://github.com/user-attachments/assets/4cade07d-c3c6-4ae9-b7ad-a53350be4482">

After:
<img width="278" alt="image" src="https://github.com/user-attachments/assets/ccbab690-9009-4e55-8eb4-248f44edda98">

https://github.com/home-assistant/core/issues/123373