### PR TITLE
Pass the local timezone to `Gateway`

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -12,3 +12,4 @@ pytest
 zigpy>=0.65.2
 ruff
 looptime
+freezegun

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -7,7 +7,9 @@ from collections.abc import Awaitable, Callable, Coroutine
 import logging
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, call, patch
+import zoneinfo
 
+from freezegun import freeze_time
 import pytest
 import zhaquirks.sinope.thermostat
 from zhaquirks.sinope.thermostat import SinopeTechnologiesThermostatCluster
@@ -379,6 +381,7 @@ async def test_climate_hvac_action_running_state(
 @pytest.mark.looptime
 async def test_sinope_time(
     device_climate_sinope: Device,
+    zha_gateway: Gateway,
 ):
     """Test hvac action via running state."""
 
@@ -393,9 +396,28 @@ async def test_sinope_time(
 
     await asyncio.sleep(4600)
 
+    write_attributes = mfg_cluster.write_attributes
     assert entity._async_update_time.await_count == 1
-    assert mfg_cluster.write_attributes.await_count == 1
-    assert "secs_since_2k" in mfg_cluster.write_attributes.await_args_list[0][0][0]
+    assert write_attributes.await_count == 1
+    assert "secs_since_2k" in write_attributes.mock_calls[0].args[0]
+
+    write_attributes.reset_mock()
+
+    # Default time zone of UTC
+    with freeze_time("2000-01-02 00:00:00"):
+        await entity._async_update_time()
+        secs_since_2k = write_attributes.mock_calls[0].args[0]["secs_since_2k"]
+        assert secs_since_2k == pytest.approx(60 * 60 * 24)
+
+    write_attributes.reset_mock()
+
+    # New time zone
+    zha_gateway.config.local_timezone = zoneinfo.ZoneInfo("America/New_York")
+
+    with freeze_time("2000-01-02 00:00:00"):
+        await entity._async_update_time()
+        secs_since_2k = write_attributes.mock_calls[0].args[0]["secs_since_2k"]
+        assert secs_since_2k == pytest.approx(60 * 60 * 24 - 5 * 60 * 60)
 
 
 async def test_climate_hvac_action_running_state_zen(

--- a/zha/application/helpers.py
+++ b/zha/application/helpers.py
@@ -8,6 +8,7 @@ import collections
 from collections.abc import Callable
 import dataclasses
 from dataclasses import dataclass
+import datetime
 import enum
 import logging
 import re
@@ -352,6 +353,7 @@ class ZHAData:
         default_factory=dict
     )
     allow_polling: bool = dataclasses.field(default=False)
+    local_timezone: datetime.tzinfo = dataclasses.field(default=datetime.UTC)
 
 
 class GlobalUpdater:

--- a/zha/application/platforms/climate/__init__.py
+++ b/zha/application/platforms/climate/__init__.py
@@ -536,9 +536,9 @@ class SinopeTechnologiesThermostat(Thermostat):
     async def _async_update_time(self) -> None:
         """Update thermostat's time display."""
 
+        now = dt.datetime.now(self._device.gateway.config.local_timezone)
         secs_2k = (
-            dt.datetime.now(dt.UTC).replace(tzinfo=None)
-            - dt.datetime(2000, 1, 1, 0, 0, 0, 0)
+            now.replace(tzinfo=None) - dt.datetime(2000, 1, 1, 0, 0, 0, 0)
         ).total_seconds()
 
         self.debug("Updating time: %s", secs_2k)


### PR DESCRIPTION
Fixes https://github.com/zigpy/zha/issues/150 (once the Core side is implemented).

The default behavior will be to use UTC. Maybe we can instead use the machine time zone?