### PR TITLE
Port Sinope changes over from core/zha

### DIFF
--- a/tests/zha_devices_list.py
+++ b/tests/zha_devices_list.py
@@ -7351,7 +7351,21 @@ DEVICES = [
         DEV_SIG_DEV_NO: 102,
         SIG_MANUFACTURER: "Sinope Technologies",
         SIG_MODEL: "SW2500ZB",
-        SIG_NODE_DESC: b"\x02@\x80|\x11RR\x00\x00\x00R\x00\x00",
+        SIG_NODE_DESC: {
+            "logical_type": 1,
+            "complex_descriptor_available": 0,
+            "user_descriptor_available": 1,
+            "reserved": 0,
+            "aps_flags": 0,
+            "frequency_band": 8,
+            "mac_capability_flags": 142,
+            "manufacturer_code": 4508,
+            "maximum_buffer_size": 71,
+            "maximum_incoming_transfer_size": 43,
+            "server_mask": 10752,
+            "maximum_outgoing_transfer_size": 43,
+            "descriptor_capability_field": 0,
+        },
         SIG_ENDPOINTS: {
             1: {
                 SIG_EP_TYPE: 257,

--- a/tests/zha_devices_list.py
+++ b/tests/zha_devices_list.py
@@ -7347,4 +7347,94 @@ DEVICES = [
             },
         },
     },
+    {
+        DEV_SIG_DEV_NO: 102,
+        SIG_MANUFACTURER: "Sinope Technologies",
+        SIG_MODEL: "SW2500ZB",
+        SIG_NODE_DESC: b"\x02@\x80|\x11RR\x00\x00\x00R\x00\x00",
+        SIG_ENDPOINTS: {
+            1: {
+                SIG_EP_TYPE: 257,
+                DEV_SIG_EP_ID: 1,
+                SIG_EP_INPUT: [0, 2, 3, 4, 5, 6, 8, 1794, 2820, 2821, 65281],
+                SIG_EP_OUTPUT: [3, 4, 10, 25],
+                SIG_EP_PROFILE: 260,
+            }
+        },
+        DEV_SIG_EVT_CLUSTER_HANDLERS: ["1:0x0019"],
+        DEV_SIG_ENT_MAP: {
+            ("button", "00:11:22:33:44:55:66:77-1-3"): {
+                DEV_SIG_CLUSTER_HANDLERS: ["identify"],
+                DEV_SIG_ENT_MAP_CLASS: "IdentifyButton",
+                DEV_SIG_ENT_MAP_ID: "button.sinope_technologies_dm2500zb_identify",
+            },
+            ("light", "00:11:22:33:44:55:66:77-1"): {
+                DEV_SIG_CLUSTER_HANDLERS: ["level", "on_off"],
+                DEV_SIG_ENT_MAP_CLASS: "Light",
+                DEV_SIG_ENT_MAP_ID: "light.sinope_technologies_dm2500zb_light",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820"): {
+                DEV_SIG_CLUSTER_HANDLERS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "PolledElectricalMeasurement",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2500zb_power",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-apparent_power"): {
+                DEV_SIG_CLUSTER_HANDLERS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementApparentPower",
+                DEV_SIG_ENT_MAP_ID: (
+                    "sensor.sinope_technologies_dm2500zb_apparent_power"
+                ),
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_current"): {
+                DEV_SIG_CLUSTER_HANDLERS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSCurrent",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2500zb_current",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_voltage"): {
+                DEV_SIG_CLUSTER_HANDLERS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSVoltage",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2500zb_voltage",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-ac_frequency"): {
+                DEV_SIG_CLUSTER_HANDLERS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementFrequency",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2500zb_ac_frequency",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2820-power_factor"): {
+                DEV_SIG_CLUSTER_HANDLERS: ["electrical_measurement"],
+                DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementPowerFactor",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2500zb_power_factor",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-0-rssi"): {
+                DEV_SIG_CLUSTER_HANDLERS: ["basic"],
+                DEV_SIG_ENT_MAP_CLASS: "RSSISensor",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2500zb_rssi",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-0-lqi"): {
+                DEV_SIG_CLUSTER_HANDLERS: ["basic"],
+                DEV_SIG_ENT_MAP_CLASS: "LQISensor",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2500zb_lqi",
+            },
+            ("update", "00:11:22:33:44:55:66:77-1-25-firmware_update"): {
+                DEV_SIG_CLUSTER_HANDLERS: ["ota"],
+                DEV_SIG_ENT_MAP_CLASS: "FirmwareUpdateEntity",
+                DEV_SIG_ENT_MAP_ID: "update.sinope_technologies_dm2500zb_firmware",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1794"): {
+                DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
+                DEV_SIG_ENT_MAP_CLASS: "SmartEnergyMetering",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2500zb_instantaneous_demand",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-1794-summation_delivered"): {
+                DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
+                DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2500zb_summation_delivered",
+            },
+            ("sensor", "00:11:22:33:44:55:66:77-1-2"): {
+                DEV_SIG_CLUSTER_HANDLERS: ["device_temperature"],
+                DEV_SIG_ENT_MAP_CLASS: "DeviceTemperature",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2500zb_device_temperature",
+            },
+        },
+    },
 ]

--- a/tests/zha_devices_list.py
+++ b/tests/zha_devices_list.py
@@ -7380,74 +7380,74 @@ DEVICES = [
             ("button", "00:11:22:33:44:55:66:77-1-3"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["identify"],
                 DEV_SIG_ENT_MAP_CLASS: "IdentifyButton",
-                DEV_SIG_ENT_MAP_ID: "button.sinope_technologies_dm2500zb_identify",
+                DEV_SIG_ENT_MAP_ID: "button.sinope_technologies_dm2550zb_identify",
             },
             ("light", "00:11:22:33:44:55:66:77-1"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["level", "on_off"],
                 DEV_SIG_ENT_MAP_CLASS: "Light",
-                DEV_SIG_ENT_MAP_ID: "light.sinope_technologies_dm2500zb_light",
+                DEV_SIG_ENT_MAP_ID: "light.sinope_technologies_dm2550zb_light",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "PolledElectricalMeasurement",
-                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2500zb_power",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2550zb_power",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820-apparent_power"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementApparentPower",
                 DEV_SIG_ENT_MAP_ID: (
-                    "sensor.sinope_technologies_dm2500zb_apparent_power"
+                    "sensor.sinope_technologies_dm2550zb_apparent_power"
                 ),
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_current"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSCurrent",
-                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2500zb_current",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2550zb_current",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820-rms_voltage"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementRMSVoltage",
-                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2500zb_voltage",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2550zb_voltage",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820-ac_frequency"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementFrequency",
-                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2500zb_ac_frequency",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2550zb_ac_frequency",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2820-power_factor"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["electrical_measurement"],
                 DEV_SIG_ENT_MAP_CLASS: "ElectricalMeasurementPowerFactor",
-                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2500zb_power_factor",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2550zb_power_factor",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-0-rssi"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["basic"],
                 DEV_SIG_ENT_MAP_CLASS: "RSSISensor",
-                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2500zb_rssi",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2550zb_rssi",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-0-lqi"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["basic"],
                 DEV_SIG_ENT_MAP_CLASS: "LQISensor",
-                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2500zb_lqi",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2550zb_lqi",
             },
             ("update", "00:11:22:33:44:55:66:77-1-25-firmware_update"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["ota"],
                 DEV_SIG_ENT_MAP_CLASS: "FirmwareUpdateEntity",
-                DEV_SIG_ENT_MAP_ID: "update.sinope_technologies_dm2500zb_firmware",
+                DEV_SIG_ENT_MAP_ID: "update.sinope_technologies_dm2550zb_firmware",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-1794"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergyMetering",
-                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2500zb_instantaneous_demand",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2550zb_instantaneous_demand",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-1794-summation_delivered"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["smartenergy_metering"],
                 DEV_SIG_ENT_MAP_CLASS: "SmartEnergySummation",
-                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2500zb_summation_delivered",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2550zb_summation_delivered",
             },
             ("sensor", "00:11:22:33:44:55:66:77-1-2"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["device_temperature"],
                 DEV_SIG_ENT_MAP_CLASS: "DeviceTemperature",
-                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2500zb_device_temperature",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_dm2550zb_device_temperature",
             },
         },
     },

--- a/tests/zha_devices_list.py
+++ b/tests/zha_devices_list.py
@@ -7350,7 +7350,7 @@ DEVICES = [
     {
         DEV_SIG_DEV_NO: 102,
         SIG_MANUFACTURER: "Sinope Technologies",
-        SIG_MODEL: "SW2500ZB",
+        SIG_MODEL: "DM2550ZB",
         SIG_NODE_DESC: {
             "logical_type": 1,
             "complex_descriptor_available": 0,

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -988,7 +988,14 @@ class SinopeDimmerOnLevelConfigurationEntity(NumberConfigurationEntity):
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names="sinope_manufacturer_specific",
-    models={"DM2500ZB", "DM2500ZB-G2", "DM2550ZB", "DM2550ZB-G2", "SW2500ZB", "SW2500ZB-G2"},
+    models={
+        "DM2500ZB",
+        "DM2500ZB-G2",
+        "DM2550ZB",
+        "DM2550ZB-G2",
+        "SW2500ZB",
+        "SW2500ZB-G2",
+    },
 )
 class SinopeLightLEDOnIntensityConfigurationEntity(NumberConfigurationEntity):
     """Representation of a Sinope switch LED on-level brightness."""
@@ -1003,7 +1010,14 @@ class SinopeLightLEDOnIntensityConfigurationEntity(NumberConfigurationEntity):
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names="sinope_manufacturer_specific",
-    models={"DM2500ZB", "DM2500ZB-G2", "DM2550ZB", "DM2550ZB-G2", "SW2500ZB", "SW2500ZB-G2"},
+    models={
+        "DM2500ZB",
+        "DM2500ZB-G2",
+        "DM2550ZB",
+        "DM2550ZB-G2",
+        "SW2500ZB",
+        "SW2500ZB-G2",
+    },
 )
 class SinopeLightLEDOffIntensityConfigurationEntity(NumberConfigurationEntity):
     """Representation of a Sinope switch LED off-level brightness."""

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -969,3 +969,48 @@ class DanfossRegulationSetpointOffset(NumberConfigurationEntity):
     _attr_native_max_value: float = 2.5
     _attr_native_step: float = 0.1
     _attr_multiplier = 1 / 10
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
+    cluster_handler_names="sinope_manufacturer_specific",
+    models={"DM2500ZB", "DM2500ZB-G2", "DM2550ZB", "DM2550ZB-G2"},
+)
+class SinopeDimmerOnLevelConfigurationEntity(NumberConfigurationEntity):
+    """Representation of a Sinope dimmer switch on level."""
+
+    _unique_id_suffix = "on_intensity"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_native_min_value: float = 1
+    _attr_native_max_value: float = 255
+    _attribute_name = "on_intensity"
+    _attr_translation_key: str = "on_level"
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
+    cluster_handler_names="sinope_manufacturer_specific",
+    models={"DM2500ZB", "DM2500ZB-G2", "DM2550ZB", "DM2550ZB-G2", "SW2500ZB", "SW2500ZB-G2"},
+)
+class SinopeLightLEDOnIntensityConfigurationEntity(NumberConfigurationEntity):
+    """Representation of a Sinope switch LED on-level brightness."""
+
+    _unique_id_suffix = "on_led_intensity"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_native_min_value: float = 1
+    _attr_native_max_value: float = 100
+    _attribute_name = "on_led_intensity"
+    _attr_translation_key: str = "on_led_intensity"
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
+    cluster_handler_names="sinope_manufacturer_specific",
+    models={"DM2500ZB", "DM2500ZB-G2", "DM2550ZB", "DM2550ZB-G2", "SW2500ZB", "SW2500ZB-G2"},
+)
+class SinopeLightLEDOffIntensityConfigurationEntity(NumberConfigurationEntity):
+    """Representation of a Sinope switch LED off-level brightness."""
+
+    _unique_id_suffix = "off_led_intensity"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_native_min_value: float = 1
+    _attr_native_max_value: float = 100
+    _attribute_name = "off_led_intensity"
+    _attr_translation_key: str = "off_led_intensity"

--- a/zha/application/platforms/select.py
+++ b/zha/application/platforms/select.py
@@ -822,11 +822,14 @@ class DanfossViewingDirection(ZCLEnumSelectEntity):
 
 
 class SinopeLightLedColors(types.enum32):
-    Lim = 0x0affdc
-    Amber = 0x000a4b
-    Fushia = 0x0100a5
-    Perle = 0x64ffff
-    Blue = 0xffff00
+    """Color values for Sinope light switch status LEDs."""
+
+    Lim = 0x0AFFDC
+    Amber = 0x000A4B
+    Fushia = 0x0100A5
+    Perle = 0x64FFFF
+    Blue = 0xFFFF00
+
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names="sinope_manufacturer_specific",
@@ -840,15 +843,13 @@ class SinopeLightLedColors(types.enum32):
     },
 )
 class SinopeLightLEDOffColorSelect(ZCLEnumSelectEntity):
-    """Representation of the marker LED color off-state color
-    of Sinope light switches
-    """
+    """Representation of the marker LED color off-state color of Sinope light switches."""
 
     _unique_id_suffix = "off_led_color"
     _attribute_name = "off_led_color"
     _attr_translation_key: str = "off_led_color"
     _enum = SinopeLightLedColors
-    _attr_icon = 'mdi:palette-outline'
+    _attr_icon: str = "mdi:palette-outline"
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
@@ -863,12 +864,10 @@ class SinopeLightLEDOffColorSelect(ZCLEnumSelectEntity):
     },
 )
 class SinopeLightLEDOnColorSelect(ZCLEnumSelectEntity):
-    """Representation of the marker LED color on-state color
-    of Sinope light switches
-    """
+    """Representation of the marker LED color on-state color of Sinope light switches."""
 
     _unique_id_suffix = "on_led_color"
     _attribute_name = "on_led_color"
     _attr_translation_key: str = "on_led_color"
     _enum = SinopeLightLedColors
-    _attr_icon = 'mdi:palette'
+    _attr_icon: str = "mdi:palette"

--- a/zha/application/platforms/select.py
+++ b/zha/application/platforms/select.py
@@ -819,3 +819,33 @@ class DanfossViewingDirection(ZCLEnumSelectEntity):
     _attribute_name = "viewing_direction"
     _attr_translation_key: str = "viewing_direction"
     _enum = danfoss_thermostat.DanfossViewingDirectionEnum
+
+
+class SinopeLightLedColors(types.enum32):
+    Lim = 0x0affdc
+    Amber = 0x000a4b
+    Fushia = 0x0100a5
+    Perle = 0x64ffff
+    Blue = 0xffff00
+
+@CONFIG_DIAGNOSTIC_MATCH(
+    cluster_handler_names="sinope_manufacturer_specific",
+    models={
+        "DM2500ZB",
+        "DM2500ZB-G2",
+        "DM2550ZB",
+        "DM2550ZB-G2",
+        "SW2500ZB",
+        "SW2500ZB-G2",
+    },
+)
+class SinopeLightLEDOffColorSelect(ZCLEnumSelectEntity):
+    """Representation of a switch that controls whether Double Tap Full option
+    is enabled on a Sinope light switch.
+    """
+
+    _unique_id_suffix = "off_led_color"
+    _attribute_name = "off_led_color"
+    _attr_translation_key: str = "sinope_off_led_color"
+    _enum = SinopeLightLedColors
+    _attr_icon = 'mdi:palette-outline'

--- a/zha/application/platforms/select.py
+++ b/zha/application/platforms/select.py
@@ -843,7 +843,7 @@ class SinopeLightLedColors(types.enum32):
     },
 )
 class SinopeLightLEDOffColorSelect(ZCLEnumSelectEntity):
-    """Representation of the marker LED color off-state color of Sinope light switches."""
+    """Representation of the marker LED Off-state color of Sinope light switches."""
 
     _unique_id_suffix = "off_led_color"
     _attribute_name = "off_led_color"
@@ -863,7 +863,7 @@ class SinopeLightLEDOffColorSelect(ZCLEnumSelectEntity):
     },
 )
 class SinopeLightLEDOnColorSelect(ZCLEnumSelectEntity):
-    """Representation of the marker LED color on-state color of Sinope light switches."""
+    """Representation of the marker LED On-state color of Sinope light switches."""
 
     _unique_id_suffix = "on_led_color"
     _attribute_name = "on_led_color"

--- a/zha/application/platforms/select.py
+++ b/zha/application/platforms/select.py
@@ -846,7 +846,7 @@ class SinopeLightLEDOffColorSelect(ZCLEnumSelectEntity):
 
     _unique_id_suffix = "off_led_color"
     _attribute_name = "off_led_color"
-    _attr_translation_key: str = "sinope_off_led_color"
+    _attr_translation_key: str = "off_led_color"
     _enum = SinopeLightLedColors
     _attr_icon = 'mdi:palette-outline'
 
@@ -869,6 +869,6 @@ class SinopeLightLEDOnColorSelect(ZCLEnumSelectEntity):
 
     _unique_id_suffix = "on_led_color"
     _attribute_name = "on_led_color"
-    _attr_translation_key: str = "sinope_on_led_color"
+    _attr_translation_key: str = "on_led_color"
     _enum = SinopeLightLedColors
     _attr_icon = 'mdi:palette'

--- a/zha/application/platforms/select.py
+++ b/zha/application/platforms/select.py
@@ -849,7 +849,6 @@ class SinopeLightLEDOffColorSelect(ZCLEnumSelectEntity):
     _attribute_name = "off_led_color"
     _attr_translation_key: str = "off_led_color"
     _enum = SinopeLightLedColors
-    _attr_icon: str = "mdi:palette-outline"
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
@@ -870,4 +869,3 @@ class SinopeLightLEDOnColorSelect(ZCLEnumSelectEntity):
     _attribute_name = "on_led_color"
     _attr_translation_key: str = "on_led_color"
     _enum = SinopeLightLedColors
-    _attr_icon: str = "mdi:palette"

--- a/zha/application/platforms/select.py
+++ b/zha/application/platforms/select.py
@@ -840,8 +840,8 @@ class SinopeLightLedColors(types.enum32):
     },
 )
 class SinopeLightLEDOffColorSelect(ZCLEnumSelectEntity):
-    """Representation of a switch that controls whether Double Tap Full option
-    is enabled on a Sinope light switch.
+    """Representation of the marker LED color off-state color
+    of Sinope light switches
     """
 
     _unique_id_suffix = "off_led_color"
@@ -849,3 +849,26 @@ class SinopeLightLEDOffColorSelect(ZCLEnumSelectEntity):
     _attr_translation_key: str = "sinope_off_led_color"
     _enum = SinopeLightLedColors
     _attr_icon = 'mdi:palette-outline'
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
+    cluster_handler_names="sinope_manufacturer_specific",
+    models={
+        "DM2500ZB",
+        "DM2500ZB-G2",
+        "DM2550ZB",
+        "DM2550ZB-G2",
+        "SW2500ZB",
+        "SW2500ZB-G2",
+    },
+)
+class SinopeLightLEDOnColorSelect(ZCLEnumSelectEntity):
+    """Representation of the marker LED color on-state color
+    of Sinope light switches
+    """
+
+    _unique_id_suffix = "on_led_color"
+    _attribute_name = "on_led_color"
+    _attr_translation_key: str = "sinope_on_led_color"
+    _enum = SinopeLightLedColors
+    _attr_icon = 'mdi:palette'

--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -856,11 +856,9 @@ class DanfossAdaptationRunSettings(SwitchConfigurationEntity):
     },
 )
 class SinopeLightDoubleTapFullSwitch(SwitchConfigurationEntity):
-    """Representation of a switch that controls whether Double Tap Full option
-    is enabled on a Sinope light switch.
-    """
+    """Representation of a config option that controls whether Double Tap Full option is enabled on a Sinope light switch."""
 
     _unique_id_suffix = "double_up_full"
     _attribute_name = "double_up_full"
     _attr_translation_key: str = "double_up_full"
-    _attr_icon = 'mdi:gesture-double-tap'
+    _attr_icon = "mdi:gesture-double-tap"

--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -844,3 +844,23 @@ class DanfossAdaptationRunSettings(SwitchConfigurationEntity):
     _unique_id_suffix = "adaptation_run_settings"
     _attribute_name: str = "adaptation_run_settings"
     _attr_translation_key: str = "adaptation_run_enabled"
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
+    cluster_handler_names="sinope_manufacturer_specific",
+    models={
+        "DM2500ZB",
+        "DM2500ZB-G2",
+        "DM2550ZB",
+        "DM2550ZB-G2",
+    },
+)
+class SinopeLightDoubleTapFullSwitch(SwitchConfigurationEntity):
+    """Representation of a switch that controls whether Double Tap Full option
+    is enabled on a Sinope light switch.
+    """
+
+    _unique_id_suffix = "double_up_full"
+    _attribute_name = "double_up_full"
+    _attr_translation_key: str = "double_up_full"
+    _attr_icon = 'mdi:gesture-double-tap'

--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -861,4 +861,3 @@ class SinopeLightDoubleTapFullSwitch(SwitchConfigurationEntity):
     _unique_id_suffix = "double_up_full"
     _attribute_name = "double_up_full"
     _attr_translation_key: str = "double_up_full"
-    _attr_icon = "mdi:gesture-double-tap"

--- a/zha/zigbee/cluster_handlers/const.py
+++ b/zha/zigbee/cluster_handlers/const.py
@@ -87,6 +87,7 @@ SMARTTHINGS_HUMIDITY_CLUSTER: Final[int] = 0xFC45
 SONOFF_CLUSTER: Final[int] = 0xFC11
 TUYA_MANUFACTURER_CLUSTER: Final[int] = 0xEF00
 VOC_LEVEL_CLUSTER: Final[int] = 0x042E
+SINOPE_MANUFACTURER_CLUSTER: Final[int] = 0xFF01
 
 CLUSTER_HANDLER_EVENT: Final[str] = "cluster_handler_event"
 CLUSTER_HANDLER_ATTRIBUTE_UPDATED: Final[str] = "cluster_handler_attribute_updated"

--- a/zha/zigbee/cluster_handlers/manufacturerspecific.py
+++ b/zha/zigbee/cluster_handlers/manufacturerspecific.py
@@ -511,7 +511,7 @@ class SinopeManufacturerClusterHandler(ClusterHandler):
     def __init__(self, cluster: zigpy.zcl.Cluster, endpoint: Endpoint) -> None:
         """Initialize Sinope cluster handler."""
         super().__init__(cluster, endpoint)
-        shared_attr = {
+        shared_attrs = {
             "double_up_full": True,
             "on_led_color": True,
             "off_led_color": True,
@@ -525,13 +525,14 @@ class SinopeManufacturerClusterHandler(ClusterHandler):
             "DM2500ZB",
         ]:
             self.ZCL_INIT_ATTRS = {
-                **shared_attr,
+                **shared_attrs,
                 "on_intensity": True,
             }
 
         elif self.cluster.endpoint.model in ["SW2500ZB", "SW2500ZB-G2"]:
-            self.ZCL_INIT_ATTRS = shared_attr.copy()
+            self.ZCL_INIT_ATTRS = shared_attrs.copy()
 
+    _value_attribute = "action_report"
     REPORT_CONFIG = (
         AttrReportConfig(
             attr="action_report",

--- a/zha/zigbee/cluster_handlers/manufacturerspecific.py
+++ b/zha/zigbee/cluster_handlers/manufacturerspecific.py
@@ -511,26 +511,21 @@ class SinopeManufacturerClusterHandler(ClusterHandler):
     def __init__(self, cluster: zigpy.zcl.Cluster, endpoint: Endpoint) -> None:
         """Initialize Sinope cluster handler."""
         super().__init__(cluster, endpoint)
-        shared_attrs = {
+        self.ZCL_INIT_ATTRS = {
             "double_up_full": True,
             "on_led_color": True,
             "off_led_color": True,
             "off_led_intensity": True,
             "on_led_intensity": True,
         }
+
         if self.cluster.endpoint.model in [
             "DM2550ZB",
             "DM2550ZB-G2",
             "DM2500ZB-G2",
             "DM2500ZB",
         ]:
-            self.ZCL_INIT_ATTRS = {
-                **shared_attrs,
-                "on_intensity": True,
-            }
-
-        elif self.cluster.endpoint.model in ["SW2500ZB", "SW2500ZB-G2"]:
-            self.ZCL_INIT_ATTRS = shared_attrs.copy()
+            self.ZCL_INIT_ATTRS["on_intensity"] = True
 
     _value_attribute = "action_report"
     REPORT_CONFIG = (

--- a/zha/zigbee/cluster_handlers/manufacturerspecific.py
+++ b/zha/zigbee/cluster_handlers/manufacturerspecific.py
@@ -40,12 +40,12 @@ from zha.zigbee.cluster_handlers.const import (
     REPORT_CONFIG_MIN_INT_IMMEDIATE,
     REPORT_CONFIG_RPT_CHANGE,
     SIGNAL_ATTR_UPDATED,
+    SINOPE_MANUFACTURER_CLUSTER,
     SMARTTHINGS_ACCELERATION_CLUSTER,
     SMARTTHINGS_HUMIDITY_CLUSTER,
     SONOFF_CLUSTER,
     TUYA_MANUFACTURER_CLUSTER,
     UNKNOWN,
-    SINOPE_MANUFACTURER_CLUSTER,
 )
 from zha.zigbee.cluster_handlers.general import MultistateInputClusterHandler
 
@@ -556,7 +556,7 @@ class SinopeManufacturerClusterHandler(ClusterHandler):
         )
 
         _LOGGER.debug(
-            f"matching sinope device to cluster handler {cluster.endpoint.model}"
+            "matching sinope device to cluster handler %s", cluster.endpoint.model
         )
 
         return (

--- a/zha/zigbee/cluster_handlers/manufacturerspecific.py
+++ b/zha/zigbee/cluster_handlers/manufacturerspecific.py
@@ -559,7 +559,4 @@ class SinopeManufacturerClusterHandler(ClusterHandler):
             "matching sinope device to cluster handler %s", cluster.endpoint.model
         )
 
-        return (
-            cluster.endpoint.model in switches
-            or cluster.endpoint.device.model in switches
-        )
+        return cluster.endpoint.model in switches


### PR DESCRIPTION
Icon diff: 

```diff
diff --git a/homeassistant/components/zha/icons.json b/homeassistant/components/zha/icons.json
index 9b060e8105..bb4224f2bd 100644
--- a/homeassistant/components/zha/icons.json
+++ b/homeassistant/components/zha/icons.json
@@ -94,6 +94,12 @@
       },
       "keypad_lockout": {
         "default": "mdi:lock"
+      },
+      "off_led_color": {
+        "default": "mdi:palette-outline"
+      },
+      "on_led_color": {
+        "default": "mdi:palette"
       }
     },
     "sensor": {
@@ -158,6 +164,9 @@
       },
       "hooks_locked": {
         "default": "mdi:lock"
+      },
+      "double_up_full": {
+        "default": "mdi:gesture-double-tap"
       }
     }
   },
```