### PR TITLE
Use a generic device name for coordinators without information

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -378,6 +378,29 @@ async def test_coordinator_info_uses_node_info(
     assert current_coordinator.manufacturer == "Real Coordinator Manufacturer"
 
 
+async def test_coordinator_info_generic_name(
+    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
+    zigpy_device: Callable[..., ZigpyDevice],  # pylint: disable=redefined-outer-name
+) -> None:
+    """Test that the current coordinator uses strings from `node_info`."""
+
+    current_coord_dev = zigpy_device(ieee="aa:bb:cc:dd:ee:ff:00:11", nwk=0x0000)
+    current_coord_dev.node_desc = current_coord_dev.node_desc.replace(
+        logical_type=zdo_t.LogicalType.Coordinator
+    )
+
+    app = current_coord_dev.application
+    app.state.node_info.ieee = current_coord_dev.ieee
+    app.state.node_info.model = None
+    app.state.node_info.manufacturer = None
+
+    current_coordinator = await device_joined(current_coord_dev)
+    assert current_coordinator.is_active_coordinator
+
+    assert current_coordinator.model == "Generic EZSP"
+    assert current_coordinator.manufacturer == "Zigbee Coordinator"
+
+
 async def test_async_get_clusters(
     device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device: Callable[..., ZigpyDevice],  # pylint: disable=redefined-outer-name

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -397,8 +397,8 @@ async def test_coordinator_info_generic_name(
     current_coordinator = await device_joined(current_coord_dev)
     assert current_coordinator.is_active_coordinator
 
-    assert current_coordinator.model == "Zigbee Coordinator"
-    assert current_coordinator.manufacturer == "Generic EZSP"
+    assert current_coordinator.model == "Generic Zigbee Coordinator (EZSP)"
+    assert current_coordinator.manufacturer == ""
 
 
 async def test_async_get_clusters(

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -397,8 +397,8 @@ async def test_coordinator_info_generic_name(
     current_coordinator = await device_joined(current_coord_dev)
     assert current_coordinator.is_active_coordinator
 
-    assert current_coordinator.model == "Generic EZSP"
-    assert current_coordinator.manufacturer == "Zigbee Coordinator"
+    assert current_coordinator.model == "Zigbee Coordinator"
+    assert current_coordinator.manufacturer == "Generic EZSP"
 
 
 async def test_async_get_clusters(

--- a/zha/application/const.py
+++ b/zha/application/const.py
@@ -152,7 +152,7 @@ class RadioType(enum.Enum):
         return self._desc
 
     @property
-    def name(self) -> str:
+    def pretty_name(self) -> str:
         """Return radio type name."""
         return self.description.split(" = ", 1)[0]
 

--- a/zha/application/const.py
+++ b/zha/application/const.py
@@ -151,6 +151,11 @@ class RadioType(enum.Enum):
         """Return radio type description."""
         return self._desc
 
+    @property
+    def name(self) -> str:
+        """Return radio type name."""
+        return self.description.split(" = ", 1)[0]
+
 
 UNKNOWN = "unknown"
 UNKNOWN_MANUFACTURER = "unk_manufacturer"

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -188,9 +188,13 @@ class Gateway(AsyncUtilMixin, EventBase):
         )
         self.config.gateway = self
 
+    @property
+    def radio_type(self) -> RadioType:
+        """Get the current radio type."""
+        return RadioType[self.config.config.coordinator_configuration.radio_type]
+
     def get_application_controller_data(self) -> tuple[ControllerApplication, dict]:
         """Get an uninitialized instance of a zigpy `ControllerApplication`."""
-        radio_type = RadioType[self.config.config.coordinator_configuration.radio_type]
         app_config = self.config.zigpy_config
         app_config[CONF_DEVICE] = {
             CONF_DEVICE_PATH: self.config.config.coordinator_configuration.path,
@@ -205,12 +209,12 @@ class Gateway(AsyncUtilMixin, EventBase):
         # event loop, when a connection to a TCP coordinator fails in a specific way
         if (
             CONF_USE_THREAD not in app_config
-            and radio_type is RadioType.ezsp
+            and self.radio_type is RadioType.ezsp
             and app_config[CONF_DEVICE][CONF_DEVICE_PATH].startswith("socket://")
         ):
             app_config[CONF_USE_THREAD] = False
 
-        return radio_type.controller, app_config
+        return self.radio_type.controller, app_config
 
     @classmethod
     async def async_from_config(cls, config: ZHAData) -> Self:

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -266,7 +266,7 @@ class Device(LogMixin, EventBase):
                 self.gateway.application_controller.state.node_info.manufacturer
             )
             if manufacturer is None:
-                return f"Generic {self.gateway.radio_type.name}"
+                return ""
             return manufacturer
 
         if self._zigpy_device.manufacturer is None:
@@ -280,7 +280,7 @@ class Device(LogMixin, EventBase):
         if self.is_active_coordinator:
             model = self.gateway.application_controller.state.node_info.model
             if model is None:
-                return "Zigbee Coordinator"
+                return f"Generic Zigbee Coordinator ({self.gateway.radio_type.pretty_name})"
             return model
 
         if self._zigpy_device.model is None:

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -266,7 +266,7 @@ class Device(LogMixin, EventBase):
                 self.gateway.application_controller.state.node_info.manufacturer
             )
             if manufacturer is None:
-                return "Zigbee Coordinator"
+                return f"Generic {self.gateway.radio_type.name}"
             return manufacturer
 
         if self._zigpy_device.manufacturer is None:
@@ -280,7 +280,7 @@ class Device(LogMixin, EventBase):
         if self.is_active_coordinator:
             model = self.gateway.application_controller.state.node_info.model
             if model is None:
-                return f"Generic {self.gateway.radio_type.name}"
+                return "Zigbee Coordinator"
             return model
 
         if self._zigpy_device.model is None:

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -262,18 +262,30 @@ class Device(LogMixin, EventBase):
     def manufacturer(self) -> str:
         """Return manufacturer for device."""
         if self.is_active_coordinator:
-            return self.gateway.application_controller.state.node_info.manufacturer
+            manufacturer = (
+                self.gateway.application_controller.state.node_info.manufacturer
+            )
+            if manufacturer is None:
+                return "Zigbee Coordinator"
+            return manufacturer
+
         if self._zigpy_device.manufacturer is None:
             return UNKNOWN_MANUFACTURER
+
         return self._zigpy_device.manufacturer
 
     @cached_property
     def model(self) -> str:
         """Return model for device."""
         if self.is_active_coordinator:
-            return self.gateway.application_controller.state.node_info.model
+            model = self.gateway.application_controller.state.node_info.model
+            if model is None:
+                return f"Generic {self.gateway.radio_type.name}"
+            return model
+
         if self._zigpy_device.model is None:
             return UNKNOWN_MODEL
+
         return self._zigpy_device.model
 
     @cached_property


### PR DESCRIPTION
Not sure if it's better to swap the model and manufacturer: `Generic EZSP by Zigbee Coordinator`. Or use other strings. Open to ideas!