### PR TITLE
Fix invalid uniqueness constraint on unique_id

### DIFF
--- a/tests/test_alarm_control_panel.py
+++ b/tests/test_alarm_control_panel.py
@@ -11,6 +11,7 @@ from zigpy.zcl.clusters import security
 import zigpy.zcl.foundation as zcl_f
 
 from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
+from zha.application import Platform
 from zha.application.gateway import Gateway
 from zha.application.platforms.alarm_control_panel import AlarmControlPanel
 from zha.application.platforms.alarm_control_panel.const import AlarmState
@@ -49,7 +50,7 @@ async def test_alarm_control_panel(
     zha_device: Device = await device_joined(zigpy_device)
     cluster: security.IasAce = zigpy_device.endpoints.get(1).ias_ace
     alarm_entity: AlarmControlPanel = zha_device.platform_entities.get(
-        "00:0d:6f:00:0a:90:69:e7-1"
+        (Platform.ALARM_CONTROL_PANEL, "00:0d:6f:00:0a:90:69:e7-1")
     )
     assert alarm_entity is not None
     assert isinstance(alarm_entity, AlarmControlPanel)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -17,6 +17,7 @@ from zigpy.zcl.foundation import Status, WriteAttributesResponse
 import zigpy.zdo.types as zdo_t
 
 from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_TYPE
+from zha.application import Platform
 from zha.application.const import (
     CLUSTER_COMMAND_SERVER,
     CLUSTER_COMMANDS_CLIENT,
@@ -766,27 +767,51 @@ async def test_device_properties(
     assert zha_device.sw_version is None
 
     assert len(zha_device.platform_entities) == 3
-    assert "00:0d:6f:00:0a:90:69:e7-3-0-lqi" in zha_device.platform_entities
-    assert "00:0d:6f:00:0a:90:69:e7-3-0-rssi" in zha_device.platform_entities
-    assert "00:0d:6f:00:0a:90:69:e7-3-6" in zha_device.platform_entities
+    assert (
+        Platform.SENSOR,
+        "00:0d:6f:00:0a:90:69:e7-3-0-lqi",
+    ) in zha_device.platform_entities
+    assert (
+        Platform.SENSOR,
+        "00:0d:6f:00:0a:90:69:e7-3-0-rssi",
+    ) in zha_device.platform_entities
+    assert (
+        Platform.SWITCH,
+        "00:0d:6f:00:0a:90:69:e7-3-6",
+    ) in zha_device.platform_entities
 
     assert isinstance(
-        zha_device.platform_entities["00:0d:6f:00:0a:90:69:e7-3-0-lqi"], LQISensor
+        zha_device.platform_entities[
+            (Platform.SENSOR, "00:0d:6f:00:0a:90:69:e7-3-0-lqi")
+        ],
+        LQISensor,
     )
     assert isinstance(
-        zha_device.platform_entities["00:0d:6f:00:0a:90:69:e7-3-0-rssi"], RSSISensor
+        zha_device.platform_entities[
+            (Platform.SENSOR, "00:0d:6f:00:0a:90:69:e7-3-0-rssi")
+        ],
+        RSSISensor,
     )
     assert isinstance(
-        zha_device.platform_entities["00:0d:6f:00:0a:90:69:e7-3-6"], Switch
+        zha_device.platform_entities[(Platform.SWITCH, "00:0d:6f:00:0a:90:69:e7-3-6")],
+        Switch,
     )
 
-    assert zha_device.get_platform_entity("00:0d:6f:00:0a:90:69:e7-3-0-lqi") is not None
+    assert (
+        zha_device.get_platform_entity(
+            Platform.SENSOR, "00:0d:6f:00:0a:90:69:e7-3-0-lqi"
+        )
+        is not None
+    )
     assert isinstance(
-        zha_device.get_platform_entity("00:0d:6f:00:0a:90:69:e7-3-0-lqi"), LQISensor
+        zha_device.get_platform_entity(
+            Platform.SENSOR, "00:0d:6f:00:0a:90:69:e7-3-0-lqi"
+        ),
+        LQISensor,
     )
 
     with pytest.raises(KeyError, match="Entity foo not found"):
-        zha_device.get_platform_entity("foo")
+        zha_device.get_platform_entity("bar", "foo")
 
     # test things are none when they aren't returned by Zigpy
     zigpy_dev.node_desc = None

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -289,14 +289,14 @@ class PlatformEntity(BaseEntity):
         self._device: Device = device
         self._endpoint = endpoint
         # we double create these in discovery tests because we reissue the create calls to count and prove them out
-        if self.unique_id not in self._device.platform_entities:
-            self._device.platform_entities[self.unique_id] = self
+        if (self.PLATFORM, self.unique_id) not in self._device.platform_entities:
+            self._device.platform_entities[(self.PLATFORM, self.unique_id)] = self
         else:
             _LOGGER.debug(
                 "Not registering entity %r, unique id %r already exists: %r",
                 self,
-                self.unique_id,
-                self._device.platform_entities[self.unique_id],
+                (self.PLATFORM, self.unique_id),
+                self._device.platform_entities[(self.PLATFORM, self.unique_id)],
             )
 
     @classmethod

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -381,8 +381,8 @@ class DeviceCounterSensor(BaseEntity):
         self._device.gateway.global_updater.register_update_listener(self.update)
 
         # we double create these in discovery tests because we reissue the create calls to count and prove them out
-        if self.unique_id not in self._device.platform_entities:
-            self._device.platform_entities[self.unique_id] = self
+        if (self.PLATFORM, self.unique_id) not in self._device.platform_entities:
+            self._device.platform_entities[(self.PLATFORM, self.unique_id)] = self
 
     @functools.cached_property
     def identifiers(self) -> DeviceCounterSensorIdentifiers:

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -672,8 +672,8 @@ class Device(LogMixin, EventBase):
             **self.device_info.__dict__,
             active_coordinator=self.is_active_coordinator,
             entities={
-                unique_id[1]: platform_entity.info_object
-                for unique_id, platform_entity in self.platform_entities.items()
+                platform_entity.unique_id: platform_entity.info_object
+                for platform_entity in self.platform_entities.values()
             },
             neighbors=[
                 NeighborInfo(


### PR DESCRIPTION
Oh boy... where to start... 

fixes: https://github.com/zigpy/zha/issues/157
related: https://github.com/home-assistant/core/issues/123387

# Back story
An incorrect assumption was made when converting ZHA to a lib that the `unique_id` of an entity in HA was globally unique. This is not the case. `unique_id` is only unique per platform. This caused unique id clashes that can be seen as detailed in the linked issues. 

![image](https://github.com/user-attachments/assets/466b8112-f131-4161-b241-f75ddbc22daa)


# Fix
To fix the issue the `platform_entities` dict is now keyed by a tuple: (platform, unique_id) and all areas that leverage the dict are updated to account for the change.
