### PR TITLE
Prevent entity creation errors from killing ZHA

### DIFF
--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -329,9 +329,17 @@ class Gateway(AsyncUtilMixin, EventBase):
 
         for platform in discovery.PLATFORMS:
             for platform_entity_class, args, kw_args in self.config.platforms[platform]:
-                platform_entity = platform_entity_class.create_platform_entity(
-                    *args, **kw_args
-                )
+                try:
+                    platform_entity = platform_entity_class.create_platform_entity(
+                        *args, **kw_args
+                    )
+                except Exception:  # pylint: disable=broad-except
+                    _LOGGER.exception(
+                        "Error creating platform entity for %s [args=%s, kwargs=%s]",
+                        platform_entity_class,
+                        args,
+                        kw_args,
+                    )
                 if platform_entity:
                     _LOGGER.debug(
                         "Platform entity data: %s", platform_entity.info_object

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -335,11 +335,12 @@ class Gateway(AsyncUtilMixin, EventBase):
                     )
                 except Exception:  # pylint: disable=broad-except
                     _LOGGER.exception(
-                        "Error creating platform entity for %s [args=%s, kwargs=%s]",
+                        "Failed to create platform entity: %s [args=%s, kwargs=%s]",
                         platform_entity_class,
                         args,
                         kw_args,
                     )
+                    continue
                 if platform_entity:
                     _LOGGER.debug(
                         "Platform entity data: %s", platform_entity.info_object

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -243,6 +243,10 @@ class Device(LogMixin, EventBase):
             if ep_id != 0:
                 self._endpoints[ep_id] = Endpoint.new(endpoint, self)
 
+    def __repr__(self) -> str:
+        """Return a string representation of the device."""
+        return f"{self._zigpy_device.__repr__()} - quirk_applied: {self.quirk_applied} - quirk_or_device_class: {self.quirk_class} - quirk_id: {self.quirk_id}"
+
     @cached_property
     def device(self) -> zigpy.device.Device:
         """Return underlying Zigpy device."""

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -245,7 +245,12 @@ class Device(LogMixin, EventBase):
 
     def __repr__(self) -> str:
         """Return a string representation of the device."""
-        return f"{self._zigpy_device.__repr__()} - quirk_applied: {self.quirk_applied} - quirk_or_device_class: {self.quirk_class} - quirk_id: {self.quirk_id}"
+        return (
+            f"{repr(self._zigpy_device)} - "
+            f"quirk_applied: {self.quirk_applied} - "
+            f"quirk_or_device_class: {self.quirk_class} - "
+            f"quirk_id: {self.quirk_id}"
+        )
 
     @cached_property
     def device(self) -> zigpy.device.Device:


### PR DESCRIPTION
We shouldn't have the application fail completely if we fail to create a single entity for whatever reason. This PR wraps entity creation in a try / except and logs the exception when there is an issue. Here is an example of the generated error:

```
ERROR    zha.application.gateway:gateway.py:337 Failed to create platform entity: <class 'zha.application.platforms.sensor.DeviceCounterSensor'> [args=(<Device model='Coordinator Model' manuf='Coordinator Manufacturer' nwk=0x0000 ieee=00:15:8d:00:02:32:4f:32 is_initialized=False> - quirk_applied: False - quirk_or_device_class: zigpy.device.Device - quirk_id: None, 'counters', 'ezsp_counters', 'counter_1'), kwargs={}]
```

This was seen in logs for this issue: https://github.com/home-assistant/core/issues/123609

Relevant exception:

```
2024-08-11 21:29:15.412 DEBUG (MainThread) [homeassistant.components.zha] Failed to set up ZHA
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/zigpy/quirks/__init__.py", line 375, in get
    attr_def = self.find_attribute(key)
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/zigpy/zcl/__init__.py", line 231, in find_attribute
    return self.attributes_by_name[name_or_id]
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
KeyError: 'consumer_connected'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/zha/__init__.py", line 151, in async_setup_entry
    await zha_gateway.async_initialize()
  File "/usr/local/lib/python3.12/site-packages/zha/application/gateway.py", line 273, in async_initialize
    await self._async_initialize()
  File "/usr/local/lib/python3.12/site-packages/zha/application/gateway.py", line 262, in _async_initialize
    self.load_devices()
  File "/usr/local/lib/python3.12/site-packages/zha/application/gateway.py", line 315, in load_devices
    self.create_platform_entities()
  File "/usr/local/lib/python3.12/site-packages/zha/application/gateway.py", line 332, in create_platform_entities
    platform_entity = platform_entity_class.create_platform_entity(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/zha/application/platforms/__init__.py", line 315, in create_platform_entity
    return cls(unique_id, cluster_handlers, endpoint, device, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/zha/application/platforms/binary_sensor/__init__.py", line 75, in __init__
    self._state: bool = self.is_on
                        ^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/zha/application/platforms/binary_sensor/__init__.py", line 111, in is_on
    self._state = raw_state = self._cluster_handler.cluster.get(
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/zigpy/quirks/__init__.py", line 377, in get
    return super().get(key, default)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/zigpy/zcl/__init__.py", line 865, in get
    attr_def = self.find_attribute(key)
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/zigpy/zcl/__init__.py", line 231, in find_attribute
    return self.attributes_by_name[name_or_id]
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
KeyError: 'consumer_connected'
```