### PR TITLE
Add guard to global updater

### DIFF
--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -730,6 +730,52 @@ async def test_pollers_skip(
     assert "Device availability checker interval skipped" in caplog.text
 
 
+async def test_global_updater_guards(
+    zha_gateway: Gateway,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test global updater guards."""
+
+    assert (
+        "listener already registered with global updater - nothing to register"
+        not in caplog.text
+    )
+    assert (
+        "listener not registered with global updater - nothing to remove"
+        not in caplog.text
+    )
+
+    def listener():
+        pass
+
+    zha_gateway.global_updater.register_update_listener(listener)
+
+    assert (
+        "listener already registered with global updater - nothing to register"
+        not in caplog.text
+    )
+
+    zha_gateway.global_updater.register_update_listener(listener)
+
+    assert (
+        "listener already registered with global updater - nothing to register"
+        in caplog.text
+    )
+
+    zha_gateway.global_updater.remove_update_listener(listener)
+
+    assert (
+        "listener not registered with global updater - nothing to remove"
+        not in caplog.text
+    )
+
+    zha_gateway.global_updater.remove_update_listener(listener)
+
+    assert (
+        "listener not registered with global updater - nothing to remove" in caplog.text
+    )
+
+
 async def test_gateway_handle_message(
     zha_gateway: Gateway,
     zha_dev_basic: Device,  # pylint: disable=redefined-outer-name

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -736,44 +736,32 @@ async def test_global_updater_guards(
 ) -> None:
     """Test global updater guards."""
 
-    assert (
+    already_registered = (
         "listener already registered with global updater - nothing to register"
-        not in caplog.text
     )
-    assert (
-        "listener not registered with global updater - nothing to remove"
-        not in caplog.text
-    )
+    not_registered = "listener not registered with global updater - nothing to remove"
+
+    assert already_registered not in caplog.text
+    assert not_registered not in caplog.text
 
     def listener():
         pass
 
     zha_gateway.global_updater.register_update_listener(listener)
 
-    assert (
-        "listener already registered with global updater - nothing to register"
-        not in caplog.text
-    )
+    assert already_registered not in caplog.text
 
     zha_gateway.global_updater.register_update_listener(listener)
 
-    assert (
-        "listener already registered with global updater - nothing to register"
-        in caplog.text
-    )
+    assert already_registered in caplog.text
 
     zha_gateway.global_updater.remove_update_listener(listener)
 
-    assert (
-        "listener not registered with global updater - nothing to remove"
-        not in caplog.text
-    )
+    assert not_registered not in caplog.text
 
     zha_gateway.global_updater.remove_update_listener(listener)
 
-    assert (
-        "listener not registered with global updater - nothing to remove" in caplog.text
-    )
+    assert not_registered in caplog.text
 
 
 async def test_gateway_handle_message(

--- a/zha/application/helpers.py
+++ b/zha/application/helpers.py
@@ -397,11 +397,21 @@ class GlobalUpdater:
     def register_update_listener(self, listener: Callable):
         """Register an update listener."""
         if listener in self._update_listeners:
+            _LOGGER.debug(
+                "listener already registered with global updater - nothing to register: %s",
+                listener,
+            )
             return
         self._update_listeners.append(listener)
 
     def remove_update_listener(self, listener: Callable):
         """Remove an update listener."""
+        if listener not in self._update_listeners:
+            _LOGGER.debug(
+                "listener not registered with global updater - nothing to remove: %s",
+                listener,
+            )
+            return
         self._update_listeners.remove(listener)
 
     @periodic(_REFRESH_INTERVAL)


### PR DESCRIPTION
This PR fixes an exception I ran into when building out the HA side of PR: https://github.com/zigpy/zha/pull/93

```
Traceback (most recent call last):
  File "/Users/dmulcahey/development/homeassistant/home-assistant/homeassistant/config_entries.py", line 819, in async_unload
    result = await component.async_unload_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dmulcahey/development/homeassistant/home-assistant/homeassistant/components/zha/__init__.py", line 234, in async_unload_entry
    await ha_zha_data.gateway_proxy.shutdown()
  File "/Users/dmulcahey/development/homeassistant/home-assistant/homeassistant/components/zha/helpers.py", line 753, in shutdown
    await self.gateway.shutdown()
  File "/Users/dmulcahey/development/homeassistant/home-assistant/venv/lib/python3.12/site-packages/zha/application/gateway.py", line 741, in shutdown
    await device.on_remove()
  File "/Users/dmulcahey/development/homeassistant/home-assistant/venv/lib/python3.12/site-packages/zha/zigbee/device.py", line 773, in on_remove
    await platform_entity.on_remove()
  File "/Users/dmulcahey/development/homeassistant/home-assistant/venv/lib/python3.12/site-packages/zha/application/platforms/sensor/__init__.py", line 467, in on_remove
    self._device.gateway.global_updater.remove_update_listener(self.update)
  File "/Users/dmulcahey/development/homeassistant/home-assistant/venv/lib/python3.12/site-packages/zha/application/helpers.py", line 405, in remove_update_listener
    self._update_listeners.remove(listener)
ValueError: list.remove(x): x not in list
```