### PR TITLE
Remove `_attr_icon` from existing entities

### DIFF
--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -922,7 +922,6 @@ class DanfossExerciseTriggerTime(NumberConfigurationEntity):
     _attr_native_max_value: int = 1439
     _attr_mode: NumberMode = NumberMode.BOX
     _attr_native_unit_of_measurement: str = UnitOfTime.MINUTES
-    _attr_icon: str = "mdi:clock"
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
@@ -937,7 +936,6 @@ class DanfossExternalMeasuredRoomSensor(ZCLTemperatureEntity):
     _attr_translation_key: str = "external_temperature_sensor"
     _attr_native_min_value: float = -80
     _attr_native_max_value: float = 35
-    _attr_icon: str = "mdi:thermometer"
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
@@ -953,7 +951,6 @@ class DanfossLoadRoomMean(NumberConfigurationEntity):
     _attr_native_min_value: int = -8000
     _attr_native_max_value: int = 2000
     _attr_mode: NumberMode = NumberMode.BOX
-    _attr_icon: str = "mdi:scale-balance"
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
@@ -968,7 +965,6 @@ class DanfossRegulationSetpointOffset(NumberConfigurationEntity):
     _attr_translation_key: str = "regulation_setpoint_offset"
     _attr_mode: NumberMode = NumberMode.BOX
     _attr_native_unit_of_measurement: str = UnitOfTemperature.CELSIUS
-    _attr_icon: str = "mdi:thermostat"
     _attr_native_min_value: float = -2.5
     _attr_native_max_value: float = 2.5
     _attr_native_step: float = 0.1

--- a/zha/application/platforms/select.py
+++ b/zha/application/platforms/select.py
@@ -731,7 +731,6 @@ class DanfossExerciseDayOfTheWeek(ZCLEnumSelectEntity):
     _attribute_name = "exercise_day_of_week"
     _attr_translation_key: str = "exercise_day_of_week"
     _enum = danfoss_thermostat.DanfossExerciseDayOfTheWeekEnum
-    _attr_icon: str = "mdi:wrench-clock"
 
 
 class DanfossOrientationEnum(types.enum8):

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -1711,7 +1711,6 @@ class DanfossOpenWindowDetection(EnumSensor):
     _unique_id_suffix = "open_window_detection"
     _attribute_name = "open_window_detection"
     _attr_translation_key: str = "open_window_detected"
-    _attr_icon: str = "mdi:window-open"
     _enum = danfoss_thermostat.DanfossOpenWindowDetectionEnum
 
 
@@ -1725,7 +1724,6 @@ class DanfossLoadEstimate(Sensor):
     _unique_id_suffix = "load_estimate"
     _attribute_name = "load_estimate"
     _attr_translation_key: str = "load_estimate"
-    _attr_icon: str = "mdi:scale-balance"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
 
@@ -1753,7 +1751,6 @@ class DanfossPreheatTime(Sensor):
     _unique_id_suffix = "preheat_time"
     _attribute_name = "preheat_time"
     _attr_translation_key: str = "preheat_time"
-    _attr_icon: str = "mdi:radiator"
     _attr_entity_registry_enabled_default = False
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 

--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -769,7 +769,6 @@ class DanfossExternalOpenWindowDetected(SwitchConfigurationEntity):
     _unique_id_suffix = "external_open_window_detected"
     _attribute_name: str = "external_open_window_detected"
     _attr_translation_key: str = "external_window_sensor"
-    _attr_icon: str = "mdi:window-open"
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
@@ -782,7 +781,6 @@ class DanfossWindowOpenFeature(SwitchConfigurationEntity):
     _unique_id_suffix = "window_open_feature"
     _attribute_name: str = "window_open_feature"
     _attr_translation_key: str = "use_internal_window_detection"
-    _attr_icon: str = "mdi:window-open"
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
@@ -807,7 +805,6 @@ class DanfossRadiatorCovered(SwitchConfigurationEntity):
     _unique_id_suffix = "radiator_covered"
     _attribute_name: str = "radiator_covered"
     _attr_translation_key: str = "prioritize_external_temperature_sensor"
-    _attr_icon: str = "mdi:thermometer"
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
@@ -820,7 +817,6 @@ class DanfossHeatAvailable(SwitchConfigurationEntity):
     _unique_id_suffix = "heat_available"
     _attribute_name: str = "heat_available"
     _attr_translation_key: str = "heat_available"
-    _attr_icon: str = "mdi:water-boiler"
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
@@ -833,7 +829,6 @@ class DanfossLoadBalancingEnable(SwitchConfigurationEntity):
     _unique_id_suffix = "load_balancing_enable"
     _attribute_name: str = "load_balancing_enable"
     _attr_translation_key: str = "use_load_balancing"
-    _attr_icon: str = "mdi:scale-balance"
 
 
 @CONFIG_DIAGNOSTIC_MATCH(


### PR DESCRIPTION
These will be moved to Core:

```diff
diff --git a/homeassistant/components/zha/icons.json b/homeassistant/components/zha/icons.json
index 9b060e8105a..8dc370a6e52 100644
--- a/homeassistant/components/zha/icons.json
+++ b/homeassistant/components/zha/icons.json
@@ -86,6 +86,18 @@
       },
       "presence_detection_timeout": {
         "default": "mdi:timer-edit"
+      },
+      "exercise_trigger_time": {
+        "default": "mdi:clock"
+      },
+      "external_temperature_sensor": {
+        "default": "mdi:thermometer"
+      },
+      "load_room_mean": {
+        "default": "mdi:scale-balance"
+      },
+      "regulation_setpoint_offset": {
+        "default": "mdi:thermostat"
       }
     },
     "select": {
@@ -94,6 +106,9 @@
       },
       "keypad_lockout": {
         "default": "mdi:lock"
+      },
+      "exercise_day_of_week": {
+        "default": "mdi:wrench-clock"
       }
     },
     "sensor": {
@@ -132,6 +147,15 @@
       },
       "hooks_state": {
         "default": "mdi:hook"
+      },
+      "open_window_detected": {
+        "default": "mdi:window-open"
+      },
+      "load_estimate": {
+        "default": "mdi:scale-balance"
+      },
+      "preheat_time": {
+        "default": "mdi:radiator"
       }
     },
     "switch": {
@@ -158,6 +182,21 @@
       },
       "hooks_locked": {
         "default": "mdi:lock"
+      },
+      "external_window_sensor": {
+        "default": "mdi:window-open"
+      },
+      "use_internal_window_detection": {
+        "default": "mdi:window-open"
+      },
+      "prioritize_external_temperature_sensor": {
+        "default": "mdi:thermometer"
+      },
+      "heat_available": {
+        "default": "mdi:water-boiler"
+      },
+      "use_load_balancing": {
+        "default": "mdi:scale-balance"
       }
     }
   },

```