### PR TITLE
Adjust pre-commit CI config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,8 @@
+ci:
+  autofix_commit_msg: "Apply pre-commit auto fixes"
+  autoupdate_commit_msg: "Auto-update pre-commit hooks"
+  skip: [mypy]
+
 repos:
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0


### PR DESCRIPTION
### Proposed change
This slightly adjusts the commit messages for [pre-commit CI](https://pre-commit.ci/#configuration).
`mypy` is also dropped from the pre-commit CI action, as we're already doing this in our own CI flow with pre-commit.

### Additional information 
Whilst pre-commit CI doesn't need any configuration and is already functional now, this PR updates the commit messages for auto-fixes (applied on PRs that didn't run pre-commit first) and the title of PRs created when the hooks are updated.

For auto-updates, this was "[pre-commit.ci] pre-commit autoupdate" before, but that doesn't really fit with how we/HA are naming PRs. For auto-fixes, it's "[pre-commit.ci] auto fixes from pre-commit.com hooks [...]" by default.
This PR changes it to more simple commit messages without a "[pre-commit.ci]" prefix.

Related PR on the quirks repo (same changes):
- https://github.com/zigpy/zha-device-handlers/pull/3345
