### PR TITLE
Remove unused `light` constants

### DIFF
--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -54,7 +54,6 @@ from zha.application.platforms.light.const import (
     DEFAULT_ON_OFF_TRANSITION,
     EFFECT_COLORLOOP,
     FLASH_EFFECTS,
-    SUPPORT_GROUP_LIGHT,
     ColorMode,
     LightEntityFeature,
 )
@@ -1211,7 +1210,11 @@ class LightGroup(GroupEntity, BaseLight):
             self._supported_features |= support
         # Bitwise-and the supported features with the GroupedLight's features
         # so that we don't break in the future when a new feature is added.
-        self._supported_features &= SUPPORT_GROUP_LIGHT
+        self._supported_features &= (
+            LightEntityFeature.EFFECT
+            | LightEntityFeature.FLASH
+            | LightEntityFeature.TRANSITION
+        )
         self.maybe_emit_state_changed_event()
 
     async def _force_member_updates(self) -> None:

--- a/zha/application/platforms/light/const.py
+++ b/zha/application/platforms/light/const.py
@@ -14,7 +14,7 @@ ASSUME_UPDATE_GROUP_FROM_CHILD_DELAY = 0.05
 
 DEFAULT_MIN_TRANSITION_MANUFACTURERS = {"sengled"}
 
-STATE_UNAVAILABLE: Final = "unavailable"
+STATE_UNAVAILABLE: Final[str] = "unavailable"
 
 
 class LightEntityFeature(IntFlag):
@@ -29,54 +29,26 @@ class ColorMode(StrEnum):
     """Possible light color modes."""
 
     UNKNOWN = "unknown"
-    """Ambiguous color mode"""
     ONOFF = "onoff"
-    """Must be the only supported mode"""
     BRIGHTNESS = "brightness"
-    """Must be the only supported mode"""
     COLOR_TEMP = "color_temp"
-    HS = "hs"
     XY = "xy"
-    RGB = "rgb"
-    RGBW = "rgbw"
-    RGBWW = "rgbww"
-    WHITE = "white"
-    """Must *NOT* be the only supported mode"""
 
-
-COLOR_MODES_GROUP_LIGHT = {ColorMode.COLOR_TEMP, ColorMode.XY}
-SUPPORT_GROUP_LIGHT = (
-    LightEntityFeature.EFFECT | LightEntityFeature.FLASH | LightEntityFeature.TRANSITION
-)
 
 # Float that represents transition time in seconds to make change.
 ATTR_TRANSITION: Final[str] = "transition"
 
 # Lists holding color values
-ATTR_RGB_COLOR: Final[str] = "rgb_color"
-ATTR_RGBW_COLOR: Final[str] = "rgbw_color"
-ATTR_RGBWW_COLOR: Final[str] = "rgbww_color"
 ATTR_XY_COLOR: Final[str] = "xy_color"
-ATTR_HS_COLOR: Final[str] = "hs_color"
 ATTR_COLOR_TEMP: Final[str] = "color_temp"
-ATTR_KELVIN: Final[str] = "kelvin"
 ATTR_MIN_MIREDS: Final[str] = "min_mireds"
 ATTR_MAX_MIREDS: Final[str] = "max_mireds"
-ATTR_COLOR_NAME: Final[str] = "color_name"
-ATTR_WHITE_VALUE: Final[str] = "white_value"
-ATTR_WHITE: Final[str] = "white"
 
 # Brightness of the light, 0..255 or percentage
 ATTR_BRIGHTNESS: Final[str] = "brightness"
-ATTR_BRIGHTNESS_PCT: Final[str] = "brightness_pct"
-ATTR_BRIGHTNESS_STEP: Final[str] = "brightness_step"
-ATTR_BRIGHTNESS_STEP_PCT: Final[str] = "brightness_step_pct"
 
 ATTR_COLOR_MODE = "color_mode"
 ATTR_SUPPORTED_COLOR_MODES = "supported_color_modes"
-
-# String representing a profile (built-in ones or external defined).
-ATTR_PROFILE: Final[str] = "profile"
 
 # If the light should flash, can be FLASH_SHORT or FLASH_LONG.
 ATTR_FLASH: Final[str] = "flash"
@@ -94,15 +66,6 @@ EFFECT_WHITE: Final[str] = "white"
 
 ATTR_SUPPORTED_FEATURES: Final[str] = "supported_features"
 
-# Bitfield of features supported by the light entity
-SUPPORT_BRIGHTNESS: Final[int] = 1  # Deprecated, replaced by color modes
-SUPPORT_COLOR_TEMP: Final[int] = 2  # Deprecated, replaced by color modes
-SUPPORT_EFFECT: Final[int] = 4
-SUPPORT_FLASH: Final[int] = 8
-SUPPORT_COLOR: Final[int] = 16  # Deprecated, replaced by color modes
-SUPPORT_TRANSITION: Final[int] = 32
-SUPPORT_WHITE_VALUE: Final[int] = 128  # Deprecated, replaced by color modes
-
 EFFECT_OKAY: Final[int] = 0x02
 EFFECT_DEFAULT_VARIANT: Final[int] = 0x00
 
@@ -111,31 +74,11 @@ FLASH_EFFECTS: Final[dict[str, int]] = {
     FLASH_LONG: Identify.EffectIdentifier.Breathe,
 }
 
-SUPPORT_GROUP_LIGHT = (
-    SUPPORT_BRIGHTNESS
-    | SUPPORT_COLOR_TEMP
-    | SUPPORT_EFFECT
-    | SUPPORT_FLASH
-    | SUPPORT_COLOR
-    | SUPPORT_TRANSITION
-)
-
 VALID_COLOR_MODES = {
     ColorMode.ONOFF,
     ColorMode.BRIGHTNESS,
     ColorMode.COLOR_TEMP,
-    ColorMode.HS,
     ColorMode.XY,
-    ColorMode.RGB,
-    ColorMode.RGBW,
-    ColorMode.RGBWW,
-    ColorMode.WHITE,
 }
 COLOR_MODES_BRIGHTNESS = VALID_COLOR_MODES - {ColorMode.ONOFF}
-COLOR_MODES_COLOR = {
-    ColorMode.HS,
-    ColorMode.RGB,
-    ColorMode.RGBW,
-    ColorMode.RGBWW,
-    ColorMode.XY,
-}
+COLOR_MODES_COLOR = {ColorMode.XY}


### PR DESCRIPTION
Remove a bunch of unused light constants.

`SUPPORT_GROUP_LIGHT` was specified twice, each with a different value. I've picked the first one as the one to keep.