### PR TITLE
Expose detection parameters for SNZB-03P

### DIFF
--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -868,7 +868,7 @@ class SonoffThermostatLocalTempCalibration(ThermostatLocalTempCalibration):
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
-    cluster_handler_names=CLUSTER_HANDLER_OCCUPANCY, models={"SNZB-06P"}
+    cluster_handler_names=CLUSTER_HANDLER_OCCUPANCY, models={"SNZB-06P", "SNZB-03P"}
 )
 class SonoffPresenceSenorTimeout(NumberConfigurationEntity):
     """Configuration of Sonoff sensor presence detection timeout."""

--- a/zha/application/platforms/select.py
+++ b/zha/application/platforms/select.py
@@ -704,7 +704,7 @@ class SonoffPresenceDetectionSensitivityEnum(types.enum8):
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
-    cluster_handler_names=CLUSTER_HANDLER_OCCUPANCY, models={"SNZB-06P"}
+    cluster_handler_names=CLUSTER_HANDLER_OCCUPANCY, models={"SNZB-06P", "SNZB-03P"}
 )
 class SonoffPresenceDetectionSensitivity(ZCLEnumSelectEntity):
     """Entity to set the detection sensitivity of the Sonoff SNZB-06P."""

--- a/zha/zigbee/cluster_handlers/helpers.py
+++ b/zha/zigbee/cluster_handlers/helpers.py
@@ -20,4 +20,4 @@ def is_sonoff_presence_sensor(cluster_handler: ClusterHandler) -> bool:
     """Return true if the manufacturer and model match known Sonoff sensor models."""
     return cluster_handler.cluster.endpoint.manufacturer in (
         "SONOFF",
-    ) and cluster_handler.cluster.endpoint.model in ("SNZB-06P",)
+    ) and cluster_handler.cluster.endpoint.model in ("SNZB-06P", "SNZB-03P")


### PR DESCRIPTION
This older(?) PIR occupancy device has some of the same parameters as the newer SNZB-06P. You can manually set them through the zigbee device management menu, but it would be nicer if there was a button in the main UI. The 03P model is a PIR sensor, but it still uses the ultrasonic tagged parameters to control the device. The PIR parameters all have a value of None. These parameters are settable if you have the official Sonoff hub/app.