### PR TITLE
Remove incorrect device class checks

### DIFF
--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -265,7 +265,7 @@ class NumberConfigurationEntity(PlatformEntity):
                 Platform.NUMBER.value,
                 _LOGGER,
             )
-        if entity_metadata.device_class is None and entity_metadata.unit is not None:
+        if entity_metadata.unit is not None:
             self._attr_native_unit_of_measurement = validate_unit(
                 entity_metadata.unit
             ).value

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -210,7 +210,7 @@ class Sensor(PlatformEntity):
                 Platform.SENSOR.value,
                 _LOGGER,
             )
-        if entity_metadata.device_class is None and entity_metadata.unit is not None:
+        if entity_metadata.unit is not None:
             self._attr_native_unit_of_measurement = validate_unit(
                 entity_metadata.unit
             ).value


### PR DESCRIPTION
We previously didn't allow quirks v2 entities to have a unit if they already had a device class. That behavior was incorrect and is removed with this PR.