### PR TITLE
Convert common fixtures to plain functions

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -2,13 +2,20 @@
 
 import asyncio
 from collections.abc import Awaitable, Callable
+from contextlib import suppress
+import json
 import logging
+import pathlib
+import time
 from typing import Any, Optional
 from unittest.mock import AsyncMock, Mock
 
+from zigpy.application import ControllerApplication
+from zigpy.quirks import get_device as quirks_get_device
 import zigpy.types as t
 import zigpy.zcl
 import zigpy.zcl.foundation as zcl_f
+import zigpy.zdo.types as zdo_t
 
 from zha.application import Platform
 from zha.application.gateway import Gateway
@@ -19,7 +26,7 @@ from zha.zigbee.group import Group
 _LOGGER = logging.getLogger(__name__)
 
 
-def patch_cluster(cluster: zigpy.zcl.Cluster) -> None:
+def patch_cluster_for_testing(cluster: zigpy.zcl.Cluster) -> None:
     """Patch a cluster for testing."""
     cluster.PLUGGED_ATTR_READS = {}
 
@@ -295,3 +302,150 @@ async def group_entity_availability_test(
     await zha_gateway.async_block_till_done()
 
     assert entity.state["available"] is True
+
+
+def zigpy_device_from_device_data(
+    app: ControllerApplication,
+    device_data: dict,
+    patch_cluster: bool = True,
+    quirk: Optional[Callable] = None,
+) -> zigpy.device.Device:
+    """Make a fake device using the specified cluster classes."""
+    ieee = zigpy.types.EUI64.convert(device_data["ieee"])
+    nwk = device_data["nwk"]
+    manufacturer = device_data["manufacturer"]
+    model = device_data["model"]
+    node_descriptor = device_data["signature"]["node_descriptor"]
+    endpoints = device_data["signature"]["endpoints"]
+    cluster_data = device_data["cluster_details"]
+
+    device = zigpy.device.Device(app, ieee, nwk)
+    device.manufacturer = manufacturer
+    device.model = model
+
+    node_desc = zdo_t.NodeDescriptor(
+        logical_type=node_descriptor["logical_type"],
+        complex_descriptor_available=node_descriptor["complex_descriptor_available"],
+        user_descriptor_available=node_descriptor["user_descriptor_available"],
+        reserved=node_descriptor["reserved"],
+        aps_flags=node_descriptor["aps_flags"],
+        frequency_band=node_descriptor["frequency_band"],
+        mac_capability_flags=node_descriptor["mac_capability_flags"],
+        manufacturer_code=node_descriptor["manufacturer_code"],
+        maximum_buffer_size=node_descriptor["maximum_buffer_size"],
+        maximum_incoming_transfer_size=node_descriptor[
+            "maximum_incoming_transfer_size"
+        ],
+        server_mask=node_descriptor["server_mask"],
+        maximum_outgoing_transfer_size=node_descriptor[
+            "maximum_outgoing_transfer_size"
+        ],
+        descriptor_capability_field=node_descriptor["descriptor_capability_field"],
+    )
+    device.node_desc = node_desc
+    device.last_seen = time.time()
+
+    orig_endpoints = (
+        device_data["original_signature"]["endpoints"]
+        if "original_signature" in device_data
+        else endpoints
+    )
+    for epid, ep in orig_endpoints.items():
+        endpoint = device.add_endpoint(int(epid))
+        profile = None
+        with suppress(Exception):
+            profile = zigpy.profiles.PROFILES[int(ep["profile_id"], 16)]
+
+        endpoint.device_type = (
+            profile.DeviceType(int(ep["device_type"], 16))
+            if profile
+            else int(ep["device_type"], 16)
+        )
+        endpoint.profile_id = (
+            profile.PROFILE_ID if profile else int(ep["profile_id"], 16)
+        )
+        endpoint.request = AsyncMock(return_value=[0])
+
+        for cluster_id in ep["input_clusters"]:
+            endpoint.add_input_cluster(int(cluster_id, 16))
+
+        for cluster_id in ep["output_clusters"]:
+            endpoint.add_output_cluster(int(cluster_id, 16))
+
+    if quirk:
+        device = quirk(app, device.ieee, device.nwk, device)
+    else:
+        device = quirks_get_device(device)
+
+    for epid, ep in cluster_data.items():
+        endpoint.request = AsyncMock(return_value=[0])
+        for cluster_id, cluster in ep["in_clusters"].items():
+            real_cluster = device.endpoints[int(epid)].in_clusters[int(cluster_id, 16)]
+            if patch_cluster:
+                patch_cluster_for_testing(real_cluster)
+            for attr_id, attr in cluster["attributes"].items():
+                if (
+                    attr["value"] is None
+                    or attr_id in cluster["unsupported_attributes"]
+                ):
+                    continue
+                real_cluster._attr_cache[int(attr_id, 16)] = attr["value"]
+                real_cluster.PLUGGED_ATTR_READS[int(attr_id, 16)] = attr["value"]
+            for unsupported_attr in cluster["unsupported_attributes"]:
+                if isinstance(unsupported_attr, str) and unsupported_attr.startswith(
+                    "0x"
+                ):
+                    attrid = int(unsupported_attr, 16)
+                    real_cluster.unsupported_attributes.add(attrid)
+                    if attrid in real_cluster.attributes:
+                        real_cluster.unsupported_attributes.add(
+                            real_cluster.attributes[attrid].name
+                        )
+                else:
+                    real_cluster.unsupported_attributes.add(unsupported_attr)
+
+        for cluster_id, cluster in ep["out_clusters"].items():
+            real_cluster = device.endpoints[int(epid)].out_clusters[int(cluster_id, 16)]
+            if patch_cluster:
+                patch_cluster_for_testing(real_cluster)
+            for attr_id, attr in cluster["attributes"].items():
+                if (
+                    attr["value"] is None
+                    or attr_id in cluster["unsupported_attributes"]
+                ):
+                    continue
+                real_cluster._attr_cache[int(attr_id, 16)] = attr["value"]
+                real_cluster.PLUGGED_ATTR_READS[int(attr_id, 16)] = attr["value"]
+            for unsupported_attr in cluster["unsupported_attributes"]:
+                if isinstance(unsupported_attr, str) and unsupported_attr.startswith(
+                    "0x"
+                ):
+                    attrid = int(unsupported_attr, 16)
+                    real_cluster.unsupported_attributes.add(attrid)
+                    if attrid in real_cluster.attributes:
+                        real_cluster.unsupported_attributes.add(
+                            real_cluster.attributes[attrid].name
+                        )
+                else:
+                    real_cluster.unsupported_attributes.add(unsupported_attr)
+
+    return device
+
+
+async def zigpy_device_from_json(
+    app: ControllerApplication,
+    json_file: str,
+    patch_cluster: bool = True,
+    quirk: Optional[Callable] = None,
+) -> zigpy.device.Device:
+    """Make a fake device using the specified cluster classes."""
+    device_data = await asyncio.get_running_loop().run_in_executor(
+        None, pathlib.Path(json_file).read_text
+    )
+
+    return zigpy_device_from_device_data(
+        app=app,
+        device_data=json.loads(device_data),
+        patch_cluster=patch_cluster,
+        quirk=quirk,
+    )

--- a/tests/common.py
+++ b/tests/common.py
@@ -449,3 +449,17 @@ async def zigpy_device_from_json(
         patch_cluster=patch_cluster,
         quirk=quirk,
     )
+
+
+async def join_zigpy_device(
+    zha_gateway: Gateway, zigpy_dev: zigpy.device.Device
+) -> Device:
+    """Return a newly joined ZHA device."""
+
+    zha_gateway.application_controller.devices[zigpy_dev.ieee] = zigpy_dev
+    await zha_gateway.async_device_initialized(zigpy_dev)
+    await zha_gateway.async_block_till_done()
+
+    device = zha_gateway.get_device(zigpy_dev.ieee)
+    assert device is not None
+    return device

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 """Test configuration for the ZHA component."""
 
 import asyncio
-from collections.abc import Awaitable, Callable, Generator
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
 import itertools
 import logging
@@ -38,7 +38,6 @@ from zha.application.helpers import (
     ZHAData,
 )
 from zha.async_ import ZHAJob
-from zha.zigbee.device import Device
 
 FIXTURE_GRP_ID = 0x1001
 FIXTURE_GRP_NAME = "fixture group"
@@ -355,24 +354,6 @@ def globally_load_quirks():
     # Disable gateway built in quirks loading
     with patch("zha.application.gateway.setup_quirks"):
         yield
-
-
-@pytest.fixture
-def device_joined(
-    zha_gateway: Gateway,  # pylint: disable=redefined-outer-name
-) -> Callable[[zigpy.device.Device], Awaitable[Device]]:
-    """Return a newly joined ZHAWS device."""
-
-    async def _zha_device(zigpy_dev: zigpy.device.Device) -> Device:
-        zha_gateway.application_controller.devices[zigpy_dev.ieee] = zigpy_dev
-        await zha_gateway.async_device_initialized(zigpy_dev)
-        await zha_gateway.async_block_till_done()
-
-        device = zha_gateway.get_device(zigpy_dev.ieee)
-        assert device is not None
-        return device
-
-    return _zha_device
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,31 +3,25 @@
 import asyncio
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
-import itertools
 import logging
 import os
 import reprlib
 import threading
-import time
 from types import TracebackType
-from typing import Any, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import zigpy
 from zigpy.application import ControllerApplication
 import zigpy.config
-from zigpy.const import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 import zigpy.device
 import zigpy.group
 import zigpy.profiles
-from zigpy.quirks import get_device
 import zigpy.types
 from zigpy.zcl.clusters.general import Basic, Groups
 from zigpy.zcl.foundation import Status
 import zigpy.zdo.types as zdo_t
 
-from tests import common
 from zha.application import Platform
 from zha.application.gateway import Gateway
 from zha.application.helpers import (
@@ -372,86 +366,3 @@ def cluster_handler() -> Callable:
         return ch
 
     return cluster_handler_factory
-
-
-@pytest.fixture
-def zigpy_device_mock(
-    zigpy_app_controller: ControllerApplication,
-) -> Callable[..., zigpy.device.Device]:
-    """Make a fake device using the specified cluster classes."""
-
-    def _mock_dev(
-        endpoints: dict[int, dict[str, Any]],
-        ieee: str = "00:0d:6f:00:0a:90:69:e7",
-        manufacturer: str = "FakeManufacturer",
-        model: str = "FakeModel",
-        node_descriptor: zdo_t.NodeDescriptor | None = None,
-        nwk: int = 0xB79C,
-        patch_cluster: bool = True,
-        quirk: Optional[Callable] = None,
-        attributes: dict[int, dict[str, dict[str, Any]]] = None,
-    ) -> zigpy.device.Device:
-        """Make a fake device using the specified cluster classes."""
-        device = zigpy.device.Device(
-            zigpy_app_controller, zigpy.types.EUI64.convert(ieee), nwk
-        )
-        device.manufacturer = manufacturer
-        device.model = model
-
-        if node_descriptor is None:
-            node_descriptor = zdo_t.NodeDescriptor(
-                logical_type=zdo_t.LogicalType.EndDevice,
-                complex_descriptor_available=0,
-                user_descriptor_available=0,
-                reserved=0,
-                aps_flags=0,
-                frequency_band=zdo_t.NodeDescriptor.FrequencyBand.Freq2400MHz,
-                mac_capability_flags=zdo_t.NodeDescriptor.MACCapabilityFlags.AllocateAddress,
-                manufacturer_code=4151,
-                maximum_buffer_size=127,
-                maximum_incoming_transfer_size=100,
-                server_mask=10752,
-                maximum_outgoing_transfer_size=100,
-                descriptor_capability_field=zdo_t.NodeDescriptor.DescriptorCapability.NONE,
-            )
-
-        device.node_desc = node_descriptor
-        device.last_seen = time.time()
-
-        for epid, ep in endpoints.items():
-            endpoint = device.add_endpoint(epid)
-            endpoint.device_type = ep[SIG_EP_TYPE]
-            endpoint.profile_id = ep.get(SIG_EP_PROFILE)
-            endpoint.request = AsyncMock(return_value=[0])
-
-            for cluster_id in ep.get(SIG_EP_INPUT, []):
-                endpoint.add_input_cluster(cluster_id)
-
-            for cluster_id in ep.get(SIG_EP_OUTPUT, []):
-                endpoint.add_output_cluster(cluster_id)
-
-        if quirk:
-            device = quirk(zigpy_app_controller, device.ieee, device.nwk, device)
-        else:
-            device = get_device(device)
-
-        if patch_cluster:
-            for endpoint in (ep for epid, ep in device.endpoints.items() if epid):
-                endpoint.request = AsyncMock(return_value=[0])
-                for cluster in itertools.chain(
-                    endpoint.in_clusters.values(), endpoint.out_clusters.values()
-                ):
-                    common.patch_cluster_for_testing(cluster)
-
-        if attributes is not None:
-            for ep_id, clusters in attributes.items():
-                for cluster_name, attrs in clusters.items():
-                    cluster = getattr(device.endpoints[ep_id], cluster_name)
-
-                    for name, value in attrs.items():
-                        attr_id = cluster.find_attribute(name).id
-                        cluster._attr_cache[attr_id] = value
-
-        return device
-
-    return _mock_dev

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -303,7 +303,6 @@ class TestGateway:
 async def zha_gateway(
     zha_data: ZHAData,
     zigpy_app_controller,
-    caplog,  # pylint: disable=unused-argument
 ):
     """Set up ZHA component."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -303,6 +303,7 @@ class TestGateway:
 async def zha_gateway(
     zha_data: ZHAData,
     zigpy_app_controller,
+    caplog,  # pylint: disable=unused-argument
 ):
     """Set up ZHA component."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,9 @@
 """Test configuration for the ZHA component."""
 
 import asyncio
-from collections.abc import Awaitable, Callable, Coroutine, Generator
-from contextlib import contextmanager, suppress
+from collections.abc import Awaitable, Callable, Generator
+from contextlib import contextmanager
 import itertools
-import json
 import logging
 import os
 import reprlib
@@ -461,7 +460,7 @@ def zigpy_device_mock(
                 for cluster in itertools.chain(
                     endpoint.in_clusters.values(), endpoint.out_clusters.values()
                 ):
-                    common.patch_cluster(cluster)
+                    common.patch_cluster_for_testing(cluster)
 
         if attributes is not None:
             for ep_id, clusters in attributes.items():
@@ -475,161 +474,3 @@ def zigpy_device_mock(
         return device
 
     return _mock_dev
-
-
-@pytest.fixture
-def zigpy_device_from_json(
-    zigpy_app_controller: ControllerApplication,
-) -> Callable[..., zigpy.device.Device]:
-    """Make a fake device using the specified cluster classes."""
-
-    def _mock_dev_from_json(
-        json_file: str,
-        patch_cluster: bool = True,
-        quirk: Optional[Callable] = None,
-    ) -> zigpy.device.Device:
-        """Make a fake device using the specified cluster classes."""
-        with open(json_file, encoding="utf-8") as file:
-            device_data = json.load(file)
-
-        ieee = zigpy.types.EUI64.convert(device_data["ieee"])
-        nwk = device_data["nwk"]
-        manufacturer = device_data["manufacturer"]
-        model = device_data["model"]
-        node_descriptor = device_data["signature"]["node_descriptor"]
-        endpoints = device_data["signature"]["endpoints"]
-        cluster_data = device_data["cluster_details"]
-
-        device = zigpy.device.Device(zigpy_app_controller, ieee, nwk)
-        device.manufacturer = manufacturer
-        device.model = model
-
-        node_desc = zdo_t.NodeDescriptor(
-            logical_type=node_descriptor["logical_type"],
-            complex_descriptor_available=node_descriptor[
-                "complex_descriptor_available"
-            ],
-            user_descriptor_available=node_descriptor["user_descriptor_available"],
-            reserved=node_descriptor["reserved"],
-            aps_flags=node_descriptor["aps_flags"],
-            frequency_band=node_descriptor["frequency_band"],
-            mac_capability_flags=node_descriptor["mac_capability_flags"],
-            manufacturer_code=node_descriptor["manufacturer_code"],
-            maximum_buffer_size=node_descriptor["maximum_buffer_size"],
-            maximum_incoming_transfer_size=node_descriptor[
-                "maximum_incoming_transfer_size"
-            ],
-            server_mask=node_descriptor["server_mask"],
-            maximum_outgoing_transfer_size=node_descriptor[
-                "maximum_outgoing_transfer_size"
-            ],
-            descriptor_capability_field=node_descriptor["descriptor_capability_field"],
-        )
-        device.node_desc = node_desc
-        device.last_seen = time.time()
-
-        orig_endpoints = (
-            device_data["original_signature"]["endpoints"]
-            if "original_signature" in device_data
-            else endpoints
-        )
-        for epid, ep in orig_endpoints.items():
-            endpoint = device.add_endpoint(int(epid))
-            profile = None
-            with suppress(Exception):
-                profile = zigpy.profiles.PROFILES[int(ep["profile_id"], 16)]
-
-            endpoint.device_type = (
-                profile.DeviceType(int(ep["device_type"], 16))
-                if profile
-                else int(ep["device_type"], 16)
-            )
-            endpoint.profile_id = (
-                profile.PROFILE_ID if profile else int(ep["profile_id"], 16)
-            )
-            endpoint.request = AsyncMock(return_value=[0])
-
-            for cluster_id in ep["input_clusters"]:
-                endpoint.add_input_cluster(int(cluster_id, 16))
-
-            for cluster_id in ep["output_clusters"]:
-                endpoint.add_output_cluster(int(cluster_id, 16))
-
-        if quirk:
-            device = quirk(zigpy_app_controller, device.ieee, device.nwk, device)
-        else:
-            device = get_device(device)
-
-        for epid, ep in cluster_data.items():
-            endpoint.request = AsyncMock(return_value=[0])
-            for cluster_id, cluster in ep["in_clusters"].items():
-                real_cluster = device.endpoints[int(epid)].in_clusters[
-                    int(cluster_id, 16)
-                ]
-                if patch_cluster:
-                    common.patch_cluster(real_cluster)
-                for attr_id, attr in cluster["attributes"].items():
-                    if (
-                        attr["value"] is None
-                        or attr_id in cluster["unsupported_attributes"]
-                    ):
-                        continue
-                    real_cluster._attr_cache[int(attr_id, 16)] = attr["value"]
-                    real_cluster.PLUGGED_ATTR_READS[int(attr_id, 16)] = attr["value"]
-                for unsupported_attr in cluster["unsupported_attributes"]:
-                    if isinstance(
-                        unsupported_attr, str
-                    ) and unsupported_attr.startswith("0x"):
-                        attrid = int(unsupported_attr, 16)
-                        real_cluster.unsupported_attributes.add(attrid)
-                        if attrid in real_cluster.attributes:
-                            real_cluster.unsupported_attributes.add(
-                                real_cluster.attributes[attrid].name
-                            )
-                    else:
-                        real_cluster.unsupported_attributes.add(unsupported_attr)
-
-            for cluster_id, cluster in ep["out_clusters"].items():
-                real_cluster = device.endpoints[int(epid)].out_clusters[
-                    int(cluster_id, 16)
-                ]
-                if patch_cluster:
-                    common.patch_cluster(real_cluster)
-                for attr_id, attr in cluster["attributes"].items():
-                    if (
-                        attr["value"] is None
-                        or attr_id in cluster["unsupported_attributes"]
-                    ):
-                        continue
-                    real_cluster._attr_cache[int(attr_id, 16)] = attr["value"]
-                    real_cluster.PLUGGED_ATTR_READS[int(attr_id, 16)] = attr["value"]
-                for unsupported_attr in cluster["unsupported_attributes"]:
-                    if isinstance(
-                        unsupported_attr, str
-                    ) and unsupported_attr.startswith("0x"):
-                        attrid = int(unsupported_attr, 16)
-                        real_cluster.unsupported_attributes.add(attrid)
-                        if attrid in real_cluster.attributes:
-                            real_cluster.unsupported_attributes.add(
-                                real_cluster.attributes[attrid].name
-                            )
-                    else:
-                        real_cluster.unsupported_attributes.add(unsupported_attr)
-
-        return device
-
-    return _mock_dev_from_json
-
-
-@pytest.fixture
-def zha_device_from_file(
-    zigpy_device_from_json: Callable[..., zigpy.device.Device],
-    device_joined: Callable[[zigpy.device.Device], Awaitable[Device]],
-) -> Callable[[str], Coroutine[Any, Any, Device]]:
-    """Return a ZHA device from a JSON file."""
-
-    async def _zha_device_from_file(file_path: str) -> Device:
-        zigpy_dev = zigpy_device_from_json(file_path)
-        return await device_joined(zigpy_dev)
-
-    return _zha_device_from_file

--- a/tests/test_alarm_control_panel.py
+++ b/tests/test_alarm_control_panel.py
@@ -1,6 +1,5 @@
 """Test zha alarm control panel."""
 
-from collections.abc import Callable
 import logging
 from unittest.mock import AsyncMock, call, patch, sentinel
 
@@ -11,8 +10,14 @@ from zigpy.zcl.clusters import security
 import zigpy.zcl.foundation as zcl_f
 import zigpy.zdo.types as zdo_t
 
-from tests.common import join_zigpy_device
-from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
+from tests.common import (
+    SIG_EP_INPUT,
+    SIG_EP_OUTPUT,
+    SIG_EP_PROFILE,
+    SIG_EP_TYPE,
+    create_mock_zigpy_device,
+    join_zigpy_device,
+)
 from zha.application import Platform
 from zha.application.gateway import Gateway
 from zha.application.platforms.alarm_control_panel import AlarmControlPanel
@@ -23,7 +28,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture
-def zigpy_device(zigpy_device_mock: Callable[..., ZigpyDevice]) -> ZigpyDevice:
+def zigpy_device(zha_gateway: Gateway) -> ZigpyDevice:
     """Device tracker zigpy device."""
     endpoints = {
         1: {
@@ -33,7 +38,8 @@ def zigpy_device(zigpy_device_mock: Callable[..., ZigpyDevice]) -> ZigpyDevice:
             SIG_EP_PROFILE: zha.PROFILE_ID,
         }
     }
-    return zigpy_device_mock(
+    return create_mock_zigpy_device(
+        zha_gateway,
         endpoints,
         node_descriptor=zdo_t.NodeDescriptor(
             logical_type=zdo_t.LogicalType.EndDevice,

--- a/tests/test_alarm_control_panel.py
+++ b/tests/test_alarm_control_panel.py
@@ -1,6 +1,6 @@
 """Test zha alarm control panel."""
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 import logging
 from unittest.mock import AsyncMock, call, patch, sentinel
 
@@ -11,6 +11,7 @@ from zigpy.zcl.clusters import security
 import zigpy.zcl.foundation as zcl_f
 import zigpy.zdo.types as zdo_t
 
+from tests.common import join_zigpy_device
 from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 from zha.application import Platform
 from zha.application.gateway import Gateway
@@ -61,13 +62,12 @@ def zigpy_device(zigpy_device_mock: Callable[..., ZigpyDevice]) -> ZigpyDevice:
     new=AsyncMock(return_value=[sentinel.data, zcl_f.Status.SUCCESS]),
 )
 async def test_alarm_control_panel(
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device: ZigpyDevice,  # pylint: disable=redefined-outer-name
     zha_gateway: Gateway,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test zhaws alarm control panel platform."""
-    zha_device: Device = await device_joined(zigpy_device)
+    zha_device: Device = await join_zigpy_device(zha_gateway, zigpy_device)
     cluster: security.IasAce = zigpy_device.endpoints.get(1).ias_ace
     alarm_entity: AlarmControlPanel = zha_device.platform_entities.get(
         (Platform.ALARM_CONTROL_PANEL, "00:0d:6f:00:0a:90:69:e7-1")

--- a/tests/test_application_helpers.py
+++ b/tests/test_application_helpers.py
@@ -1,6 +1,6 @@
 """Test zha application helpers."""
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 
 import pytest
 from zigpy.device import Device as ZigpyDevice
@@ -8,10 +8,10 @@ from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Basic, OnOff
 from zigpy.zcl.clusters.security import IasZone
 
+from tests.common import join_zigpy_device
 from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 from zha.application.gateway import Gateway
 from zha.application.helpers import async_is_bindable_target, get_matched_clusters
-from zha.zigbee.device import Device
 
 IEEE_GROUPABLE_DEVICE = "01:2d:6f:00:0a:90:69:e8"
 IEEE_GROUPABLE_DEVICE2 = "02:2d:6f:00:0a:90:69:e8"
@@ -71,16 +71,17 @@ def remote_zigpy_device(zigpy_device_mock: Callable[..., ZigpyDevice]) -> ZigpyD
 
 
 async def test_async_is_bindable_target(
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device: ZigpyDevice,  # pylint: disable=redefined-outer-name
     zigpy_device_not_bindable: ZigpyDevice,  # pylint: disable=redefined-outer-name
     remote_zigpy_device: ZigpyDevice,  # pylint: disable=redefined-outer-name
     zha_gateway: Gateway,  # pylint: disable=unused-argument
 ) -> None:
     """Test zha if a device is a binding target for another device."""
-    zha_device = await device_joined(zigpy_device)
-    not_bindable_zha_device = await device_joined(zigpy_device_not_bindable)
-    remote_zha_device = await device_joined(remote_zigpy_device)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
+    not_bindable_zha_device = await join_zigpy_device(
+        zha_gateway, zigpy_device_not_bindable
+    )
+    remote_zha_device = await join_zigpy_device(zha_gateway, remote_zigpy_device)
 
     assert async_is_bindable_target(remote_zha_device, zha_device)
 
@@ -88,16 +89,17 @@ async def test_async_is_bindable_target(
 
 
 async def test_get_matched_clusters(
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device: ZigpyDevice,  # pylint: disable=redefined-outer-name
     zigpy_device_not_bindable: ZigpyDevice,  # pylint: disable=redefined-outer-name
     remote_zigpy_device: ZigpyDevice,  # pylint: disable=redefined-outer-name
     zha_gateway: Gateway,  # pylint: disable=unused-argument
 ) -> None:
     """Test getting matched clusters for 2 zha devices."""
-    zha_device = await device_joined(zigpy_device)
-    not_bindable_zha_device = await device_joined(zigpy_device_not_bindable)
-    remote_zha_device = await device_joined(remote_zigpy_device)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
+    not_bindable_zha_device = await join_zigpy_device(
+        zha_gateway, zigpy_device_not_bindable
+    )
+    remote_zha_device = await join_zigpy_device(zha_gateway, remote_zigpy_device)
 
     matches = await get_matched_clusters(remote_zha_device, zha_device)
     assert len(matches) == 1

--- a/tests/test_application_helpers.py
+++ b/tests/test_application_helpers.py
@@ -1,15 +1,19 @@
 """Test zha application helpers."""
 
-from collections.abc import Callable
-
 import pytest
 from zigpy.device import Device as ZigpyDevice
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import Basic, OnOff
 from zigpy.zcl.clusters.security import IasZone
 
-from tests.common import join_zigpy_device
-from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
+from tests.common import (
+    SIG_EP_INPUT,
+    SIG_EP_OUTPUT,
+    SIG_EP_PROFILE,
+    SIG_EP_TYPE,
+    create_mock_zigpy_device,
+    join_zigpy_device,
+)
 from zha.application.gateway import Gateway
 from zha.application.helpers import async_is_bindable_target, get_matched_clusters
 
@@ -18,7 +22,7 @@ IEEE_GROUPABLE_DEVICE2 = "02:2d:6f:00:0a:90:69:e8"
 
 
 @pytest.fixture
-def zigpy_device(zigpy_device_mock: Callable[..., ZigpyDevice]) -> ZigpyDevice:
+def zigpy_device(zha_gateway: Gateway) -> ZigpyDevice:
     """Device tracker zigpy device."""
     endpoints = {
         1: {
@@ -28,16 +32,14 @@ def zigpy_device(zigpy_device_mock: Callable[..., ZigpyDevice]) -> ZigpyDevice:
             SIG_EP_PROFILE: zha.PROFILE_ID,
         }
     }
-    zigpy_dev: ZigpyDevice = zigpy_device_mock(endpoints)
+    zigpy_dev: ZigpyDevice = create_mock_zigpy_device(zha_gateway, endpoints)
     # this one is mains powered
     zigpy_dev.node_desc.mac_capability_flags |= 0b_0000_0100
     return zigpy_dev
 
 
 @pytest.fixture
-def zigpy_device_not_bindable(
-    zigpy_device_mock: Callable[..., ZigpyDevice],
-) -> ZigpyDevice:
+def zigpy_device_not_bindable(zha_gateway: Gateway) -> ZigpyDevice:
     """Device tracker zigpy device."""
     endpoints = {
         1: {
@@ -47,14 +49,14 @@ def zigpy_device_not_bindable(
             SIG_EP_PROFILE: zha.PROFILE_ID,
         }
     }
-    zigpy_dev: ZigpyDevice = zigpy_device_mock(
-        endpoints, ieee=IEEE_GROUPABLE_DEVICE2, nwk=0x2345
+    zigpy_dev: ZigpyDevice = create_mock_zigpy_device(
+        zha_gateway, endpoints, ieee=IEEE_GROUPABLE_DEVICE2, nwk=0x2345
     )
     return zigpy_dev
 
 
 @pytest.fixture
-def remote_zigpy_device(zigpy_device_mock: Callable[..., ZigpyDevice]) -> ZigpyDevice:
+def remote_zigpy_device(zha_gateway: Gateway) -> ZigpyDevice:
     """Device tracker zigpy device."""
     endpoints = {
         1: {
@@ -64,8 +66,8 @@ def remote_zigpy_device(zigpy_device_mock: Callable[..., ZigpyDevice]) -> ZigpyD
             SIG_EP_PROFILE: zha.PROFILE_ID,
         }
     }
-    remote_zigpy_dev: ZigpyDevice = zigpy_device_mock(
-        endpoints, ieee=IEEE_GROUPABLE_DEVICE, nwk=0x1234
+    remote_zigpy_dev: ZigpyDevice = create_mock_zigpy_device(
+        zha_gateway, endpoints, ieee=IEEE_GROUPABLE_DEVICE, nwk=0x1234
     )
     return remote_zigpy_dev
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -4,18 +4,21 @@ from collections.abc import Awaitable, Callable
 from unittest.mock import MagicMock, call
 
 import pytest
-from zigpy.device import Device as ZigpyDevice
 import zigpy.profiles.zha
 from zigpy.zcl.clusters import general, measurement, security
 
 from tests.common import (
+    SIG_EP_INPUT,
+    SIG_EP_OUTPUT,
+    SIG_EP_PROFILE,
+    SIG_EP_TYPE,
+    create_mock_zigpy_device,
     find_entity,
     get_entity,
     join_zigpy_device,
     send_attributes_report,
     update_attribute_cache,
 )
-from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 from zha.application import Platform
 from zha.application.gateway import Gateway
 from zha.application.platforms import PlatformEntity
@@ -145,7 +148,6 @@ async def async_test_iaszone_on_off(
     ],
 )
 async def test_binary_sensor(
-    zigpy_device_mock: Callable[..., ZigpyDevice],
     zha_gateway: Gateway,
     device: dict,
     on_off_test: Callable[..., Awaitable[None]],
@@ -154,7 +156,7 @@ async def test_binary_sensor(
     plugs: dict[str, int],
 ) -> None:
     """Test ZHA binary_sensor platform."""
-    zigpy_device = zigpy_device_mock(device)
+    zigpy_device = create_mock_zigpy_device(zha_gateway, device)
     zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
 
     entity: PlatformEntity = find_entity(zha_device, Platform.BINARY_SENSOR)
@@ -169,12 +171,11 @@ async def test_binary_sensor(
 
 
 async def test_smarttthings_multi(
-    zigpy_device_mock: Callable[..., ZigpyDevice],
     zha_gateway: Gateway,
 ) -> None:
     """Test smartthings multi."""
-    zigpy_device = zigpy_device_mock(
-        DEVICE_SMARTTHINGS_MULTI, manufacturer="Samjin", model="multi"
+    zigpy_device = create_mock_zigpy_device(
+        zha_gateway, DEVICE_SMARTTHINGS_MULTI, manufacturer="Samjin", model="multi"
     )
     zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -11,6 +11,7 @@ from zigpy.zcl.clusters import general, measurement, security
 from tests.common import (
     find_entity,
     get_entity,
+    join_zigpy_device,
     send_attributes_report,
     update_attribute_cache,
 )
@@ -20,7 +21,6 @@ from zha.application.gateway import Gateway
 from zha.application.platforms import PlatformEntity
 from zha.application.platforms.binary_sensor import Accelerometer, IASZone, Occupancy
 from zha.zigbee.cluster_handlers.const import SMARTTHINGS_ACCELERATION_CLUSTER
-from zha.zigbee.device import Device
 
 DEVICE_IAS = {
     1: {
@@ -146,7 +146,6 @@ async def async_test_iaszone_on_off(
 )
 async def test_binary_sensor(
     zigpy_device_mock: Callable[..., ZigpyDevice],
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zha_gateway: Gateway,
     device: dict,
     on_off_test: Callable[..., Awaitable[None]],
@@ -156,7 +155,7 @@ async def test_binary_sensor(
 ) -> None:
     """Test ZHA binary_sensor platform."""
     zigpy_device = zigpy_device_mock(device)
-    zha_device = await device_joined(zigpy_device)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
 
     entity: PlatformEntity = find_entity(zha_device, Platform.BINARY_SENSOR)
     assert entity is not None
@@ -171,14 +170,13 @@ async def test_binary_sensor(
 
 async def test_smarttthings_multi(
     zigpy_device_mock: Callable[..., ZigpyDevice],
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zha_gateway: Gateway,
 ) -> None:
     """Test smartthings multi."""
     zigpy_device = zigpy_device_mock(
         DEVICE_SMARTTHINGS_MULTI, manufacturer="Samjin", model="multi"
     )
-    zha_device = await device_joined(zigpy_device)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
 
     entity: PlatformEntity = get_entity(
         zha_device, Platform.BINARY_SENSOR, entity_type=Accelerometer

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,6 +1,5 @@
 """Test ZHA button."""
 
-from collections.abc import Callable
 from typing import Final
 from unittest.mock import call, patch
 
@@ -13,7 +12,6 @@ from zhaquirks.const import (
     PROFILE_ID,
 )
 from zhaquirks.tuya.ts0601_valve import ParksideTuyaValveManufCluster
-from zigpy.device import Device as ZigpyDevice
 from zigpy.exceptions import ZigbeeException
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice
@@ -24,12 +22,16 @@ from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
 import zigpy.zcl.foundation as zcl_f
 
 from tests.common import (
+    SIG_EP_INPUT,
+    SIG_EP_OUTPUT,
+    SIG_EP_PROFILE,
+    SIG_EP_TYPE,
+    create_mock_zigpy_device,
     get_entity,
     join_zigpy_device,
     mock_coro,
     update_attribute_cache,
 )
-from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 from zha.application import Platform
 from zha.application.gateway import Gateway
 from zha.application.platforms import EntityCategory, PlatformEntity
@@ -40,13 +42,11 @@ from zha.zigbee.device import Device
 
 
 @pytest.fixture
-async def contact_sensor(
-    zigpy_device_mock: Callable[..., ZigpyDevice],
-    zha_gateway: Gateway,
-) -> tuple[Device, general.Identify]:
+async def contact_sensor(zha_gateway: Gateway) -> tuple[Device, general.Identify]:
     """Contact sensor fixture."""
 
-    zigpy_device = zigpy_device_mock(
+    zigpy_device = create_mock_zigpy_device(
+        zha_gateway,
         {
             1: {
                 SIG_EP_INPUT: [
@@ -89,13 +89,11 @@ class FrostLockQuirk(CustomDevice):
 
 
 @pytest.fixture
-async def tuya_water_valve(
-    zigpy_device_mock,
-    zha_gateway: Gateway,
-):
+async def tuya_water_valve(zha_gateway: Gateway):
     """Tuya Water Valve fixture."""
 
-    zigpy_device = zigpy_device_mock(
+    zigpy_device = create_mock_zigpy_device(
+        zha_gateway,
         {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -218,13 +216,11 @@ class FakeManufacturerCluster(CustomCluster, ManufacturerSpecificCluster):
 
 
 @pytest.fixture
-async def custom_button_device(
-    zha_gateway: Gateway,
-    zigpy_device_mock,
-):
+async def custom_button_device(zha_gateway: Gateway):
     """Button device fixture for quirks button tests."""
 
-    zigpy_device = zigpy_device_mock(
+    zigpy_device = create_mock_zigpy_device(
+        zha_gateway,
         {
             1: {
                 SIG_EP_INPUT: [

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -14,15 +14,22 @@ import pytest
 import zhaquirks.sinope.thermostat
 from zhaquirks.sinope.thermostat import SinopeTechnologiesThermostatCluster
 import zhaquirks.tuya.ts0601_trv
-from zigpy.device import Device as ZigpyDevice
 import zigpy.profiles
 import zigpy.quirks
 import zigpy.zcl.clusters
 from zigpy.zcl.clusters.hvac import Thermostat
 import zigpy.zcl.foundation as zcl_f
 
-from tests.common import get_entity, join_zigpy_device, send_attributes_report
-from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
+from tests.common import (
+    SIG_EP_INPUT,
+    SIG_EP_OUTPUT,
+    SIG_EP_PROFILE,
+    SIG_EP_TYPE,
+    create_mock_zigpy_device,
+    get_entity,
+    join_zigpy_device,
+    send_attributes_report,
+)
 from zha.application import Platform
 from zha.application.const import (
     PRESET_AWAY,
@@ -194,7 +201,6 @@ ATTR_PRESET_MODE = "preset_mode"
 
 @pytest.fixture
 def device_climate_mock(
-    zigpy_device_mock: Callable[..., ZigpyDevice],
     zha_gateway: Gateway,
 ) -> Callable[
     [
@@ -214,7 +220,9 @@ def device_climate_mock(
         quirk: type[zigpy.quirks.CustomDevice] | None = None,
     ) -> Device:
         plugged_attrs = ZCL_ATTR_PLUG if plug is None else {**ZCL_ATTR_PLUG, **plug}
-        zigpy_device = zigpy_device_mock(clusters, manufacturer=manuf, quirk=quirk)
+        zigpy_device = create_mock_zigpy_device(
+            zha_gateway, clusters, manufacturer=manuf, quirk=quirk
+        )
         zigpy_device.node_desc.mac_capability_flags |= 0b_0000_0100
         zigpy_device.endpoints[1].thermostat.PLUGGED_ATTR_READS = plugged_attrs
         zha_device = await join_zigpy_device(zha_gateway, zigpy_device)

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -21,7 +21,7 @@ import zigpy.zcl.clusters
 from zigpy.zcl.clusters.hvac import Thermostat
 import zigpy.zcl.foundation as zcl_f
 
-from tests.common import get_entity, send_attributes_report
+from tests.common import get_entity, join_zigpy_device, send_attributes_report
 from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 from zha.application import Platform
 from zha.application.const import (
@@ -195,7 +195,7 @@ ATTR_PRESET_MODE = "preset_mode"
 @pytest.fixture
 def device_climate_mock(
     zigpy_device_mock: Callable[..., ZigpyDevice],
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
+    zha_gateway: Gateway,
 ) -> Callable[
     [
         dict[int, dict[str, Any]],
@@ -217,7 +217,7 @@ def device_climate_mock(
         zigpy_device = zigpy_device_mock(clusters, manufacturer=manuf, quirk=quirk)
         zigpy_device.node_desc.mac_capability_flags |= 0b_0000_0100
         zigpy_device.endpoints[1].thermostat.PLUGGED_ATTR_READS = plugged_attrs
-        zha_device = await device_joined(zigpy_device)
+        zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
         return zha_device
 
     return _dev

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -3,7 +3,6 @@
 # pylint: disable=redefined-outer-name
 
 import asyncio
-from collections.abc import Callable
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -14,13 +13,17 @@ from zigpy.zcl.clusters import closures, general
 import zigpy.zcl.foundation as zcl_f
 
 from tests.common import (
+    SIG_EP_INPUT,
+    SIG_EP_OUTPUT,
+    SIG_EP_PROFILE,
+    SIG_EP_TYPE,
+    create_mock_zigpy_device,
     get_entity,
     join_zigpy_device,
     make_zcl_header,
     send_attributes_report,
     update_attribute_cache,
 )
-from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 from zha.application import Platform
 from zha.application.const import ATTR_COMMAND
 from zha.application.gateway import Gateway
@@ -40,9 +43,7 @@ Default_Response = zcl_f.GENERAL_COMMANDS[zcl_f.GeneralCommand.Default_Response]
 
 
 @pytest.fixture
-def zigpy_cover_device(
-    zigpy_device_mock: Callable[..., ZigpyDevice],
-) -> ZigpyDevice:
+def zigpy_cover_device(zha_gateway: Gateway) -> ZigpyDevice:
     """Zigpy cover device."""
 
     endpoints = {
@@ -53,13 +54,11 @@ def zigpy_cover_device(
             SIG_EP_OUTPUT: [],
         }
     }
-    return zigpy_device_mock(endpoints)
+    return create_mock_zigpy_device(zha_gateway, endpoints)
 
 
 @pytest.fixture
-def zigpy_cover_remote(
-    zigpy_device_mock: Callable[..., ZigpyDevice],
-) -> ZigpyDevice:
+def zigpy_cover_remote(zha_gateway: Gateway) -> ZigpyDevice:
     """Zigpy cover remote device."""
 
     endpoints = {
@@ -70,13 +69,11 @@ def zigpy_cover_remote(
             SIG_EP_OUTPUT: [closures.WindowCovering.cluster_id],
         }
     }
-    return zigpy_device_mock(endpoints)
+    return create_mock_zigpy_device(zha_gateway, endpoints)
 
 
 @pytest.fixture
-def zigpy_shade_device(
-    zigpy_device_mock: Callable[..., ZigpyDevice],
-) -> ZigpyDevice:
+def zigpy_shade_device(zha_gateway: Gateway) -> ZigpyDevice:
     """Zigpy shade device."""
 
     endpoints = {
@@ -91,13 +88,11 @@ def zigpy_shade_device(
             SIG_EP_OUTPUT: [],
         }
     }
-    return zigpy_device_mock(endpoints)
+    return create_mock_zigpy_device(zha_gateway, endpoints)
 
 
 @pytest.fixture
-def zigpy_keen_vent(
-    zigpy_device_mock: Callable[..., ZigpyDevice],
-) -> ZigpyDevice:
+def zigpy_keen_vent(zha_gateway: Gateway) -> ZigpyDevice:
     """Zigpy Keen Vent device."""
 
     endpoints = {
@@ -108,8 +103,8 @@ def zigpy_keen_vent(
             SIG_EP_OUTPUT: [],
         }
     }
-    return zigpy_device_mock(
-        endpoints, manufacturer="Keen Home Inc", model="SV02-612-MP-1.3"
+    return create_mock_zigpy_device(
+        zha_gateway, endpoints, manufacturer="Keen Home Inc", model="SV02-612-MP-1.3"
     )
 
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,7 +1,7 @@
 """Test ZHA device switch."""
 
 import asyncio
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 import logging
 import time
 from unittest import mock
@@ -16,6 +16,7 @@ from zigpy.zcl.clusters import general
 from zigpy.zcl.foundation import Status, WriteAttributesResponse
 import zigpy.zdo.types as zdo_t
 
+from tests.common import join_zigpy_device
 from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_TYPE
 from zha.application import Platform
 from zha.application.const import (
@@ -118,8 +119,8 @@ def device_without_basic_cluster_handler(
 
 @pytest.fixture
 async def ota_zha_device(
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device_mock: Callable[..., ZigpyDevice],
+    zha_gateway: Gateway,
 ) -> Device:
     """ZHA device with OTA cluster fixture."""
     zigpy_dev = zigpy_device_mock(
@@ -135,7 +136,7 @@ async def ota_zha_device(
         "test model",
     )
 
-    zha_device = await device_joined(zigpy_dev)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
     return zha_device
 
 
@@ -153,11 +154,10 @@ async def _send_time_changed(zha_gateway: Gateway, seconds: int):
 async def test_check_available_success(
     zha_gateway: Gateway,
     device_with_basic_cluster_handler: ZigpyDevice,  # pylint: disable=redefined-outer-name
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Check device availability success on 1st try."""
-    zha_device = await device_joined(device_with_basic_cluster_handler)
+    zha_device = await join_zigpy_device(zha_gateway, device_with_basic_cluster_handler)
     basic_ch = device_with_basic_cluster_handler.endpoints[3].basic
 
     assert not zha_device.is_coordinator
@@ -249,11 +249,10 @@ async def test_check_available_success(
 async def test_check_available_unsuccessful(
     zha_gateway: Gateway,
     device_with_basic_cluster_handler: ZigpyDevice,  # pylint: disable=redefined-outer-name
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
 ) -> None:
     """Check device availability all tries fail."""
 
-    zha_device = await device_joined(device_with_basic_cluster_handler)
+    zha_device = await join_zigpy_device(zha_gateway, device_with_basic_cluster_handler)
     basic_ch = device_with_basic_cluster_handler.endpoints[3].basic
 
     assert zha_device.available is True
@@ -320,13 +319,14 @@ async def test_check_available_unsuccessful(
 async def test_check_available_no_basic_cluster_handler(
     zha_gateway: Gateway,
     device_without_basic_cluster_handler: ZigpyDevice,  # pylint: disable=redefined-outer-name
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Check device availability for a device without basic cluster."""
     caplog.set_level(logging.DEBUG, logger="homeassistant.components.zha")
 
-    zha_device = await device_joined(device_without_basic_cluster_handler)
+    zha_device = await join_zigpy_device(
+        zha_gateway, device_without_basic_cluster_handler
+    )
 
     assert zha_device.available is True
 
@@ -344,8 +344,8 @@ async def test_check_available_no_basic_cluster_handler(
 
 
 async def test_device_is_active_coordinator(
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device: Callable[..., ZigpyDevice],  # pylint: disable=redefined-outer-name
+    zha_gateway: Gateway,
 ) -> None:
     """Test that the current coordinator is uniquely detected."""
 
@@ -362,8 +362,8 @@ async def test_device_is_active_coordinator(
     # The two coordinators have different IEEE addresses
     assert current_coord_dev.ieee != old_coord_dev.ieee
 
-    current_coordinator = await device_joined(current_coord_dev)
-    stale_coordinator = await device_joined(old_coord_dev)
+    current_coordinator = await join_zigpy_device(zha_gateway, current_coord_dev)
+    stale_coordinator = await join_zigpy_device(zha_gateway, old_coord_dev)
 
     # Ensure the current ApplicationController's IEEE matches our coordinator's
     current_coordinator.gateway.application_controller.state.node_info.ieee = (
@@ -375,8 +375,8 @@ async def test_device_is_active_coordinator(
 
 
 async def test_coordinator_info_uses_node_info(
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device: Callable[..., ZigpyDevice],  # pylint: disable=redefined-outer-name
+    zha_gateway: Gateway,
 ) -> None:
     """Test that the current coordinator uses strings from `node_info`."""
 
@@ -390,7 +390,7 @@ async def test_coordinator_info_uses_node_info(
     app.state.node_info.model = "Real Coordinator Model"
     app.state.node_info.manufacturer = "Real Coordinator Manufacturer"
 
-    current_coordinator = await device_joined(current_coord_dev)
+    current_coordinator = await join_zigpy_device(zha_gateway, current_coord_dev)
     assert current_coordinator.is_active_coordinator
 
     assert current_coordinator.model == "Real Coordinator Model"
@@ -398,8 +398,8 @@ async def test_coordinator_info_uses_node_info(
 
 
 async def test_coordinator_info_generic_name(
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device: Callable[..., ZigpyDevice],  # pylint: disable=redefined-outer-name
+    zha_gateway: Gateway,
 ) -> None:
     """Test that the current coordinator uses strings from `node_info`."""
 
@@ -413,7 +413,7 @@ async def test_coordinator_info_generic_name(
     app.state.node_info.model = None
     app.state.node_info.manufacturer = None
 
-    current_coordinator = await device_joined(current_coord_dev)
+    current_coordinator = await join_zigpy_device(zha_gateway, current_coord_dev)
     assert current_coordinator.is_active_coordinator
 
     assert current_coordinator.model == "Generic Zigbee Coordinator (EZSP)"
@@ -421,12 +421,12 @@ async def test_coordinator_info_generic_name(
 
 
 async def test_async_get_clusters(
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device: Callable[..., ZigpyDevice],  # pylint: disable=redefined-outer-name
+    zha_gateway: Gateway,
 ) -> None:
     """Test async_get_clusters method."""
     zigpy_dev = zigpy_device(with_basic_cluster_handler=True)
-    zha_device = await device_joined(zigpy_dev)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
 
     assert zha_device.async_get_clusters() == {
         3: {
@@ -444,25 +444,25 @@ async def test_async_get_clusters(
 
 
 async def test_async_get_groupable_endpoints(
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device: Callable[..., ZigpyDevice],  # pylint: disable=redefined-outer-name
+    zha_gateway: Gateway,
 ) -> None:
     """Test async_get_groupable_endpoints method."""
     zigpy_dev = zigpy_device(with_basic_cluster_handler=True)
     zigpy_dev.endpoints[3].add_input_cluster(general.Groups.cluster_id)
-    zha_device = await device_joined(zigpy_dev)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
 
     assert zha_device.async_get_groupable_endpoints() == [3]
 
 
 async def test_async_get_std_clusters(
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device: Callable[..., ZigpyDevice],  # pylint: disable=redefined-outer-name
+    zha_gateway: Gateway,
 ) -> None:
     """Test async_get_std_clusters method."""
     zigpy_dev = zigpy_device(with_basic_cluster_handler=True)
     zigpy_dev.endpoints[3].profile_id = zigpy.profiles.zha.PROFILE_ID
-    zha_device = await device_joined(zigpy_dev)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
 
     assert zha_device.async_get_std_clusters() == {
         3: {
@@ -480,12 +480,12 @@ async def test_async_get_std_clusters(
 
 
 async def test_async_get_cluster(
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device: Callable[..., ZigpyDevice],  # pylint: disable=redefined-outer-name
+    zha_gateway: Gateway,
 ) -> None:
     """Test async_get_cluster method."""
     zigpy_dev = zigpy_device(with_basic_cluster_handler=True)
-    zha_device = await device_joined(zigpy_dev)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
 
     assert zha_device.async_get_cluster(3, general.OnOff.cluster_id) == (
         zigpy_dev.endpoints[3].on_off
@@ -493,12 +493,12 @@ async def test_async_get_cluster(
 
 
 async def test_async_get_cluster_attributes(
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device: Callable[..., ZigpyDevice],  # pylint: disable=redefined-outer-name
+    zha_gateway: Gateway,
 ) -> None:
     """Test async_get_cluster_attributes method."""
     zigpy_dev = zigpy_device(with_basic_cluster_handler=True)
-    zha_device = await device_joined(zigpy_dev)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
 
     assert (
         zha_device.async_get_cluster_attributes(3, general.OnOff.cluster_id)
@@ -513,12 +513,12 @@ async def test_async_get_cluster_attributes(
 
 
 async def test_async_get_cluster_commands(
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device: Callable[..., ZigpyDevice],  # pylint: disable=redefined-outer-name
+    zha_gateway: Gateway,
 ) -> None:
     """Test async_get_cluster_commands method."""
     zigpy_dev = zigpy_device(with_basic_cluster_handler=True)
-    zha_device = await device_joined(zigpy_dev)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
 
     assert zha_device.async_get_cluster_commands(3, general.OnOff.cluster_id) == {
         CLUSTER_COMMANDS_CLIENT: zigpy_dev.endpoints[3].on_off.client_commands,
@@ -527,12 +527,12 @@ async def test_async_get_cluster_commands(
 
 
 async def test_write_zigbee_attribute(
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device: Callable[..., ZigpyDevice],  # pylint: disable=redefined-outer-name
+    zha_gateway: Gateway,
 ) -> None:
     """Test write_zigbee_attribute method."""
     zigpy_dev = zigpy_device(with_basic_cluster_handler=True)
-    zha_device = await device_joined(zigpy_dev)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
 
     with pytest.raises(
         ValueError,
@@ -588,12 +588,12 @@ async def test_write_zigbee_attribute(
 
 
 async def test_issue_cluster_command(
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device: Callable[..., ZigpyDevice],  # pylint: disable=redefined-outer-name
+    zha_gateway: Gateway,
 ) -> None:
     """Test issue_cluster_command method."""
     zigpy_dev = zigpy_device(with_basic_cluster_handler=True)
-    zha_device = await device_joined(zigpy_dev)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
 
     with pytest.raises(
         ValueError,
@@ -624,14 +624,14 @@ async def test_issue_cluster_command(
 
 
 async def test_async_add_to_group_remove_from_group(
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device: Callable[..., ZigpyDevice],  # pylint: disable=redefined-outer-name
+    zha_gateway: Gateway,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test async_add_to_group and async_remove_from_group methods."""
     zigpy_dev = zigpy_device(with_basic_cluster_handler=True)
     zigpy_dev.endpoints[3].add_input_cluster(general.Groups.cluster_id)
-    zha_device = await device_joined(zigpy_dev)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
 
     group: Group = zha_device.gateway.groups[0x1001]
 
@@ -694,19 +694,19 @@ async def test_async_add_to_group_remove_from_group(
 
 
 async def test_async_bind_to_group(
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device: Callable[..., ZigpyDevice],  # pylint: disable=redefined-outer-name
+    zha_gateway: Gateway,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test async_bind_to_group method."""
     zigpy_dev = zigpy_device(with_basic_cluster_handler=True)
     zigpy_dev.endpoints[3].add_input_cluster(general.Groups.cluster_id)
-    zha_device = await device_joined(zigpy_dev)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
 
     zigpy_dev_remote = zigpy_device(with_basic_cluster_handler=True)
     zigpy_dev_remote._ieee = zigpy.types.EUI64.convert("00:0d:7f:00:0a:90:69:e8")
     zigpy_dev_remote.endpoints[3].add_output_cluster(general.OnOff.cluster_id)
-    zha_device_remote = await device_joined(zigpy_dev_remote)
+    zha_device_remote = await join_zigpy_device(zha_gateway, zigpy_dev_remote)
     assert zha_device_remote is not None
 
     group: Group = zha_device.gateway.groups[0x1001]
@@ -735,12 +735,12 @@ async def test_async_bind_to_group(
 
 
 async def test_device_automation_triggers(
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device: Callable[..., ZigpyDevice],  # pylint: disable=redefined-outer-name
+    zha_gateway: Gateway,
 ) -> None:
     """Test device automation triggers."""
     zigpy_dev = zigpy_device(with_basic_cluster_handler=True)
-    zha_device = await device_joined(zigpy_dev)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
 
     assert get_device_automation_triggers(zha_device) == {
         ("device_offline", "device_offline"): {"device_event_type": "device_offline"}
@@ -753,12 +753,12 @@ async def test_device_automation_triggers(
 
 
 async def test_device_properties(
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device: Callable[..., ZigpyDevice],  # pylint: disable=redefined-outer-name
+    zha_gateway: Gateway,
 ) -> None:
     """Test device properties."""
     zigpy_dev = zigpy_device(with_basic_cluster_handler=True)
-    zha_device = await device_joined(zigpy_dev)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
 
     assert zha_device.is_mains_powered is False
     assert zha_device.is_end_device is True

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -16,8 +16,13 @@ from zigpy.zcl.clusters import general
 from zigpy.zcl.foundation import Status, WriteAttributesResponse
 import zigpy.zdo.types as zdo_t
 
-from tests.common import join_zigpy_device
-from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_TYPE
+from tests.common import (
+    SIG_EP_INPUT,
+    SIG_EP_OUTPUT,
+    SIG_EP_TYPE,
+    create_mock_zigpy_device,
+    join_zigpy_device,
+)
 from zha.application import Platform
 from zha.application.const import (
     CLUSTER_COMMAND_SERVER,
@@ -36,9 +41,7 @@ from zha.zigbee.group import Group
 
 
 @pytest.fixture
-def zigpy_device(
-    zigpy_device_mock: Callable[..., ZigpyDevice],
-) -> Callable[..., ZigpyDevice]:
+def zigpy_device(zha_gateway: Gateway) -> Callable[..., ZigpyDevice]:
     """Device tracker zigpy device."""
 
     def _dev(with_basic_cluster_handler: bool = True, **kwargs):
@@ -53,15 +56,13 @@ def zigpy_device(
                 SIG_EP_TYPE: zigpy.profiles.zha.DeviceType.ON_OFF_SWITCH,
             }
         }
-        return zigpy_device_mock(endpoints, **kwargs)
+        return create_mock_zigpy_device(zha_gateway, endpoints, **kwargs)
 
     return _dev
 
 
 @pytest.fixture
-def zigpy_device_mains(
-    zigpy_device_mock: Callable[..., ZigpyDevice],
-) -> Callable[..., ZigpyDevice]:
+def zigpy_device_mains(zha_gateway: Gateway) -> Callable[..., ZigpyDevice]:
     """Device tracker zigpy device."""
 
     def _dev(with_basic_cluster_handler: bool = True):
@@ -76,7 +77,8 @@ def zigpy_device_mains(
                 SIG_EP_TYPE: zigpy.profiles.zha.DeviceType.ON_OFF_SWITCH,
             }
         }
-        return zigpy_device_mock(
+        return create_mock_zigpy_device(
+            zha_gateway,
             endpoints,
             node_descriptor=zdo_t.NodeDescriptor(
                 logical_type=zdo_t.LogicalType.EndDevice,
@@ -119,11 +121,11 @@ def device_without_basic_cluster_handler(
 
 @pytest.fixture
 async def ota_zha_device(
-    zigpy_device_mock: Callable[..., ZigpyDevice],
     zha_gateway: Gateway,
 ) -> Device:
     """ZHA device with OTA cluster fixture."""
-    zigpy_dev = zigpy_device_mock(
+    zigpy_dev = create_mock_zigpy_device(
+        zha_gateway,
         {
             1: {
                 SIG_EP_INPUT: [general.Basic.cluster_id],

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -8,7 +8,7 @@ import pytest
 import zigpy.profiles.zha
 from zigpy.zcl.clusters import general
 
-from tests.common import get_entity, send_attributes_report
+from tests.common import get_entity, join_zigpy_device, send_attributes_report
 from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 from zha.application import Platform
 from zha.application.gateway import Gateway
@@ -39,12 +39,11 @@ def zigpy_device_dt(zigpy_device_mock):
 @pytest.mark.looptime
 async def test_device_tracker(
     zha_gateway: Gateway,
-    device_joined,
     zigpy_device_dt,  # pylint: disable=redefined-outer-name
 ) -> None:
     """Test ZHA device tracker platform."""
 
-    zha_device = await device_joined(zigpy_device_dt)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device_dt)
     cluster = zigpy_device_dt.endpoints.get(1).power
     entity = get_entity(zha_device, platform=Platform.DEVICE_TRACKER)
 

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -8,8 +8,16 @@ import pytest
 import zigpy.profiles.zha
 from zigpy.zcl.clusters import general
 
-from tests.common import get_entity, join_zigpy_device, send_attributes_report
-from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
+from tests.common import (
+    SIG_EP_INPUT,
+    SIG_EP_OUTPUT,
+    SIG_EP_PROFILE,
+    SIG_EP_TYPE,
+    create_mock_zigpy_device,
+    get_entity,
+    join_zigpy_device,
+    send_attributes_report,
+)
 from zha.application import Platform
 from zha.application.gateway import Gateway
 from zha.application.platforms.device_tracker import SourceType
@@ -17,7 +25,7 @@ from zha.application.registries import SMARTTHINGS_ARRIVAL_SENSOR_DEVICE_TYPE
 
 
 @pytest.fixture
-def zigpy_device_dt(zigpy_device_mock):
+def zigpy_device_dt(zha_gateway: Gateway) -> zigpy.device.Device:
     """Device tracker zigpy device."""
     endpoints = {
         1: {
@@ -33,7 +41,7 @@ def zigpy_device_dt(zigpy_device_mock):
             SIG_EP_PROFILE: zigpy.profiles.zha.PROFILE_ID,
         }
     }
-    return zigpy_device_mock(endpoints)
+    return create_mock_zigpy_device(zha_gateway, endpoints)
 
 
 @pytest.mark.looptime

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -3,7 +3,7 @@
 # pylint: disable=redefined-outer-name
 
 import asyncio
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 import logging
 from typing import Optional
 from unittest.mock import AsyncMock, call, patch
@@ -21,6 +21,7 @@ from tests.common import (
     get_entity,
     get_group_entity,
     group_entity_availability_test,
+    join_zigpy_device,
     send_attributes_report,
 )
 from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
@@ -89,7 +90,7 @@ def zigpy_device(
 @pytest.fixture
 async def device_fan_1(
     zigpy_device_mock: Callable[..., ZigpyDevice],
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
+    zha_gateway: Gateway,
 ) -> Device:
     """Test zha fan platform."""
 
@@ -108,7 +109,7 @@ async def device_fan_1(
         },
         ieee=IEEE_GROUPABLE_DEVICE,
     )
-    zha_device = await device_joined(zigpy_dev)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
     zha_device.available = True
     return zha_device
 
@@ -116,7 +117,7 @@ async def device_fan_1(
 @pytest.fixture
 async def device_fan_2(
     zigpy_device_mock: Callable[..., ZigpyDevice],
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
+    zha_gateway: Gateway,
 ) -> Device:
     """Test zha fan platform."""
 
@@ -136,19 +137,18 @@ async def device_fan_2(
         },
         ieee=IEEE_GROUPABLE_DEVICE2,
     )
-    zha_device = await device_joined(zigpy_dev)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
     zha_device.available = True
     return zha_device
 
 
 async def test_fan(
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device: ZigpyDevice,
     zha_gateway: Gateway,
 ) -> None:
     """Test zha fan platform."""
 
-    zha_device = await device_joined(zigpy_device)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
     cluster = zigpy_device.endpoints.get(1).fan
 
     entity = get_entity(zha_device, platform=Platform.FAN)
@@ -283,7 +283,9 @@ async def async_set_preset_mode(
 )
 @pytest.mark.looptime
 async def test_zha_group_fan_entity(
-    device_fan_1: Device, device_fan_2: Device, zha_gateway: Gateway
+    device_fan_1: Device,
+    device_fan_2: Device,
+    zha_gateway: Gateway,
 ):
     """Test the fan entity for a ZHAWS group."""
 
@@ -450,7 +452,6 @@ async def test_zha_group_fan_entity_failure_state(
     ),
 )
 async def test_fan_init(
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device: ZigpyDevice,
     zha_gateway: Gateway,  # pylint: disable=unused-argument
     plug_read: dict,
@@ -462,7 +463,7 @@ async def test_fan_init(
 
     cluster = zigpy_device.endpoints.get(1).fan
     cluster.PLUGGED_ATTR_READS = plug_read
-    zha_device = await device_joined(zigpy_device)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
 
     entity = get_entity(zha_device, platform=Platform.FAN)
 
@@ -473,7 +474,6 @@ async def test_fan_init(
 
 
 async def test_fan_update_entity(
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device: ZigpyDevice,
     zha_gateway: Gateway,
 ):
@@ -481,7 +481,7 @@ async def test_fan_update_entity(
 
     cluster = zigpy_device.endpoints.get(1).fan
     cluster.PLUGGED_ATTR_READS = {"fan_mode": 0}
-    zha_device = await device_joined(zigpy_device)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
 
     entity = get_entity(zha_device, platform=Platform.FAN)
 
@@ -555,11 +555,10 @@ def zigpy_device_ikea(zigpy_device_mock) -> ZigpyDevice:
 
 async def test_fan_ikea(
     zha_gateway: Gateway,
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device_ikea: ZigpyDevice,
 ) -> None:
     """Test ZHA fan Ikea platform."""
-    zha_device = await device_joined(zigpy_device_ikea)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device_ikea)
     cluster = zigpy_device_ikea.endpoints.get(1).ikea_airpurifier
     entity = get_entity(zha_device, platform=Platform.FAN)
 
@@ -649,18 +648,18 @@ async def test_fan_ikea(
     ],
 )
 async def test_fan_ikea_init(
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device_ikea: ZigpyDevice,
     ikea_plug_read: dict,
     ikea_expected_state: bool,
     ikea_expected_percentage: int,
     ikea_preset_mode: Optional[str],
+    zha_gateway: Gateway,
 ) -> None:
     """Test ZHA fan platform."""
     cluster = zigpy_device_ikea.endpoints.get(1).ikea_airpurifier
     cluster.PLUGGED_ATTR_READS = ikea_plug_read
 
-    zha_device = await device_joined(zigpy_device_ikea)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device_ikea)
     entity = get_entity(zha_device, platform=Platform.FAN)
     assert entity.state["is_on"] == ikea_expected_state
     assert entity.state["percentage"] == ikea_expected_percentage
@@ -669,14 +668,13 @@ async def test_fan_ikea_init(
 
 async def test_fan_ikea_update_entity(
     zha_gateway: Gateway,
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device_ikea: ZigpyDevice,
 ) -> None:
     """Test ZHA fan platform."""
     cluster = zigpy_device_ikea.endpoints.get(1).ikea_airpurifier
     cluster.PLUGGED_ATTR_READS = {"fan_mode": 0, "fan_speed": 0}
 
-    zha_device = await device_joined(zigpy_device_ikea)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device_ikea)
     entity = get_entity(zha_device, platform=Platform.FAN)
 
     assert entity.state["is_on"] is False
@@ -741,11 +739,10 @@ def zigpy_device_kof(zigpy_device_mock) -> ZigpyDevice:
 
 async def test_fan_kof(
     zha_gateway: Gateway,
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device_kof: ZigpyDevice,
 ) -> None:
     """Test ZHA fan platform for King of Fans."""
-    zha_device = await device_joined(zigpy_device_kof)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device_kof)
     cluster = zigpy_device_kof.endpoints.get(1).fan
     entity = get_entity(zha_device, platform=Platform.FAN)
 
@@ -807,8 +804,8 @@ async def test_fan_kof(
     ],
 )
 async def test_fan_kof_init(
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device_kof: ZigpyDevice,
+    zha_gateway: Gateway,
     plug_read: dict,
     expected_state: bool,
     expected_percentage: Optional[int],
@@ -819,7 +816,7 @@ async def test_fan_kof_init(
     cluster = zigpy_device_kof.endpoints.get(1).fan
     cluster.PLUGGED_ATTR_READS = plug_read
 
-    zha_device = await device_joined(zigpy_device_kof)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device_kof)
     entity = get_entity(zha_device, platform=Platform.FAN)
 
     assert entity.state["is_on"] is expected_state
@@ -829,7 +826,6 @@ async def test_fan_kof_init(
 
 async def test_fan_kof_update_entity(
     zha_gateway: Gateway,
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zigpy_device_kof: ZigpyDevice,
 ) -> None:
     """Test ZHA fan platform for King of Fans."""
@@ -837,7 +833,7 @@ async def test_fan_kof_update_entity(
     cluster = zigpy_device_kof.endpoints.get(1).fan
     cluster.PLUGGED_ATTR_READS = {"fan_mode": 0}
 
-    zha_device = await device_joined(zigpy_device_kof)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device_kof)
     entity = get_entity(zha_device, platform=Platform.FAN)
 
     assert entity.state["is_on"] is False

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -3,7 +3,6 @@
 # pylint: disable=redefined-outer-name
 
 import asyncio
-from collections.abc import Callable
 import logging
 from typing import Optional
 from unittest.mock import AsyncMock, call, patch
@@ -18,13 +17,17 @@ import zigpy.zcl.foundation as zcl_f
 import zigpy.zdo.types as zdo_t
 
 from tests.common import (
+    SIG_EP_INPUT,
+    SIG_EP_OUTPUT,
+    SIG_EP_PROFILE,
+    SIG_EP_TYPE,
+    create_mock_zigpy_device,
     get_entity,
     get_group_entity,
     group_entity_availability_test,
     join_zigpy_device,
     send_attributes_report,
 )
-from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 from zha.application import Platform
 from zha.application.gateway import Gateway
 from zha.application.platforms import GroupEntity, PlatformEntity
@@ -51,9 +54,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture
-def zigpy_device(
-    zigpy_device_mock: Callable[..., ZigpyDevice],
-) -> ZigpyDevice:
+def zigpy_device(zha_gateway: Gateway) -> ZigpyDevice:
     """Device tracker zigpy device."""
     endpoints = {
         1: {
@@ -63,7 +64,8 @@ def zigpy_device(
             SIG_EP_PROFILE: zha.PROFILE_ID,
         }
     }
-    return zigpy_device_mock(
+    return create_mock_zigpy_device(
+        zha_gateway,
         endpoints,
         node_descriptor=zdo_t.NodeDescriptor(
             logical_type=zdo_t.LogicalType.EndDevice,
@@ -88,13 +90,11 @@ def zigpy_device(
 
 
 @pytest.fixture
-async def device_fan_1(
-    zigpy_device_mock: Callable[..., ZigpyDevice],
-    zha_gateway: Gateway,
-) -> Device:
+async def device_fan_1(zha_gateway: Gateway) -> Device:
     """Test zha fan platform."""
 
-    zigpy_dev = zigpy_device_mock(
+    zigpy_dev = create_mock_zigpy_device(
+        zha_gateway,
         {
             1: {
                 SIG_EP_INPUT: [
@@ -115,13 +115,11 @@ async def device_fan_1(
 
 
 @pytest.fixture
-async def device_fan_2(
-    zigpy_device_mock: Callable[..., ZigpyDevice],
-    zha_gateway: Gateway,
-) -> Device:
+async def device_fan_2(zha_gateway: Gateway) -> Device:
     """Test zha fan platform."""
 
-    zigpy_dev = zigpy_device_mock(
+    zigpy_dev = create_mock_zigpy_device(
+        zha_gateway,
         {
             1: {
                 SIG_EP_INPUT: [
@@ -510,7 +508,7 @@ async def test_fan_update_entity(
 
 
 @pytest.fixture
-def zigpy_device_ikea(zigpy_device_mock) -> ZigpyDevice:
+def zigpy_device_ikea(zha_gateway: Gateway) -> ZigpyDevice:
     """Ikea fan zigpy device."""
     endpoints = {
         1: {
@@ -526,7 +524,8 @@ def zigpy_device_ikea(zigpy_device_mock) -> ZigpyDevice:
             SIG_EP_PROFILE: zha.PROFILE_ID,
         },
     }
-    return zigpy_device_mock(
+    return create_mock_zigpy_device(
+        zha_gateway,
         endpoints,
         manufacturer="IKEA of Sweden",
         model="STARKVIND Air purifier",
@@ -694,7 +693,7 @@ async def test_fan_ikea_update_entity(
 
 
 @pytest.fixture
-def zigpy_device_kof(zigpy_device_mock) -> ZigpyDevice:
+def zigpy_device_kof(zha_gateway: Gateway) -> ZigpyDevice:
     """Fan by King of Fans zigpy device."""
     endpoints = {
         1: {
@@ -710,7 +709,8 @@ def zigpy_device_kof(zigpy_device_mock) -> ZigpyDevice:
             SIG_EP_PROFILE: zha.PROFILE_ID,
         },
     }
-    return zigpy_device_mock(
+    return create_mock_zigpy_device(
+        zha_gateway,
         endpoints,
         manufacturer="King Of Fans, Inc.",
         model="HBUniversalCFRemote",

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -110,7 +110,6 @@ async def device_fan_1(zha_gateway: Gateway) -> Device:
         ieee=IEEE_GROUPABLE_DEVICE,
     )
     zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
-    zha_device.available = True
     return zha_device
 
 
@@ -136,7 +135,6 @@ async def device_fan_2(zha_gateway: Gateway) -> Device:
         ieee=IEEE_GROUPABLE_DEVICE2,
     )
     zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
-    zha_device.available = True
     return zha_device
 
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1,7 +1,7 @@
 """Test ZHA Gateway."""
 
 import asyncio
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, call, patch
 
 import pytest
@@ -14,7 +14,7 @@ import zigpy.zdo.types
 import zigpy.zdo.types as zdo_t
 from zigpy.zdo.types import LogicalType, NodeDescriptor
 
-from tests.common import get_entity, get_group_entity
+from tests.common import get_entity, get_group_entity, join_zigpy_device
 from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 from zha.application import Platform
 from zha.application.const import (
@@ -59,19 +59,19 @@ def zigpy_dev_basic(zigpy_device_mock: Callable[..., ZigpyDevice]) -> ZigpyDevic
 
 @pytest.fixture
 async def zha_dev_basic(
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
+    zha_gateway: Gateway,
     zigpy_dev_basic: ZigpyDevice,  # pylint: disable=redefined-outer-name
 ) -> Device:
     """ZHA device with just a basic cluster."""
 
-    zha_device = await device_joined(zigpy_dev_basic)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_dev_basic)
     return zha_device
 
 
 @pytest.fixture
 async def coordinator(
     zigpy_device_mock: Callable[..., ZigpyDevice],
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
+    zha_gateway: Gateway,
 ) -> Device:
     """Test ZHA light platform."""
 
@@ -108,7 +108,7 @@ async def coordinator(
             descriptor_capability_field=zdo_t.NodeDescriptor.DescriptorCapability.NONE,
         ),
     )
-    zha_device = await device_joined(zigpy_device)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
     zha_device.available = True
     return zha_device
 
@@ -116,7 +116,7 @@ async def coordinator(
 @pytest.fixture
 async def device_light_1(
     zigpy_device_mock: Callable[..., ZigpyDevice],
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
+    zha_gateway: Gateway,
 ) -> Device:
     """Test ZHA light platform."""
 
@@ -138,7 +138,7 @@ async def device_light_1(
         manufacturer="Philips",
         model="LWA004",
     )
-    zha_device = await device_joined(zigpy_device)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
     zha_device.available = True
     return zha_device
 
@@ -146,7 +146,7 @@ async def device_light_1(
 @pytest.fixture
 async def device_light_2(
     zigpy_device_mock: Callable[..., ZigpyDevice],
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
+    zha_gateway: Gateway,
 ) -> Device:
     """Test ZHA light platform."""
 
@@ -167,7 +167,7 @@ async def device_light_2(
         ieee=IEEE_GROUPABLE_DEVICE2,
         manufacturer="Sengled",
     )
-    zha_device = await device_joined(zigpy_device)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
     zha_device.available = True
     return zha_device
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1,7 +1,6 @@
 """Test ZHA Gateway."""
 
 import asyncio
-from collections.abc import Callable
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, call, patch
 
 import pytest
@@ -14,8 +13,16 @@ import zigpy.zdo.types
 import zigpy.zdo.types as zdo_t
 from zigpy.zdo.types import LogicalType, NodeDescriptor
 
-from tests.common import get_entity, get_group_entity, join_zigpy_device
-from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
+from tests.common import (
+    SIG_EP_INPUT,
+    SIG_EP_OUTPUT,
+    SIG_EP_PROFILE,
+    SIG_EP_TYPE,
+    create_mock_zigpy_device,
+    get_entity,
+    get_group_entity,
+    join_zigpy_device,
+)
 from zha.application import Platform
 from zha.application.const import (
     CONF_USE_THREAD,
@@ -43,9 +50,10 @@ IEEE_GROUPABLE_DEVICE2 = "02:2d:6f:00:0a:90:69:e8"
 
 
 @pytest.fixture
-def zigpy_dev_basic(zigpy_device_mock: Callable[..., ZigpyDevice]) -> ZigpyDevice:
+def zigpy_dev_basic(zha_gateway: Gateway) -> ZigpyDevice:
     """Zigpy device with just a basic cluster."""
-    return zigpy_device_mock(
+    return create_mock_zigpy_device(
+        zha_gateway,
         {
             1: {
                 SIG_EP_INPUT: [general.Basic.cluster_id],
@@ -53,7 +61,7 @@ def zigpy_dev_basic(zigpy_device_mock: Callable[..., ZigpyDevice]) -> ZigpyDevic
                 SIG_EP_TYPE: zha.DeviceType.ON_OFF_SWITCH,
                 SIG_EP_PROFILE: zha.PROFILE_ID,
             }
-        }
+        },
     )
 
 
@@ -69,13 +77,11 @@ async def zha_dev_basic(
 
 
 @pytest.fixture
-async def coordinator(
-    zigpy_device_mock: Callable[..., ZigpyDevice],
-    zha_gateway: Gateway,
-) -> Device:
+async def coordinator(zha_gateway: Gateway) -> Device:
     """Test ZHA light platform."""
 
-    zigpy_device = zigpy_device_mock(
+    zigpy_device = create_mock_zigpy_device(
+        zha_gateway,
         {
             1: {
                 SIG_EP_INPUT: [],
@@ -114,13 +120,11 @@ async def coordinator(
 
 
 @pytest.fixture
-async def device_light_1(
-    zigpy_device_mock: Callable[..., ZigpyDevice],
-    zha_gateway: Gateway,
-) -> Device:
+async def device_light_1(zha_gateway: Gateway) -> Device:
     """Test ZHA light platform."""
 
-    zigpy_device = zigpy_device_mock(
+    zigpy_device = create_mock_zigpy_device(
+        zha_gateway,
         {
             1: {
                 SIG_EP_INPUT: [
@@ -144,13 +148,11 @@ async def device_light_1(
 
 
 @pytest.fixture
-async def device_light_2(
-    zigpy_device_mock: Callable[..., ZigpyDevice],
-    zha_gateway: Gateway,
-) -> Device:
+async def device_light_2(zha_gateway: Gateway) -> Device:
     """Test ZHA light platform."""
 
-    zigpy_device = zigpy_device_mock(
+    zigpy_device = create_mock_zigpy_device(
+        zha_gateway,
         {
             1: {
                 SIG_EP_INPUT: [
@@ -509,7 +511,6 @@ async def test_startup_concurrency_limit(
     radio_concurrency: int,
     zigpy_app_controller: ControllerApplication,
     zha_data: ZHAData,
-    zigpy_device_mock,
 ):
     """Test ZHA gateway limits concurrency on startup."""
     zha_gw = Gateway(zha_data)
@@ -521,7 +522,8 @@ async def test_startup_concurrency_limit(
         await zha_gw.async_initialize()
 
     for i in range(50):
-        zigpy_dev = zigpy_device_mock(
+        zigpy_dev = create_mock_zigpy_device(
+            zha_gw,
             {
                 1: {
                     SIG_EP_INPUT: [

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -115,7 +115,6 @@ async def coordinator(zha_gateway: Gateway) -> Device:
         ),
     )
     zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
-    zha_device.available = True
     return zha_device
 
 
@@ -143,7 +142,6 @@ async def device_light_1(zha_gateway: Gateway) -> Device:
         model="LWA004",
     )
     zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
-    zha_device.available = True
     return zha_device
 
 
@@ -170,7 +168,6 @@ async def device_light_2(zha_gateway: Gateway) -> Device:
         manufacturer="Sengled",
     )
     zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
-    zha_device.available = True
     return zha_device
 
 

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -130,7 +130,6 @@ async def coordinator(
         ),
     )
     zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
-    zha_device.available = True
     return zha_device
 
 
@@ -167,7 +166,6 @@ async def device_light_1(
         | lighting.Color.ColorCapabilities.XY_attributes
     }
     zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
-    zha_device.available = True
     return zha_device
 
 
@@ -203,7 +201,6 @@ async def device_light_2(
         | lighting.Color.ColorCapabilities.XY_attributes
     }
     zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
-    zha_device.available = True
     return zha_device
 
 
@@ -242,7 +239,6 @@ async def device_light_3(
     }
 
     zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
-    zha_device.available = True
     return zha_device
 
 
@@ -282,7 +278,6 @@ async def eWeLink_light(
         "color_temp_physical_max": 0,
     }
     zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
-    zha_device.available = True
     return zha_device
 
 

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,6 +1,6 @@
 """Test zha lock."""
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from unittest.mock import patch
 
 import pytest
@@ -9,7 +9,12 @@ import zigpy.profiles.zha
 from zigpy.zcl.clusters import closures, general
 import zigpy.zcl.foundation as zcl_f
 
-from tests.common import get_entity, send_attributes_report, update_attribute_cache
+from tests.common import (
+    get_entity,
+    join_zigpy_device,
+    send_attributes_report,
+    update_attribute_cache,
+)
 from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 from zha.application import Platform
 from zha.application.gateway import Gateway
@@ -27,7 +32,7 @@ SET_USER_STATUS = 9
 @pytest.fixture
 async def lock(
     zigpy_device_mock: Callable[..., ZigpyDevice],
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
+    zha_gateway: Gateway,
 ) -> tuple[Device, closures.DoorLock]:
     """Lock cluster fixture."""
 
@@ -42,7 +47,7 @@ async def lock(
         },
     )
 
-    zha_device = await device_joined(zigpy_device)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
     return zha_device, zigpy_device.endpoints[1].door_lock
 
 

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,21 +1,23 @@
 """Test zha lock."""
 
-from collections.abc import Callable
 from unittest.mock import patch
 
 import pytest
-from zigpy.device import Device as ZigpyDevice
 import zigpy.profiles.zha
 from zigpy.zcl.clusters import closures, general
 import zigpy.zcl.foundation as zcl_f
 
 from tests.common import (
+    SIG_EP_INPUT,
+    SIG_EP_OUTPUT,
+    SIG_EP_PROFILE,
+    SIG_EP_TYPE,
+    create_mock_zigpy_device,
     get_entity,
     join_zigpy_device,
     send_attributes_report,
     update_attribute_cache,
 )
-from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 from zha.application import Platform
 from zha.application.gateway import Gateway
 from zha.application.platforms import PlatformEntity
@@ -31,12 +33,12 @@ SET_USER_STATUS = 9
 
 @pytest.fixture
 async def lock(
-    zigpy_device_mock: Callable[..., ZigpyDevice],
     zha_gateway: Gateway,
 ) -> tuple[Device, closures.DoorLock]:
     """Lock cluster fixture."""
 
-    zigpy_device = zigpy_device_mock(
+    zigpy_device = create_mock_zigpy_device(
+        zha_gateway,
         {
             1: {
                 SIG_EP_INPUT: [closures.DoorLock.cluster_id, general.Basic.cluster_id],

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,6 +1,5 @@
 """Test zha number platform."""
 
-from collections.abc import Callable
 from unittest.mock import call
 
 import pytest
@@ -12,12 +11,16 @@ from zigpy.zcl.clusters import general, lighting
 import zigpy.zdo.types as zdo_t
 
 from tests.common import (
+    SIG_EP_INPUT,
+    SIG_EP_OUTPUT,
+    SIG_EP_PROFILE,
+    SIG_EP_TYPE,
+    create_mock_zigpy_device,
     get_entity,
     join_zigpy_device,
     send_attributes_report,
     update_attribute_cache,
 )
-from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 from zha.application import Platform
 from zha.application.gateway import Gateway
 from zha.application.platforms import EntityCategory, PlatformEntity
@@ -27,9 +30,7 @@ from zha.zigbee.device import Device
 
 
 @pytest.fixture
-def zigpy_analog_output_device(
-    zigpy_device_mock: Callable[..., ZigpyDevice],
-) -> ZigpyDevice:
+def zigpy_analog_output_device(zha_gateway: Gateway) -> ZigpyDevice:
     """Zigpy analog_output device."""
 
     endpoints = {
@@ -40,14 +41,15 @@ def zigpy_analog_output_device(
             SIG_EP_PROFILE: zha.PROFILE_ID,
         }
     }
-    return zigpy_device_mock(endpoints)
+    return create_mock_zigpy_device(zha_gateway, endpoints)
 
 
 @pytest.fixture
-async def light(zigpy_device_mock: Callable[..., ZigpyDevice]) -> ZigpyDevice:
+async def light(zha_gateway: Gateway) -> ZigpyDevice:
     """Siren fixture."""
 
-    zigpy_device = zigpy_device_mock(
+    zigpy_device = create_mock_zigpy_device(
+        zha_gateway,
         {
             1: {
                 SIG_EP_PROFILE: zha.PROFILE_ID,

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,6 +1,6 @@
 """Test zha number platform."""
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from unittest.mock import call
 
 import pytest
@@ -11,7 +11,12 @@ import zigpy.types
 from zigpy.zcl.clusters import general, lighting
 import zigpy.zdo.types as zdo_t
 
-from tests.common import get_entity, send_attributes_report, update_attribute_cache
+from tests.common import (
+    get_entity,
+    join_zigpy_device,
+    send_attributes_report,
+    update_attribute_cache,
+)
 from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 from zha.application import Platform
 from zha.application.gateway import Gateway
@@ -82,7 +87,6 @@ async def light(zigpy_device_mock: Callable[..., ZigpyDevice]) -> ZigpyDevice:
 
 async def test_number(
     zigpy_analog_output_device: ZigpyDevice,  # pylint: disable=redefined-outer-name
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
     zha_gateway: Gateway,
 ) -> None:
     """Test zha number platform."""
@@ -101,7 +105,7 @@ async def test_number(
     update_attribute_cache(cluster)
     cluster.PLUGGED_ATTR_READS["present_value"] = 15.0
 
-    zha_device = await device_joined(zigpy_analog_output_device)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_analog_output_device)
     # one for present_value and one for the rest configuration attributes
     assert cluster.read_attributes.call_count == 3
     attr_reads = set()
@@ -193,7 +197,6 @@ async def test_number(
 async def test_level_control_number(
     zha_gateway: Gateway,  # pylint: disable=unused-argument
     light: Device,  # pylint: disable=redefined-outer-name
-    device_joined,
     attr: str,
     initial_value: int,
     new_value: int,
@@ -205,7 +208,7 @@ async def test_level_control_number(
     level_control_cluster.PLUGGED_ATTR_READS = {
         attr: initial_value,
     }
-    zha_device = await device_joined(light)
+    zha_device = await join_zigpy_device(zha_gateway, light)
 
     entity = get_entity(zha_device, platform=Platform.NUMBER, qualifier=attr)
 
@@ -318,7 +321,6 @@ async def test_level_control_number(
 async def test_color_number(
     zha_gateway: Gateway,  # pylint: disable=unused-argument
     light: Device,  # pylint: disable=redefined-outer-name
-    device_joined,
     attr: str,
     initial_value: int,
     new_value: int,
@@ -329,7 +331,7 @@ async def test_color_number(
     color_cluster.PLUGGED_ATTR_READS = {
         attr: initial_value,
     }
-    zha_device = await device_joined(light)
+    zha_device = await join_zigpy_device(zha_gateway, light)
 
     entity = get_entity(zha_device, platform=Platform.NUMBER, qualifier=attr)
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,6 +1,6 @@
 """Test ZHA select entities."""
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from unittest.mock import call, patch
 
 import pytest
@@ -21,7 +21,7 @@ from zigpy.zcl import foundation
 from zigpy.zcl.clusters import general, security
 from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
 
-from tests.common import get_entity, send_attributes_report
+from tests.common import get_entity, join_zigpy_device, send_attributes_report
 from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_TYPE
 from zha.application import Platform
 from zha.application.gateway import Gateway
@@ -33,7 +33,7 @@ from zha.zigbee.device import Device
 @pytest.fixture
 async def siren(
     zigpy_device_mock: Callable[..., ZigpyDevice],
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
+    zha_gateway: Gateway,
 ) -> tuple[Device, security.IasWd]:
     """Siren fixture."""
 
@@ -48,7 +48,7 @@ async def siren(
         },
     )
 
-    zha_device = await device_joined(zigpy_device)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
     return zha_device, zigpy_device.endpoints[1].ias_wd
 
 
@@ -117,9 +117,7 @@ class MotionSensitivityQuirk(CustomDevice):
 
 
 @pytest.fixture
-async def zigpy_device_aqara_sensor(
-    zha_gateway: Gateway, zigpy_device_mock, device_joined
-):
+async def zigpy_device_aqara_sensor(zha_gateway: Gateway, zigpy_device_mock):
     """Device tracker zigpy Aqara motion sensor device."""
 
     zigpy_device = zigpy_device_mock(
@@ -136,7 +134,7 @@ async def zigpy_device_aqara_sensor(
     )
 
     zigpy_device = get_device(zigpy_device)
-    zha_device = await device_joined(zigpy_device)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
     zha_device.available = True
     await zha_gateway.async_block_till_done()
     return zigpy_device
@@ -144,12 +142,11 @@ async def zigpy_device_aqara_sensor(
 
 async def test_on_off_select_attribute_report(
     zha_gateway: Gateway,
-    device_joined,
     zigpy_device_aqara_sensor,  # pylint: disable=redefined-outer-name
 ) -> None:
     """Test ZHA attribute report parsing for select platform."""
 
-    zha_device = await device_joined(zigpy_device_aqara_sensor)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device_aqara_sensor)
     cluster = zigpy_device_aqara_sensor.endpoints.get(1).opple_cluster
 
     entity = get_entity(zha_device, platform=Platform.SELECT)
@@ -185,7 +182,6 @@ async def test_on_off_select_attribute_report(
 async def zigpy_device_aqara_sensor_v2(
     zha_gateway: Gateway,  # pylint: disable=unused-argument
     zigpy_device_mock,
-    device_joined,
 ):
     """Device tracker zigpy Aqara motion sensor device."""
 
@@ -205,7 +201,7 @@ async def zigpy_device_aqara_sensor_v2(
     )
     zigpy_device = get_device(zigpy_device)
 
-    zha_device = await device_joined(zigpy_device)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
     return zha_device, zigpy_device.endpoints[1].opple_cluster
 
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -122,7 +122,7 @@ class MotionSensitivityQuirk(CustomDevice):
 
 
 @pytest.fixture
-async def zigpy_device_aqara_sensor(zha_gateway: Gateway):
+async def aqara_sensor(zha_gateway: Gateway) -> Device:
     """Device tracker zigpy Aqara motion sensor device."""
 
     zigpy_device = create_mock_zigpy_device(
@@ -141,21 +141,18 @@ async def zigpy_device_aqara_sensor(zha_gateway: Gateway):
 
     zigpy_device = get_device(zigpy_device)
     zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
-    zha_device.available = True
-    await zha_gateway.async_block_till_done()
-    return zigpy_device
+    return zha_device
 
 
 async def test_on_off_select_attribute_report(
     zha_gateway: Gateway,
-    zigpy_device_aqara_sensor,  # pylint: disable=redefined-outer-name
+    aqara_sensor,  # pylint: disable=redefined-outer-name
 ) -> None:
     """Test ZHA attribute report parsing for select platform."""
 
-    zha_device = await join_zigpy_device(zha_gateway, zigpy_device_aqara_sensor)
-    cluster = zigpy_device_aqara_sensor.endpoints.get(1).opple_cluster
+    cluster = aqara_sensor.device.endpoints.get(1).opple_cluster
 
-    entity = get_entity(zha_device, platform=Platform.SELECT)
+    entity = get_entity(aqara_sensor, platform=Platform.SELECT)
     assert entity.state["state"] == AqaraMotionSensitivities.Medium.name
 
     # send attribute report from device

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,6 +1,5 @@
 """Test ZHA select entities."""
 
-from collections.abc import Callable
 from unittest.mock import call, patch
 
 import pytest
@@ -12,7 +11,6 @@ from zhaquirks import (
     PROFILE_ID,
 )
 from zigpy.const import SIG_EP_PROFILE
-from zigpy.device import Device as ZigpyDevice
 from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice, get_device
 from zigpy.quirks.v2 import CustomDeviceV2, QuirkBuilder
@@ -21,8 +19,15 @@ from zigpy.zcl import foundation
 from zigpy.zcl.clusters import general, security
 from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
 
-from tests.common import get_entity, join_zigpy_device, send_attributes_report
-from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_TYPE
+from tests.common import (
+    SIG_EP_INPUT,
+    SIG_EP_OUTPUT,
+    SIG_EP_TYPE,
+    create_mock_zigpy_device,
+    get_entity,
+    join_zigpy_device,
+    send_attributes_report,
+)
 from zha.application import Platform
 from zha.application.gateway import Gateway
 from zha.application.platforms import EntityCategory
@@ -32,12 +37,12 @@ from zha.zigbee.device import Device
 
 @pytest.fixture
 async def siren(
-    zigpy_device_mock: Callable[..., ZigpyDevice],
     zha_gateway: Gateway,
 ) -> tuple[Device, security.IasWd]:
     """Siren fixture."""
 
-    zigpy_device = zigpy_device_mock(
+    zigpy_device = create_mock_zigpy_device(
+        zha_gateway,
         {
             1: {
                 SIG_EP_INPUT: [general.Basic.cluster_id, security.IasWd.cluster_id],
@@ -117,10 +122,11 @@ class MotionSensitivityQuirk(CustomDevice):
 
 
 @pytest.fixture
-async def zigpy_device_aqara_sensor(zha_gateway: Gateway, zigpy_device_mock):
+async def zigpy_device_aqara_sensor(zha_gateway: Gateway):
     """Device tracker zigpy Aqara motion sensor device."""
 
-    zigpy_device = zigpy_device_mock(
+    zigpy_device = create_mock_zigpy_device(
+        zha_gateway,
         {
             1: {
                 SIG_EP_INPUT: [general.Basic.cluster_id],
@@ -181,11 +187,11 @@ async def test_on_off_select_attribute_report(
 @pytest.fixture
 async def zigpy_device_aqara_sensor_v2(
     zha_gateway: Gateway,  # pylint: disable=unused-argument
-    zigpy_device_mock,
 ):
     """Device tracker zigpy Aqara motion sensor device."""
 
-    zigpy_device = zigpy_device_mock(
+    zigpy_device = create_mock_zigpy_device(
+        zha_gateway,
         {
             1: {
                 SIG_EP_INPUT: [

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -82,7 +82,6 @@ async def elec_measurement_zha_dev(
     """Electric Measurement ZHA device."""
 
     zha_dev = await join_zigpy_device(zha_gateway, elec_measurement_zigpy_dev)
-    zha_dev.available = True
     return zha_dev
 
 

--- a/tests/test_siren.py
+++ b/tests/test_siren.py
@@ -1,7 +1,7 @@
 """Test zha siren."""
 
 import asyncio
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from unittest.mock import patch
 
 import pytest
@@ -11,7 +11,7 @@ from zigpy.profiles import zha
 from zigpy.zcl.clusters import general, security
 import zigpy.zcl.foundation as zcl_f
 
-from tests.common import get_entity, mock_coro
+from tests.common import get_entity, join_zigpy_device, mock_coro
 from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_TYPE
 from zha.application import Platform
 from zha.application.gateway import Gateway
@@ -22,7 +22,7 @@ from zha.zigbee.device import Device
 @pytest.fixture
 async def siren(
     zigpy_device_mock: Callable[..., ZigpyDevice],
-    device_joined: Callable[[ZigpyDevice], Awaitable[Device]],
+    zha_gateway: Gateway,
 ) -> tuple[Device, security.IasWd]:
     """Siren fixture."""
 
@@ -37,7 +37,7 @@ async def siren(
         },
     )
 
-    zha_device = await device_joined(zigpy_device)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
     return zha_device, zigpy_device.endpoints[1].ias_wd
 
 

--- a/tests/test_siren.py
+++ b/tests/test_siren.py
@@ -1,18 +1,23 @@
 """Test zha siren."""
 
 import asyncio
-from collections.abc import Callable
 from unittest.mock import patch
 
 import pytest
 from zigpy.const import SIG_EP_PROFILE
-from zigpy.device import Device as ZigpyDevice
 from zigpy.profiles import zha
 from zigpy.zcl.clusters import general, security
 import zigpy.zcl.foundation as zcl_f
 
-from tests.common import get_entity, join_zigpy_device, mock_coro
-from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_TYPE
+from tests.common import (
+    SIG_EP_INPUT,
+    SIG_EP_OUTPUT,
+    SIG_EP_TYPE,
+    create_mock_zigpy_device,
+    get_entity,
+    join_zigpy_device,
+    mock_coro,
+)
 from zha.application import Platform
 from zha.application.gateway import Gateway
 from zha.application.platforms.siren import SirenEntityFeature
@@ -21,12 +26,12 @@ from zha.zigbee.device import Device
 
 @pytest.fixture
 async def siren(
-    zigpy_device_mock: Callable[..., ZigpyDevice],
     zha_gateway: Gateway,
 ) -> tuple[Device, security.IasWd]:
     """Siren fixture."""
 
-    zigpy_device = zigpy_device_mock(
+    zigpy_device = create_mock_zigpy_device(
+        zha_gateway,
         {
             1: {
                 SIG_EP_INPUT: [general.Basic.cluster_id, security.IasWd.cluster_id],

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,7 +1,6 @@
 """Test zha switch."""
 
 import asyncio
-from collections.abc import Callable
 import logging
 from unittest.mock import call, patch
 
@@ -24,6 +23,7 @@ from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
 import zigpy.zcl.foundation as zcl_f
 
 from tests.common import (
+    create_mock_zigpy_device,
     get_entity,
     get_group_entity,
     group_entity_availability_test,
@@ -47,7 +47,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture
-def zigpy_device(zigpy_device_mock: Callable[..., ZigpyDevice]) -> ZigpyDevice:
+def zigpy_device(zha_gateway: Gateway) -> ZigpyDevice:
     """Device tracker zigpy device."""
     endpoints = {
         1: {
@@ -57,14 +57,14 @@ def zigpy_device(zigpy_device_mock: Callable[..., ZigpyDevice]) -> ZigpyDevice:
             SIG_EP_PROFILE: zha.PROFILE_ID,
         }
     }
-    zigpy_dev: ZigpyDevice = zigpy_device_mock(endpoints)
+    zigpy_dev: ZigpyDevice = create_mock_zigpy_device(zha_gateway, endpoints)
     # this one is mains powered
     zigpy_dev.node_desc.mac_capability_flags |= 0b_0000_0100
     return zigpy_dev
 
 
 @pytest.fixture
-def zigpy_cover_device(zigpy_device_mock):
+def zigpy_cover_device(zha_gateway: Gateway):
     """Zigpy cover device."""
 
     endpoints = {
@@ -78,17 +78,15 @@ def zigpy_cover_device(zigpy_device_mock):
             SIG_EP_OUTPUT: [],
         }
     }
-    return zigpy_device_mock(endpoints)
+    return create_mock_zigpy_device(zha_gateway, endpoints)
 
 
 @pytest.fixture
-async def device_switch_1(
-    zigpy_device_mock: Callable[..., ZigpyDevice],
-    zha_gateway: Gateway,
-) -> Device:
+async def device_switch_1(zha_gateway: Gateway) -> Device:
     """Test zha switch platform."""
 
-    zigpy_dev = zigpy_device_mock(
+    zigpy_dev = create_mock_zigpy_device(
+        zha_gateway,
         {
             1: {
                 SIG_EP_INPUT: [general.OnOff.cluster_id, general.Groups.cluster_id],
@@ -105,13 +103,11 @@ async def device_switch_1(
 
 
 @pytest.fixture
-async def device_switch_2(
-    zigpy_device_mock: Callable[..., ZigpyDevice],
-    zha_gateway: Gateway,
-) -> Device:
+async def device_switch_2(zha_gateway: Gateway) -> Device:
     """Test zha switch platform."""
 
-    zigpy_dev = zigpy_device_mock(
+    zigpy_dev = create_mock_zigpy_device(
+        zha_gateway,
         {
             1: {
                 SIG_EP_INPUT: [general.OnOff.cluster_id, general.Groups.cluster_id],
@@ -391,11 +387,11 @@ class WindowDetectionFunctionQuirk(CustomDevice):
 
 async def test_switch_configurable(
     zha_gateway: Gateway,
-    zigpy_device_mock,
 ) -> None:
     """Test ZHA configurable switch platform."""
 
-    zigpy_dev = zigpy_device_mock(
+    zigpy_dev = create_mock_zigpy_device(
+        zha_gateway,
         {
             1: {
                 SIG_EP_INPUT: [general.Basic.cluster_id],
@@ -502,12 +498,11 @@ async def test_switch_configurable(
     ]
 
 
-async def test_switch_configurable_custom_on_off_values(
-    zha_gateway: Gateway, zigpy_device_mock
-) -> None:
+async def test_switch_configurable_custom_on_off_values(zha_gateway: Gateway) -> None:
     """Test ZHA configurable switch platform."""
 
-    zigpy_dev = zigpy_device_mock(
+    zigpy_dev = create_mock_zigpy_device(
+        zha_gateway,
         {
             1: {
                 SIG_EP_INPUT: [general.Basic.cluster_id],
@@ -579,11 +574,12 @@ async def test_switch_configurable_custom_on_off_values(
 
 
 async def test_switch_configurable_custom_on_off_values_force_inverted(
-    zha_gateway: Gateway, zigpy_device_mock
+    zha_gateway: Gateway,
 ) -> None:
     """Test ZHA configurable switch platform."""
 
-    zigpy_dev = zigpy_device_mock(
+    zigpy_dev = create_mock_zigpy_device(
+        zha_gateway,
         {
             1: {
                 SIG_EP_INPUT: [general.Basic.cluster_id],
@@ -656,11 +652,12 @@ async def test_switch_configurable_custom_on_off_values_force_inverted(
 
 
 async def test_switch_configurable_custom_on_off_values_inverter_attribute(
-    zha_gateway: Gateway, zigpy_device_mock
+    zha_gateway: Gateway,
 ) -> None:
     """Test ZHA configurable switch platform."""
 
-    zigpy_dev = zigpy_device_mock(
+    zigpy_dev = create_mock_zigpy_device(
+        zha_gateway,
         {
             1: {
                 SIG_EP_INPUT: [general.Basic.cluster_id],

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -101,7 +101,6 @@ async def device_switch_1(zha_gateway: Gateway) -> Device:
         ieee=IEEE_GROUPABLE_DEVICE,
     )
     zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
-    zha_device.available = True
     return zha_device
 
 
@@ -122,7 +121,6 @@ async def device_switch_2(zha_gateway: Gateway) -> Device:
         ieee=IEEE_GROUPABLE_DEVICE2,
     )
     zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
-    zha_device.available = True
     return zha_device
 
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -23,6 +23,10 @@ from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
 import zigpy.zcl.foundation as zcl_f
 
 from tests.common import (
+    SIG_EP_INPUT,
+    SIG_EP_OUTPUT,
+    SIG_EP_PROFILE,
+    SIG_EP_TYPE,
     create_mock_zigpy_device,
     get_entity,
     get_group_entity,
@@ -31,7 +35,6 @@ from tests.common import (
     send_attributes_report,
     update_attribute_cache,
 )
-from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 from zha.application import Platform
 from zha.application.gateway import Gateway
 from zha.application.platforms import GroupEntity, PlatformEntity

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -14,8 +14,15 @@ from zigpy.zcl import Cluster, foundation
 from zigpy.zcl.clusters import general
 import zigpy.zdo.types as zdo_t
 
-from tests.common import get_entity, join_zigpy_device, update_attribute_cache
-from tests.conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_TYPE
+from tests.common import (
+    SIG_EP_INPUT,
+    SIG_EP_OUTPUT,
+    SIG_EP_TYPE,
+    create_mock_zigpy_device,
+    get_entity,
+    join_zigpy_device,
+    update_attribute_cache,
+)
 from zha.application import Platform
 from zha.application.gateway import Gateway
 from zha.application.platforms.update import (
@@ -28,7 +35,7 @@ from zha.exceptions import ZHAException
 
 
 @pytest.fixture
-def zigpy_device(zigpy_device_mock):
+def zigpy_device(zha_gateway: Gateway):
     """Device tracker zigpy device."""
     endpoints = {
         1: {
@@ -37,7 +44,8 @@ def zigpy_device(zigpy_device_mock):
             SIG_EP_TYPE: zha.DeviceType.ON_OFF_SWITCH,
         }
     }
-    return zigpy_device_mock(
+    return create_mock_zigpy_device(
+        zha_gateway,
         endpoints,
         node_descriptor=zdo_t.NodeDescriptor(
             logical_type=zdo_t.LogicalType.EndDevice,


### PR DESCRIPTION
The dependency chains created by pytest fixtures unfortunately make selectively applying fixtures (or figuring out how they work at times) difficult. I've converted the following fixtures to normal functions that usually operate on a single `Gateway` object:

- `zha_device_from_file` -> `zigpy_device_from_device_data` and `zigpy_device_from_json`
- `device_joined` -> `join_zigpy_device`
- `zigpy_device_mock` -> `create_mock_zigpy_device`

Going forward, I think mock devices created within fixtures should ideally be replaced with real device mocks created from JSON dumps.