### PR TITLE
Support Timestamp class Sensor

### DIFF
--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -92,6 +92,7 @@ IGNORE_SUFFIXES = [
     "default_move_rate",
     "start_up_current_level",
     "counter",
+    "setpoint_change_source_timestamp",
 ]
 
 

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -92,7 +92,6 @@ IGNORE_SUFFIXES = [
     "default_move_rate",
     "start_up_current_level",
     "counter",
-    "setpoint_change_source_timestamp",
 ]
 
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from collections.abc import Awaitable, Callable
-from datetime import datetime
+from datetime import UTC, datetime
 import math
 from typing import Any, Optional
 from unittest.mock import AsyncMock, MagicMock
@@ -404,7 +404,7 @@ async def async_test_change_source_timestamp(
         cluster,
         {hvac.Thermostat.AttributeDefs.setpoint_change_source_timestamp.id: 2674725315},
     )
-    assert entity.state["state"] == datetime(2024, 10, 4, 11, 15, 15)
+    assert entity.state["state"] == datetime(2024, 10, 4, 11, 15, 15, tzinfo=UTC)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from collections.abc import Awaitable, Callable
+from datetime import datetime
 import math
 from typing import Any, Optional
 from unittest.mock import AsyncMock, MagicMock
@@ -394,6 +395,18 @@ async def async_test_pi_heating_demand(
     assert_state(entity, 1, "%")
 
 
+async def async_test_change_source_timestamp(
+    zha_gateway: Gateway, cluster: Cluster, entity: PlatformEntity
+):
+    """Test change source timestamp is correctly returned."""
+    await send_attributes_report(
+        zha_gateway,
+        cluster,
+        {hvac.Thermostat.AttributeDefs.setpoint_change_source_timestamp.id: 2674725315},
+    )
+    assert entity.state["state"] == datetime(2024, 10, 4, 11, 15, 15)
+
+
 @pytest.mark.parametrize(
     "cluster_id, entity_type, test_func, read_plug, unsupported_attrs",
     (
@@ -544,6 +557,13 @@ async def async_test_pi_heating_demand(
             hvac.Thermostat.cluster_id,
             sensor.PiHeatingDemand,
             async_test_pi_heating_demand,
+            None,
+            None,
+        ),
+        (
+            hvac.Thermostat.cluster_id,
+            sensor.SetpointChangeSourceTimestamp,
+            async_test_change_source_timestamp,
             None,
             None,
         ),

--- a/tests/zha_devices_list.py
+++ b/tests/zha_devices_list.py
@@ -5917,6 +5917,14 @@ DEVICES = [
                 DEV_SIG_ENT_MAP_CLASS: "SetpointChangeSource",
                 DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_th1123zb_setpoint_change_source",
             },
+            (
+                "sensor",
+                "00:11:22:33:44:55:66:77-1-513-setpoint_change_source_timestamp",
+            ): {
+                DEV_SIG_CLUSTER_HANDLERS: ["thermostat"],
+                DEV_SIG_ENT_MAP_CLASS: "SetpointChangeSourceTimestamp",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_th1123zb_setpoint_change_source_timestamp",
+            },
             ("update", "00:11:22:33:44:55:66:77-1-25-firmware_update"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["ota"],
                 DEV_SIG_ENT_MAP_CLASS: "FirmwareUpdateEntity",
@@ -6035,6 +6043,14 @@ DEVICES = [
                 DEV_SIG_CLUSTER_HANDLERS: ["thermostat"],
                 DEV_SIG_ENT_MAP_CLASS: "SetpointChangeSource",
                 DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_th1124zb_setpoint_change_source",
+            },
+            (
+                "sensor",
+                "00:11:22:33:44:55:66:77-1-513-setpoint_change_source_timestamp",
+            ): {
+                DEV_SIG_CLUSTER_HANDLERS: ["thermostat"],
+                DEV_SIG_ENT_MAP_CLASS: "SetpointChangeSourceTimestamp",
+                DEV_SIG_ENT_MAP_ID: "sensor.sinope_technologies_th1124zb_setpoint_change_source_timestamp",
             },
             ("update", "00:11:22:33:44:55:66:77-1-25-firmware_update"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["ota"],
@@ -6452,6 +6468,14 @@ DEVICES = [
                 DEV_SIG_CLUSTER_HANDLERS: ["thermostat"],
                 DEV_SIG_ENT_MAP_CLASS: "SetpointChangeSource",
                 DEV_SIG_ENT_MAP_ID: "sensor.zen_within_zen_01_setpoint_change_source",
+            },
+            (
+                "sensor",
+                "00:11:22:33:44:55:66:77-1-513-setpoint_change_source_timestamp",
+            ): {
+                DEV_SIG_CLUSTER_HANDLERS: ["thermostat"],
+                DEV_SIG_ENT_MAP_CLASS: "SetpointChangeSourceTimestamp",
+                DEV_SIG_ENT_MAP_ID: "sensor.zen_within_zen_01_setpoint_change_source_timestamp",
             },
             ("update", "00:11:22:33:44:55:66:77-1-25-firmware_update"): {
                 DEV_SIG_CLUSTER_HANDLERS: ["ota"],

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from asyncio import Task
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 import enum
 import functools
 import logging
@@ -289,7 +289,7 @@ class Sensor(PlatformEntity):
 
     def timestamp_formatter(self, value: int) -> datetime | None:
         """Timestamp pass-through formatter."""
-        return datetime.fromtimestamp(value - UNIX_EPOCH_TO_ZCL_EPOCH)
+        return datetime.fromtimestamp(value - UNIX_EPOCH_TO_ZCL_EPOCH, tz=UTC)
 
 
 class PollableSensor(Sensor):

--- a/zha/application/platforms/sensor/const.py
+++ b/zha/application/platforms/sensor/const.py
@@ -390,3 +390,9 @@ NON_NUMERIC_DEVICE_CLASSES = {
     SensorDeviceClass.ENUM,
     SensorDeviceClass.TIMESTAMP,
 }
+
+NON_NUMERIC_FORMATTERS = {
+    SensorDeviceClass.TIMESTAMP: "timestamp_formatter",
+}
+
+UNIX_EPOCH_TO_ZCL_EPOCH = 946684800


### PR DESCRIPTION
It does add support for the HVAC Thermostat attribute `setpoint_change_source_timestamp`, primarily so I would have an attribute to test against.

Closes: https://github.com/zigpy/zha/issues/220 