### PR TITLE
Add Timestamp Sensor

### DIFF
--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -40,6 +40,7 @@ from zha.application.platforms import (  # noqa: F401 pylint: disable=unused-imp
     switch,
     update,
 )
+from zha.application.platforms.sensor.const import SensorDeviceClass
 from zha.application.registries import (
     DEVICE_CLASS,
     PLATFORM_ENTITIES,
@@ -163,6 +164,10 @@ QUIRKS_ENTITY_META_TO_ENTITY_CLASS = {
     ): switch.ConfigurableAttributeSwitch,
 }
 
+QUIRKS_SENSOR_DEV_CLASS_TO_ENTITY_CLASS = {
+    SensorDeviceClass.TIMESTAMP: sensor.TimestampSensor
+}
+
 
 class DeviceProbe:
     """Probe to discover entities for a device."""
@@ -279,6 +284,11 @@ class DeviceProbe:
                         },
                     )
                     continue
+
+                if entity_class is sensor.Sensor:
+                    entity_class = QUIRKS_SENSOR_DEV_CLASS_TO_ENTITY_CLASS.get(
+                        entity_metadata.device_class, entity_class
+                    )
 
                 # automatically add the attribute to ZCL_INIT_ATTRS for the cluster
                 # handler if it is not already in the list

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from asyncio import Task
 from dataclasses import dataclass
+from datetime import UTC, date, datetime
 import enum
 import functools
 import logging
@@ -29,7 +30,11 @@ from zha.application.platforms import (
 )
 from zha.application.platforms.climate.const import HVACAction
 from zha.application.platforms.helpers import validate_device_class
-from zha.application.platforms.sensor.const import SensorDeviceClass, SensorStateClass
+from zha.application.platforms.sensor.const import (
+    UNIX_EPOCH_TO_ZCL_EPOCH,
+    SensorDeviceClass,
+    SensorStateClass,
+)
 from zha.application.registries import PLATFORM_ENTITIES
 from zha.decorators import periodic
 from zha.units import (
@@ -240,7 +245,7 @@ class Sensor(PlatformEntity):
         return response
 
     @property
-    def native_value(self) -> str | int | float | None:
+    def native_value(self) -> date | datetime | str | int | float | None:
         """Return the state of the entity."""
         assert self._attribute_name is not None
         raw_state = self._cluster_handler.cluster.get(self._attribute_name)
@@ -264,13 +269,23 @@ class Sensor(PlatformEntity):
         ):
             self.maybe_emit_state_changed_event()
 
-    def formatter(self, value: int | enum.IntEnum) -> int | float | str | None:
+    def formatter(
+        self, value: int | enum.IntEnum
+    ) -> datetime | int | float | str | None:
         """Numeric pass-through formatter."""
         if self._decimals > 0:
             return round(
                 float(value * self._multiplier) / self._divisor, self._decimals
             )
         return round(float(value * self._multiplier) / self._divisor)
+
+
+class TimestampSensor(Sensor):
+    """Timestamp ZHA sensor."""
+
+    def formatter(self, value: int | enum.IntEnum) -> datetime | None:
+        """Pass-through formatter."""
+        return datetime.fromtimestamp(value - UNIX_EPOCH_TO_ZCL_EPOCH, tz=UTC)
 
 
 class PollableSensor(Sensor):
@@ -1629,6 +1644,20 @@ class SetpointChangeSource(EnumSensor):
     _attr_translation_key: str = "setpoint_change_source"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _enum = SetpointChangeSourceEnum
+
+
+@CONFIG_DIAGNOSTIC_MATCH(cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT)
+class SetpointChangeSourceTimestamp(TimestampSensor):
+    """Sensor that displays the timestamp the setpoint change.
+
+    Optional thermostat attribute.
+    """
+
+    _unique_id_suffix = "setpoint_change_source_timestamp"
+    _attribute_name = "setpoint_change_source_timestamp"
+    _attr_translation_key: str = "setpoint_change_source_timestamp"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
 
 
 @CONFIG_DIAGNOSTIC_MATCH(cluster_handler_names=CLUSTER_HANDLER_COVER)

--- a/zha/application/platforms/sensor/const.py
+++ b/zha/application/platforms/sensor/const.py
@@ -390,3 +390,5 @@ NON_NUMERIC_DEVICE_CLASSES = {
     SensorDeviceClass.ENUM,
     SensorDeviceClass.TIMESTAMP,
 }
+
+UNIX_EPOCH_TO_ZCL_EPOCH = 946684800


### PR DESCRIPTION
Alternative to https://github.com/zigpy/zha/pull/222

It does add support for the HVAC Thermostat attribute setpoint_change_source_timestamp, primarily so I would have an attribute to test against.

Closes: https://github.com/zigpy/zha/issues/220