### PR TITLE
Clean up the fan platform

### DIFF
--- a/zha/application/platforms/fan/const.py
+++ b/zha/application/platforms/fan/const.py
@@ -6,23 +6,25 @@
 from enum import IntFlag
 from typing import Final
 
+DEFAULT_ON_PERCENTAGE: Final[int] = 50
+
+
+class FanEntityFeature(IntFlag):
+    """Supported features of the fan entity."""
+
+    SET_SPEED = 1
+    OSCILLATE = 2
+    DIRECTION = 4
+    PRESET_MODE = 8
+    TURN_OFF = 16
+    TURN_ON = 32
+
+
 PRESET_MODE_ON: Final[str] = "on"
 # The fan speed is self-regulated
 PRESET_MODE_AUTO: Final[str] = "auto"
 # When the heated/cooled space is occupied, the fan is always on
 PRESET_MODE_SMART: Final[str] = "smart"
-
-SPEED_RANGE: Final = (1, 3)  # off is not included
-PRESET_MODES_TO_NAME: Final[dict[int, str]] = {
-    4: PRESET_MODE_ON,
-    5: PRESET_MODE_AUTO,
-    6: PRESET_MODE_SMART,
-}
-
-NAME_TO_PRESET_MODE = {v: k for k, v in PRESET_MODES_TO_NAME.items()}
-PRESET_MODES = list(NAME_TO_PRESET_MODE)
-
-DEFAULT_ON_PERCENTAGE: Final[int] = 50
 
 ATTR_PERCENTAGE: Final[str] = "percentage"
 ATTR_PERCENTAGE_STEP: Final[str] = "percentage_step"
@@ -35,17 +37,3 @@ SPEED_OFF: Final[str] = "off"
 SPEED_LOW: Final[str] = "low"
 SPEED_MEDIUM: Final[str] = "medium"
 SPEED_HIGH: Final[str] = "high"
-
-OFF_SPEED_VALUES: list[str | None] = [SPEED_OFF, None]
-LEGACY_SPEED_LIST: list[str] = [SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
-
-
-class FanEntityFeature(IntFlag):
-    """Supported features of the fan entity."""
-
-    SET_SPEED = 1
-    OSCILLATE = 2
-    DIRECTION = 4
-    PRESET_MODE = 8
-    TURN_OFF = 16
-    TURN_ON = 32


### PR DESCRIPTION
https://github.com/zigpy/zha/issues/226

I'm trying to separate entity implementations into an explicit base class showing the API, a `StandardsCompliant` class that works according to the spec, and then all non-compliant implementations afterwards.

Very WIP and probably breaks a lot of entities. I think for the IKEA fan, we may want to remove any conversion logic from the quirk and do it entirely in the entity.