### PR TITLE
Fix `quirk_applied` check only working for v1 quirks

### DIFF
--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -207,7 +207,7 @@ class Device(LogMixin, EventBase):
         self._gateway: Gateway = _gateway
         self._zigpy_device: ZigpyDevice = zigpy_device
         self.quirk_applied: bool = isinstance(
-            self._zigpy_device, zigpy.quirks.CustomDevice
+            self._zigpy_device, zigpy.quirks.BaseCustomDevice
         )
         self.quirk_class: str = (
             f"{self._zigpy_device.__class__.__module__}."


### PR DESCRIPTION
https://github.com/zigpy/zigpy/pull/1450 must have broken this check to no longer be `True` for v2 quirks, since `CustomDeviceV2` no longer extends `CustomDevice`, only `BaseCustomDevice`.  This PR checks for the base class now.

(Noticed this whilst working on https://github.com/zigpy/zha/pull/231)