### PR TITLE
Allow translation key even when device class is overridden

### DIFF
--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -340,21 +340,19 @@ class PlatformEntity(BaseEntity):
         if entity_metadata.initially_disabled:
             self._attr_entity_registry_enabled_default = False
 
-        has_device_class = hasattr(entity_metadata, "device_class")
         has_attribute_name = hasattr(entity_metadata, "attribute_name")
         has_command_name = hasattr(entity_metadata, "command_name")
         has_fallback_name = hasattr(entity_metadata, "fallback_name")
 
-        if not has_device_class or entity_metadata.device_class is None:
-            if has_fallback_name:
-                self._attr_fallback_name = entity_metadata.fallback_name
+        if has_fallback_name:
+            self._attr_fallback_name = entity_metadata.fallback_name
 
-            if entity_metadata.translation_key:
-                self._attr_translation_key = entity_metadata.translation_key
-            elif has_attribute_name:
-                self._attr_translation_key = entity_metadata.attribute_name
-            elif has_command_name:
-                self._attr_translation_key = entity_metadata.command_name
+        if entity_metadata.translation_key:
+            self._attr_translation_key = entity_metadata.translation_key
+        elif has_attribute_name:
+            self._attr_translation_key = entity_metadata.attribute_name
+        elif has_command_name:
+            self._attr_translation_key = entity_metadata.command_name
 
         if has_attribute_name:
             self._unique_id_suffix = entity_metadata.attribute_name


### PR DESCRIPTION
Since https://github.com/zigpy/zigpy/pull/1474 was merged, translation_key and/or fallback_name is a mandatory field for a V2 quirk entity, and the restriction of not being able to set them when device class is explictly set has been dropped.

From what I can tell, there isn't a good reason for this restriction, and the device class alone isn't a replacement for not having a translation key (such as the case when a device has two sensors of the same device class and you need a way to differentiate between them). If my understanding is flawed here, please let me know and we can drop this PR.

On the ZHA side, the check for device is still present. This pull request is for its removal.