### PR TITLE
Apply custom quirks config before configuring cluster handlers

### DIFF
--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -719,12 +719,14 @@ class Device(LogMixin, EventBase):
         self.debug("started configuration")
         await self._zdo_handler.async_configure()
         self._zdo_handler.debug("'async_configure' stage succeeded")
-        await asyncio.gather(
-            *(endpoint.async_configure() for endpoint in self._endpoints.values())
-        )
+
         if isinstance(self._zigpy_device, zigpy.quirks.BaseCustomDevice):
             self.debug("applying quirks custom device configuration")
             await self._zigpy_device.apply_custom_configuration()
+
+        await asyncio.gather(
+            *(endpoint.async_configure() for endpoint in self._endpoints.values())
+        )
 
         self.emit(
             ZHA_CLUSTER_HANDLER_CFG_DONE,


### PR DESCRIPTION
This PR slightly changes the order in which device configuration happens.
Previously, custom quirks configuration would be applied after all the cluster handlers are configured.
With this PR, it's changed so that it happens before cluster configuration (after ZDO handler configuration).

When devices need to get custom commands (like the "Tuya spell"), it should happen as soon as possible.
This is somewhat required by this quirks PR:
- https://github.com/zigpy/zha-device-handlers/pull/3414

Before that PR, "Tuya spell casting" was called from the `bind()` method in `PowerConfiguration` or `OnOff` clusters. Since they both have low cluster ids, it happens pretty early on, before any manufacturer specific cluster handlers are configured.

If, for some reason, we need to have a post cluster handler configuration method in the future, we can add it then. I doubt we'll need it though, so I'd just move the `apply_custom_configuration()` method up to happen earlier for now.