### PR TITLE
Use enum value when looking up entity class by entity device_class

### DIFF
--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -13,6 +13,9 @@ from zigpy.device import Device as ZigpyDevice
 import zigpy.profiles.zha
 from zigpy.quirks import CustomCluster, get_device
 from zigpy.quirks.v2 import CustomDeviceV2, QuirkBuilder
+from zigpy.quirks.v2.homeassistant.sensor import (
+    SensorDeviceClass as SensorDeviceClassV2,
+)
 import zigpy.types as t
 from zigpy.zcl import Cluster
 from zigpy.zcl.clusters import general, homeautomation, hvac, measurement, smartenergy
@@ -1168,7 +1171,7 @@ class TimestampCluster(CustomCluster, ManufacturerSpecificCluster):
     .sensor(
         "start_time",
         TimestampCluster.cluster_id,
-        device_class=SensorDeviceClass.TIMESTAMP,
+        device_class=SensorDeviceClassV2.TIMESTAMP,  # Use the zigpy enum
         translation_key="start_time",
         fallback_name="Start Time",
     )

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -285,9 +285,12 @@ class DeviceProbe:
                     )
                     continue
 
-                if entity_class is sensor.Sensor:
+                if (
+                    entity_class is sensor.Sensor
+                    and entity_metadata.device_class is not None
+                ):
                     entity_class = QUIRKS_SENSOR_DEV_CLASS_TO_ENTITY_CLASS.get(
-                        entity_metadata.device_class, entity_class
+                        entity_metadata.device_class.value, entity_class
                     )
 
                 # automatically add the attribute to ZCL_INIT_ATTRS for the cluster


### PR DESCRIPTION
We have two definitions for SensorDeviceClass.

`zha.application.platforms.sensor.const.SensorDeviceClass` and `zigpy.quirks.v2.homeassistant.sensor.SensorDeviceClass`

Quirks will import from zigpy and the current logic would fail to match. This works for both enums and modifies the tests to ensure we test both enums.