### PR TITLE
Remove defaulting of `translation_key`

### DIFF
--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -349,10 +349,6 @@ class PlatformEntity(BaseEntity):
 
         if entity_metadata.translation_key:
             self._attr_translation_key = entity_metadata.translation_key
-        elif has_attribute_name:
-            self._attr_translation_key = entity_metadata.attribute_name
-        elif has_command_name:
-            self._attr_translation_key = entity_metadata.command_name
 
         if has_attribute_name:
             self._unique_id_suffix = entity_metadata.attribute_name


### PR DESCRIPTION
Part 2 of changes related to: https://github.com/zigpy/zigpy/pull/1488


## Proposed change

`translation_key` no longer defaults to `attribute_name` or `command_name`.
There's more information in the linked zigpy PR below on why this should be the case.


## Additional information

Somewhat requires this zigpy PR to ensure `translation_key` or `device_class` is provided for a proper name:
- https://github.com/zigpy/zigpy/pull/1488

Requires for tests to pass:
- https://github.com/zigpy/zha/pull/252

I wanted to keep these changes separate from #252, as the changes are only semi-related.