### PR TITLE
Add `translation_key` and `fallback_name` to tests

### DIFF
--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -206,11 +206,15 @@ class FakeManufacturerCluster(CustomCluster, ManufacturerSpecificCluster):
         FakeManufacturerCluster.ServerCommandDefs.self_test.name,
         FakeManufacturerCluster.cluster_id,
         command_args=(5,),
+        translation_key="self_test",
+        fallback_name="Self test",
     )
     .write_attr_button(
         FakeManufacturerCluster.AttributeDefs.feed.name,
         2,
         FakeManufacturerCluster.cluster_id,
+        translation_key="feed",
+        fallback_name="Feed",
     )
 )
 

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -524,6 +524,7 @@ def _get_test_device(
             unit=UnitOfTime.SECONDS,
             multiplier=1,
             translation_key="on_off_transition_time",
+            fallback_name="On off transition time",
         )
         .number(
             zigpy.zcl.clusters.general.OnOff.AttributeDefs.off_wait_time.name,
@@ -534,12 +535,14 @@ def _get_test_device(
             unit=UnitOfTime.SECONDS,
             multiplier=1,
             translation_key="on_off_transition_time",
+            fallback_name="On off transition time",
         )
         .sensor(
             zigpy.zcl.clusters.general.OnOff.AttributeDefs.off_wait_time.name,
             zigpy.zcl.clusters.general.OnOff.cluster_id,
             entity_type=EntityType.CONFIG,
             translation_key="analog_input",
+            fallback_name="Analog input",
         )
     )
 
@@ -608,8 +611,8 @@ async def test_quirks_v2_entity_discovery_errors(
         "entity_type=<EntityType.CONFIG: 'config'>, cluster_id=6, endpoint_id=1, "
         "cluster_type=<ClusterType.Server: 0>, initially_disabled=False, "
         "attribute_initialized_from_cache=True, translation_key='analog_input', "
-        "fallback_name=None, attribute_name='off_wait_time', divisor=1, multiplier=1, "
-        "unit=None, device_class=None, state_class=None)}"
+        "fallback_name='Analog input', attribute_name='off_wait_time', divisor=1, "
+        "multiplier=1, unit=None, device_class=None, state_class=None)}"
     )
     # fmt: on
 
@@ -711,6 +714,8 @@ def bad_binary_sensor_device_class(
     return quirk_builder.binary_sensor(
         zigpy.zcl.clusters.general.OnOff.AttributeDefs.on_off.name,
         zigpy.zcl.clusters.general.OnOff.cluster_id,
+        translation_key="on_off",
+        fallback_name="On off",
         device_class=BadDeviceClass.BAD,
     )
 
@@ -723,6 +728,8 @@ def bad_sensor_device_class(
     return quirk_builder.sensor(
         zigpy.zcl.clusters.general.OnOff.AttributeDefs.off_wait_time.name,
         zigpy.zcl.clusters.general.OnOff.cluster_id,
+        translation_key="off_wait_time",
+        fallback_name="Off wait time",
         device_class=BadDeviceClass.BAD,
     )
 
@@ -735,6 +742,8 @@ def bad_number_device_class(
     return quirk_builder.number(
         zigpy.zcl.clusters.general.OnOff.AttributeDefs.on_time.name,
         zigpy.zcl.clusters.general.OnOff.cluster_id,
+        translation_key="on_time",
+        fallback_name="On time",
         device_class=BadDeviceClass.BAD,
     )
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -169,12 +169,15 @@ async def test_on_off_select_attribute_report(
         "motion_sensitivity",
         AqaraMotionSensitivities,
         MotionSensitivityQuirk.OppleCluster.cluster_id,
+        translation_key="motion_sensitivity",
+        fallback_name="Motion sensitivity",
     )
     .enum(
         "motion_sensitivity_disabled",
         AqaraMotionSensitivities,
         MotionSensitivityQuirk.OppleCluster.cluster_id,
         translation_key="motion_sensitivity",
+        fallback_name="Motion sensitivity",
         initially_disabled=True,
     )
     .add_to_registry()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1246,6 +1246,8 @@ class OppleCluster(CustomCluster, ManufacturerSpecificCluster):
         divisor=1,
         multiplier=1,
         unit=UnitOfMass.GRAMS,
+        translation_key="last_feeding_size",
+        fallback_name="Last feeding size",
     )
     .add_to_registry()
 )

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -523,6 +523,8 @@ async def test_switch_configurable_custom_on_off_values(zha_gateway: Gateway) ->
             WindowDetectionFunctionQuirk.TuyaManufCluster.cluster_id,
             on_value=3,
             off_value=5,
+            translation_key="window_detection_function",
+            fallback_name="Window detection function",
         )
         .add_to_registry()
     )
@@ -601,6 +603,8 @@ async def test_switch_configurable_custom_on_off_values_force_inverted(
             on_value=3,
             off_value=5,
             force_inverted=True,
+            translation_key="window_detection_function",
+            fallback_name="Window detection function",
         )
         .add_to_registry()
     )
@@ -679,6 +683,8 @@ async def test_switch_configurable_custom_on_off_values_inverter_attribute(
             on_value=3,
             off_value=5,
             invert_attribute_name="window_detection_function_inverter",
+            translation_key="window_detection_function",
+            fallback_name="Window detection function",
         )
         .add_to_registry()
     )


### PR DESCRIPTION
Part 1 of changes related to: https://github.com/zigpy/zigpy/pull/1488


## Proposed change

This adds `translation_key` and `fallback_name` to all tests where a v2 quirk entity is created.


## Additional information

With the PR below, zigpy always requires `fallback_name` name to be set. `translation_key` also needs to be set if `device_class` is not set.

This PR should be merged before a zigpy bump with the PR below to ensure tests still pass. However, this PR only makes sense if we go through with the changes from the PR below.
- https://github.com/zigpy/zigpy/pull/1488