### PR TITLE
Support configuration of entity reporting for V2 quirks

### DIFF
--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -20,6 +20,7 @@ import zigpy.types as t
 from zigpy.zcl import Cluster
 from zigpy.zcl.clusters import general, homeautomation, hvac, measurement, smartenergy
 from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
+from zigpy.zcl.foundation import ReportingConfig
 
 from tests.common import (
     SIG_EP_INPUT,
@@ -1244,6 +1245,9 @@ class OppleCluster(CustomCluster, ManufacturerSpecificCluster):
         unit=UnitOfMass.GRAMS,
         translation_key="last_feeding_size",
         fallback_name="Last feeding size",
+        reporting_config=ReportingConfig(
+            min_interval=0, max_interval=60, reportable_change=1
+        ),
     )
     .add_to_registry()
 )

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -12,7 +12,7 @@ from zhaquirks.danfoss import thermostat as danfoss_thermostat
 from zigpy.device import Device as ZigpyDevice
 import zigpy.profiles.zha
 from zigpy.quirks import CustomCluster, get_device
-from zigpy.quirks.v2 import CustomDeviceV2, QuirkBuilder
+from zigpy.quirks.v2 import CustomDeviceV2, QuirkBuilder, ReportingConfig
 from zigpy.quirks.v2.homeassistant.sensor import (
     SensorDeviceClass as SensorDeviceClassV2,
 )
@@ -20,7 +20,6 @@ import zigpy.types as t
 from zigpy.zcl import Cluster
 from zigpy.zcl.clusters import general, homeautomation, hvac, measurement, smartenergy
 from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
-from zigpy.zcl.foundation import ReportingConfig
 
 from tests.common import (
     SIG_EP_INPUT,

--- a/zha/application/const.py
+++ b/zha/application/const.py
@@ -94,6 +94,7 @@ PRESET_NONE = "none"
 ENTITY_METADATA = "entity_metadata"
 
 ZCL_INIT_ATTRS = "ZCL_INIT_ATTRS"
+REPORT_CONFIG = "REPORT_CONFIG"
 
 _ControllerClsType = type[zigpy.application.ControllerApplication]
 

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -51,6 +51,7 @@ from zha.application.registries import (
 
 # importing cluster handlers updates registries
 from zha.zigbee.cluster_handlers import (  # noqa: F401 pylint: disable=unused-import
+    AttrReportConfig,
     ClusterHandler,
     closures,
     general,
@@ -311,6 +312,27 @@ class DeviceProbe:
                     )
                     cluster_handler.__dict__[zha_const.ZCL_INIT_ATTRS] = init_attrs
 
+                if (
+                    hasattr(entity_metadata, "attribute_name")
+                    and hasattr(entity_metadata, "report_config")
+                    and entity_metadata.report_config
+                ):
+                    report_config = tuple(
+                        filter(
+                            lambda cfg: cfg["attr"] != entity_metadata.attribute_name,
+                            cluster_handler.REPORT_CONFIG,
+                        )
+                    )
+                    report_config += (
+                        AttrReportConfig(
+                            attr=entity_metadata.attribute_name,
+                            config=entity_metadata.report_config,
+                        ),
+                    )
+
+                    cluster_handler.__dict__[zha_const.REPORT_CONFIG] = report_config
+
+                endpoint.claim_cluster_handlers([cluster_handler])
                 endpoint.async_new_entity(
                     platform=platform,
                     entity_class=entity_class,

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import Counter
+from dataclasses import astuple
 import logging
 from typing import TYPE_CHECKING, cast
 
@@ -314,23 +315,23 @@ class DeviceProbe:
 
                 if (
                     hasattr(entity_metadata, "attribute_name")
-                    and hasattr(entity_metadata, "report_config")
-                    and entity_metadata.report_config
+                    and hasattr(entity_metadata, "reporting_config")
+                    and entity_metadata.reporting_config
                 ):
-                    report_config = tuple(
+                    reporting_config = tuple(
                         filter(
                             lambda cfg: cfg["attr"] != entity_metadata.attribute_name,
                             cluster_handler.REPORT_CONFIG,
                         )
                     )
-                    report_config += (
+                    reporting_config += (
                         AttrReportConfig(
                             attr=entity_metadata.attribute_name,
-                            config=entity_metadata.report_config,
+                            config=astuple(entity_metadata.reporting_config),
                         ),
                     )
 
-                    cluster_handler.__dict__[zha_const.REPORT_CONFIG] = report_config
+                    cluster_handler.__dict__[zha_const.REPORT_CONFIG] = reporting_config
 
                 endpoint.claim_cluster_handlers([cluster_handler])
                 endpoint.async_new_entity(

--- a/zha/zigbee/cluster_handlers/__init__.py
+++ b/zha/zigbee/cluster_handlers/__init__.py
@@ -455,9 +455,10 @@ class ClusterHandler(LogMixin, EventBase):
             return
 
         self.debug("initializing cluster handler: from_cache: %s", from_cache)
-        cached = [a for a, cached in self.ZCL_INIT_ATTRS.items() if cached]
-        uncached = [a for a, cached in self.ZCL_INIT_ATTRS.items() if not cached]
-        uncached.extend([cfg["attr"] for cfg in self.REPORT_CONFIG])
+        cache_config = self.ZCL_INIT_ATTRS.copy()
+        cache_config |= {cfg["attr"]: False for cfg in self.REPORT_CONFIG}
+        cached = [a for a, cached in cache_config.items() if cached]
+        uncached = [a for a, cached in cache_config.items() if not cached]
 
         if cached:
             self.debug("initializing cached cluster handler attributes: %s", cached)


### PR DESCRIPTION
# Proposed change

This change hooks up the V2 Quirk `report_config` option to the cluster handler created for V2 quirks. It also 'claims' the cluster, which is required for reporting and binding hooks to work upon configuration of the cluster and previously wasn't being done for V2 Quirk clusters.

![Screenshot 2024-10-21 111956](https://github.com/user-attachments/assets/36205b94-3836-4439-bb91-a571c8da050c)

# Additional information

Please refer to https://github.com/zigpy/zigpy/pull/1490 for more information on the motivation behind this patch. This patch will need to be merged after that has been merged and zigpy dependency has been bumped.

