### PR TITLE
Fix missing `add_to_registry` backwards compatibility

### DIFF
--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -222,11 +222,14 @@ class Gateway(AsyncUtilMixin, EventBase):
 
         if config.config.quirks_configuration.enabled:
             for quirk in UNBUILT_QUIRK_BUILDERS:
-                _LOGGER.warning(
-                    "Found a v2 quirk that was not added to the registry: %s",
-                    quirk,
-                )
-                quirk.add_to_registry()
+                # v2 quirks with no manufacturer model metadata explicitly do not call
+                # add_to_registry. They are used to share code between v2 quirks.
+                if quirk.manufacturer_model_metadata:
+                    _LOGGER.warning(
+                        "Found a v2 quirk that was not added to the registry: %s",
+                        quirk,
+                    )
+                    quirk.add_to_registry()
 
             UNBUILT_QUIRK_BUILDERS.clear()
 


### PR DESCRIPTION
https://github.com/zigpy/zha/pull/124 introduced backwards compatibility in ZHA for v2 quirks that do not call `add_to_registry()`. ZHA calls `add_to_registry()` manually for these.
https://github.com/zigpy/zigpy/pull/1478 added the ability to have a base v2 quirk, clone it, and then apply model info to the clones. This is useful for sharing code between v2 quirks without duplicating it.

However, those base v2 quirks do not have manufacturer/model metadata and explicitly do not call `add_to_registry()`.
We need to make sure to not apply the backwards compatibility to those, as we otherwise add incomplete quirks to the registry (resulting in failing tests).

Unblocks the latest quirks bump (which utilizes a base v2 quirk):
- https://github.com/zigpy/zha/pull/262