### PR TITLE
Fix quirk ID test ignoring custom clusters in v2 quirks

### DIFF
--- a/tests/test_cluster_handlers.py
+++ b/tests/test_cluster_handlers.py
@@ -566,6 +566,18 @@ def test_cluster_handler_registry() -> None:
     all_quirk_ids = {}
     for cluster_id in CLUSTERS_BY_ID:
         all_quirk_ids[cluster_id] = {None}
+
+    # loop over custom clusters in v2 quirks registry
+    for quirks in _DEVICE_REGISTRY._registry_v2.values():
+        for quirk_reg_entry in quirks:
+            # get standalone adds_metadata and adds_metadata from replaces_metadata
+            all_metadata = set(quirk_reg_entry.adds_metadata) | {
+                rm.add for rm in quirk_reg_entry.replaces_metadata
+            }
+            for metadata in all_metadata:
+                all_quirk_ids[metadata.cluster.cluster_id] = {None}
+
+    # loop over custom clusters in v1 quirks registry
     for manufacturer in _DEVICE_REGISTRY.registry.values():
         for model_quirk_list in manufacturer.values():
             for quirk in model_quirk_list:

--- a/tests/test_cluster_handlers.py
+++ b/tests/test_cluster_handlers.py
@@ -563,9 +563,9 @@ def test_cluster_handler_registry() -> None:
     """Test ZIGBEE cluster handler Registry."""
 
     # get all quirk ID from zigpy quirks registry
-    all_quirk_ids = {}
+    cluster_quirk_id_map = {}
     for cluster_id in CLUSTERS_BY_ID:
-        all_quirk_ids[cluster_id] = {None}
+        cluster_quirk_id_map[cluster_id] = {None}
 
     # loop over custom clusters in v2 quirks registry
     for quirks in _DEVICE_REGISTRY._registry_v2.values():
@@ -575,7 +575,7 @@ def test_cluster_handler_registry() -> None:
                 rm.add for rm in quirk_reg_entry.replaces_metadata
             }
             for metadata in all_metadata:
-                all_quirk_ids[metadata.cluster.cluster_id] = {None}
+                cluster_quirk_id_map[metadata.cluster.cluster_id] = {None}
 
     # loop over custom clusters in v1 quirks registry
     for manufacturer in _DEVICE_REGISTRY.registry.values():
@@ -595,9 +595,9 @@ def test_cluster_handler_registry() -> None:
                     for cluster_id in cluster_ids:
                         if not isinstance(cluster_id, int):
                             cluster_id = cluster_id.cluster_id
-                        if cluster_id not in all_quirk_ids:
-                            all_quirk_ids[cluster_id] = {None}
-                        all_quirk_ids[cluster_id].add(quirk_id)
+                        if cluster_id not in cluster_quirk_id_map:
+                            cluster_quirk_id_map[cluster_id] = {None}
+                        cluster_quirk_id_map[cluster_id].add(quirk_id)
 
     for (
         cluster_id,
@@ -605,12 +605,12 @@ def test_cluster_handler_registry() -> None:
     ) in CLUSTER_HANDLER_REGISTRY.items():
         assert isinstance(cluster_id, int)
         assert 0 <= cluster_id <= 0xFFFF
-        assert cluster_id in all_quirk_ids
+        assert cluster_id in cluster_quirk_id_map
         assert isinstance(cluster_handler_classes, dict)
         for quirk_id, cluster_handler in cluster_handler_classes.items():
             assert quirk_id is None or isinstance(quirk_id, str)
             assert issubclass(cluster_handler, ClusterHandler)
-            assert quirk_id in all_quirk_ids[cluster_id]
+            assert quirk_id in cluster_quirk_id_map[cluster_id]
 
 
 def test_epch_unclaimed_cluster_handlers(cluster_handler) -> None:

--- a/tests/test_cluster_handlers.py
+++ b/tests/test_cluster_handlers.py
@@ -2,6 +2,8 @@
 
 # pylint:disable=redefined-outer-name,too-many-lines
 
+from __future__ import annotations
+
 import logging
 import math
 from typing import TYPE_CHECKING, Any
@@ -563,7 +565,7 @@ def test_cluster_handler_registry() -> None:
     """Test ZIGBEE cluster handler Registry."""
 
     # get all quirk ID from zigpy quirks registry
-    cluster_quirk_id_map = {}
+    cluster_quirk_id_map: dict[int, set[str | None]] = {}
     for cluster_id in CLUSTERS_BY_ID:
         cluster_quirk_id_map[cluster_id] = {None}
 


### PR DESCRIPTION
### Proposed change
The quirk ID cluster handler test currently also checks that all cluster handlers in the registry have a cluster that ZHA can find somewhere.
Previously, the ZHA test only looped through the v1 quirks registry to get all custom clusters. With this PR, we also go over `adds_metadata` and `replaces_metadata.add` to include the cluster ids of custom clusters used in v2 quirks.

`all_quirk_ids` was also renamed to `cluster_quirk_id_map`, as that name should hopefully be slightly more clear.
The renaming is done in a separate commit, so feel free to look at the individual commits for a smaller diff.

### Additional information

Unblocks:
- https://github.com/zigpy/zha/pull/238

This test should likely be separated in the future (Filed: https://github.com/zigpy/zha/issues/265).

We also have places in zha-quirks that would need similar logic. Maybe we can unify this for v2 quirks somewhere, so we don't have to access `adds_metadata` and `replaces_metadata.add` directly in all those tests? (Filed: https://github.com/zigpy/zha/issues/266)