### PR TITLE
Convert ZCL attributes from strings when writing

### DIFF
--- a/zha/application/helpers.py
+++ b/zha/application/helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import asyncio
 import binascii
 import collections
@@ -156,6 +157,13 @@ def convert_zcl_value(value: Any, field_type: Any) -> Any:
             if isinstance(value, str)
             else field_type(value)
         )
+    elif issubclass(field_type, zigpy.types.SerializableBytes):
+        if value.startswith(("b'", 'b"')):
+            value = ast.from_literal(value)
+        else:
+            value = bytes.fromhex(value)
+
+        value = field_type(value)
     else:
         value = field_type(value)
 

--- a/zha/application/helpers.py
+++ b/zha/application/helpers.py
@@ -138,7 +138,7 @@ def convert_zcl_value(value: Any, field_type: Any) -> Any:
         if isinstance(value, int):
             value = field_type(value)
         elif isinstance(value, str):
-            # List of flags: `SomeFlag.field1 | field2
+            # List of flags: `SomeFlag.field1 | field2`
             value = [v.strip() for v in value.split(".", 1)[-1].split("|")]
 
         if isinstance(value, list):
@@ -185,13 +185,13 @@ def convert_to_zcl_values(
             continue
 
         value = fields[field.name]
-        converted_fields[field.name] = convert_zcl_value(value, field.type)
+        new_value = converted_fields[field.name] = convert_zcl_value(value, field.type)
 
         _LOGGER.debug(
             "Converted ZCL schema field(%s) value from: %s to: %s",
             field.name,
             value,
-            fields[field.name],
+            new_value,
         )
 
     return converted_fields

--- a/zha/application/helpers.py
+++ b/zha/application/helpers.py
@@ -6,6 +6,7 @@ import asyncio
 import binascii
 import collections
 from collections.abc import Callable
+import contextlib
 import dataclasses
 from dataclasses import dataclass
 import datetime
@@ -126,6 +127,41 @@ async def get_matched_clusters(
     return clusters_to_bind
 
 
+def convert_zcl_value(value: Any, field_type: Any) -> Any:
+    """Convert user input to ZCL value."""
+    if issubclass(field_type, enum.Flag):
+        if isinstance(value, str):
+            with contextlib.suppress(ValueError):
+                value = int(value)
+
+        if isinstance(value, int):
+            value = field_type(value)
+        elif isinstance(value, str):
+            # List of flags: `SomeFlag.field1 | field2
+            value = [v.strip() for v in value.split(".", 1)[-1].split("|")]
+
+        if isinstance(value, list):
+            new_value = 0
+
+            for flag in value:
+                if isinstance(flag, str):
+                    new_value |= field_type[flag.replace(" ", "_")]
+                else:
+                    new_value |= flag
+
+            value = field_type(new_value)
+    elif issubclass(field_type, enum.Enum):
+        value = (
+            field_type[value.replace(" ", "_")]
+            if isinstance(value, str)
+            else field_type(value)
+        )
+    else:
+        value = field_type(value)
+
+    return value
+
+
 def convert_to_zcl_values(
     fields: dict[str, Any], schema: CommandSchema
 ) -> dict[str, Any]:
@@ -134,32 +170,17 @@ def convert_to_zcl_values(
     for field in schema.fields:
         if field.name not in fields:
             continue
+
         value = fields[field.name]
-        if issubclass(field.type, enum.Flag) and isinstance(value, list):
-            new_value = 0
+        converted_fields[field.name] = convert_zcl_value(value, field.type)
 
-            for flag in value:
-                if isinstance(flag, str):
-                    new_value |= field.type[flag.replace(" ", "_")]
-                else:
-                    new_value |= flag
-
-            value = field.type(new_value)
-        elif issubclass(field.type, enum.Enum):
-            value = (
-                field.type[value.replace(" ", "_")]
-                if isinstance(value, str)
-                else field.type(value)
-            )
-        else:
-            value = field.type(value)
         _LOGGER.debug(
             "Converted ZCL schema field(%s) value from: %s to: %s",
             field.name,
-            fields[field.name],
             value,
+            fields[field.name],
         )
-        converted_fields[field.name] = value
+
     return converted_fields
 
 

--- a/zha/application/helpers.py
+++ b/zha/application/helpers.py
@@ -153,15 +153,20 @@ def convert_zcl_value(value: Any, field_type: Any) -> Any:
             value = field_type(new_value)
     elif issubclass(field_type, enum.Enum):
         value = (
-            field_type[value.replace(" ", "_")]
+            field_type[value.replace(" ", "_").split(".", 1)[-1]]
             if isinstance(value, str)
             else field_type(value)
         )
     elif issubclass(field_type, zigpy.types.SerializableBytes):
         if value.startswith(("b'", 'b"')):
-            value = ast.from_literal(value)
+            value = ast.literal_eval(value)
         else:
             value = bytes.fromhex(value)
+
+        value = field_type(value)
+    elif issubclass(field_type, int):
+        if isinstance(value, str) and value.startswith("0x"):
+            value = int(value, 16)
 
         value = field_type(value)
     else:

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -59,7 +59,7 @@ from zha.application.const import (
     ZHA_CLUSTER_HANDLER_MSG,
     ZHA_EVENT,
 )
-from zha.application.helpers import convert_to_zcl_values
+from zha.application.helpers import convert_to_zcl_values, convert_zcl_value
 from zha.application.platforms import BaseEntityInfo, PlatformEntity
 from zha.event import EventBase
 from zha.exceptions import ZHAException
@@ -864,6 +864,9 @@ class Device(LogMixin, EventBase):
                 f"Cluster {cluster_id} not found on endpoint {endpoint_id} while"
                 f" writing attribute {attribute} with value {value}"
             ) from exc
+
+        attr_def = cluster.find_attribute(attribute)
+        value = convert_zcl_value(value, attr_def.type)
 
         try:
             response = await cluster.write_attributes(


### PR DESCRIPTION
When writing attributes via the ZCL cluster management dialog, strings aren't currently converted into their correct type. I believe this is a regression.

We'll need to figure out a generic way to do string conversion for complex types, like arrays and structs.