### PR TITLE
Decimal OTA progress

### DIFF
--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -29,7 +29,7 @@ from zha.application.platforms.update import (
     ATTR_IN_PROGRESS,
     ATTR_INSTALLED_VERSION,
     ATTR_LATEST_VERSION,
-    ATTR_PROGRESS,
+    ATTR_UPDATE_PERCENTAGE,
 )
 from zha.exceptions import ZHAException
 
@@ -309,7 +309,9 @@ async def test_firmware_update_success(zha_gateway: Gateway) -> None:
                         == f"0x{installed_fw_version:08x}"
                     )
                     assert entity.state[ATTR_IN_PROGRESS] is True
-                    assert entity.state[ATTR_PROGRESS] == pytest.approx(100 * (40 / 70))
+                    assert entity.state[ATTR_UPDATE_PERCENTAGE] == pytest.approx(
+                        100 * (40 / 70)
+                    )
                     assert (
                         entity.state[ATTR_LATEST_VERSION]
                         == f"0x{fw_image.firmware.header.file_version:08x}"

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -309,7 +309,7 @@ async def test_firmware_update_success(zha_gateway: Gateway) -> None:
                         == f"0x{installed_fw_version:08x}"
                     )
                     assert entity.state[ATTR_IN_PROGRESS] is True
-                    assert entity.state[ATTR_PROGRESS] == 57
+                    assert entity.state[ATTR_PROGRESS] == pytest.approx(100 * (40 / 70))
                     assert (
                         entity.state[ATTR_LATEST_VERSION]
                         == f"0x{fw_image.firmware.header.file_version:08x}"
@@ -364,7 +364,8 @@ async def test_firmware_update_success(zha_gateway: Gateway) -> None:
     assert entity.state[ATTR_LATEST_VERSION] == entity.state[ATTR_INSTALLED_VERSION]
 
     # If we send a progress notification incorrectly, it won't be handled
-    entity._update_progress(50, 100, 0.50)
+    entity._raw_progress_callback(50, 100, 0.50)
+    entity._emit_progress_update()
 
     assert not entity.state[ATTR_IN_PROGRESS]
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -364,8 +364,7 @@ async def test_firmware_update_success(zha_gateway: Gateway) -> None:
     assert entity.state[ATTR_LATEST_VERSION] == entity.state[ATTR_INSTALLED_VERSION]
 
     # If we send a progress notification incorrectly, it won't be handled
-    entity._raw_progress_callback(50, 100, 0.50)
-    entity._emit_progress_update()
+    entity._update_progress(50, 100, 0.50)
 
     assert not entity.state[ATTR_IN_PROGRESS]
 

--- a/zha/application/platforms/update.py
+++ b/zha/application/platforms/update.py
@@ -54,7 +54,7 @@ class UpdateEntityFeature(IntFlag):
 ATTR_BACKUP: Final = "backup"
 ATTR_INSTALLED_VERSION: Final = "installed_version"
 ATTR_IN_PROGRESS: Final = "in_progress"
-ATTR_PROGRESS: Final = "progress"
+ATTR_UPDATE_PERCENTAGE: Final = "update_percentage"
 ATTR_LATEST_VERSION: Final = "latest_version"
 ATTR_RELEASE_SUMMARY: Final = "release_summary"
 ATTR_RELEASE_NOTES: Final = "release_notes"
@@ -87,7 +87,7 @@ class FirmwareUpdateEntity(PlatformEntity):
     )
     _attr_installed_version: str | None = None
     _attr_in_progress: bool = False
-    _attr_progress: float = 0
+    _attr_update_percentage: float | None = None
     _attr_latest_version: str | None = None
     _attr_release_summary: str | None = None
     _attr_release_notes: str | None = None
@@ -150,14 +150,13 @@ class FirmwareUpdateEntity(PlatformEntity):
         return self._attr_in_progress
 
     @property
-    def progress(self) -> float | None:
+    def update_percentage(self) -> float | None:
         """Update installation progress.
 
-        Needs UpdateEntityFeature.PROGRESS flag to be set for it to be used.
-
-        Returns a number indicating the progress from 0 to 100%.
+        Returns a number indicating the progress from 0 to 100%. If an update's progress
+        is indeterminate, this will return None.
         """
-        return self._attr_progress
+        return self._attr_update_percentage
 
     @property
     def latest_version(self) -> str | None:
@@ -198,7 +197,7 @@ class FirmwareUpdateEntity(PlatformEntity):
         return {
             ATTR_INSTALLED_VERSION: self.installed_version,
             ATTR_IN_PROGRESS: self.in_progress,
-            ATTR_PROGRESS: self.progress,
+            ATTR_UPDATE_PERCENTAGE: self.update_percentage,
             ATTR_LATEST_VERSION: self.latest_version,
             ATTR_RELEASE_SUMMARY: release_summary,
             ATTR_RELEASE_NOTES: self.release_notes,
@@ -258,7 +257,7 @@ class FirmwareUpdateEntity(PlatformEntity):
         if not self._attr_in_progress:
             return
 
-        self._attr_progress = progress
+        self._attr_update_percentage = progress
         self.maybe_emit_state_changed_event()
 
     async def async_install(self, version: str | None) -> None:
@@ -282,7 +281,7 @@ class FirmwareUpdateEntity(PlatformEntity):
                 raise ZHAException(f"Version {version!r} is not available")
 
         self._attr_in_progress = True
-        self._attr_progress = 0.0
+        self._attr_update_percentage = None
         self.maybe_emit_state_changed_event()
 
         try:

--- a/zha/application/platforms/update.py
+++ b/zha/application/platforms/update.py
@@ -16,7 +16,6 @@ from zigpy.zcl.foundation import Status
 from zha.application import Platform
 from zha.application.platforms import BaseEntityInfo, EntityCategory, PlatformEntity
 from zha.application.registries import PLATFORM_ENTITIES
-from zha.debounce import Debouncer
 from zha.exceptions import ZHAException
 from zha.zigbee.cluster_handlers import ClusterAttributeUpdatedEvent
 from zha.zigbee.cluster_handlers.const import (
@@ -61,10 +60,6 @@ ATTR_RELEASE_SUMMARY: Final = "release_summary"
 ATTR_RELEASE_NOTES: Final = "release_notes"
 ATTR_RELEASE_URL: Final = "release_url"
 ATTR_VERSION: Final = "version"
-
-# Mains-powered devices can update quickly. We don't want to flood the receiving end
-# with unnecessary updates.
-PROGRESS_CHANGE_COOLDOWN = 0.25  # seconds
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -122,17 +117,6 @@ class FirmwareUpdateEntity(PlatformEntity):
         self._ota_cluster_handler.on_event(
             CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
             self.handle_cluster_handler_attribute_updated,
-        )
-
-        # To prevent unnecessary progress state changes, we debounce the progress
-        # percentage
-        self._raw_progress: float = 0
-        self._progress_debouncer = Debouncer(
-            gateway=self.device.gateway,
-            logger=_LOGGER,
-            cooldown=PROGRESS_CHANGE_COOLDOWN,
-            immediate=True,
-            function=self._emit_progress_update,
         )
 
     @functools.cached_property
@@ -268,24 +252,14 @@ class FirmwareUpdateEntity(PlatformEntity):
 
         self.maybe_emit_state_changed_event()
 
-    def _emit_progress_update(self) -> None:
-        self._attr_progress = self._raw_progress
-        self.maybe_emit_state_changed_event()
-
-    def _raw_progress_callback(self, current: int, total: int, progress: float) -> None:
+    def _update_progress(self, current: int, total: int, progress: float) -> None:
         """Update install progress on event."""
         # If we are not supposed to be updating, do nothing
         if not self._attr_in_progress:
             return
 
-        self._raw_progress = progress
-
-        if progress < 100.0:
-            # Debounce progress updates
-            self._progress_debouncer.async_schedule_call()
-        else:
-            # Unless we are at 100%, then we can update immediately
-            self._emit_progress_update()
+        self._attr_progress = progress
+        self.maybe_emit_state_changed_event()
 
     async def async_install(self, version: str | None) -> None:
         """Install an update."""
@@ -314,7 +288,7 @@ class FirmwareUpdateEntity(PlatformEntity):
         try:
             result = await self.device.device.update_firmware(
                 image=firmware,
-                progress_callback=self._raw_progress_callback,
+                progress_callback=self._update_progress,
             )
         except Exception as ex:
             self._attr_in_progress = False
@@ -334,6 +308,5 @@ class FirmwareUpdateEntity(PlatformEntity):
     async def on_remove(self) -> None:
         """Call when entity will be removed."""
         self._attr_in_progress = False
-        self._progress_debouncer.async_cancel()
         self.device.device.remove_listener(self)
         await super().on_remove()

--- a/zha/application/platforms/update.py
+++ b/zha/application/platforms/update.py
@@ -16,6 +16,7 @@ from zigpy.zcl.foundation import Status
 from zha.application import Platform
 from zha.application.platforms import BaseEntityInfo, EntityCategory, PlatformEntity
 from zha.application.registries import PLATFORM_ENTITIES
+from zha.debounce import Debouncer
 from zha.exceptions import ZHAException
 from zha.zigbee.cluster_handlers import ClusterAttributeUpdatedEvent
 from zha.zigbee.cluster_handlers.const import (
@@ -51,8 +52,6 @@ class UpdateEntityFeature(IntFlag):
     RELEASE_NOTES = 16
 
 
-SERVICE_INSTALL: Final = "install"
-
 ATTR_BACKUP: Final = "backup"
 ATTR_INSTALLED_VERSION: Final = "installed_version"
 ATTR_IN_PROGRESS: Final = "in_progress"
@@ -62,6 +61,10 @@ ATTR_RELEASE_SUMMARY: Final = "release_summary"
 ATTR_RELEASE_NOTES: Final = "release_notes"
 ATTR_RELEASE_URL: Final = "release_url"
 ATTR_VERSION: Final = "version"
+
+# Mains-powered devices can update quickly. We don't want to flood the receiving end
+# with unnecessary updates.
+PROGRESS_CHANGE_COOLDOWN = 0.25  # seconds
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -89,7 +92,7 @@ class FirmwareUpdateEntity(PlatformEntity):
     )
     _attr_installed_version: str | None = None
     _attr_in_progress: bool = False
-    _attr_progress: int = 0
+    _attr_progress: float = 0
     _attr_latest_version: str | None = None
     _attr_release_summary: str | None = None
     _attr_release_notes: str | None = None
@@ -119,6 +122,17 @@ class FirmwareUpdateEntity(PlatformEntity):
         self._ota_cluster_handler.on_event(
             CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
             self.handle_cluster_handler_attribute_updated,
+        )
+
+        # To prevent unnecessary progress state changes, we debounce the progress
+        # percentage
+        self._raw_progress: float = 0
+        self._progress_debouncer = Debouncer(
+            gateway=self.device.gateway,
+            logger=_LOGGER,
+            cooldown=PROGRESS_CHANGE_COOLDOWN,
+            immediate=True,
+            function=self._emit_progress_update,
         )
 
     @functools.cached_property
@@ -152,12 +166,12 @@ class FirmwareUpdateEntity(PlatformEntity):
         return self._attr_in_progress
 
     @property
-    def progress(self) -> int | None:
+    def progress(self) -> float | None:
         """Update installation progress.
 
         Needs UpdateEntityFeature.PROGRESS flag to be set for it to be used.
 
-        Returns an integer indicating the progress from 0 to 100%.
+        Returns a number indicating the progress from 0 to 100%.
         """
         return self._attr_progress
 
@@ -254,14 +268,24 @@ class FirmwareUpdateEntity(PlatformEntity):
 
         self.maybe_emit_state_changed_event()
 
-    def _update_progress(self, current: int, total: int, progress: float) -> None:
+    def _emit_progress_update(self) -> None:
+        self._attr_progress = self._raw_progress
+        self.maybe_emit_state_changed_event()
+
+    def _raw_progress_callback(self, current: int, total: int, progress: float) -> None:
         """Update install progress on event."""
         # If we are not supposed to be updating, do nothing
         if not self._attr_in_progress:
             return
 
-        self._attr_progress = int(progress)
-        self.maybe_emit_state_changed_event()
+        self._raw_progress = progress
+
+        if progress < 100.0:
+            # Debounce progress updates
+            self._progress_debouncer.async_schedule_call()
+        else:
+            # Unless we are at 100%, then we can update immediately
+            self._emit_progress_update()
 
     async def async_install(self, version: str | None) -> None:
         """Install an update."""
@@ -284,13 +308,13 @@ class FirmwareUpdateEntity(PlatformEntity):
                 raise ZHAException(f"Version {version!r} is not available")
 
         self._attr_in_progress = True
-        self._attr_progress = 0
+        self._attr_progress = 0.0
         self.maybe_emit_state_changed_event()
 
         try:
             result = await self.device.device.update_firmware(
                 image=firmware,
-                progress_callback=self._update_progress,
+                progress_callback=self._raw_progress_callback,
             )
         except Exception as ex:
             self._attr_in_progress = False
@@ -309,5 +333,7 @@ class FirmwareUpdateEntity(PlatformEntity):
 
     async def on_remove(self) -> None:
         """Call when entity will be removed."""
-        await super().on_remove()
         self._attr_in_progress = False
+        self._progress_debouncer.async_cancel()
+        self.device.device.remove_listener(self)
+        await super().on_remove()


### PR DESCRIPTION
Home Assistant Core now supports OTA progress with decimal places!

I originally wrote this PR to use the ZHA debouncer object but even with fast mains-powered devices, we emit only a few events per second so it's probably unnecessary to filter.

To match Core naming conventions, `progress` has been renamed to `progress_percentage`, since we already provide an independent `in_progress` attribute.


https://github.com/user-attachments/assets/68bc6c0f-fb70-44e1-ac56-4258c2f07559

