### PR TITLE
Use an explicit entity category of `CONTROL` instead of `None`

### DIFF
--- a/tests/data/devices/adurosmart-eria-ad-rgbw3001.json
+++ b/tests/data/devices/adurosmart-eria-ad-rgbw3001.json
@@ -1309,7 +1309,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/adurosmart-eria-vms-adurolight.json
+++ b/tests/data/devices/adurosmart-eria-vms-adurolight.json
@@ -497,7 +497,7 @@
           "translation_key": null,
           "device_class": "motion",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/aqara-lumi-motion-ac01.json
+++ b/tests/data/devices/aqara-lumi-motion-ac01.json
@@ -230,7 +230,7 @@
           "translation_key": null,
           "device_class": "occupancy",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/centralite-3320-l.json
+++ b/tests/data/devices/centralite-3320-l.json
@@ -1159,7 +1159,7 @@
           "translation_key": null,
           "device_class": "opening",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1317,7 +1317,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/centralite-3326-l.json
+++ b/tests/data/devices/centralite-3326-l.json
@@ -1139,7 +1139,7 @@
           "translation_key": null,
           "device_class": "motion",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1297,7 +1297,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/centralite-3405-l.json
+++ b/tests/data/devices/centralite-3405-l.json
@@ -827,7 +827,7 @@
           "translation_key": "alarm_control_panel",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -877,7 +877,7 @@
           "translation_key": "alarm_control_panel",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -929,7 +929,7 @@
           "translation_key": "ias_zone",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1087,7 +1087,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/climaxtechnology-sd8sc-00-00-03-12tc.json
+++ b/tests/data/devices/climaxtechnology-sd8sc-00-00-03-12tc.json
@@ -379,7 +379,7 @@
           "translation_key": null,
           "device_class": "smoke",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -807,7 +807,7 @@
           "translation_key": null,
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/ecolink-4655bc0-r.json
+++ b/tests/data/devices/ecolink-4655bc0-r.json
@@ -256,7 +256,7 @@
           "translation_key": null,
           "device_class": "opening",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -414,7 +414,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/ericsity-gl-c-008p.json
+++ b/tests/data/devices/ericsity-gl-c-008p.json
@@ -599,7 +599,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/ericsity-gl-c-009p.json
+++ b/tests/data/devices/ericsity-gl-c-009p.json
@@ -1006,7 +1006,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/ewelink-ck-bl702-al-01-7009-z102lg03-1.json
+++ b/tests/data/devices/ewelink-ck-bl702-al-01-7009-z102lg03-1.json
@@ -902,7 +902,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/ewelink-sa-003-zigbee.json
+++ b/tests/data/devices/ewelink-sa-003-zigbee.json
@@ -810,7 +810,7 @@
           "translation_key": "switch",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/ewelink-snzb-02p.json
+++ b/tests/data/devices/ewelink-snzb-02p.json
@@ -303,7 +303,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -459,7 +459,7 @@
           "translation_key": null,
           "device_class": "humidity",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/ewelink-zb-sw02.json
+++ b/tests/data/devices/ewelink-zb-sw02.json
@@ -789,7 +789,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -852,7 +852,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/feibit-inc-co-fzb56-zcw27lx1-0.json
+++ b/tests/data/devices/feibit-inc-co-fzb56-zcw27lx1-0.json
@@ -313,7 +313,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/gledopto-gl-b-008p.json
+++ b/tests/data/devices/gledopto-gl-b-008p.json
@@ -699,7 +699,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/homr-hrmsn01.json
+++ b/tests/data/devices/homr-hrmsn01.json
@@ -414,7 +414,7 @@
           "translation_key": null,
           "device_class": "occupancy",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -517,7 +517,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -888,7 +888,7 @@
           "translation_key": null,
           "device_class": "illuminance",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -940,7 +940,7 @@
           "translation_key": null,
           "device_class": "pressure",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -992,7 +992,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1148,7 +1148,7 @@
           "translation_key": null,
           "device_class": "humidity",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1202,7 +1202,7 @@
           "translation_key": null,
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/ikea-of-sweden-fyrtur-block-out-roller-blind.json
+++ b/tests/data/devices/ikea-of-sweden-fyrtur-block-out-roller-blind.json
@@ -343,7 +343,7 @@
           "translation_key": "cover",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/ikea-of-sweden-parasoll-door-window-sensor.json
+++ b/tests/data/devices/ikea-of-sweden-parasoll-door-window-sensor.json
@@ -273,7 +273,7 @@
           "translation_key": null,
           "device_class": "opening",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/ikea-of-sweden-praktlysing-cellular-blind.json
+++ b/tests/data/devices/ikea-of-sweden-praktlysing-cellular-blind.json
@@ -349,7 +349,7 @@
           "translation_key": "cover",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/ikea-of-sweden-starkvind-air-purifier.json
+++ b/tests/data/devices/ikea-of-sweden-starkvind-air-purifier.json
@@ -692,7 +692,7 @@
           "translation_key": "fan",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -827,7 +827,7 @@
           "translation_key": null,
           "device_class": "pm25",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-w-op-ch-400lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-w-op-ch-400lm.json
@@ -947,7 +947,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-ws-opal-400lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-ws-opal-400lm.json
@@ -641,7 +641,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-opal-1000lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-opal-1000lm.json
@@ -888,7 +888,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-w-opal-1000lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-w-opal-1000lm.json
@@ -955,7 +955,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-ws-opal-980lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-ws-opal-980lm.json
@@ -1043,7 +1043,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-gu10-ws-400lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-gu10-ws-400lm.json
@@ -636,7 +636,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/ikea-of-sweden-tradfri-control-outlet.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-control-outlet.json
@@ -960,7 +960,7 @@
           "translation_key": "switch",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/ikea-of-sweden-vallhorn-wireless-motion-sensor.json
+++ b/tests/data/devices/ikea-of-sweden-vallhorn-wireless-motion-sensor.json
@@ -1232,7 +1232,7 @@
           "translation_key": null,
           "device_class": "opening",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1280,7 +1280,7 @@
           "translation_key": null,
           "device_class": "occupancy",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1542,7 +1542,7 @@
           "translation_key": null,
           "device_class": "illuminance",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/ikea-of-sweden-vindstyrka.json
+++ b/tests/data/devices/ikea-of-sweden-vindstyrka.json
@@ -571,7 +571,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -623,7 +623,7 @@
           "translation_key": null,
           "device_class": "pm25",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -779,7 +779,7 @@
           "translation_key": null,
           "device_class": "humidity",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/innr-ae-280-c.json
+++ b/tests/data/devices/innr-ae-280-c.json
@@ -1016,7 +1016,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/innr-rb-285-c.json
+++ b/tests/data/devices/innr-rb-285-c.json
@@ -757,7 +757,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/innr-sp-234.json
+++ b/tests/data/devices/innr-sp-234.json
@@ -1265,7 +1265,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1318,7 +1318,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1475,7 +1475,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1528,7 +1528,7 @@
           "translation_key": "summation_delivered",
           "device_class": "energy",
           "state_class": "total_increasing",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1585,7 +1585,7 @@
           "translation_key": "switch",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/isilentllc-dog-feeder.json
+++ b/tests/data/devices/isilentllc-dog-feeder.json
@@ -751,7 +751,7 @@
           "translation_key": "binary_input",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -799,7 +799,7 @@
           "translation_key": "binary_input",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -847,7 +847,7 @@
           "translation_key": "binary_input",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -897,7 +897,7 @@
           "translation_key": "number",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1057,7 +1057,7 @@
           "translation_key": "switch",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/isilentllc-doorbell.json
+++ b/tests/data/devices/isilentllc-doorbell.json
@@ -337,7 +337,7 @@
           "translation_key": "binary_input",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -491,7 +491,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -543,7 +543,7 @@
           "translation_key": null,
           "device_class": "humidity",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/isilentllc-freezer-monitor.json
+++ b/tests/data/devices/isilentllc-freezer-monitor.json
@@ -454,7 +454,7 @@
           "translation_key": "binary_input",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -661,7 +661,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/isilentllc-home-energy-monitor.json
+++ b/tests/data/devices/isilentllc-home-energy-monitor.json
@@ -3901,7 +3901,7 @@
           "translation_key": null,
           "device_class": "apparent_power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -3954,7 +3954,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -4007,7 +4007,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -4060,7 +4060,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -4113,7 +4113,7 @@
           "translation_key": null,
           "device_class": "power_factor",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -4166,7 +4166,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -4219,7 +4219,7 @@
           "translation_key": null,
           "device_class": "apparent_power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -4272,7 +4272,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -4325,7 +4325,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -4378,7 +4378,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -4431,7 +4431,7 @@
           "translation_key": null,
           "device_class": "power_factor",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -4484,7 +4484,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -4537,7 +4537,7 @@
           "translation_key": null,
           "device_class": "apparent_power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -4590,7 +4590,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -4643,7 +4643,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -4696,7 +4696,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -4749,7 +4749,7 @@
           "translation_key": null,
           "device_class": "power_factor",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -4802,7 +4802,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -4855,7 +4855,7 @@
           "translation_key": null,
           "device_class": "apparent_power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -4908,7 +4908,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -4961,7 +4961,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -5014,7 +5014,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -5067,7 +5067,7 @@
           "translation_key": null,
           "device_class": "power_factor",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -5120,7 +5120,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -5173,7 +5173,7 @@
           "translation_key": null,
           "device_class": "apparent_power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -5226,7 +5226,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -5279,7 +5279,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -5332,7 +5332,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -5385,7 +5385,7 @@
           "translation_key": null,
           "device_class": "power_factor",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -5438,7 +5438,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -5491,7 +5491,7 @@
           "translation_key": null,
           "device_class": "apparent_power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -5544,7 +5544,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -5597,7 +5597,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -5650,7 +5650,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -5703,7 +5703,7 @@
           "translation_key": null,
           "device_class": "power_factor",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -5756,7 +5756,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -5809,7 +5809,7 @@
           "translation_key": null,
           "device_class": "apparent_power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -5862,7 +5862,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -5915,7 +5915,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -5968,7 +5968,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -6021,7 +6021,7 @@
           "translation_key": null,
           "device_class": "power_factor",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -6074,7 +6074,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -6127,7 +6127,7 @@
           "translation_key": null,
           "device_class": "apparent_power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -6180,7 +6180,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -6233,7 +6233,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -6286,7 +6286,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -6339,7 +6339,7 @@
           "translation_key": null,
           "device_class": "power_factor",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -6392,7 +6392,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -6445,7 +6445,7 @@
           "translation_key": null,
           "device_class": "apparent_power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -6498,7 +6498,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -6551,7 +6551,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -6604,7 +6604,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -6657,7 +6657,7 @@
           "translation_key": null,
           "device_class": "power_factor",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -6710,7 +6710,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -6763,7 +6763,7 @@
           "translation_key": null,
           "device_class": "apparent_power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -6816,7 +6816,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -6869,7 +6869,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -6922,7 +6922,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -6975,7 +6975,7 @@
           "translation_key": null,
           "device_class": "power_factor",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -7028,7 +7028,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -7081,7 +7081,7 @@
           "translation_key": null,
           "device_class": "apparent_power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -7134,7 +7134,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -7187,7 +7187,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -7240,7 +7240,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -7293,7 +7293,7 @@
           "translation_key": null,
           "device_class": "power_factor",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -7346,7 +7346,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -7399,7 +7399,7 @@
           "translation_key": null,
           "device_class": "apparent_power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -7452,7 +7452,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -7505,7 +7505,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -7558,7 +7558,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -7611,7 +7611,7 @@
           "translation_key": null,
           "device_class": "power_factor",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -7664,7 +7664,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -7717,7 +7717,7 @@
           "translation_key": null,
           "device_class": "apparent_power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -7770,7 +7770,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -7823,7 +7823,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -7876,7 +7876,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -7929,7 +7929,7 @@
           "translation_key": null,
           "device_class": "power_factor",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -7982,7 +7982,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -8035,7 +8035,7 @@
           "translation_key": null,
           "device_class": "apparent_power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -8088,7 +8088,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -8141,7 +8141,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -8194,7 +8194,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -8247,7 +8247,7 @@
           "translation_key": null,
           "device_class": "power_factor",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -8300,7 +8300,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -8353,7 +8353,7 @@
           "translation_key": null,
           "device_class": "apparent_power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -8406,7 +8406,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -8459,7 +8459,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -8512,7 +8512,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -8565,7 +8565,7 @@
           "translation_key": null,
           "device_class": "power_factor",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -8618,7 +8618,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -8671,7 +8671,7 @@
           "translation_key": null,
           "device_class": "apparent_power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -8724,7 +8724,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -8777,7 +8777,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -8830,7 +8830,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -8883,7 +8883,7 @@
           "translation_key": null,
           "device_class": "power_factor",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -8936,7 +8936,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -8989,7 +8989,7 @@
           "translation_key": null,
           "device_class": "apparent_power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -9042,7 +9042,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -9095,7 +9095,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -9148,7 +9148,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -9201,7 +9201,7 @@
           "translation_key": null,
           "device_class": "power_factor",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -9254,7 +9254,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -9307,7 +9307,7 @@
           "translation_key": null,
           "device_class": "apparent_power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -9360,7 +9360,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -9413,7 +9413,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -9466,7 +9466,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -9519,7 +9519,7 @@
           "translation_key": null,
           "device_class": "power_factor",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -9572,7 +9572,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -9625,7 +9625,7 @@
           "translation_key": null,
           "device_class": "apparent_power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -9678,7 +9678,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -9731,7 +9731,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -9784,7 +9784,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -9837,7 +9837,7 @@
           "translation_key": null,
           "device_class": "power_factor",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -9890,7 +9890,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -9943,7 +9943,7 @@
           "translation_key": null,
           "device_class": "apparent_power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -9996,7 +9996,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -10049,7 +10049,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -10102,7 +10102,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -10155,7 +10155,7 @@
           "translation_key": null,
           "device_class": "power_factor",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -10208,7 +10208,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -10261,7 +10261,7 @@
           "translation_key": null,
           "device_class": "apparent_power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -10314,7 +10314,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -10367,7 +10367,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -10420,7 +10420,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -10473,7 +10473,7 @@
           "translation_key": null,
           "device_class": "power_factor",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -10526,7 +10526,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -10579,7 +10579,7 @@
           "translation_key": null,
           "device_class": "apparent_power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -10632,7 +10632,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -10685,7 +10685,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -10738,7 +10738,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -10791,7 +10791,7 @@
           "translation_key": null,
           "device_class": "power_factor",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -10844,7 +10844,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -10897,7 +10897,7 @@
           "translation_key": null,
           "device_class": "apparent_power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -10950,7 +10950,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -11003,7 +11003,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -11056,7 +11056,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -11109,7 +11109,7 @@
           "translation_key": null,
           "device_class": "power_factor",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -11162,7 +11162,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -11215,7 +11215,7 @@
           "translation_key": null,
           "device_class": "apparent_power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -11268,7 +11268,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -11321,7 +11321,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -11374,7 +11374,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -11427,7 +11427,7 @@
           "translation_key": null,
           "device_class": "power_factor",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -11480,7 +11480,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -11533,7 +11533,7 @@
           "translation_key": null,
           "device_class": "apparent_power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -11586,7 +11586,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -11639,7 +11639,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -11692,7 +11692,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -11745,7 +11745,7 @@
           "translation_key": null,
           "device_class": "power_factor",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -11798,7 +11798,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/isilentllc-masterbed-light-controller.json
+++ b/tests/data/devices/isilentllc-masterbed-light-controller.json
@@ -670,7 +670,7 @@
           "translation_key": "binary_input",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -718,7 +718,7 @@
           "translation_key": "binary_input",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -768,7 +768,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -866,7 +866,7 @@
           "translation_key": "number",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -918,7 +918,7 @@
           "translation_key": "number",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1076,7 +1076,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1128,7 +1128,7 @@
           "translation_key": null,
           "device_class": "humidity",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/isilentllc-safe.json
+++ b/tests/data/devices/isilentllc-safe.json
@@ -588,7 +588,7 @@
           "translation_key": "binary_input",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -636,7 +636,7 @@
           "translation_key": "ias_zone",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -686,7 +686,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -888,7 +888,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -940,7 +940,7 @@
           "translation_key": null,
           "device_class": "humidity",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/isilentllc-test-device.json
+++ b/tests/data/devices/isilentllc-test-device.json
@@ -337,7 +337,7 @@
           "translation_key": "switch",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -384,7 +384,7 @@
           "translation_key": "switch",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/isilentllc-test-mule.json
+++ b/tests/data/devices/isilentllc-test-mule.json
@@ -441,7 +441,7 @@
           "translation_key": "binary_input",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/isilentllc-water-heater.json
+++ b/tests/data/devices/isilentllc-water-heater.json
@@ -459,7 +459,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -512,7 +512,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -566,7 +566,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -724,7 +724,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -776,7 +776,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -830,7 +830,7 @@
           "translation_key": "switch",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/jasco-products-45856.json
+++ b/tests/data/devices/jasco-products-45856.json
@@ -655,7 +655,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -824,7 +824,7 @@
           "translation_key": "instantaneous_demand",
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -879,7 +879,7 @@
           "translation_key": "summation_delivered",
           "device_class": "energy",
           "state_class": "total_increasing",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/jasco-products-45857.json
+++ b/tests/data/devices/jasco-products-45857.json
@@ -652,7 +652,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -889,7 +889,7 @@
           "translation_key": "instantaneous_demand",
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -944,7 +944,7 @@
           "translation_key": "summation_delivered",
           "device_class": "energy",
           "state_class": "total_increasing",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/keen-home-inc-sv02-610-mp-1-3.json
+++ b/tests/data/devices/keen-home-inc-sv02-610-mp-1-3.json
@@ -1101,7 +1101,7 @@
           "translation_key": "keen_vent",
           "device_class": "damper",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1221,7 +1221,7 @@
           "translation_key": null,
           "device_class": "pressure",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1273,7 +1273,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/keen-home-inc-sv02-612-mp-1-3.json
+++ b/tests/data/devices/keen-home-inc-sv02-612-mp-1-3.json
@@ -1117,7 +1117,7 @@
           "translation_key": "keen_vent",
           "device_class": "damper",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1237,7 +1237,7 @@
           "translation_key": null,
           "device_class": "pressure",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1289,7 +1289,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/king-of-fans-inc-hbuniversalcfremote.json
+++ b/tests/data/devices/king-of-fans-inc-hbuniversalcfremote.json
@@ -286,7 +286,7 @@
           "translation_key": "fan",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -350,7 +350,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/king-of-fans-inc-hdc52eastwindfan.json
+++ b/tests/data/devices/king-of-fans-inc-hdc52eastwindfan.json
@@ -290,7 +290,7 @@
           "translation_key": "fan",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -354,7 +354,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/konke-3afe140103020000.json
+++ b/tests/data/devices/konke-3afe140103020000.json
@@ -310,7 +310,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -466,7 +466,7 @@
           "translation_key": null,
           "device_class": "humidity",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/konke-3afe220103020000.json
+++ b/tests/data/devices/konke-3afe220103020000.json
@@ -310,7 +310,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -466,7 +466,7 @@
           "translation_key": null,
           "device_class": "humidity",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/konke-3afe270104020015.json
+++ b/tests/data/devices/konke-3afe270104020015.json
@@ -213,7 +213,7 @@
           "translation_key": null,
           "device_class": "opening",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/konke-3afe28010402000d.json
+++ b/tests/data/devices/konke-3afe28010402000d.json
@@ -232,7 +232,7 @@
           "translation_key": null,
           "device_class": "occupancy",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -280,7 +280,7 @@
           "translation_key": null,
           "device_class": "motion",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/kwikset-smartcode-convert-gen1.json
+++ b/tests/data/devices/kwikset-smartcode-convert-gen1.json
@@ -300,7 +300,7 @@
           "translation_key": "door_lock",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -404,7 +404,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/ledvance-flex-rgbw.json
+++ b/tests/data/devices/ledvance-flex-rgbw.json
@@ -621,7 +621,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/ledvance-outdoor-accent-light-rgb.json
+++ b/tests/data/devices/ledvance-outdoor-accent-light-rgb.json
@@ -531,7 +531,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/ledvance-plug.json
+++ b/tests/data/devices/ledvance-plug.json
@@ -625,7 +625,7 @@
           "translation_key": "switch",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/level-home-b2.json
+++ b/tests/data/devices/level-home-b2.json
@@ -952,7 +952,7 @@
           "translation_key": "door_lock",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/lk-zb-doorsensor-d0003.json
+++ b/tests/data/devices/lk-zb-doorsensor-d0003.json
@@ -185,7 +185,7 @@
           "translation_key": null,
           "device_class": "opening",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/lk-zbt-onoffplug-d0001.json
+++ b/tests/data/devices/lk-zbt-onoffplug-d0001.json
@@ -1287,7 +1287,7 @@
           "translation_key": "switch",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/lumi-lumi-airmonitor-acn01.json
+++ b/tests/data/devices/lumi-lumi-airmonitor-acn01.json
@@ -807,7 +807,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -963,7 +963,7 @@
           "translation_key": null,
           "device_class": "humidity",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1015,7 +1015,7 @@
           "translation_key": null,
           "device_class": "volatile_organic_compounds_parts",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/lumi-lumi-curtain-agl001.json
+++ b/tests/data/devices/lumi-lumi-curtain-agl001.json
@@ -980,7 +980,7 @@
           "translation_key": "cover",
           "device_class": "curtain",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1090,7 +1090,7 @@
           "translation_key": null,
           "device_class": "illuminance",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/lumi-lumi-flood-acn001.json
+++ b/tests/data/devices/lumi-lumi-flood-acn001.json
@@ -609,7 +609,7 @@
           "translation_key": null,
           "device_class": "moisture",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/lumi-lumi-flood-agl02.json
+++ b/tests/data/devices/lumi-lumi-flood-agl02.json
@@ -596,7 +596,7 @@
           "translation_key": null,
           "device_class": "moisture",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/lumi-lumi-magnet-ac01.json
+++ b/tests/data/devices/lumi-lumi-magnet-ac01.json
@@ -597,7 +597,7 @@
           "translation_key": null,
           "device_class": "opening",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/lumi-lumi-magnet-acn001.json
+++ b/tests/data/devices/lumi-lumi-magnet-acn001.json
@@ -617,7 +617,7 @@
           "translation_key": "ias_zone",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/lumi-lumi-motion-ac02.json
+++ b/tests/data/devices/lumi-lumi-motion-ac02.json
@@ -267,7 +267,7 @@
           "translation_key": null,
           "device_class": "occupancy",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -315,7 +315,7 @@
           "translation_key": null,
           "device_class": "motion",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -581,7 +581,7 @@
           "translation_key": null,
           "device_class": "illuminance",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/lumi-lumi-motion-agl02.json
+++ b/tests/data/devices/lumi-lumi-motion-agl02.json
@@ -710,7 +710,7 @@
           "translation_key": null,
           "device_class": "occupancy",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -758,7 +758,7 @@
           "translation_key": null,
           "device_class": "motion",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -916,7 +916,7 @@
           "translation_key": null,
           "device_class": "illuminance",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/lumi-lumi-motion-agl04.json
+++ b/tests/data/devices/lumi-lumi-motion-agl04.json
@@ -743,7 +743,7 @@
           "translation_key": null,
           "device_class": "occupancy",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -791,7 +791,7 @@
           "translation_key": null,
           "device_class": "motion",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/lumi-lumi-plug-maus01.json
+++ b/tests/data/devices/lumi-lumi-plug-maus01.json
@@ -2673,7 +2673,7 @@
           "translation_key": "binary_input",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -2776,7 +2776,7 @@
           "translation_key": null,
           "device_class": "apparent_power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -2828,7 +2828,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -2880,7 +2880,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -2932,7 +2932,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -3140,7 +3140,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -3192,7 +3192,7 @@
           "translation_key": "instantaneous_demand",
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -3246,7 +3246,7 @@
           "translation_key": "summation_delivered",
           "device_class": "energy",
           "state_class": "total_increasing",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -3302,7 +3302,7 @@
           "translation_key": "switch",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/lumi-lumi-relay-c2acn01.json
+++ b/tests/data/devices/lumi-lumi-relay-c2acn01.json
@@ -1035,7 +1035,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1098,7 +1098,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1163,7 +1163,7 @@
           "translation_key": null,
           "device_class": "power_factor",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1371,7 +1371,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1423,7 +1423,7 @@
           "translation_key": "instantaneous_demand",
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1477,7 +1477,7 @@
           "translation_key": "summation_delivered",
           "device_class": "energy",
           "state_class": "total_increasing",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/lumi-lumi-sen-ill-mgl01.json
+++ b/tests/data/devices/lumi-lumi-sen-ill-mgl01.json
@@ -645,7 +645,7 @@
           "translation_key": null,
           "device_class": "illuminance",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/lumi-lumi-sensor-ht-agl02.json
+++ b/tests/data/devices/lumi-lumi-sensor-ht-agl02.json
@@ -784,7 +784,7 @@
           "translation_key": null,
           "device_class": "pressure",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -836,7 +836,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -992,7 +992,7 @@
           "translation_key": null,
           "device_class": "humidity",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/lumi-lumi-sensor-magnet-aq2.json
+++ b/tests/data/devices/lumi-lumi-sensor-magnet-aq2.json
@@ -713,7 +713,7 @@
           "translation_key": null,
           "device_class": "opening",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/lumi-lumi-sensor-motion-aq2.json
+++ b/tests/data/devices/lumi-lumi-sensor-motion-aq2.json
@@ -863,7 +863,7 @@
           "translation_key": null,
           "device_class": "occupancy",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -911,7 +911,7 @@
           "translation_key": null,
           "device_class": "motion",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1069,7 +1069,7 @@
           "translation_key": null,
           "device_class": "illuminance",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/lumi-lumi-sensor-smoke-acn03.json
+++ b/tests/data/devices/lumi-lumi-sensor-smoke-acn03.json
@@ -660,7 +660,7 @@
           "translation_key": "linkage_alarm_state",
           "device_class": "smoke",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -708,7 +708,7 @@
           "translation_key": null,
           "device_class": "smoke",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -859,7 +859,7 @@
           "translation_key": "smoke_density",
           "device_class": null,
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/lumi-lumi-sensor-smoke.json
+++ b/tests/data/devices/lumi-lumi-sensor-smoke.json
@@ -278,7 +278,7 @@
           "translation_key": null,
           "device_class": "smoke",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/lumi-lumi-switch-b1laus01.json
+++ b/tests/data/devices/lumi-lumi-switch-b1laus01.json
@@ -261,7 +261,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/lumi-lumi-switch-b1naus01.json
+++ b/tests/data/devices/lumi-lumi-switch-b1naus01.json
@@ -1424,7 +1424,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1645,7 +1645,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1698,7 +1698,7 @@
           "translation_key": "summation_delivered",
           "device_class": "energy",
           "state_class": "total_increasing",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/lumi-lumi-vibration-aq1.json
+++ b/tests/data/devices/lumi-lumi-vibration-aq1.json
@@ -1134,7 +1134,7 @@
           "translation_key": null,
           "device_class": "vibration",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/lumi-lumi-weather.json
+++ b/tests/data/devices/lumi-lumi-weather.json
@@ -355,7 +355,7 @@
           "translation_key": null,
           "device_class": "pressure",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -407,7 +407,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -563,7 +563,7 @@
           "translation_key": null,
           "device_class": "humidity",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/philips-7602031u7.json
+++ b/tests/data/devices/philips-7602031u7.json
@@ -860,7 +860,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/philips-lct014.json
+++ b/tests/data/devices/philips-lct014.json
@@ -902,7 +902,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/philips-llc020.json
+++ b/tests/data/devices/philips-llc020.json
@@ -894,7 +894,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/philips-rwl020.json
+++ b/tests/data/devices/philips-rwl020.json
@@ -285,7 +285,7 @@
           "translation_key": "binary_input",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/philips-sml001.json
+++ b/tests/data/devices/philips-sml001.json
@@ -1349,7 +1349,7 @@
           "translation_key": null,
           "device_class": "motion",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1397,7 +1397,7 @@
           "translation_key": null,
           "device_class": "occupancy",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1712,7 +1712,7 @@
           "translation_key": null,
           "device_class": "illuminance",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1764,7 +1764,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/plaid-systems-ps-sprzms-slp3.json
+++ b/tests/data/devices/plaid-systems-ps-sprzms-slp3.json
@@ -328,7 +328,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -484,7 +484,7 @@
           "translation_key": null,
           "device_class": "humidity",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/samjin-button.json
+++ b/tests/data/devices/samjin-button.json
@@ -233,7 +233,7 @@
           "translation_key": "ias_zone",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -389,7 +389,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/samjin-multi.json
+++ b/tests/data/devices/samjin-multi.json
@@ -717,7 +717,7 @@
           "translation_key": "accelerometer",
           "device_class": "moving",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -765,7 +765,7 @@
           "translation_key": null,
           "device_class": "opening",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -921,7 +921,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/securifi-ltd-unk-model.json
+++ b/tests/data/devices/securifi-ltd-unk-model.json
@@ -2567,7 +2567,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -2620,7 +2620,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -2673,7 +2673,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -2726,7 +2726,7 @@
           "translation_key": null,
           "device_class": "power_factor",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -2883,7 +2883,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -2938,7 +2938,7 @@
           "translation_key": "switch",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/sengled-e11-g13.json
+++ b/tests/data/devices/sengled-e11-g13.json
@@ -1220,7 +1220,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1457,7 +1457,7 @@
           "translation_key": "instantaneous_demand",
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1512,7 +1512,7 @@
           "translation_key": "summation_delivered",
           "device_class": "energy",
           "state_class": "total_increasing",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/sengled-e12-n14.json
+++ b/tests/data/devices/sengled-e12-n14.json
@@ -1217,7 +1217,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1454,7 +1454,7 @@
           "translation_key": "instantaneous_demand",
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1509,7 +1509,7 @@
           "translation_key": "summation_delivered",
           "device_class": "energy",
           "state_class": "total_increasing",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/sengled-e12-n1e.json
+++ b/tests/data/devices/sengled-e12-n1e.json
@@ -1465,7 +1465,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1668,7 +1668,7 @@
           "translation_key": "instantaneous_demand",
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1723,7 +1723,7 @@
           "translation_key": "summation_delivered",
           "device_class": "energy",
           "state_class": "total_increasing",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/sengled-e1c-nb6.json
+++ b/tests/data/devices/sengled-e1c-nb6.json
@@ -315,7 +315,7 @@
           "translation_key": "switch",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/sengled-e1c-nb7.json
+++ b/tests/data/devices/sengled-e1c-nb7.json
@@ -1399,7 +1399,7 @@
           "translation_key": "instantaneous_demand",
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1454,7 +1454,7 @@
           "translation_key": "summation_delivered",
           "device_class": "energy",
           "state_class": "total_increasing",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1511,7 +1511,7 @@
           "translation_key": "switch",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/sengled-e1f-n9g.json
+++ b/tests/data/devices/sengled-e1f-n9g.json
@@ -336,7 +336,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -573,7 +573,7 @@
           "translation_key": "instantaneous_demand",
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -628,7 +628,7 @@
           "translation_key": "summation_delivered",
           "device_class": "energy",
           "state_class": "total_increasing",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/sengled-e1g-g8e.json
+++ b/tests/data/devices/sengled-e1g-g8e.json
@@ -393,7 +393,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -596,7 +596,7 @@
           "translation_key": "instantaneous_demand",
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -651,7 +651,7 @@
           "translation_key": "summation_delivered",
           "device_class": "energy",
           "state_class": "total_increasing",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/sengled-e21-n1ea.json
+++ b/tests/data/devices/sengled-e21-n1ea.json
@@ -409,7 +409,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -767,7 +767,7 @@
           "translation_key": "instantaneous_demand",
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -822,7 +822,7 @@
           "translation_key": "summation_delivered",
           "device_class": "energy",
           "state_class": "total_increasing",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/sengled-z01-a19nae26.json
+++ b/tests/data/devices/sengled-z01-a19nae26.json
@@ -1453,7 +1453,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1705,7 +1705,7 @@
           "translation_key": "instantaneous_demand",
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1760,7 +1760,7 @@
           "translation_key": "summation_delivered",
           "device_class": "energy",
           "state_class": "total_increasing",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/signify-netherlands-b-v-lca005.json
+++ b/tests/data/devices/signify-netherlands-b-v-lca005.json
@@ -1041,7 +1041,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/signify-netherlands-b-v-lca007.json
+++ b/tests/data/devices/signify-netherlands-b-v-lca007.json
@@ -1253,7 +1253,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/signify-netherlands-b-v-lcb001.json
+++ b/tests/data/devices/signify-netherlands-b-v-lcb001.json
@@ -1046,7 +1046,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/signify-netherlands-b-v-lcb002.json
+++ b/tests/data/devices/signify-netherlands-b-v-lcb002.json
@@ -1102,7 +1102,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/signify-netherlands-b-v-lta010.json
+++ b/tests/data/devices/signify-netherlands-b-v-lta010.json
@@ -1043,7 +1043,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/signify-netherlands-b-v-ltb003.json
+++ b/tests/data/devices/signify-netherlands-b-v-ltb003.json
@@ -1105,7 +1105,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/signify-netherlands-b-v-lwa003.json
+++ b/tests/data/devices/signify-netherlands-b-v-lwa003.json
@@ -964,7 +964,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/signify-netherlands-b-v-sml004.json
+++ b/tests/data/devices/signify-netherlands-b-v-sml004.json
@@ -868,7 +868,7 @@
           "translation_key": null,
           "device_class": "occupancy",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -916,7 +916,7 @@
           "translation_key": null,
           "device_class": "opening",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1129,7 +1129,7 @@
           "translation_key": null,
           "device_class": "illuminance",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1181,7 +1181,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/smartthings-tagv4.json
+++ b/tests/data/devices/smartthings-tagv4.json
@@ -666,7 +666,7 @@
           "translation_key": "binary_input",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -769,7 +769,7 @@
           "translation_key": null,
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/smartwings-wm25-l-z.json
+++ b/tests/data/devices/smartwings-wm25-l-z.json
@@ -343,7 +343,7 @@
           "translation_key": "cover",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/sonoff-01minizb.json
+++ b/tests/data/devices/sonoff-01minizb.json
@@ -458,7 +458,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/sonoff-s31-lite-zb.json
+++ b/tests/data/devices/sonoff-s31-lite-zb.json
@@ -616,7 +616,7 @@
           "translation_key": "switch",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/sonoff-snzb-02d.json
+++ b/tests/data/devices/sonoff-snzb-02d.json
@@ -303,7 +303,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -459,7 +459,7 @@
           "translation_key": null,
           "device_class": "humidity",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/sonoff-zbmicro.json
+++ b/tests/data/devices/sonoff-zbmicro.json
@@ -799,7 +799,7 @@
           "translation_key": "switch",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/the-home-depot-ecosmart-zbt-a19-cct-bulb.json
+++ b/tests/data/devices/the-home-depot-ecosmart-zbt-a19-cct-bulb.json
@@ -1285,7 +1285,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/third-reality-inc-3rds17bz.json
+++ b/tests/data/devices/third-reality-inc-3rds17bz.json
@@ -541,7 +541,7 @@
           "translation_key": null,
           "device_class": "opening",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/third-reality-inc-3rms16bz.json
+++ b/tests/data/devices/third-reality-inc-3rms16bz.json
@@ -541,7 +541,7 @@
           "translation_key": null,
           "device_class": "motion",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/third-reality-inc-3rsb015bz.json
+++ b/tests/data/devices/third-reality-inc-3rsb015bz.json
@@ -792,7 +792,7 @@
           "translation_key": null,
           "device_class": "opening",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -842,7 +842,7 @@
           "translation_key": "cover",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1108,7 +1108,7 @@
           "translation_key": "switch",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/third-reality-inc-3rsnl02043z.json
+++ b/tests/data/devices/third-reality-inc-3rsnl02043z.json
@@ -1315,7 +1315,7 @@
           "translation_key": null,
           "device_class": "motion",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1418,7 +1418,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1781,7 +1781,7 @@
           "translation_key": null,
           "device_class": "illuminance",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/third-reality-inc-3rsp019bz.json
+++ b/tests/data/devices/third-reality-inc-3rsp019bz.json
@@ -1482,7 +1482,7 @@
           "translation_key": "switch",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/third-reality-inc-3rsp02028bz.json
+++ b/tests/data/devices/third-reality-inc-3rsp02028bz.json
@@ -1350,7 +1350,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1402,7 +1402,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1454,7 +1454,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1610,7 +1610,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1664,7 +1664,7 @@
           "translation_key": "switch",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/third-reality-inc-3rspe01044bz.json
+++ b/tests/data/devices/third-reality-inc-3rspe01044bz.json
@@ -1870,7 +1870,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1922,7 +1922,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -1974,7 +1974,7 @@
           "translation_key": "ac_frequency",
           "device_class": "frequency",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -2130,7 +2130,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -2182,7 +2182,7 @@
           "translation_key": "summation_delivered",
           "device_class": "energy",
           "state_class": "total_increasing",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -2238,7 +2238,7 @@
           "translation_key": "switch",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/third-reality-inc-3rss007z.json
+++ b/tests/data/devices/third-reality-inc-3rss007z.json
@@ -530,7 +530,7 @@
           "translation_key": "switch",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/third-reality-inc-3rths24bz.json
+++ b/tests/data/devices/third-reality-inc-3rths24bz.json
@@ -625,7 +625,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -781,7 +781,7 @@
           "translation_key": null,
           "device_class": "humidity",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/third-reality-inc-3rvs01031z.json
+++ b/tests/data/devices/third-reality-inc-3rvs01031z.json
@@ -583,7 +583,7 @@
           "translation_key": null,
           "device_class": "motion",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/third-reality-inc-3rws18bz.json
+++ b/tests/data/devices/third-reality-inc-3rws18bz.json
@@ -576,7 +576,7 @@
           "translation_key": null,
           "device_class": "moisture",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -624,7 +624,7 @@
           "translation_key": null,
           "device_class": "opening",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/tuyatec-gqhxixyk-rh3052.json
+++ b/tests/data/devices/tuyatec-gqhxixyk-rh3052.json
@@ -289,7 +289,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -445,7 +445,7 @@
           "translation_key": null,
           "device_class": "humidity",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/tuyatec-r9hgssol-rh3001.json
+++ b/tests/data/devices/tuyatec-r9hgssol-rh3001.json
@@ -172,7 +172,7 @@
           "translation_key": null,
           "device_class": "opening",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/tuyatec-rkqiqvcs-rh3001.json
+++ b/tests/data/devices/tuyatec-rkqiqvcs-rh3001.json
@@ -175,7 +175,7 @@
           "translation_key": null,
           "device_class": "opening",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/tuyatec-yg5dcbfu-rh3052.json
+++ b/tests/data/devices/tuyatec-yg5dcbfu-rh3052.json
@@ -297,7 +297,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -453,7 +453,7 @@
           "translation_key": null,
           "device_class": "humidity",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/tyst11-i5j6ifxj-5j6ifxj.json
+++ b/tests/data/devices/tyst11-i5j6ifxj-5j6ifxj.json
@@ -193,7 +193,7 @@
           "translation_key": null,
           "device_class": "motion",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/tyzb01-o63ssaah-ts0207.json
+++ b/tests/data/devices/tyzb01-o63ssaah-ts0207.json
@@ -193,7 +193,7 @@
           "translation_key": null,
           "device_class": "moisture",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/tyzb01-rifa0wlb-ts0011.json
+++ b/tests/data/devices/tyzb01-rifa0wlb-ts0011.json
@@ -180,7 +180,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/tyzb01-vkwryfdr-ts0115.json
+++ b/tests/data/devices/tyzb01-vkwryfdr-ts0115.json
@@ -809,7 +809,7 @@
           "translation_key": "switch",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -856,7 +856,7 @@
           "translation_key": "switch",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -903,7 +903,7 @@
           "translation_key": "switch",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -950,7 +950,7 @@
           "translation_key": "switch",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -997,7 +997,7 @@
           "translation_key": "switch",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/tyzb01-zanh6v1o-ts0121.json
+++ b/tests/data/devices/tyzb01-zanh6v1o-ts0121.json
@@ -595,7 +595,7 @@
           "translation_key": null,
           "device_class": "current",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -647,7 +647,7 @@
           "translation_key": null,
           "device_class": "voltage",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -803,7 +803,7 @@
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -855,7 +855,7 @@
           "translation_key": "summation_delivered",
           "device_class": "energy",
           "state_class": "total_increasing",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -912,7 +912,7 @@
           "translation_key": "switch",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/tz3000-8yhypbo7-ts0203.json
+++ b/tests/data/devices/tz3000-8yhypbo7-ts0203.json
@@ -210,7 +210,7 @@
           "translation_key": null,
           "device_class": "opening",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -258,7 +258,7 @@
           "translation_key": null,
           "device_class": "opening",
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/tz3000-bguser20-ts0201.json
+++ b/tests/data/devices/tz3000-bguser20-ts0201.json
@@ -302,7 +302,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -458,7 +458,7 @@
           "translation_key": null,
           "device_class": "humidity",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/tz3000-f2bw0b6k-ts0201.json
+++ b/tests/data/devices/tz3000-f2bw0b6k-ts0201.json
@@ -294,7 +294,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -450,7 +450,7 @@
           "translation_key": null,
           "device_class": "humidity",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/tz3000-itnrsufe-ts0201.json
+++ b/tests/data/devices/tz3000-itnrsufe-ts0201.json
@@ -321,7 +321,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -477,7 +477,7 @@
           "translation_key": null,
           "device_class": "humidity",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/tz3210-dse8ogfy-ts0001.json
+++ b/tests/data/devices/tz3210-dse8ogfy-ts0001.json
@@ -382,7 +382,7 @@
           "translation_key": "switch",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/tz3210-jaap6jeb-ts0505b.json
+++ b/tests/data/devices/tz3210-jaap6jeb-ts0505b.json
@@ -644,7 +644,7 @@
           "translation_key": "light",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/tze200-9caxna4s-ts0301.json
+++ b/tests/data/devices/tze200-9caxna4s-ts0301.json
@@ -270,7 +270,7 @@
           "translation_key": "cover",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/tze200-myd45weu-ts0601.json
+++ b/tests/data/devices/tze200-myd45weu-ts0601.json
@@ -290,7 +290,7 @@
           "translation_key": "soil_moisture",
           "device_class": "humidity",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -342,7 +342,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/xiaomi-lywsd03mmc.json
+++ b/tests/data/devices/xiaomi-lywsd03mmc.json
@@ -288,7 +288,7 @@
           "translation_key": null,
           "device_class": "temperature",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {
@@ -444,7 +444,7 @@
           "translation_key": null,
           "device_class": "humidity",
           "state_class": "measurement",
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/yale-yrd256-tsdb.json
+++ b/tests/data/devices/yale-yrd256-tsdb.json
@@ -278,7 +278,7 @@
           "translation_key": "door_lock",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/yooksmart-d10110.json
+++ b/tests/data/devices/yooksmart-d10110.json
@@ -282,7 +282,7 @@
           "translation_key": "cover",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/tests/data/devices/yunding-ford.json
+++ b/tests/data/devices/yunding-ford.json
@@ -1012,7 +1012,7 @@
           "translation_key": "door_lock",
           "device_class": null,
           "state_class": null,
-          "entity_category": null,
+          "entity_category": "control",
           "entity_registry_enabled_default": true,
           "cluster_handlers": [
             {

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -36,6 +36,9 @@ DEFAULT_UPDATE_GROUP_FROM_CHILD_DELAY: float = 0.5
 class EntityCategory(StrEnum):
     """Category of an entity."""
 
+    # Control: An entity which allows controlling a device.
+    CONTROL = "control"
+
     # Config: An entity which allows changing the configuration of a device.
     CONFIG = "config"
 
@@ -112,7 +115,7 @@ class BaseEntity(LogMixin, EventBase):
 
     _attr_fallback_name: str | None
     _attr_translation_key: str | None
-    _attr_entity_category: EntityCategory | None
+    _attr_entity_category: EntityCategory = EntityCategory.CONTROL
     _attr_entity_registry_enabled_default: bool = True
     _attr_device_class: str | None
     _attr_state_class: str | None
@@ -158,11 +161,9 @@ class BaseEntity(LogMixin, EventBase):
         return None
 
     @property
-    def entity_category(self) -> EntityCategory | None:
+    def entity_category(self) -> EntityCategory:
         """Return the entity category."""
-        if hasattr(self, "_attr_entity_category"):
-            return self._attr_entity_category
-        return None
+        return self._attr_entity_category
 
     @property
     def entity_registry_enabled_default(self) -> bool:
@@ -360,7 +361,7 @@ class PlatformEntity(BaseEntity):
         elif entity_metadata.entity_type is EntityType.DIAGNOSTIC:
             self._attr_entity_category = EntityCategory.DIAGNOSTIC
         else:
-            self._attr_entity_category = None
+            self._attr_entity_category = EntityCategory.CONTROL
 
     @cached_property
     def identifiers(self) -> PlatformEntityIdentifiers:


### PR DESCRIPTION
Having `None` be the "control" entity category always felt a little strange. This PR makes the mapping explicit in the ZHA lib.

Core diff:

```diff
diff --git a/homeassistant/components/zha/entity.py b/homeassistant/components/zha/entity.py
index 3e3d0642ca2..c26f93ecfb6 100644
--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -9,6 +9,7 @@ import logging
 from typing import Any
 
 from propcache import cached_property
+from zha.application.platforms import EntityCategory as ZhaEntityCategory
 from zha.mixins import LogMixin
 
 from homeassistant.const import ATTR_MANUFACTURER, ATTR_MODEL, ATTR_NAME, EntityCategory
@@ -45,7 +46,9 @@ class ZHAEntity(LogMixin, RestoreEntity, Entity):
         meta = self.entity_data.entity.info_object
         self._attr_unique_id = meta.unique_id
 
-        if meta.entity_category is not None:
+        if meta.entity_category is ZhaEntityCategory.CONTROL:
+            self._attr_entity_category = None
+        else:
             self._attr_entity_category = EntityCategory(meta.entity_category)
 
         self._attr_entity_registry_enabled_default = (
```