### PR TITLE
Adjust step to 0.1 for Sonoff thermostat calibration

### DIFF
--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -864,7 +864,7 @@ class SonoffThermostatLocalTempCalibration(ThermostatLocalTempCalibration):
 
     _attr_native_min_value: float = -12.8
     _attr_native_max_value: float = 12.7
-    _attr_native_step: float = 0.2
+    _attr_native_step: float = 0.1
 
 
 @CONFIG_DIAGNOSTIC_MATCH(


### PR DESCRIPTION
## Proposed change

This changes the step size to `0.1` (from `0.2`) for the Sonoff thermostat calibration number configuration entity. 
`0.1` is also used for the ZCL entity above.

## Additional information

Addresses https://github.com/zigpy/zha/pull/300#issuecomment-2496228491
cc @tr4nt0r

Both of the `local_temperature_calibration` config entities (ZCL and Sonoff one) are also one of the few entities that explicitly set `NumberMode.SLIDER` (instead of using `BOX` or `AUTO`). Should we change that too?