### PR TITLE
Use `NumberMode.BOX` for local temperature calibration

### DIFF
--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -850,7 +850,7 @@ class ThermostatLocalTempCalibration(NumberConfigurationEntity):
     _attribute_name = "local_temperature_calibration"
     _attr_translation_key: str = "local_temperature_calibration"
 
-    _attr_mode: NumberMode = NumberMode.SLIDER
+    _attr_mode: NumberMode = NumberMode.BOX
     _attr_native_unit_of_measurement: str = UnitOfTemperature.CELSIUS
 
 


### PR DESCRIPTION
## Proposed changed
This changes the number configuration entity for the `local_temperature_calibration` entity from `NumberMode.SLIDER` to `NumberMode.BOX`.
This change will also affect both the ZCL entity and the Sonoff specific entity. They both have a small step size (0.1) and you want to be precise in both cases. A box makes more sense for that than a slider.

## Additional information

Related discussion in:
- https://github.com/zigpy/zha/pull/304