### PR TITLE
Add UnitOfLength support for ZHA entities

### DIFF
--- a/zha/units.py
+++ b/zha/units.py
@@ -117,6 +117,19 @@ class UnitOfTime(StrEnum):
     YEARS = "y"
 
 
+class UnitOfLength(StrEnum):
+    """Length units."""
+
+    MILLIMETERS = "mm"
+    CENTIMETERS = "cm"
+    METERS = "m"
+    KILOMETERS = "km"
+    INCHES = "in"
+    FEET = "ft"
+    YARDS = "yd"
+    MILES = "mi"
+
+
 class UnitOfEnergy(StrEnum):
     """Energy units."""
 
@@ -158,6 +171,7 @@ UNITS_OF_MEASURE = {
     UnitOfPressure.__name__: UnitOfPressure,
     UnitOfVolume.__name__: UnitOfVolume,
     UnitOfVolumeFlowRate.__name__: UnitOfVolumeFlowRate,
+    UnitOfLength.__name__: UnitOfLength,
     UnitOfMass.__name__: UnitOfMass,
 }
 


### PR DESCRIPTION
Addresses the bug https://github.com/zigpy/zha/issues/290 where v2 quirks allow creation of custom entities with a distance device class, however specifying a UnitOfLength unit for the entity results in an error loading the quirk.

This change adds the missing UnitOfLength class to `units.py` to allow for their successful validation.