### PR TITLE
Add support for DIAGNOSTIC WriteAttributeButton entities

### DIFF
--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -112,6 +112,11 @@ QUIRKS_ENTITY_META_TO_ENTITY_CLASS = {
         WriteAttributeButtonMetadata,
         EntityType.STANDARD,
     ): button.WriteAttributeButton,
+    (
+        Platform.BUTTON,
+        WriteAttributeButtonMetadata,
+        EntityType.DIAGNOSTIC,
+    ): button.WriteAttributeButton,
     (Platform.BUTTON, ZCLCommandButtonMetadata, EntityType.CONFIG): button.Button,
     (
         Platform.BUTTON,


### PR DESCRIPTION
Addresses the bug https://github.com/zigpy/zha/issues/291 where v2 quirks can't create WriteAttributeButton entities with a DIAGNOSTIC EntityType.

This change adds the required mapping to QUIRKS_ENTITY_META_TO_ENTITY_CLASS in `discovery.py`