### PR TITLE
Fix `IndexError` in `issue_cluster_command` for IAS ACE arm response

### DIFF
--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -955,6 +955,9 @@ class Device(LogMixin, EventBase):
             return  # client commands don't return a response
         if isinstance(response, Exception):
             raise ZHAException("Failed to issue cluster command") from response
+        if not isinstance(response, tuple) or len(response) < 2:
+            _LOGGER.warning("Received unknown/unsupported response: %s", response)
+            return  # ignore this response instead of failing
         if response[1] is not ZclStatus.SUCCESS:
             raise ZHAException(
                 f"Failed to issue cluster command with status: {response[1]}"


### PR DESCRIPTION
Fix issue on sending IasAce:arm_response which does not return a tuple but only a single state but in general to be more fail tolerante as we can't always guarantee the result from the multitude of Zigbee devices