### PR TITLE
Add room_temperature attribute for Sinope floor heat thermostat

### DIFF
--- a/zha/zigbee/cluster_handlers/manufacturerspecific.py
+++ b/zha/zigbee/cluster_handlers/manufacturerspecific.py
@@ -535,8 +535,8 @@ class SinopeManufacturerClusterHandler(ClusterHandler):
 
         if self.cluster.endpoint.model == "TH1300ZB":
             self.ZCL_INIT_ATTRS["room_temperature"] = True
-            return # Don't apply switch-specific attributes below
-        
+            return  # Don't apply switch-specific attributes below
+
         self.ZCL_INIT_ATTRS = {
             "double_up_full": True,
             "on_led_color": True,
@@ -576,9 +576,7 @@ class SinopeManufacturerClusterHandler(ClusterHandler):
             "DM2550ZB",
             "DM2550ZB-G2",
         )
-        thermostats = (
-            "TH1300ZB",
-        )
+        thermostats = ("TH1300ZB",)
 
         _LOGGER.debug(
             "matching sinope device to cluster handler %s", cluster.endpoint.model

--- a/zha/zigbee/cluster_handlers/manufacturerspecific.py
+++ b/zha/zigbee/cluster_handlers/manufacturerspecific.py
@@ -532,6 +532,11 @@ class SinopeManufacturerClusterHandler(ClusterHandler):
     def __init__(self, cluster: zigpy.zcl.Cluster, endpoint: Endpoint) -> None:
         """Initialize Sinope cluster handler."""
         super().__init__(cluster, endpoint)
+
+        if self.cluster.endpoint.model == "TH1300ZB":
+            self.ZCL_INIT_ATTRS["room_temperature"] = True
+            return # Don't apply switch-specific attributes below
+        
         self.ZCL_INIT_ATTRS = {
             "double_up_full": True,
             "on_led_color": True,
@@ -571,9 +576,12 @@ class SinopeManufacturerClusterHandler(ClusterHandler):
             "DM2550ZB",
             "DM2550ZB-G2",
         )
+        thermostats = (
+            "TH1300ZB",
+        )
 
         _LOGGER.debug(
             "matching sinope device to cluster handler %s", cluster.endpoint.model
         )
 
-        return cluster.endpoint.model in switches
+        return cluster.endpoint.model in (switches + thermostats)


### PR DESCRIPTION
Hi folks - this is my first time contributing here. I've got this Sinope floor heat thermostat. The quirk for it already knows about the `room_temperature` attribute. But I want to expose that attribute as a Home Assistant sensor.

I think this is how to do it, but I'd appreciate any feedback. Also, I'm not sure how to test this - is there an easy way to try this on my HA instance to verify that it works?

Thanks for your help!