### PR TITLE
Configure local temperature calibration range for Bosch thermostats

### DIFF
--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -868,6 +868,24 @@ class SonoffThermostatLocalTempCalibration(ThermostatLocalTempCalibration):
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
+    cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
+    models={
+        "RBSH-RTH0-ZB-EU",
+        "RBSH-TRV0-ZB-EU",
+        "RBSH-TRV1-ZB-EU",
+        "RBSH-RTH0-BAT-ZB-EU",
+    },
+    stop_on_match_group=CLUSTER_HANDLER_THERMOSTAT,
+)
+class BoschThermostatLocalTempCalibration(ThermostatLocalTempCalibration):
+    """Local temperature calibration for the Bosch TRV/RTH."""
+
+    _attr_native_min_value: float = -5.0
+    _attr_native_max_value: float = 5.0
+    _attr_native_step: float = 0.1
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_OCCUPANCY, models={"SNZB-06P", "SNZB-03P"}
 )
 class SonoffPresenceSenorTimeout(NumberConfigurationEntity):


### PR DESCRIPTION
Applies to Bosch Zigbee thermostats models: 
- RBSH-RTH0-ZB-EU
- RBSH-TRV0-ZB-EU
- RBSH-TRV1-ZB-EU
- RBSH-RTH0-BAT-ZB-EU

Workaround until (if ever) the general solution https://github.com/zigpy/zha/pull/328 gets adopted.

Fixes https://github.com/home-assistant/core/issues/128253 for Bosch Zigbee thermostats.

Required by https://github.com/zigpy/zha-device-handlers/pull/2808