### PR TITLE
Add a generic Centralite thermostat quirk

### DIFF
--- a/zha/application/platforms/climate/__init__.py
+++ b/zha/application/platforms/climate/__init__.py
@@ -600,6 +600,38 @@ class CentralitePearl(ZenWithinThermostat):
     """Centralite Pearl Thermostat implementation."""
 
 
+@MULTI_MATCH(
+    cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
+    aux_cluster_handlers=CLUSTER_HANDLER_FAN,
+    manufacturers="Centralite",
+    models={"3156105"},
+    stop_on_match_group=CLUSTER_HANDLER_THERMOSTAT,
+)
+class Centralite(Thermostat):
+    """Centralite Thermostat implementation."""
+
+    @property
+    def _rm_rs_action(self) -> HVACAction:
+        """Return the current HVAC action based on running mode and running state."""
+
+        running_mode = self._thermostat_cluster_handler.running_mode
+        if running_mode == SystemMode.Heat:
+            return HVACAction.HEATING
+        if running_mode == SystemMode.Cool:
+            return HVACAction.COOLING
+
+        running_state = self._thermostat_cluster_handler.running_state
+        if running_state and running_state & (
+            RunningState.Fan_State_On
+            | RunningState.Fan_2nd_Stage_On
+            | RunningState.Fan_3rd_Stage_On
+        ):
+            return HVACAction.FAN
+        if self.hvac_mode != HVACMode.OFF and running_mode == SystemMode.Off:
+            return HVACAction.IDLE
+        return HVACAction.OFF
+
+
 @STRICT_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
     manufacturers={


### PR DESCRIPTION
This adds a "quirk" (if that's the right name) for the Centralite 3156105 thermostat to correctly report the HVAC Action. This thermostat's running_state includes heat even when the heat is not running, you have to look at running_mode to determine that. I noticed that this was the same as the Sinope `_rm_rs_action` override, but I just copied it.

For the time being, this is "open loop" development, since I haven't figured out how to get my modified code onto my Home Assistant appliance to try it, but I figure early feedback can't hurt.