### PR TITLE
Provide effects on supported Philips Hue lights

### DIFF
--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -72,6 +72,7 @@ from zha.zigbee.cluster_handlers.const import (
     CLUSTER_HANDLER_LEVEL,
     CLUSTER_HANDLER_LEVEL_CHANGED,
     CLUSTER_HANDLER_ON_OFF,
+    CLUSTER_HANDLER_PHILIPS_HUE_LIGHT,
 )
 from zha.zigbee.cluster_handlers.general import LevelChangeEvent
 
@@ -996,7 +997,7 @@ class HueLight(Light):
     aux_cluster_handlers={
         CLUSTER_HANDLER_COLOR,
         CLUSTER_HANDLER_LEVEL,
-        "philips_hue_cluster",
+        CLUSTER_HANDLER_PHILIPS_HUE_LIGHT,
     },
     manufacturers={"Philips", "Signify Netherlands B.V."},
 )
@@ -1018,14 +1019,16 @@ class HueEffectLight(HueLight):
     ) -> None:
         """Initialize the ZHA light."""
         super().__init__(unique_id, cluster_handlers, endpoint, device, **kwargs)
-        self._hue_cluster = self.cluster_handlers.get("philips_hue_cluster")
+        self._hue_light_cluster = self.cluster_handlers.get(
+            CLUSTER_HANDLER_PHILIPS_HUE_LIGHT
+        )
         self._effect_list.extend(self.HUE_EFFECTS.keys())
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
-        # If only change of brightness is requested, the effect doesn't have to be interupted
+        # If only change of brightness is requested, the effect doesn't have to be interrupted
         if kwargs.get(ATTR_BRIGHTNESS) is not None and all(
-            attr == ATTR_BRIGHTNESS or kwargs.get(attr) is None for attr in kwargs
+            kwargs.get(attr) is None for attr in (kwargs.keys() - {ATTR_BRIGHTNESS})
         ):
             effect = self._effect
         else:
@@ -1038,7 +1041,7 @@ class HueEffectLight(HueLight):
 
         if effect in self.HUE_EFFECTS:
             effect_id = self.HUE_EFFECTS[effect]
-            await self._hue_cluster.multicolor(
+            await self._hue_light_cluster.multicolor(
                 data=bytearray([0x22, 0x00, self._brightness, effect_id])
             )
             self._effect = effect
@@ -1047,7 +1050,9 @@ class HueEffectLight(HueLight):
         ) and self._effect in self.HUE_EFFECTS:
             # Only stop effect if it was started by us
             # Following command will stop the effect while preserving brightness
-            await self._hue_cluster.multicolor(data=bytearray([0x20, 0x00, 0x00, 0x00]))
+            await self._hue_light_cluster.multicolor(
+                data=bytearray([0x20, 0x00, 0x00, 0x00])
+            )
             self._effect = EFFECT_OFF
         else:
             # Don't react on unknown effects, for example 'colorloop'

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -993,6 +993,69 @@ class HueLight(Light):
 
 @STRICT_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_ON_OFF,
+    aux_cluster_handlers={
+        CLUSTER_HANDLER_COLOR,
+        CLUSTER_HANDLER_LEVEL,
+        "philips_hue_cluster",
+    },
+    manufacturers={"Philips", "Signify Netherlands B.V."},
+)
+class HueEffectLight(HueLight):
+    # Supported effects and their ID used in commands
+    HUE_EFFECTS = {"candle": 1, "fireplace": 2, "prism": 3}
+
+    """Representation of a HUE light with effects."""
+
+    def __init__(
+        self,
+        unique_id: str,
+        cluster_handlers: list[ClusterHandler],
+        endpoint: Endpoint,
+        device: Device,
+        **kwargs,
+    ) -> None:
+        """Initialize the ZHA light."""
+        super().__init__(unique_id, cluster_handlers, endpoint, device, **kwargs)
+        self._hue_cluster = self.cluster_handlers.get("philips_hue_cluster")
+        self._effect_list.extend(self.HUE_EFFECTS.keys())
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        # If only change of brightness is requested, the effect doesn't have to be interupted
+        if kwargs.get(ATTR_BRIGHTNESS) is not None and all(
+            attr == ATTR_BRIGHTNESS or kwargs.get(attr) is None
+            for attr in kwargs.keys()
+        ):
+            effect = self._effect
+        else:
+            effect = kwargs.get(ATTR_EFFECT)
+
+        await super().async_turn_on(**kwargs)
+
+        if effect == self._effect:
+            return
+
+        if effect in self.HUE_EFFECTS:
+            effect_id = self.HUE_EFFECTS[effect]
+            await self._hue_cluster.multicolor(
+                data=bytearray([0x22, 0x00, self._brightness, effect_id])
+            )
+            self._effect = effect
+        elif (
+            effect is None or effect == EFFECT_OFF and self._effect in self.HUE_EFFECTS
+        ):
+            # Only stop effect if it was started by us
+            # Following command will stop the effect while preserving brightness
+            await self._hue_cluster.multicolor(data=bytearray([0x20, 0x00, 0x00, 0x00]))
+            self._effect = EFFECT_OFF
+        else:
+            # Don't react on unknown effects, for example 'colorloop'
+            return
+
+        self.maybe_emit_state_changed_event()
+
+
+@STRICT_MATCH(
+    cluster_handler_names=CLUSTER_HANDLER_ON_OFF,
     aux_cluster_handlers={CLUSTER_HANDLER_COLOR, CLUSTER_HANDLER_LEVEL},
     manufacturers={"Jasco", "Jasco Products", "Quotra-Vision", "eWeLight", "eWeLink"},
 )

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -1022,8 +1022,7 @@ class HueEffectLight(HueLight):
     async def async_turn_on(self, **kwargs: Any) -> None:
         # If only change of brightness is requested, the effect doesn't have to be interupted
         if kwargs.get(ATTR_BRIGHTNESS) is not None and all(
-            attr == ATTR_BRIGHTNESS or kwargs.get(attr) is None
-            for attr in kwargs.keys()
+            attr == ATTR_BRIGHTNESS or kwargs.get(attr) is None for attr in kwargs
         ):
             effect = self._effect
         else:

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -1001,6 +1001,8 @@ class HueLight(Light):
     manufacturers={"Philips", "Signify Netherlands B.V."},
 )
 class HueEffectLight(HueLight):
+    """Specialization of a HUE light with effects."""
+
     # Supported effects and their ID used in commands
     HUE_EFFECTS = {"candle": 1, "fireplace": 2, "prism": 3}
 
@@ -1020,6 +1022,7 @@ class HueEffectLight(HueLight):
         self._effect_list.extend(self.HUE_EFFECTS.keys())
 
     async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the entity on."""
         # If only change of brightness is requested, the effect doesn't have to be interupted
         if kwargs.get(ATTR_BRIGHTNESS) is not None and all(
             attr == ATTR_BRIGHTNESS or kwargs.get(attr) is None for attr in kwargs
@@ -1040,8 +1043,8 @@ class HueEffectLight(HueLight):
             )
             self._effect = effect
         elif (
-            effect is None or effect == EFFECT_OFF and self._effect in self.HUE_EFFECTS
-        ):
+            effect is None or effect == EFFECT_OFF
+        ) and self._effect in self.HUE_EFFECTS:
             # Only stop effect if it was started by us
             # Following command will stop the effect while preserving brightness
             await self._hue_cluster.multicolor(data=bytearray([0x20, 0x00, 0x00, 0x00]))

--- a/zha/zigbee/cluster_handlers/const.py
+++ b/zha/zigbee/cluster_handlers/const.py
@@ -76,6 +76,7 @@ CLUSTER_HANDLER_ZDO: Final[str] = "zdo"
 CLUSTER_HANDLER_ZONE: Final[str] = "ias_zone"
 ZONE: Final[str] = CLUSTER_HANDLER_ZONE
 CLUSTER_HANDLER_INOVELLI = "inovelli_vzm31sn_cluster"
+CLUSTER_HANDLER_PHILIPS_HUE_LIGHT: Final[str] = "philips_hue_light_cluster"
 
 AQARA_OPPLE_CLUSTER: Final[int] = 0xFCC0
 IKEA_AIR_PURIFIER_CLUSTER: Final[int] = 0xFC7D


### PR DESCRIPTION
## Description
Adds additional effects to supported Philips Hue lights. To control the effects, commands are sent to a exposed cluster.
Implements HA / UI portion of https://github.com/zigpy/zha-device-handlers/issues/2517, which contains detailed discussion.

The effect is turned on by command 0x22 that accepts brightness and the effect ID.
To turn off, command 0x20 is used that will preserve most recent color and brightness while stopping further effect execution.

## Testing
Tested with Philips Hue Go. See video below:
https://github.com/user-attachments/assets/9d6236f6-4d8f-40ee-8525-82e674d4ca85

## Prerequisite
PR implementing quirk for the Philips cluster: https://github.com/zigpy/zha-device-handlers/issues/2517