### PR TITLE
Fix issues with `read_attributes` and `attribute_updated`

### DIFF
--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -322,13 +322,13 @@ class ConfigurableAttributeSwitch(PlatformEntity):
     async def async_update(self) -> None:
         """Attempt to retrieve the state of the entity."""
         self.debug("Polling current state")
+
+        polling_attrs = [self._attribute_name]
+        if self._inverter_attribute_name:
+            polling_attrs.append(self._inverter_attribute_name)
+
         results = await self._cluster_handler.get_attributes(
-            [
-                self._attribute_name,
-                self._inverter_attribute_name,
-            ],
-            from_cache=False,
-            only_cache=False,
+            polling_attrs, from_cache=False, only_cache=False
         )
 
         self.debug("read values=%s", results)

--- a/zha/zigbee/cluster_handlers/__init__.py
+++ b/zha/zigbee/cluster_handlers/__init__.py
@@ -604,7 +604,14 @@ class ClusterHandler(LogMixin, EventBase):
             rest = rest[CLUSTER_READS_PER_REQ:]
         return result
 
-    get_attributes = functools.partialmethod(_get_attributes, False)
+    async def get_attributes(
+        self,
+        attributes: list[str],
+        from_cache: bool = True,
+        only_cache: bool = True,
+    ) -> dict[int | str, Any]:
+        """Get the values for a list of attributes and raise no exceptions."""
+        return await self._get_attributes(False, attributes, from_cache, only_cache)
 
     async def write_attributes_safe(
         self, attributes: dict[str, Any], manufacturer: int | None = None

--- a/zha/zigbee/cluster_handlers/__init__.py
+++ b/zha/zigbee/cluster_handlers/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable, Coroutine, Iterator
 import contextlib
 from dataclasses import dataclass
+from datetime import datetime
 from enum import Enum
 import functools
 import logging
@@ -489,7 +490,7 @@ class ClusterHandler(LogMixin, EventBase):
     def cluster_command(self, tsn, command_id, args) -> None:
         """Handle commands received to this cluster."""
 
-    def attribute_updated(self, attrid: int, value: Any, _: Any) -> None:
+    def attribute_updated(self, attrid: int, value: Any, timestamp: datetime) -> None:
         """Handle attribute updates on this cluster."""
         attr_name = self._get_attribute_name(attrid)
         self.debug(
@@ -704,7 +705,7 @@ class ZDOClusterHandler(LogMixin):
 class ClientClusterHandler(ClusterHandler):
     """ClusterHandler for Zigbee client (output) clusters."""
 
-    def attribute_updated(self, attrid: int, value: Any, timestamp: Any) -> None:
+    def attribute_updated(self, attrid: int, value: Any, timestamp: datetime) -> None:
         """Handle an attribute updated on this cluster."""
         super().attribute_updated(attrid, value, timestamp)
 

--- a/zha/zigbee/cluster_handlers/closures.py
+++ b/zha/zigbee/cluster_handlers/closures.py
@@ -154,7 +154,7 @@ class WindowCoveringClusterHandler(ClusterHandler):
 
     async def async_update(self):
         """Retrieve latest state."""
-        results = await self.get_attributes(
+        await self.get_attributes(
             [
                 WindowCovering.AttributeDefs.current_position_lift_percentage.name,
                 WindowCovering.AttributeDefs.current_position_tilt_percentage.name,
@@ -162,42 +162,6 @@ class WindowCoveringClusterHandler(ClusterHandler):
             from_cache=False,
             only_cache=False,
         )
-        self.debug(
-            "read current_position_lift_percentage and current_position_tilt_percentage - results: %s",
-            results,
-        )
-        if (
-            results
-            and results.get(
-                WindowCovering.AttributeDefs.current_position_lift_percentage.name
-            )
-            is not None
-        ):
-            # the 100 - value is because we need to invert the value before giving it to the entity
-            self.attribute_updated(
-                WindowCovering.AttributeDefs.current_position_lift_percentage.id,
-                WindowCovering.AttributeDefs.current_position_lift_percentage.name,
-                100
-                - results.get(
-                    WindowCovering.AttributeDefs.current_position_lift_percentage.name
-                ),
-            )
-        if (
-            results
-            and results.get(
-                WindowCovering.AttributeDefs.current_position_tilt_percentage.name
-            )
-            is not None
-        ):
-            # the 100 - value is because we need to invert the value before giving it to the entity
-            self.attribute_updated(
-                WindowCovering.AttributeDefs.current_position_tilt_percentage.id,
-                WindowCovering.AttributeDefs.current_position_tilt_percentage.name,
-                100
-                - results.get(
-                    WindowCovering.AttributeDefs.current_position_tilt_percentage.name
-                ),
-            )
 
     @property
     def inverted(self):

--- a/zha/zigbee/cluster_handlers/general.py
+++ b/zha/zigbee/cluster_handlers/general.py
@@ -562,7 +562,7 @@ class OtaClientClusterHandler(ClientClusterHandler):
         """Return cached value of current_file_version attribute."""
         return self.cluster.get(Ota.AttributeDefs.current_file_version.name)
 
-    def attribute_updated(self, attrid: int, value: Any, timestamp: Any) -> None:
+    def attribute_updated(self, attrid: int, value: Any, timestamp: datetime) -> None:
         """Handle an attribute updated on this cluster."""
 
         # We intentionally avoid the `ClientClusterHandler` attribute update handler:

--- a/zha/zigbee/cluster_handlers/homeautomation.py
+++ b/zha/zigbee/cluster_handlers/homeautomation.py
@@ -168,14 +168,7 @@ class ElectricalMeasurementClusterHandler(ClusterHandler):
             for attr in self.ZCL_POLLING_ATTRS
             if attr not in self.cluster.unsupported_attributes
         ]
-        result = await self.get_attributes(attrs, from_cache=False, only_cache=False)
-        if result:
-            for attr, value in result.items():
-                self.attribute_updated(
-                    self.cluster.find_attribute(attr).id,
-                    attr,
-                    value,
-                )
+        await self.get_attributes(attrs, from_cache=False, only_cache=False)
 
     @property
     def ac_current_divisor(self) -> int:

--- a/zha/zigbee/cluster_handlers/manufacturerspecific.py
+++ b/zha/zigbee/cluster_handlers/manufacturerspecific.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -231,9 +232,9 @@ class SmartThingsAccelerationClusterHandler(ClusterHandler):
             "SmartThings",
         )
 
-    def attribute_updated(self, attrid: int, value: Any, _: Any) -> None:
+    def attribute_updated(self, attrid: int, value: Any, timestamp: datetime) -> None:
         """Handle attribute updates on this cluster."""
-        super().attribute_updated(attrid, value, _)
+        super().attribute_updated(attrid, value, timestamp)
         try:
             attr_name = self._cluster.attributes[attrid].name
         except KeyError:

--- a/zha/zigbee/cluster_handlers/smartenergy.py
+++ b/zha/zigbee/cluster_handlers/smartenergy.py
@@ -320,14 +320,7 @@ class MeteringClusterHandler(ClusterHandler):
             for a in self.REPORT_CONFIG
             if a["attr"] not in self.cluster.unsupported_attributes
         ]
-        result = await self.get_attributes(attrs, from_cache=False, only_cache=False)
-        if result:
-            for attr, value in result.items():
-                self.attribute_updated(
-                    self.cluster.find_attribute(attr).id,
-                    attr,
-                    value,
-                )
+        await self.get_attributes(attrs, from_cache=False, only_cache=False)
 
     @staticmethod
     def get_formatting(formatting: int) -> str:


### PR DESCRIPTION
## Proposed change

This PR converts the `get_attributes` partialmethod to an actual coroutine that calls `_get_attributes` with `raise_exceptions=False` (fix: https://github.com/zigpy/zha/commit/4fda764b7686db5ebc6b98c5dd5a944637af0388).

This is needed, as `partialmethod` doesn't correctly work with coroutines nor with mypy type checking.
~~This was seen in [tests](https://github.com/zigpy/zha/actions/runs/12940028032/job/36093455183): "Warning: coroutine 'Cluster.read_attributes' was never awaited"~~
EDIT: The test warnings might be unrelated and still seem to happen. This should be looked into.

After doing this, mypy was now able to correctly do type checking and threw some other errors:
- the switch platform tried to poll a `None` attribute (`_inverter_attribute_name` is `None` by default) (fix: https://github.com/zigpy/zha/commit/2baa937b6117f3d53fcbbc1d3a234740ad27b91a)
- the cover platform called `attribute_updated` with some types being (potentially) incompatible (fix in: https://github.com/zigpy/zha/commit/c042eec3983f7fafc7a3dadaf434501e712a62c2)

This led me to look into `attribute_updated`. This is called by zigpy in `_update_attribute`.
So, when we read/poll an attribute, zigpy automatically calls that method. For some reason, we also called it in ZHA:

### Incorrectly calling `attribute_updated`

We also called that method incorrectly with the "attribute name" being provided as the "value" and the actual "value" being provided as the "timestamp".
It seems like this never manifested into a real issue, because we never actually access the event data from `CLUSTER_HANDLER_ATTRIBUTE_UPDATED` that's fired in `ClusterHandler.attribute_updated`, instead relying on directly reading zigpy attribute cache in the various platforms.

This is why https://github.com/zigpy/zha/commit/c042eec3983f7fafc7a3dadaf434501e712a62c2 allows us to remove manually calling `attribute_updated` completely, zigpy already does it for us.

### Cover platform

The cover platform also tried to do some inversion in `WindowCoveringClusterHandler.async_update`, but due to us never actually accessing the inverted value from the event in the [cover platform here](https://github.com/zigpy/zha/blob/7292a0cc638d294438a8e75080af95f595d32e2a/zha/application/platforms/cover/__init__.py#L252-L271) (that was incorrectly provided as the `timestamp` value), those values were never used anywhere. That's why we can completely remove that code too.

The values are [properly inverted in the cluster handler properties](https://github.com/zigpy/zha/blob/7292a0cc638d294438a8e75080af95f595d32e2a/zha/zigbee/cluster_handlers/closures.py#L213-L233). This is what's actually used.


## Additional information

If needed, this PR can also be split up a bit. We can remove the `attribute_updated` calls in a first PR and only then replace the `get_attributes` partialmethod. Doing this the other way around would cause some mypy errors.

This PR wasn't tested manually yet, but tests still pass. Still, we should probably try to see if plugs are still being polled correctly and that covers didn't break. I doubt they did though.