### PR TITLE
[RFC] Explicit entity object discovery, lifetimes, and registration

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -229,8 +229,11 @@ def get_entity(
     exact_entity_type: type[BaseEntity] | None = None,
     qualifier: str | None = None,
     qualifier_func: Callable[[BaseEntity], bool] = lambda e: True,
+    strict: bool = False,
 ) -> PlatformEntity:
     """Get the first entity of the specified platform on the given device."""
+    results = []
+
     for entity in device.platform_entities.values():
         if platform != entity.PLATFORM:
             continue
@@ -247,11 +250,19 @@ def get_entity(
         if not qualifier_func(entity):
             continue
 
-        return entity
+        results.append(entity)
 
-    raise KeyError(
-        f"No {entity_type} entity found for platform {platform!r} on device {device}: {device.platform_entities}"
-    )
+    if len(results) == 0:
+        raise KeyError(
+            f"No {entity_type} entity found for platform {platform!r} on device {device}: {device.platform_entities}"
+        )
+
+    if strict and len(results) != 1:
+        raise KeyError(
+            f"Multiple {entity_type} entities found for platform {platform!r} on device {device}: {results}"
+        )
+
+    return results[0]
 
 
 async def group_entity_availability_test(

--- a/tests/common.py
+++ b/tests/common.py
@@ -229,7 +229,6 @@ def get_entity(
     exact_entity_type: type[BaseEntity] | None = None,
     qualifier: str | None = None,
     qualifier_func: Callable[[BaseEntity], bool] = lambda e: True,
-    strict: bool = False,
 ) -> PlatformEntity:
     """Get the first entity of the specified platform on the given device."""
     results = []
@@ -257,7 +256,7 @@ def get_entity(
             f"No {entity_type} entity found for platform {platform!r} on device {device}: {device.platform_entities}"
         )
 
-    if strict and len(results) != 1:
+    if len(results) != 1:
         raise KeyError(
             f"Multiple {entity_type} entities found for platform {platform!r} on device {device}: {results}"
         )

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -36,7 +36,11 @@ from tests.common import (
 from zha.application import Platform
 from zha.application.gateway import Gateway
 from zha.application.platforms import EntityCategory, PlatformEntity
-from zha.application.platforms.button import Button, WriteAttributeButton
+from zha.application.platforms.button import (
+    Button,
+    FrostLockResetButton,
+    WriteAttributeButton,
+)
 from zha.application.platforms.button.const import ButtonDeviceClass
 from zha.exceptions import ZHAException
 from zha.zigbee.device import Device
@@ -136,9 +140,12 @@ async def test_frost_unlock(
     cluster = zigpy_device.endpoints[1].tuya_manufacturer
     assert cluster is not None
     entity: PlatformEntity = get_entity(
-        zha_device, platform=Platform.BUTTON, entity_type=WriteAttributeButton
+        zha_device,
+        platform=Platform.BUTTON,
+        entity_type=FrostLockResetButton,
+        strict=True,
     )
-    assert isinstance(entity, WriteAttributeButton)
+    assert isinstance(entity, FrostLockResetButton)
 
     assert entity._attr_device_class == ButtonDeviceClass.RESTART
     assert entity._attr_entity_category == EntityCategory.CONFIG

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -143,7 +143,6 @@ async def test_frost_unlock(
         zha_device,
         platform=Platform.BUTTON,
         entity_type=FrostLockResetButton,
-        strict=True,
     )
     assert isinstance(entity, FrostLockResetButton)
 
@@ -253,7 +252,9 @@ async def test_quirks_command_button(
     """Test ZHA button platform."""
     zha_device, cluster = await custom_button_device(zha_gateway)
     assert cluster is not None
-    entity: PlatformEntity = get_entity(zha_device, platform=Platform.BUTTON)
+    entity: PlatformEntity = get_entity(
+        zha_device, platform=Platform.BUTTON, entity_type=Button
+    )
 
     with patch(
         "zigpy.zcl.Cluster.request",

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -304,7 +304,7 @@ async def test_climate_hvac_action_running_state(
     await zha_gateway.async_block_till_done(wait_background_tasks=True)
     assert entity.state["hvac_action"] == "off"
     assert sensor_entity.state["state"] == "off"
-    assert len(subscriber1.mock_calls) == len(subscriber2.mock_calls) == 1
+    assert len(subscriber1.mock_calls) == len(subscriber2.mock_calls) == 0
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001C: Thermostat.SystemMode.Auto}
@@ -312,7 +312,7 @@ async def test_climate_hvac_action_running_state(
     await zha_gateway.async_block_till_done(wait_background_tasks=True)
     assert entity.state["hvac_action"] == "idle"
     assert sensor_entity.state["state"] == "idle"
-    assert len(subscriber1.mock_calls) == len(subscriber2.mock_calls) == 2
+    assert len(subscriber1.mock_calls) == len(subscriber2.mock_calls) == 1
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001E: Thermostat.RunningMode.Cool}
@@ -320,7 +320,7 @@ async def test_climate_hvac_action_running_state(
     await zha_gateway.async_block_till_done(wait_background_tasks=True)
     assert entity.state["hvac_action"] == "cooling"
     assert sensor_entity.state["state"] == "cooling"
-    assert len(subscriber1.mock_calls) == len(subscriber2.mock_calls) == 3
+    assert len(subscriber1.mock_calls) == len(subscriber2.mock_calls) == 2
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001E: Thermostat.RunningMode.Heat}
@@ -328,7 +328,7 @@ async def test_climate_hvac_action_running_state(
     await zha_gateway.async_block_till_done(wait_background_tasks=True)
     assert entity.state["hvac_action"] == "heating"
     assert sensor_entity.state["state"] == "heating"
-    assert len(subscriber1.mock_calls) == len(subscriber2.mock_calls) == 4
+    assert len(subscriber1.mock_calls) == len(subscriber2.mock_calls) == 3
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001E: Thermostat.RunningMode.Off}
@@ -336,7 +336,7 @@ async def test_climate_hvac_action_running_state(
     await zha_gateway.async_block_till_done(wait_background_tasks=True)
     assert entity.state["hvac_action"] == "idle"
     assert sensor_entity.state["state"] == "idle"
-    assert len(subscriber1.mock_calls) == len(subscriber2.mock_calls) == 5
+    assert len(subscriber1.mock_calls) == len(subscriber2.mock_calls) == 4
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Fan_State_On}
@@ -344,7 +344,7 @@ async def test_climate_hvac_action_running_state(
     await zha_gateway.async_block_till_done(wait_background_tasks=True)
     assert entity.state["hvac_action"] == "fan"
     assert sensor_entity.state["state"] == "fan"
-    assert len(subscriber1.mock_calls) == len(subscriber2.mock_calls) == 6
+    assert len(subscriber1.mock_calls) == len(subscriber2.mock_calls) == 5
 
 
 async def test_sinope_time(

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -290,9 +290,10 @@ async def test_climate_hvac_action_running_state(
         dev_climate_sinope, platform=Platform.SENSOR, entity_type=SinopeHVACAction
     )
 
-    subscriber = MagicMock()
-    entity.on_event(STATE_CHANGED, subscriber)
-    sensor_entity.on_event(STATE_CHANGED, subscriber)
+    subscriber1 = MagicMock()
+    subscriber2 = MagicMock()
+    entity.on_event(STATE_CHANGED, subscriber1)
+    sensor_entity.on_event(STATE_CHANGED, subscriber2)
 
     assert entity.state["hvac_action"] == "off"
     assert sensor_entity.state["state"] == "off"
@@ -300,41 +301,50 @@ async def test_climate_hvac_action_running_state(
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001E: Thermostat.RunningMode.Off}
     )
+    await zha_gateway.async_block_till_done(wait_background_tasks=True)
     assert entity.state["hvac_action"] == "off"
     assert sensor_entity.state["state"] == "off"
+    assert len(subscriber1.mock_calls) == len(subscriber2.mock_calls) == 1
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001C: Thermostat.SystemMode.Auto}
     )
+    await zha_gateway.async_block_till_done(wait_background_tasks=True)
     assert entity.state["hvac_action"] == "idle"
     assert sensor_entity.state["state"] == "idle"
+    assert len(subscriber1.mock_calls) == len(subscriber2.mock_calls) == 2
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001E: Thermostat.RunningMode.Cool}
     )
+    await zha_gateway.async_block_till_done(wait_background_tasks=True)
     assert entity.state["hvac_action"] == "cooling"
     assert sensor_entity.state["state"] == "cooling"
+    assert len(subscriber1.mock_calls) == len(subscriber2.mock_calls) == 3
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001E: Thermostat.RunningMode.Heat}
     )
+    await zha_gateway.async_block_till_done(wait_background_tasks=True)
     assert entity.state["hvac_action"] == "heating"
     assert sensor_entity.state["state"] == "heating"
+    assert len(subscriber1.mock_calls) == len(subscriber2.mock_calls) == 4
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001E: Thermostat.RunningMode.Off}
     )
+    await zha_gateway.async_block_till_done(wait_background_tasks=True)
     assert entity.state["hvac_action"] == "idle"
     assert sensor_entity.state["state"] == "idle"
+    assert len(subscriber1.mock_calls) == len(subscriber2.mock_calls) == 5
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Fan_State_On}
     )
+    await zha_gateway.async_block_till_done(wait_background_tasks=True)
     assert entity.state["hvac_action"] == "fan"
     assert sensor_entity.state["state"] == "fan"
-
-    # Both entities are updated!
-    assert len(subscriber.mock_calls) == 2 * 6
+    assert len(subscriber1.mock_calls) == len(subscriber2.mock_calls) == 6
 
 
 async def test_sinope_time(

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -7,7 +7,7 @@ import json
 import pathlib
 import re
 from unittest import mock
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, call
 
 import pytest
 from zhaquirks.ikea import PowerConfig1CRCluster, ScenesCluster
@@ -49,7 +49,7 @@ from tests.common import (
     update_attribute_cache,
     zigpy_device_from_json,
 )
-from zha.application import Platform, discovery
+from zha.application import Platform
 from zha.application.discovery import ENDPOINT_PROBE, EndpointProbe
 from zha.application.gateway import Gateway
 from zha.application.helpers import DeviceOverridesConfiguration
@@ -70,7 +70,11 @@ def _get_identify_cluster(zigpy_device):
 def test_discover_entities(m1, m2) -> None:
     """Test discover endpoint class method."""
     endpoint = mock.MagicMock()
-    ENDPOINT_PROBE.discover_entities(endpoint)
+    endpoint.device.is_coordinator = False
+
+    for _entity in ENDPOINT_PROBE.discover_entities(endpoint, device_overrides={}):
+        pass
+
     assert m1.call_count == 1
     assert m1.call_args[0][0] is endpoint
     assert m2.call_count == 1
@@ -95,21 +99,30 @@ def test_discover_by_device_type(device_type, platform, hit) -> None:
     ep_mock.return_value.device_type = device_type
     type(endpoint).zigpy_endpoint = ep_mock
 
-    get_entity_mock = mock.MagicMock(
-        return_value=(mock.sentinel.entity_cls, mock.sentinel.claimed)
-    )
+    entity_cls = mock.MagicMock()
+
+    get_entity_mock = mock.MagicMock(return_value=(entity_cls, mock.sentinel.claimed))
     with mock.patch(
         "zha.application.registries.PLATFORM_ENTITIES.get_entity",
         get_entity_mock,
     ):
-        ENDPOINT_PROBE.discover_by_device_type(endpoint)
+        entities = list(
+            ENDPOINT_PROBE.discover_by_device_type(endpoint, device_overrides={})
+        )
+
     if hit:
-        assert get_entity_mock.call_count == 1
-        assert endpoint.claim_cluster_handlers.call_count == 1
-        assert endpoint.claim_cluster_handlers.call_args[0][0] is mock.sentinel.claimed
-        assert endpoint.async_new_entity.call_count == 1
-        assert endpoint.async_new_entity.call_args[0][0] == platform
-        assert endpoint.async_new_entity.call_args[0][1] == mock.sentinel.entity_cls
+        assert len(entities) == 1
+        assert entity_cls.mock_calls == [
+            call(
+                unique_id=endpoint.unique_id,
+                endpoint=endpoint,
+                device=endpoint.device,
+                cluster_handlers=mock.sentinel.claimed,
+            )
+        ]
+    else:
+        assert not entities
+        assert entity_cls.mock_calls == []
 
 
 def test_discover_by_device_type_override() -> None:
@@ -121,24 +134,37 @@ def test_discover_by_device_type_override() -> None:
     ep_mock.return_value.device_type = 0x0100
     type(endpoint).zigpy_endpoint = ep_mock
 
-    overrides = {endpoint.unique_id: DeviceOverridesConfiguration(type=Platform.SWITCH)}
-    get_entity_mock = mock.MagicMock(
-        return_value=(mock.sentinel.entity_cls, mock.sentinel.claimed)
-    )
+    entity_cls = mock.MagicMock()
+
+    get_entity_mock = mock.MagicMock(return_value=(entity_cls, mock.sentinel.claimed))
     with (
         mock.patch(
             "zha.application.registries.PLATFORM_ENTITIES.get_entity",
             get_entity_mock,
         ),
-        mock.patch.dict(ENDPOINT_PROBE._device_configs, overrides, clear=True),
     ):
-        ENDPOINT_PROBE.discover_by_device_type(endpoint)
-        assert get_entity_mock.call_count == 1
-        assert endpoint.claim_cluster_handlers.call_count == 1
-        assert endpoint.claim_cluster_handlers.call_args[0][0] is mock.sentinel.claimed
-        assert endpoint.async_new_entity.call_count == 1
-        assert endpoint.async_new_entity.call_args[0][0] == Platform.SWITCH
-        assert endpoint.async_new_entity.call_args[0][1] == mock.sentinel.entity_cls
+        entities = list(
+            ENDPOINT_PROBE.discover_by_device_type(
+                endpoint,
+                device_overrides={
+                    endpoint.unique_id: DeviceOverridesConfiguration(
+                        type=Platform.SIREN
+                    )
+                },
+            )
+        )
+
+        assert len(entities) == 1
+        assert entity_cls.mock_calls == [
+            call(
+                unique_id=endpoint.unique_id,
+                endpoint=endpoint,
+                device=endpoint.device,
+                cluster_handlers=mock.sentinel.claimed,
+            )
+        ]
+
+        assert get_entity_mock.mock_calls[0].args[0] == Platform.SIREN
 
 
 def test_discover_probe_single_cluster() -> None:
@@ -150,25 +176,28 @@ def test_discover_probe_single_cluster() -> None:
     ep_mock.return_value.device_type = 0x0100
     type(endpoint).zigpy_endpoint = ep_mock
 
-    get_entity_mock = mock.MagicMock(
-        return_value=(mock.sentinel.entity_cls, mock.sentinel.claimed)
-    )
+    entity_cls = mock.MagicMock()
+    get_entity_mock = mock.MagicMock(return_value=(entity_cls, mock.sentinel.claimed))
     cluster_handler_mock = mock.MagicMock(spec_set=ClusterHandler)
     with mock.patch(
         "zha.application.registries.PLATFORM_ENTITIES.get_entity",
         get_entity_mock,
     ):
-        ENDPOINT_PROBE.probe_single_cluster(
+        for _entity in ENDPOINT_PROBE.probe_single_cluster(
             Platform.SWITCH, cluster_handler_mock, endpoint
-        )
+        ):
+            pass
 
-    assert get_entity_mock.call_count == 1
-    assert endpoint.claim_cluster_handlers.call_count == 1
-    assert endpoint.claim_cluster_handlers.call_args[0][0] is mock.sentinel.claimed
-    assert endpoint.async_new_entity.call_count == 1
-    assert endpoint.async_new_entity.call_args[0][0] == Platform.SWITCH
-    assert endpoint.async_new_entity.call_args[0][1] == mock.sentinel.entity_cls
-    assert endpoint.async_new_entity.call_args[0][3] == mock.sentinel.claimed
+    assert entity_cls.mock_calls == [
+        call(
+            unique_id=f"{endpoint.unique_id}-{cluster_handler_mock.cluster.cluster_id}",
+            endpoint=endpoint,
+            device=endpoint.device,
+            cluster_handlers=mock.sentinel.claimed,
+        )
+    ]
+
+    assert get_entity_mock.mock_calls[0].args[0] == Platform.SWITCH
 
 
 def _ch_mock(cluster):
@@ -180,29 +209,19 @@ def _ch_mock(cluster):
     return cluster_handler
 
 
-@mock.patch(
-    (
-        "zha.application.discovery.EndpointProbe"
-        ".handle_on_off_output_cluster_exception"
-    ),
-    new=mock.MagicMock(),
-)
-@mock.patch("zha.application.discovery.EndpointProbe.probe_single_cluster")
-def _test_single_input_cluster_device_class(probe_mock):
+def test_single_input_cluster_device_class_by_cluster_class() -> None:
     """Test SINGLE_INPUT_CLUSTER_DEVICE_CLASS matching by cluster id or class."""
-
-    door_ch = _ch_mock(zigpy.zcl.clusters.closures.DoorLock)
-    cover_ch = _ch_mock(zigpy.zcl.clusters.closures.WindowCovering)
-    multistate_ch = _ch_mock(zigpy.zcl.clusters.general.MultistateInput)
 
     class QuirkedIAS(zigpy.quirks.CustomCluster, zigpy.zcl.clusters.security.IasZone):
         """Quirked IAS Zone cluster."""
 
-    ias_ch = _ch_mock(QuirkedIAS)
-
     class _Analog(zigpy.quirks.CustomCluster, zigpy.zcl.clusters.general.AnalogInput):
         pass
 
+    door_ch = _ch_mock(zigpy.zcl.clusters.closures.DoorLock)
+    cover_ch = _ch_mock(zigpy.zcl.clusters.closures.WindowCovering)
+    multistate_ch = _ch_mock(zigpy.zcl.clusters.general.MultistateInput)
+    ias_ch = _ch_mock(QuirkedIAS)
     analog_ch = _ch_mock(_Analog)
 
     endpoint = mock.MagicMock(spec_set=Endpoint)
@@ -213,33 +232,34 @@ def _test_single_input_cluster_device_class(probe_mock):
         ias_ch,
     ]
 
-    EndpointProbe().discover_by_cluster_id(endpoint)
-    assert probe_mock.call_count == len(endpoint.unclaimed_cluster_handlers())
-    probes = (
-        (Platform.LOCK, door_ch),
-        (Platform.COVER, cover_ch),
-        (Platform.SENSOR, multistate_ch),
-        (Platform.BINARY_SENSOR, ias_ch),
-        (Platform.SENSOR, analog_ch),
-    )
-    for call, details in zip(probe_mock.call_args_list, probes):
-        platform, ch = details
-        assert call[0][0] == platform
-        assert call[0][1] == ch
+    with (
+        mock.patch.dict(
+            SINGLE_INPUT_CLUSTER_DEVICE_CLASS,
+            {
+                zigpy.zcl.clusters.closures.DoorLock.cluster_id: Platform.LOCK,
+                zigpy.zcl.clusters.closures.WindowCovering.cluster_id: Platform.COVER,
+                zigpy.zcl.clusters.general.AnalogInput: Platform.SENSOR,
+                zigpy.zcl.clusters.general.MultistateInput: Platform.SENSOR,
+                zigpy.zcl.clusters.security.IasZone: Platform.BINARY_SENSOR,
+            },
+            clear=True,
+        ),
+        mock.patch(
+            "zha.application.discovery.EndpointProbe.probe_single_cluster",
+            new=mock.MagicMock(),
+        ) as probe_mock,
+    ):
+        for _entity in EndpointProbe().discover_by_cluster_id(endpoint):
+            pass
 
-
-def test_single_input_cluster_device_class_by_cluster_class() -> None:
-    """Test SINGLE_INPUT_CLUSTER_DEVICE_CLASS matching by cluster id or class."""
-    mock_reg = {
-        zigpy.zcl.clusters.closures.DoorLock.cluster_id: Platform.LOCK,
-        zigpy.zcl.clusters.closures.WindowCovering.cluster_id: Platform.COVER,
-        zigpy.zcl.clusters.general.AnalogInput: Platform.SENSOR,
-        zigpy.zcl.clusters.general.MultistateInput: Platform.SENSOR,
-        zigpy.zcl.clusters.security.IasZone: Platform.BINARY_SENSOR,
-    }
-
-    with mock.patch.dict(SINGLE_INPUT_CLUSTER_DEVICE_CLASS, mock_reg, clear=True):
-        _test_single_input_cluster_device_class()
+        assert probe_mock.call_count == len(endpoint.unclaimed_cluster_handlers())
+        assert [m for m in probe_mock.mock_calls if m != call().__iter__()] == [
+            call(Platform.LOCK, door_ch, endpoint),
+            call(Platform.COVER, cover_ch, endpoint),
+            call(Platform.SENSOR, multistate_ch, endpoint),
+            call(Platform.BINARY_SENSOR, ias_ch, endpoint),
+            call(Platform.SENSOR, analog_ch, endpoint),
+        ]
 
 
 @pytest.mark.parametrize("override", [None, "switch"])
@@ -271,7 +291,6 @@ async def test_device_override(
             "00:11:22:33:44:55:66:77-1": DeviceOverridesConfiguration(type=override)
         }
         zha_gateway.config.config.device_overrides = overrides
-        discovery.ENDPOINT_PROBE.initialize(zha_gateway)
 
     await zha_gateway.async_device_initialized(zigpy_device)
     await zha_gateway.async_block_till_done()

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -230,6 +230,7 @@ def test_single_input_cluster_device_class_by_cluster_class() -> None:
         cover_ch,
         multistate_ch,
         ias_ch,
+        analog_ch,
     ]
 
     with (
@@ -238,9 +239,9 @@ def test_single_input_cluster_device_class_by_cluster_class() -> None:
             {
                 zigpy.zcl.clusters.closures.DoorLock.cluster_id: Platform.LOCK,
                 zigpy.zcl.clusters.closures.WindowCovering.cluster_id: Platform.COVER,
-                zigpy.zcl.clusters.general.AnalogInput: Platform.SENSOR,
-                zigpy.zcl.clusters.general.MultistateInput: Platform.SENSOR,
-                zigpy.zcl.clusters.security.IasZone: Platform.BINARY_SENSOR,
+                zigpy.zcl.clusters.general.AnalogInput.cluster_id: Platform.SENSOR,
+                zigpy.zcl.clusters.general.MultistateInput.cluster_id: Platform.SENSOR,
+                zigpy.zcl.clusters.security.IasZone.cluster_id: Platform.BINARY_SENSOR,
             },
             clear=True,
         ),

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -437,7 +437,7 @@ async def test_remove_device_cleans_up_group_membership(
 
 @patch(
     "zha.application.gateway.Gateway.load_devices",
-    MagicMock(),
+    AsyncMock(),
 )
 @patch(
     "zha.application.gateway.Gateway.load_groups",

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -197,7 +197,7 @@ async def test_gateway_starts_entity_exception(
             return_value=zigpy_app_controller,
         ),
         patch(
-            "zha.application.platforms.sensor.DeviceCounterSensor.create_platform_entity",
+            "zha.application.platforms.sensor.DeviceCounterSensor.__init__",
             side_effect=Exception,
         ),
     ):
@@ -206,7 +206,7 @@ async def test_gateway_starts_entity_exception(
         await zha_gateway.async_block_till_done()
         await zha_gateway.async_initialize_devices_and_entities()
 
-        assert "Failed to create platform entity" in caplog.text
+        assert "Failed to create entity" in caplog.text
 
         await zha_gateway.shutdown()
 

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -160,8 +160,10 @@ async def device_light_1_mock(
     )
     color_cluster = zigpy_device.endpoints[1].light_color
     color_cluster.PLUGGED_ATTR_READS = {
-        "color_capabilities": lighting.Color.ColorCapabilities.Color_temperature
-        | lighting.Color.ColorCapabilities.XY_attributes
+        "color_capabilities": (
+            lighting.Color.ColorCapabilities.Color_temperature
+            | lighting.Color.ColorCapabilities.XY_attributes
+        )
     }
     zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
     return zha_device

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -186,7 +186,11 @@ async def test_on_off_select_attribute_report_v2(
     cluster = zigpy_device.endpoints[1].opple_cluster
     assert isinstance(zha_device.device, CustomDeviceV2)
 
-    entity = get_entity(zha_device, platform=Platform.SELECT)
+    entity = get_entity(
+        zha_device,
+        platform=Platform.SELECT,
+        qualifier_func=lambda e: e.info_object.unique_id.endswith("motion_sensitivity"),
+    )
 
     # test that the state is in default medium state
     assert entity.state["state"] == AqaraMotionSensitivities.Medium.name

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1103,7 +1103,11 @@ async def test_elec_measurement_sensor_type(
 
     zha_dev = await join_zigpy_device(zha_gateway, zigpy_dev)
 
-    entity = get_entity(zha_dev, platform=Platform.SENSOR)
+    entity = get_entity(
+        zha_dev,
+        platform=Platform.SENSOR,
+        entity_type=sensor.ElectricalMeasurementApparentPower,
+    )
     assert entity.state["measurement_type"] == expected_type
 
 
@@ -1450,8 +1454,16 @@ async def test_state_class(
 
     zha_device, cluster = await zigpy_device_aqara_sensor_v2_mock(zha_gateway)
     assert isinstance(zha_device.device, CustomDeviceV2)
-    power_entity = get_entity(zha_device, platform=Platform.SENSOR, qualifier="power")
-    energy_entity = get_entity(zha_device, platform=Platform.SENSOR, qualifier="energy")
+    power_entity = get_entity(
+        zha_device,
+        platform=Platform.SENSOR,
+        qualifier_func=lambda e: e.info_object.unique_id.endswith("power"),
+    )
+    energy_entity = get_entity(
+        zha_device,
+        platform=Platform.SENSOR,
+        qualifier_func=lambda e: e.info_object.unique_id.endswith("energy"),
+    )
     energy_delivered_entity = get_entity(
         zha_device, platform=Platform.SENSOR, qualifier="energy_delivered"
     )
@@ -1518,7 +1530,13 @@ async def test_device_counter_sensors(zha_gateway: Gateway) -> None:
 
     coordinator = zha_gateway.coordinator_zha_device
     assert coordinator.is_coordinator
-    entity = get_entity(coordinator, platform=Platform.SENSOR)
+    entity = get_entity(
+        coordinator,
+        platform=Platform.SENSOR,
+        qualifier_func=lambda e: e.info_object.unique_id.endswith(
+            "ezsp_counters_counter_1"
+        ),
+    )
 
     assert entity.state["state"] == 1
 

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -119,13 +119,21 @@ QUIRKS_ENTITY_META_TO_ENTITY_CLASS = {
         WriteAttributeButtonMetadata,
         EntityType.DIAGNOSTIC,
     ): button.WriteAttributeButton,
-    (Platform.BUTTON, ZCLCommandButtonMetadata, EntityType.CONFIG): button.Button,
+    (
+        Platform.BUTTON,
+        ZCLCommandButtonMetadata,
+        EntityType.CONFIG,
+    ): button.Button,
     (
         Platform.BUTTON,
         ZCLCommandButtonMetadata,
         EntityType.DIAGNOSTIC,
     ): button.Button,
-    (Platform.BUTTON, ZCLCommandButtonMetadata, EntityType.STANDARD): button.Button,
+    (
+        Platform.BUTTON,
+        ZCLCommandButtonMetadata,
+        EntityType.STANDARD,
+    ): button.Button,
     (
         Platform.BINARY_SENSOR,
         BinarySensorMetadata,
@@ -141,12 +149,36 @@ QUIRKS_ENTITY_META_TO_ENTITY_CLASS = {
         BinarySensorMetadata,
         EntityType.STANDARD,
     ): binary_sensor.BinarySensor,
-    (Platform.SENSOR, ZCLEnumMetadata, EntityType.DIAGNOSTIC): sensor.EnumSensor,
-    (Platform.SENSOR, ZCLEnumMetadata, EntityType.STANDARD): sensor.EnumSensor,
-    (Platform.SENSOR, ZCLSensorMetadata, EntityType.DIAGNOSTIC): sensor.Sensor,
-    (Platform.SENSOR, ZCLSensorMetadata, EntityType.STANDARD): sensor.Sensor,
-    (Platform.SELECT, ZCLEnumMetadata, EntityType.CONFIG): select.ZCLEnumSelectEntity,
-    (Platform.SELECT, ZCLEnumMetadata, EntityType.STANDARD): select.ZCLEnumSelectEntity,
+    (
+        Platform.SENSOR,
+        ZCLEnumMetadata,
+        EntityType.DIAGNOSTIC,
+    ): sensor.EnumSensor,
+    (
+        Platform.SENSOR,
+        ZCLEnumMetadata,
+        EntityType.STANDARD,
+    ): sensor.EnumSensor,
+    (
+        Platform.SENSOR,
+        ZCLSensorMetadata,
+        EntityType.DIAGNOSTIC,
+    ): sensor.Sensor,
+    (
+        Platform.SENSOR,
+        ZCLSensorMetadata,
+        EntityType.STANDARD,
+    ): sensor.Sensor,
+    (
+        Platform.SELECT,
+        ZCLEnumMetadata,
+        EntityType.CONFIG,
+    ): select.ZCLEnumSelectEntity,
+    (
+        Platform.SELECT,
+        ZCLEnumMetadata,
+        EntityType.STANDARD,
+    ): select.ZCLEnumSelectEntity,
     (
         Platform.SELECT,
         ZCLEnumMetadata,
@@ -157,8 +189,16 @@ QUIRKS_ENTITY_META_TO_ENTITY_CLASS = {
         NumberMetadata,
         EntityType.CONFIG,
     ): number.NumberConfigurationEntity,
-    (Platform.NUMBER, NumberMetadata, EntityType.DIAGNOSTIC): number.Number,
-    (Platform.NUMBER, NumberMetadata, EntityType.STANDARD): number.Number,
+    (
+        Platform.NUMBER,
+        NumberMetadata,
+        EntityType.DIAGNOSTIC,
+    ): number.Number,
+    (
+        Platform.NUMBER,
+        NumberMetadata,
+        EntityType.STANDARD,
+    ): number.Number,
     (
         Platform.SWITCH,
         SwitchMetadata,

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -331,14 +331,12 @@ class DeviceProbe:
                             entity_metadata.attribute_initialized_from_cache
                         )
 
-                yield (
-                    entity_class.create_platform_entity(
-                        unique_id=endpoint.unique_id,
-                        cluster_handlers=[cluster_handler],
-                        endpoint=endpoint,
-                        device=device,
-                        entity_metadata=entity_metadata,
-                    )
+                yield entity_class(
+                    unique_id=endpoint.unique_id,
+                    cluster_handlers=[cluster_handler],
+                    endpoint=endpoint,
+                    device=device,
+                    entity_metadata=entity_metadata,
                 )
 
                 _LOGGER.debug(
@@ -365,13 +363,11 @@ class DeviceProbe:
         ):
             for counter_group, counters in getattr(state, counter_groups).items():
                 for counter in counters:
-                    yield (
-                        sensor.DeviceCounterSensor.create_platform_entity(
-                            zha_device=device,
-                            counter_groups=counter_groups,
-                            counter_group=counter_group,
-                            counter=counter,
-                        )
+                    yield sensor.DeviceCounterSensor(
+                        zha_device=device,
+                        counter_groups=counter_groups,
+                        counter_group=counter_group,
+                        counter=counter,
                     )
 
                     _LOGGER.debug(
@@ -433,7 +429,7 @@ class EndpointProbe:
             endpoint.claim_cluster_handlers(claimed)
 
             if endpoint.device.status != DeviceStatus.INITIALIZED:
-                yield platform_entity_class.create_platform_entity(
+                yield platform_entity_class(
                     unique_id=unique_id,
                     endpoint=endpoint,
                     device=endpoint.device,
@@ -465,13 +461,11 @@ class EndpointProbe:
         endpoint.claim_cluster_handlers(claimed)
 
         if endpoint.device.status != DeviceStatus.INITIALIZED:
-            yield (
-                entity_class.create_platform_entity(
-                    unique_id=unique_id,
-                    endpoint=endpoint,
-                    device=endpoint.device,
-                    cluster_handlers=claimed,
-                )
+            yield entity_class(
+                unique_id=unique_id,
+                endpoint=endpoint,
+                device=endpoint.device,
+                cluster_handlers=claimed,
             )
 
     def discover_by_cluster_id(self, endpoint: Endpoint) -> None:
@@ -579,25 +573,21 @@ class EndpointProbe:
                     # for well known device types,
                     # like thermostats we'll take only 1st class
                     if endpoint.device.status != DeviceStatus.INITIALIZED:
-                        yield (
-                            entity_and_handler.entity_class.create_platform_entity(
-                                unique_id=endpoint.unique_id,
-                                endpoint=endpoint,
-                                device=endpoint.device,
-                                cluster_handlers=entity_and_handler.claimed_cluster_handlers,
-                            )
+                        yield entity_and_handler.entity_class(
+                            unique_id=endpoint.unique_id,
+                            endpoint=endpoint,
+                            device=endpoint.device,
+                            cluster_handlers=entity_and_handler.claimed_cluster_handlers,
                         )
                     break
 
                 first_ch = entity_and_handler.claimed_cluster_handlers[0]
                 if endpoint.device.status != DeviceStatus.INITIALIZED:
-                    yield (
-                        entity_and_handler.entity_class.create_platform_entity(
-                            unique_id=f"{endpoint.unique_id}-{first_ch.cluster.cluster_id}",
-                            endpoint=endpoint,
-                            device=endpoint.device,
-                            cluster_handlers=entity_and_handler.claimed_cluster_handlers,
-                        )
+                    yield entity_and_handler.entity_class(
+                        unique_id=f"{endpoint.unique_id}-{first_ch.cluster.cluster_id}",
+                        endpoint=endpoint,
+                        device=endpoint.device,
+                        cluster_handlers=entity_and_handler.claimed_cluster_handlers,
                     )
 
 

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -191,7 +191,6 @@ class DeviceProbe:
             yield from self.discover_coordinator_device_entities(device)
         else:
             yield from self.discover_quirks_v2_entities(device)
-            PLATFORM_ENTITIES.clean_up()
 
         for ep_id, endpoint in device.endpoints.items():
             if ep_id != 0:
@@ -199,6 +198,8 @@ class DeviceProbe:
                     endpoint,
                     device.gateway.config.config.device_overrides,
                 )
+
+        PLATFORM_ENTITIES.clean_up()
 
     def discover_quirks_v2_entities(self, device: Device) -> None:
         """Discover entities for a ZHA device exposed by quirks v2."""

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -70,7 +70,6 @@ from zha.zigbee.cluster_handlers.registries import (
     CLUSTER_HANDLER_ONLY_CLUSTERS,
     CLUSTER_HANDLER_REGISTRY,
 )
-from zha.zigbee.device import DeviceStatus
 from zha.zigbee.group import Group
 
 if TYPE_CHECKING:
@@ -428,13 +427,12 @@ class EndpointProbe:
 
             endpoint.claim_cluster_handlers(claimed)
 
-            if endpoint.device.status != DeviceStatus.INITIALIZED:
-                yield platform_entity_class(
-                    unique_id=unique_id,
-                    endpoint=endpoint,
-                    device=endpoint.device,
-                    cluster_handlers=claimed,
-                )
+            yield platform_entity_class(
+                unique_id=unique_id,
+                endpoint=endpoint,
+                device=endpoint.device,
+                cluster_handlers=claimed,
+            )
 
     def probe_single_cluster(
         self,
@@ -460,13 +458,12 @@ class EndpointProbe:
 
         endpoint.claim_cluster_handlers(claimed)
 
-        if endpoint.device.status != DeviceStatus.INITIALIZED:
-            yield entity_class(
-                unique_id=unique_id,
-                endpoint=endpoint,
-                device=endpoint.device,
-                cluster_handlers=claimed,
-            )
+        yield entity_class(
+            unique_id=unique_id,
+            endpoint=endpoint,
+            device=endpoint.device,
+            cluster_handlers=claimed,
+        )
 
     def discover_by_cluster_id(self, endpoint: Endpoint) -> None:
         """Process an endpoint on a zigpy device."""
@@ -572,23 +569,21 @@ class EndpointProbe:
                 if platform == cmpt_by_dev_type:
                     # for well known device types,
                     # like thermostats we'll take only 1st class
-                    if endpoint.device.status != DeviceStatus.INITIALIZED:
-                        yield entity_and_handler.entity_class(
-                            unique_id=endpoint.unique_id,
-                            endpoint=endpoint,
-                            device=endpoint.device,
-                            cluster_handlers=entity_and_handler.claimed_cluster_handlers,
-                        )
-                    break
-
-                first_ch = entity_and_handler.claimed_cluster_handlers[0]
-                if endpoint.device.status != DeviceStatus.INITIALIZED:
                     yield entity_and_handler.entity_class(
-                        unique_id=f"{endpoint.unique_id}-{first_ch.cluster.cluster_id}",
+                        unique_id=endpoint.unique_id,
                         endpoint=endpoint,
                         device=endpoint.device,
                         cluster_handlers=entity_and_handler.claimed_cluster_handlers,
                     )
+                    break
+
+                first_ch = entity_and_handler.claimed_cluster_handlers[0]
+                yield entity_and_handler.entity_class(
+                    unique_id=f"{endpoint.unique_id}-{first_ch.cluster.cluster_id}",
+                    endpoint=endpoint,
+                    device=endpoint.device,
+                    cluster_handlers=entity_and_handler.claimed_cluster_handlers,
+                )
 
 
 class GroupProbe:

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -27,6 +27,7 @@ from zigpy.zcl.clusters.general import Ota
 from zha.application import Platform, const as zha_const
 from zha.application.helpers import DeviceOverridesConfiguration
 from zha.application.platforms import (  # noqa: F401 pylint: disable=unused-import
+    BaseEntity,
     PlatformEntity,
     alarm_control_panel,
     binary_sensor,
@@ -246,9 +247,7 @@ class DeviceProbe:
     """Probe to discover entities for a device."""
 
     @ignore_exceptions_during_iteration
-    def discover_device_entities(
-        self, device: Device
-    ) -> Iterator[PlatformEntity | sensor.DeviceCounterSensor]:
+    def discover_device_entities(self, device: Device) -> Iterator[BaseEntity]:
         """Discover entities for a ZHA device."""
         _LOGGER.debug(
             "Discovering entities for device: %s-%s",
@@ -256,10 +255,9 @@ class DeviceProbe:
             device.name,
         )
 
-        if device.is_active_coordinator:
-            yield from self.discover_coordinator_device_entities(device)
-        else:
-            yield from self.discover_quirks_v2_entities(device)
+        assert not device.is_active_coordinator
+
+        yield from self.discover_quirks_v2_entities(device)
 
         for ep_id, endpoint in device.endpoints.items():
             if ep_id != 0:
@@ -415,6 +413,7 @@ class DeviceProbe:
                     [cluster_handler.name],
                 )
 
+    @ignore_exceptions_during_iteration
     def discover_coordinator_device_entities(
         self, device: Device
     ) -> Iterator[sensor.DeviceCounterSensor]:

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -24,7 +24,6 @@ from zigpy.zcl import ClusterType
 from zigpy.zcl.clusters.general import Ota
 
 from zha.application import Platform, const as zha_const
-from zha.application.helpers import DeviceOverridesConfiguration
 from zha.application.platforms import (  # noqa: F401 pylint: disable=unused-import
     alarm_control_panel,
     binary_sensor,
@@ -75,7 +74,6 @@ from zha.zigbee.device import DeviceStatus
 from zha.zigbee.group import Group
 
 if TYPE_CHECKING:
-    from zha.application.gateway import Gateway
     from zha.application.platforms import GroupEntity
     from zha.zigbee.device import Device
     from zha.zigbee.endpoint import Endpoint
@@ -182,19 +180,6 @@ QUIRKS_SENSOR_DEV_CLASS_TO_ENTITY_CLASS = {
 class DeviceProbe:
     """Probe to discover entities for a device."""
 
-    def __init__(self) -> None:
-        """Initialize instance."""
-        self._gateway: Gateway
-
-    def initialize(self, gateway: Gateway) -> None:
-        """Initialize the group probe."""
-        self._gateway = gateway
-
-    @property
-    def platforms(self) -> dict[Platform, list]:
-        """Platform entity mapping."""
-        return self._gateway.config.platforms
-
     def discover_device_entities(self, device: Device) -> None:
         """Discover entities for a ZHA device."""
         _LOGGER.debug(
@@ -204,11 +189,17 @@ class DeviceProbe:
         )
 
         if device.is_active_coordinator:
-            self.discover_coordinator_device_entities(device)
-            return
+            yield from self.discover_coordinator_device_entities(device)
+        else:
+            yield from self.discover_quirks_v2_entities(device)
+            PLATFORM_ENTITIES.clean_up()
 
-        self.discover_quirks_v2_entities(device)
-        PLATFORM_ENTITIES.clean_up()
+        for ep_id, endpoint in device.endpoints.items():
+            if ep_id != 0:
+                yield from ENDPOINT_PROBE.discover_entities(
+                    endpoint,
+                    device.gateway.config.config.device_overrides,
+                )
 
     def discover_quirks_v2_entities(self, device: Device) -> None:
         """Discover entities for a ZHA device exposed by quirks v2."""
@@ -340,7 +331,7 @@ class DeviceProbe:
                             entity_metadata.attribute_initialized_from_cache
                         )
 
-                self.platforms[platform].append(
+                yield (
                     entity_class.create_platform_entity(
                         unique_id=endpoint.unique_id,
                         cluster_handlers=[cluster_handler],
@@ -374,7 +365,7 @@ class DeviceProbe:
         ):
             for counter_group, counters in getattr(state, counter_groups).items():
                 for counter in counters:
-                    self.platforms[Platform.SENSOR].append(
+                    yield (
                         sensor.DeviceCounterSensor.create_platform_entity(
                             zha_device=device,
                             counter_groups=counter_groups,
@@ -394,37 +385,32 @@ class DeviceProbe:
 class EndpointProbe:
     """All discovered cluster handlers and entities of an endpoint."""
 
-    def __init__(self) -> None:
-        """Initialize instance."""
-        self._gateway: Gateway
-        self._device_configs: dict[str, DeviceOverridesConfiguration] = {}
-
-    @property
-    def platforms(self) -> dict[Platform, list]:
-        """Platform entity mapping."""
-        return self._gateway.config.platforms
-
-    def discover_entities(self, endpoint: Endpoint) -> None:
+    def discover_entities(self, endpoint: Endpoint, device_overrides) -> None:
         """Process an endpoint on a zigpy device."""
+        if endpoint.device.is_coordinator:
+            return
+
         _LOGGER.debug(
             "Discovering entities for endpoint: %s-%s",
             str(endpoint.device.ieee),
             endpoint.id,
         )
-        self.discover_by_device_type(endpoint)
-        self.discover_multi_entities(endpoint)
-        self.discover_by_cluster_id(endpoint)
-        self.discover_multi_entities(endpoint, config_diagnostic_entities=True)
-        PLATFORM_ENTITIES.clean_up()
 
-    def discover_by_device_type(self, endpoint: Endpoint) -> None:
+        yield from self.discover_by_device_type(endpoint, device_overrides)
+        yield from self.discover_multi_entities(endpoint)
+        yield from self.discover_by_cluster_id(endpoint)
+        yield from self.discover_multi_entities(
+            endpoint, config_diagnostic_entities=True
+        )
+
+    def discover_by_device_type(self, endpoint: Endpoint, device_overrides) -> None:
         """Process an endpoint on a zigpy device."""
 
         unique_id = endpoint.unique_id
 
         platform: str | None = None
-        if unique_id in self._device_configs:
-            platform = self._device_configs.get(unique_id).type
+        if unique_id in device_overrides:
+            platform = device_overrides.get(unique_id).type
         if platform is None:
             ep_profile_id = endpoint.zigpy_endpoint.profile_id
             ep_device_type = endpoint.zigpy_endpoint.device_type
@@ -447,13 +433,11 @@ class EndpointProbe:
             endpoint.claim_cluster_handlers(claimed)
 
             if endpoint.device.status != DeviceStatus.INITIALIZED:
-                self.platforms[platform].append(
-                    platform_entity_class.create_platform_entity(
-                        unique_id=unique_id,
-                        endpoint=endpoint,
-                        device=endpoint.device,
-                        cluster_handlers=claimed,
-                    )
+                yield platform_entity_class.create_platform_entity(
+                    unique_id=unique_id,
+                    endpoint=endpoint,
+                    device=endpoint.device,
+                    cluster_handlers=claimed,
                 )
 
     def probe_single_cluster(
@@ -481,7 +465,7 @@ class EndpointProbe:
         endpoint.claim_cluster_handlers(claimed)
 
         if endpoint.device.status != DeviceStatus.INITIALIZED:
-            self.platforms[platform].append(
+            yield (
                 entity_class.create_platform_entity(
                     unique_id=unique_id,
                     endpoint=endpoint,
@@ -514,10 +498,10 @@ class EndpointProbe:
                         platform = match
                         break
 
-            self.probe_single_cluster(platform, cluster_handler, endpoint)
+            yield from self.probe_single_cluster(platform, cluster_handler, endpoint)
 
         # until we can get rid of registries
-        self.handle_on_off_output_cluster_exception(endpoint)
+        yield from self.handle_on_off_output_cluster_exception(endpoint)
 
     def handle_on_off_output_cluster_exception(self, endpoint: Endpoint) -> None:
         """Process output clusters of the endpoint."""
@@ -547,7 +531,7 @@ class EndpointProbe:
             )
 
             cluster_handler = cluster_handler_class(cluster, endpoint)
-            self.probe_single_cluster(platform, cluster_handler, endpoint)
+            yield from self.probe_single_cluster(platform, cluster_handler, endpoint)
 
     def discover_multi_entities(
         self,
@@ -595,7 +579,7 @@ class EndpointProbe:
                     # for well known device types,
                     # like thermostats we'll take only 1st class
                     if endpoint.device.status != DeviceStatus.INITIALIZED:
-                        self.platforms[platform].append(
+                        yield (
                             entity_and_handler.entity_class.create_platform_entity(
                                 unique_id=endpoint.unique_id,
                                 endpoint=endpoint,
@@ -607,7 +591,7 @@ class EndpointProbe:
 
                 first_ch = entity_and_handler.claimed_cluster_handlers[0]
                 if endpoint.device.status != DeviceStatus.INITIALIZED:
-                    self.platforms[platform].append(
+                    yield (
                         entity_and_handler.entity_class.create_platform_entity(
                             unique_id=f"{endpoint.unique_id}-{first_ch.cluster.cluster_id}",
                             endpoint=endpoint,
@@ -616,28 +600,12 @@ class EndpointProbe:
                         )
                     )
 
-    def initialize(self, gateway: Gateway) -> None:
-        """Update device overrides config."""
-        self._gateway = gateway
-
-        if overrides := gateway.config.config.device_overrides:
-            self._device_configs.update(overrides)
-
 
 class GroupProbe:
     """Determine the appropriate platform for a group."""
 
-    def __init__(self) -> None:
-        """Initialize instance."""
-        self._gateway: Gateway
-
-    def initialize(self, gateway: Gateway) -> None:
-        """Initialize the group probe."""
-        self._gateway = gateway
-
-    def discover_group_entities(
-        self, group: Group
-    ) -> Generator[GroupEntity, None, None]:
+    @staticmethod
+    def discover_group_entities(group: Group) -> Generator[GroupEntity, None, None]:
         """Process a group and create any entities that are needed."""
         # only create a group entity if there are 2 or more members in a group
         if len(group.members) < 2:
@@ -649,7 +617,6 @@ class GroupProbe:
             group.group_entities.clear()
             return
 
-        assert self._gateway
         entity_platforms = GroupProbe.determine_entity_platforms(group)
 
         if not entity_platforms:

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -396,7 +396,13 @@ class EndpointProbe:
 
     def __init__(self) -> None:
         """Initialize instance."""
+        self._gateway: Gateway
         self._device_configs: dict[str, DeviceOverridesConfiguration] = {}
+
+    @property
+    def platforms(self) -> dict[Platform, list]:
+        """Platform entity mapping."""
+        return self._gateway.config.platforms
 
     def discover_entities(self, endpoint: Endpoint) -> None:
         """Process an endpoint on a zigpy device."""
@@ -612,6 +618,8 @@ class EndpointProbe:
 
     def initialize(self, gateway: Gateway) -> None:
         """Update device overrides config."""
+        self._gateway = gateway
+
         if overrides := gateway.config.config.device_overrides:
             self._device_configs.update(overrides)
 

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import Counter
+from collections.abc import Generator
 from dataclasses import astuple
 import logging
 from typing import TYPE_CHECKING, cast
@@ -70,10 +71,12 @@ from zha.zigbee.cluster_handlers.registries import (
     CLUSTER_HANDLER_ONLY_CLUSTERS,
     CLUSTER_HANDLER_REGISTRY,
 )
+from zha.zigbee.device import DeviceStatus
 from zha.zigbee.group import Group
 
 if TYPE_CHECKING:
     from zha.application.gateway import Gateway
+    from zha.application.platforms import GroupEntity
     from zha.zigbee.device import Device
     from zha.zigbee.endpoint import Endpoint
 
@@ -186,6 +189,11 @@ class DeviceProbe:
     def initialize(self, gateway: Gateway) -> None:
         """Initialize the group probe."""
         self._gateway = gateway
+
+    @property
+    def platforms(self) -> dict[Platform, list]:
+        """Platform entity mapping."""
+        return self._gateway.config.platforms
 
     def discover_device_entities(self, device: Device) -> None:
         """Discover entities for a ZHA device."""
@@ -332,12 +340,14 @@ class DeviceProbe:
                             entity_metadata.attribute_initialized_from_cache
                         )
 
-                endpoint.async_new_entity(
-                    platform=platform,
-                    entity_class=entity_class,
-                    unique_id=endpoint.unique_id,
-                    cluster_handlers=[cluster_handler],
-                    entity_metadata=entity_metadata,
+                self.platforms[platform].append(
+                    entity_class.create_platform_entity(
+                        unique_id=endpoint.unique_id,
+                        cluster_handlers=[cluster_handler],
+                        endpoint=endpoint,
+                        device=device,
+                        entity_metadata=entity_metadata,
+                    )
                 )
 
                 _LOGGER.debug(
@@ -355,34 +365,30 @@ class DeviceProbe:
             device.name,
         )
         state: State = device.gateway.application_controller.state
-        platforms: dict[Platform, list] = self._gateway.config.platforms
 
-        def process_counters(counter_groups: str) -> None:
+        for counter_groups in (
+            "counters",
+            "broadcast_counters",
+            "device_counters",
+            "group_counters",
+        ):
             for counter_group, counters in getattr(state, counter_groups).items():
                 for counter in counters:
-                    platforms[Platform.SENSOR].append(
-                        (
-                            sensor.DeviceCounterSensor,
-                            (
-                                device,
-                                counter_groups,
-                                counter_group,
-                                counter,
-                            ),
-                            {},
+                    self.platforms[Platform.SENSOR].append(
+                        sensor.DeviceCounterSensor.create_platform_entity(
+                            zha_device=device,
+                            counter_groups=counter_groups,
+                            counter_group=counter_group,
+                            counter=counter,
                         )
                     )
+
                     _LOGGER.debug(
                         "'%s' platform -> '%s' using %s",
                         Platform.SENSOR,
                         sensor.DeviceCounterSensor.__name__,
                         f"counter groups[{counter_groups}] counter group[{counter_group}] counter[{counter}]",
                     )
-
-        process_counters("counters")
-        process_counters("broadcast_counters")
-        process_counters("device_counters")
-        process_counters("group_counters")
 
 
 class EndpointProbe:
@@ -431,9 +437,51 @@ class EndpointProbe:
             )
             if platform_entity_class is None:
                 return
+
             endpoint.claim_cluster_handlers(claimed)
-            endpoint.async_new_entity(
-                platform, platform_entity_class, unique_id, claimed
+
+            if endpoint.device.status != DeviceStatus.INITIALIZED:
+                self.platforms[platform].append(
+                    platform_entity_class.create_platform_entity(
+                        unique_id=unique_id,
+                        endpoint=endpoint,
+                        device=endpoint.device,
+                        cluster_handlers=claimed,
+                    )
+                )
+
+    def probe_single_cluster(
+        self,
+        platform: Platform | None,
+        cluster_handler: ClusterHandler,
+        endpoint: Endpoint,
+    ) -> None:
+        """Probe specified cluster for specific platform."""
+        if platform is None or platform not in PLATFORMS:
+            return
+        cluster_handler_list = [cluster_handler]
+        unique_id = f"{endpoint.unique_id}-{cluster_handler.cluster.cluster_id}"
+
+        entity_class, claimed = PLATFORM_ENTITIES.get_entity(
+            platform,
+            endpoint.device.manufacturer,
+            endpoint.device.model,
+            cluster_handler_list,
+            endpoint.device.quirk_id,
+        )
+        if entity_class is None:
+            return
+
+        endpoint.claim_cluster_handlers(claimed)
+
+        if endpoint.device.status != DeviceStatus.INITIALIZED:
+            self.platforms[platform].append(
+                entity_class.create_platform_entity(
+                    unique_id=unique_id,
+                    endpoint=endpoint,
+                    device=endpoint.device,
+                    cluster_handlers=claimed,
+                )
             )
 
     def discover_by_cluster_id(self, endpoint: Endpoint) -> None:
@@ -465,30 +513,6 @@ class EndpointProbe:
         # until we can get rid of registries
         self.handle_on_off_output_cluster_exception(endpoint)
 
-    @staticmethod
-    def probe_single_cluster(
-        platform: Platform | None,
-        cluster_handler: ClusterHandler,
-        endpoint: Endpoint,
-    ) -> None:
-        """Probe specified cluster for specific platform."""
-        if platform is None or platform not in PLATFORMS:
-            return
-        cluster_handler_list = [cluster_handler]
-        unique_id = f"{endpoint.unique_id}-{cluster_handler.cluster.cluster_id}"
-
-        entity_class, claimed = PLATFORM_ENTITIES.get_entity(
-            platform,
-            endpoint.device.manufacturer,
-            endpoint.device.model,
-            cluster_handler_list,
-            endpoint.device.quirk_id,
-        )
-        if entity_class is None:
-            return
-        endpoint.claim_cluster_handlers(claimed)
-        endpoint.async_new_entity(platform, entity_class, unique_id, claimed)
-
     def handle_on_off_output_cluster_exception(self, endpoint: Endpoint) -> None:
         """Process output clusters of the endpoint."""
 
@@ -519,8 +543,8 @@ class EndpointProbe:
             cluster_handler = cluster_handler_class(cluster, endpoint)
             self.probe_single_cluster(platform, cluster_handler, endpoint)
 
-    @staticmethod
     def discover_multi_entities(
+        self,
         endpoint: Endpoint,
         config_diagnostic_entities: bool = False,
     ) -> None:
@@ -564,20 +588,27 @@ class EndpointProbe:
                 if platform == cmpt_by_dev_type:
                     # for well known device types,
                     # like thermostats we'll take only 1st class
-                    endpoint.async_new_entity(
-                        platform,
-                        entity_and_handler.entity_class,
-                        endpoint.unique_id,
-                        entity_and_handler.claimed_cluster_handlers,
-                    )
+                    if endpoint.device.status != DeviceStatus.INITIALIZED:
+                        self.platforms[platform].append(
+                            entity_and_handler.entity_class.create_platform_entity(
+                                unique_id=endpoint.unique_id,
+                                endpoint=endpoint,
+                                device=endpoint.device,
+                                cluster_handlers=entity_and_handler.claimed_cluster_handlers,
+                            )
+                        )
                     break
+
                 first_ch = entity_and_handler.claimed_cluster_handlers[0]
-                endpoint.async_new_entity(
-                    platform,
-                    entity_and_handler.entity_class,
-                    f"{endpoint.unique_id}-{first_ch.cluster.cluster_id}",
-                    entity_and_handler.claimed_cluster_handlers,
-                )
+                if endpoint.device.status != DeviceStatus.INITIALIZED:
+                    self.platforms[platform].append(
+                        entity_and_handler.entity_class.create_platform_entity(
+                            unique_id=f"{endpoint.unique_id}-{first_ch.cluster.cluster_id}",
+                            endpoint=endpoint,
+                            device=endpoint.device,
+                            cluster_handlers=entity_and_handler.claimed_cluster_handlers,
+                        )
+                    )
 
     def initialize(self, gateway: Gateway) -> None:
         """Update device overrides config."""
@@ -596,7 +627,9 @@ class GroupProbe:
         """Initialize the group probe."""
         self._gateway = gateway
 
-    def discover_group_entities(self, group: Group) -> None:
+    def discover_group_entities(
+        self, group: Group
+    ) -> Generator[GroupEntity, None, None]:
         """Process a group and create any entities that are needed."""
         # only create a group entity if there are 2 or more members in a group
         if len(group.members) < 2:
@@ -620,7 +653,7 @@ class GroupProbe:
             if entity_class is None:
                 continue
             _LOGGER.info("Creating entity : %s for group %s", entity_class, group.name)
-            entity_class(group)
+            yield entity_class(group)
 
     @staticmethod
     def determine_entity_platforms(group: Group) -> list[Platform]:

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -266,8 +266,6 @@ class DeviceProbe:
                     device.gateway.config.config.device_overrides,
                 )
 
-        PLATFORM_ENTITIES.clean_up()
-
     def discover_quirks_v2_entities(self, device: Device) -> Iterator[PlatformEntity]:
         """Discover entities for a ZHA device exposed by quirks v2."""
         _LOGGER.debug(

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -523,6 +523,8 @@ class EndpointProbe:
             )
 
             cluster_handler = cluster_handler_class(cluster, endpoint)
+            cluster_handler.on_add()
+
             yield from self.probe_single_cluster(platform, cluster_handler, endpoint)
 
     def discover_multi_entities(

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from collections import Counter
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import astuple
+import functools
 import logging
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, ParamSpec, TypeVar, cast
 
 from zigpy.quirks.v2 import (
     BinarySensorMetadata,
@@ -218,9 +219,33 @@ QUIRKS_SENSOR_DEV_CLASS_TO_ENTITY_CLASS = {
 }
 
 
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+def ignore_exceptions_during_iteration(
+    func: Callable[P, Iterator[T]],
+) -> Callable[P, Iterator[T]]:
+    """Ignore exceptions during iteration for wrapped function."""
+
+    @functools.wraps(func)
+    def inner(*args: P.args, **kwargs: P.kwargs) -> Iterator[T]:
+        iterator = func(*args, **kwargs)
+        while True:
+            try:
+                yield next(iterator)
+            except StopIteration:
+                break
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Failed to create entity during discovery")
+
+    return inner
+
+
 class DeviceProbe:
     """Probe to discover entities for a device."""
 
+    @ignore_exceptions_during_iteration
     def discover_device_entities(
         self, device: Device
     ) -> Iterator[PlatformEntity | sensor.DeviceCounterSensor]:
@@ -649,8 +674,8 @@ class EndpointProbe:
 class GroupProbe:
     """Determine the appropriate platform for a group."""
 
-    @staticmethod
-    def discover_group_entities(group: Group) -> Iterator[GroupEntity]:
+    @ignore_exceptions_during_iteration
+    def discover_group_entities(self, group: Group) -> Iterator[GroupEntity]:
         """Process a group and create any entities that are needed."""
         # only create a group entity if there are 2 or more members in a group
         if len(group.members) < 2:
@@ -662,7 +687,7 @@ class GroupProbe:
             group.group_entities.clear()
             return
 
-        entity_platforms = GroupProbe.determine_entity_platforms(group)
+        entity_platforms = self.determine_entity_platforms(group)
 
         if not entity_platforms:
             _LOGGER.info("No entity platforms discovered for group %s", group.name)
@@ -675,8 +700,7 @@ class GroupProbe:
             _LOGGER.info("Creating entity : %s for group %s", entity_class, group.name)
             yield entity_class(group)
 
-    @staticmethod
-    def determine_entity_platforms(group: Group) -> list[Platform]:
+    def determine_entity_platforms(self, group: Group) -> list[Platform]:
         """Determine the entity platforms for this group."""
         entity_domains: list[Platform] = []
         all_platform_occurrences = []

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -24,6 +24,7 @@ from zigpy.zcl import ClusterType
 from zigpy.zcl.clusters.general import Ota
 
 from zha.application import Platform, const as zha_const
+from zha.application.helpers import DeviceOverridesConfiguration
 from zha.application.platforms import (  # noqa: F401 pylint: disable=unused-import
     PlatformEntity,
     alarm_control_panel,
@@ -427,9 +428,12 @@ class EndpointProbe:
     """All discovered cluster handlers and entities of an endpoint."""
 
     def discover_entities(
-        self, endpoint: Endpoint, device_overrides
+        self,
+        endpoint: Endpoint,
+        device_overrides: dict[str, DeviceOverridesConfiguration],
     ) -> Iterator[PlatformEntity]:
         """Process an endpoint on a zigpy device."""
+
         if endpoint.device.is_coordinator:
             return
 
@@ -447,7 +451,9 @@ class EndpointProbe:
         )
 
     def discover_by_device_type(
-        self, endpoint: Endpoint, device_overrides
+        self,
+        endpoint: Endpoint,
+        device_overrides: dict[str, DeviceOverridesConfiguration],
     ) -> Iterator[PlatformEntity]:
         """Process an endpoint on a zigpy device."""
 

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import Counter
-from collections.abc import Generator
+from collections.abc import Iterator
 from dataclasses import astuple
 import logging
 from typing import TYPE_CHECKING, cast
@@ -25,6 +25,7 @@ from zigpy.zcl.clusters.general import Ota
 
 from zha.application import Platform, const as zha_const
 from zha.application.platforms import (  # noqa: F401 pylint: disable=unused-import
+    PlatformEntity,
     alarm_control_panel,
     binary_sensor,
     button,
@@ -219,7 +220,9 @@ QUIRKS_SENSOR_DEV_CLASS_TO_ENTITY_CLASS = {
 class DeviceProbe:
     """Probe to discover entities for a device."""
 
-    def discover_device_entities(self, device: Device) -> None:
+    def discover_device_entities(
+        self, device: Device
+    ) -> Iterator[PlatformEntity | sensor.DeviceCounterSensor]:
         """Discover entities for a ZHA device."""
         _LOGGER.debug(
             "Discovering entities for device: %s-%s",
@@ -241,7 +244,7 @@ class DeviceProbe:
 
         PLATFORM_ENTITIES.clean_up()
 
-    def discover_quirks_v2_entities(self, device: Device) -> None:
+    def discover_quirks_v2_entities(self, device: Device) -> Iterator[PlatformEntity]:
         """Discover entities for a ZHA device exposed by quirks v2."""
         _LOGGER.debug(
             "Attempting to discover quirks v2 entities for device: %s-%s",
@@ -386,7 +389,9 @@ class DeviceProbe:
                     [cluster_handler.name],
                 )
 
-    def discover_coordinator_device_entities(self, device: Device) -> None:
+    def discover_coordinator_device_entities(
+        self, device: Device
+    ) -> Iterator[sensor.DeviceCounterSensor]:
         """Discover entities for the coordinator device."""
         _LOGGER.debug(
             "Discovering entities for coordinator device: %s-%s",
@@ -421,7 +426,9 @@ class DeviceProbe:
 class EndpointProbe:
     """All discovered cluster handlers and entities of an endpoint."""
 
-    def discover_entities(self, endpoint: Endpoint, device_overrides) -> None:
+    def discover_entities(
+        self, endpoint: Endpoint, device_overrides
+    ) -> Iterator[PlatformEntity]:
         """Process an endpoint on a zigpy device."""
         if endpoint.device.is_coordinator:
             return
@@ -439,7 +446,9 @@ class EndpointProbe:
             endpoint, config_diagnostic_entities=True
         )
 
-    def discover_by_device_type(self, endpoint: Endpoint, device_overrides) -> None:
+    def discover_by_device_type(
+        self, endpoint: Endpoint, device_overrides
+    ) -> Iterator[PlatformEntity]:
         """Process an endpoint on a zigpy device."""
 
         unique_id = endpoint.unique_id
@@ -480,7 +489,7 @@ class EndpointProbe:
         platform: Platform | None,
         cluster_handler: ClusterHandler,
         endpoint: Endpoint,
-    ) -> None:
+    ) -> Iterator[PlatformEntity]:
         """Probe specified cluster for specific platform."""
         if platform is None or platform not in PLATFORMS:
             return
@@ -506,7 +515,7 @@ class EndpointProbe:
             cluster_handlers=claimed,
         )
 
-    def discover_by_cluster_id(self, endpoint: Endpoint) -> None:
+    def discover_by_cluster_id(self, endpoint: Endpoint) -> Iterator[PlatformEntity]:
         """Process an endpoint on a zigpy device."""
 
         items = SINGLE_INPUT_CLUSTER_DEVICE_CLASS.items()
@@ -535,7 +544,9 @@ class EndpointProbe:
         # until we can get rid of registries
         yield from self.handle_on_off_output_cluster_exception(endpoint)
 
-    def handle_on_off_output_cluster_exception(self, endpoint: Endpoint) -> None:
+    def handle_on_off_output_cluster_exception(
+        self, endpoint: Endpoint
+    ) -> Iterator[PlatformEntity]:
         """Process output clusters of the endpoint."""
 
         profile_id = endpoint.zigpy_endpoint.profile_id
@@ -571,7 +582,7 @@ class EndpointProbe:
         self,
         endpoint: Endpoint,
         config_diagnostic_entities: bool = False,
-    ) -> None:
+    ) -> Iterator[PlatformEntity]:
         """Process an endpoint on and discover multiple entities."""
 
         ep_profile_id = endpoint.zigpy_endpoint.profile_id
@@ -633,7 +644,7 @@ class GroupProbe:
     """Determine the appropriate platform for a group."""
 
     @staticmethod
-    def discover_group_entities(group: Group) -> Generator[GroupEntity, None, None]:
+    def discover_group_entities(group: Group) -> Iterator[GroupEntity]:
         """Process a group and create any entities that are needed."""
         # only create a group entity if there are 2 or more members in a group
         if len(group.members) < 2:

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -242,10 +242,6 @@ class Gateway(AsyncUtilMixin, EventBase):
 
     async def _async_initialize(self) -> None:
         """Initialize controller and connect radio."""
-        discovery.DEVICE_PROBE.initialize(self)
-        discovery.ENDPOINT_PROBE.initialize(self)
-        discovery.GROUP_PROBE.initialize(self)
-
         self.shutting_down = False
 
         app_controller_cls, app_config = self.get_application_controller_data()
@@ -314,7 +310,13 @@ class Gateway(AsyncUtilMixin, EventBase):
                 delta_msg,
                 zha_device.consider_unavailable_time,
             )
-        self.create_platform_entities()
+
+            for entity in discovery.DEVICE_PROBE.discover_device_entities(zha_device):
+                if entity is not None:
+                    entity.on_add()
+                    zha_device.platform_entities[
+                        (entity.PLATFORM, entity.unique_id)
+                    ] = entity
 
     def load_groups(self) -> None:
         """Initialize ZHA groups."""
@@ -328,20 +330,12 @@ class Gateway(AsyncUtilMixin, EventBase):
             for entity in discovery.GROUP_PROBE.discover_group_entities(zha_group):
                 entity.on_add()
 
-    def create_platform_entities(self) -> None:
-        """Create platform entities."""
-
-        for platform in discovery.PLATFORMS:
-            for entity in self.config.platforms[platform]:
-                if entity is not None:
-                    entity.on_add()
-
-            self.config.platforms[platform].clear()
-
     @property
     def radio_concurrency(self) -> int:
         """Maximum configured radio concurrency."""
-        return self.application_controller._concurrent_requests_semaphore.max_value  # pylint: disable=protected-access
+        return (
+            self.application_controller._concurrent_requests_semaphore.max_value
+        )  # pylint: disable=protected-access
 
     async def async_fetch_updated_state_mains(self) -> None:
         """Fetch updated state for mains powered devices."""
@@ -411,7 +405,9 @@ class Gateway(AsyncUtilMixin, EventBase):
             ),
         )
 
-    def raw_device_initialized(self, device: zigpy.device.Device) -> None:  # pylint: disable=unused-argument
+    def raw_device_initialized(
+        self, device: zigpy.device.Device
+    ) -> None:  # pylint: disable=unused-argument
         """Handle a device initialization without quirks loaded."""
 
         self.emit(
@@ -562,6 +558,14 @@ class Gateway(AsyncUtilMixin, EventBase):
         if (zha_device := self._devices.get(zigpy_device.ieee)) is None:
             zha_device = Device.new(zigpy_device, self)
             self._devices[zigpy_device.ieee] = zha_device
+
+            for entity in discovery.DEVICE_PROBE.discover_device_entities(zha_device):
+                if entity is not None:
+                    entity.on_add()
+                    zha_device.platform_entities[
+                        (entity.PLATFORM, entity.unique_id)
+                    ] = entity
+
         return zha_device
 
     def get_or_create_group(self, zigpy_group: zigpy.group.Group) -> Group:
@@ -629,7 +633,14 @@ class Gateway(AsyncUtilMixin, EventBase):
             **zha_device.extended_device_info.__dict__,
         )
         await zha_device.async_initialize(from_cache=False)
-        self.create_platform_entities()
+
+        for entity in discovery.DEVICE_PROBE.discover_device_entities(zha_device):
+            if entity is not None:
+                entity.on_add()
+                zha_device.platform_entities[
+                    (entity.PLATFORM, entity.unique_id)
+                ] = entity
+
         self.emit(
             ZHA_GW_MSG_DEVICE_FULL_INIT,
             DeviceFullInitEvent(device_info=device_info, new_join=True),

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -327,9 +327,7 @@ class Gateway(AsyncUtilMixin, EventBase):
     @property
     def radio_concurrency(self) -> int:
         """Maximum configured radio concurrency."""
-        return (
-            self.application_controller._concurrent_requests_semaphore.max_value
-        )  # pylint: disable=protected-access
+        return self.application_controller._concurrent_requests_semaphore.max_value  # pylint: disable=protected-access
 
     async def async_fetch_updated_state_mains(self) -> None:
         """Fetch updated state for mains powered devices."""
@@ -399,9 +397,7 @@ class Gateway(AsyncUtilMixin, EventBase):
             ),
         )
 
-    def raw_device_initialized(
-        self, device: zigpy.device.Device
-    ) -> None:  # pylint: disable=unused-argument
+    def raw_device_initialized(self, device: zigpy.device.Device) -> None:  # pylint: disable=unused-argument
         """Handle a device initialization without quirks loaded."""
 
         self.emit(
@@ -556,6 +552,9 @@ class Gateway(AsyncUtilMixin, EventBase):
             if (entity.PLATFORM, entity.unique_id) in device.platform_entities:
                 continue
 
+            if not entity.is_supported():
+                continue
+
             entity.on_add()
             device.platform_entities[(entity.PLATFORM, entity.unique_id)] = entity
 
@@ -564,7 +563,6 @@ class Gateway(AsyncUtilMixin, EventBase):
         if (zha_device := self._devices.get(zigpy_device.ieee)) is None:
             zha_device = Device.new(zigpy_device, self)
             self._devices[zigpy_device.ieee] = zha_device
-            self._maybe_create_device_entities(zha_device)
 
         return zha_device
 
@@ -653,6 +651,8 @@ class Gateway(AsyncUtilMixin, EventBase):
             pairing_status=DevicePairingStatus.CONFIGURED,
             **zha_device.extended_device_info.__dict__,
         )
+        self._maybe_create_device_entities(zha_device)
+
         self.emit(
             ZHA_GW_MSG_DEVICE_FULL_INIT,
             DeviceFullInitEvent(device_info=device_info),

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -635,7 +635,6 @@ class Gateway(AsyncUtilMixin, EventBase):
         # we don't have to do this on a nwk swap
         # but we don't have a way to tell currently
         await zha_device.async_configure()
-        await zha_device.async_initialize(from_cache=True)
 
         self.emit(
             ZHA_GW_MSG_DEVICE_FULL_INIT,
@@ -646,7 +645,7 @@ class Gateway(AsyncUtilMixin, EventBase):
                 )
             ),
         )
-        # force async_initialize() to fire so don't explicitly call it
+        # Mark the device as unavailable, `async_initialize` will be called later
         zha_device.available = False
         zha_device.on_network = True
 

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -310,7 +310,7 @@ class Gateway(AsyncUtilMixin, EventBase):
                 delta_msg,
                 zha_device.consider_unavailable_time,
             )
-            self._maybe_create_device_entities(zha_device)
+            self._maybe_create_entities(zha_device)
 
     def load_groups(self) -> None:
         """Initialize ZHA groups."""
@@ -543,7 +543,7 @@ class Gateway(AsyncUtilMixin, EventBase):
         """Return groups."""
         return self._groups
 
-    def _maybe_create_device_entities(self, device: Device) -> list:
+    def _maybe_create_entities(self, device: Device) -> list:
         """Create entities for a device if it is already initialized."""
         entities = []
 
@@ -630,7 +630,7 @@ class Gateway(AsyncUtilMixin, EventBase):
             pairing_status=DevicePairingStatus.CONFIGURED,
             **zha_device.extended_device_info.__dict__,
         )
-        entities = self._maybe_create_device_entities(zha_device)
+        entities = self._maybe_create_entities(zha_device)
         await zha_device.async_initialize(from_cache=False)
 
         for entity in entities:
@@ -658,7 +658,7 @@ class Gateway(AsyncUtilMixin, EventBase):
             pairing_status=DevicePairingStatus.CONFIGURED,
             **zha_device.extended_device_info.__dict__,
         )
-        entities = self._maybe_create_device_entities(zha_device)
+        entities = self._maybe_create_entities(zha_device)
 
         for entity in entities:
             entity.recompute_capabilities()

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -548,9 +548,6 @@ class Gateway(AsyncUtilMixin, EventBase):
         entities = []
 
         for entity in discovery.DEVICE_PROBE.discover_device_entities(device):
-            if entity is None:
-                continue
-
             if (entity.PLATFORM, entity.unique_id) in device.platform_entities:
                 continue
 

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -257,7 +257,7 @@ class Gateway(AsyncUtilMixin, EventBase):
             self._find_coordinator_device()
         )
 
-        self.load_devices()
+        await self.load_devices()
         self.load_groups()
 
         self.application_controller.add_listener(self)
@@ -289,7 +289,7 @@ class Gateway(AsyncUtilMixin, EventBase):
 
         return zigpy_coordinator
 
-    def load_devices(self) -> None:
+    async def load_devices(self) -> None:
         """Restore ZHA devices from zigpy application state."""
 
         assert self.application_controller
@@ -310,7 +310,8 @@ class Gateway(AsyncUtilMixin, EventBase):
                 delta_msg,
                 zha_device.consider_unavailable_time,
             )
-            self._maybe_create_entities(zha_device)
+
+            await zha_device.async_initialize(from_cache=True)
 
     def load_groups(self) -> None:
         """Initialize ZHA groups."""
@@ -543,21 +544,6 @@ class Gateway(AsyncUtilMixin, EventBase):
         """Return groups."""
         return self._groups
 
-    def _maybe_create_entities(self, device: Device) -> list:
-        """Create entities for a device if it is already initialized."""
-        entities = []
-
-        for entity in discovery.DEVICE_PROBE.discover_device_entities(device):
-            if (entity.PLATFORM, entity.unique_id) in device.platform_entities:
-                continue
-
-            entity.on_add()
-            device.platform_entities[(entity.PLATFORM, entity.unique_id)] = entity
-
-            entities.append(entity)
-
-        return entities
-
     def get_or_create_device(self, zigpy_device: zigpy.device.Device) -> Device:
         """Get or create a ZHA device."""
         if (zha_device := self._devices.get(zigpy_device.ieee)) is None:
@@ -630,15 +616,8 @@ class Gateway(AsyncUtilMixin, EventBase):
             pairing_status=DevicePairingStatus.CONFIGURED,
             **zha_device.extended_device_info.__dict__,
         )
-        entities = self._maybe_create_entities(zha_device)
-        await zha_device.async_initialize(from_cache=False)
 
-        for entity in entities:
-            entity.recompute_capabilities()
-
-            if not entity.is_supported():
-                del zha_device.platform_entities[(entity.PLATFORM, entity.unique_id)]
-                await entity.on_remove()
+        await zha_device.async_initialize()
 
         self.emit(
             ZHA_GW_MSG_DEVICE_FULL_INIT,
@@ -658,10 +637,8 @@ class Gateway(AsyncUtilMixin, EventBase):
             pairing_status=DevicePairingStatus.CONFIGURED,
             **zha_device.extended_device_info.__dict__,
         )
-        entities = self._maybe_create_entities(zha_device)
 
-        for entity in entities:
-            entity.recompute_capabilities()
+        await zha_device.async_initialize(from_cache=True)
 
         self.emit(
             ZHA_GW_MSG_DEVICE_FULL_INIT,

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -333,7 +333,8 @@ class Gateway(AsyncUtilMixin, EventBase):
 
         for platform in discovery.PLATFORMS:
             for entity in self.config.platforms[platform]:
-                entity.on_add()
+                if entity is not None:
+                    entity.on_add()
 
             self.config.platforms[platform].clear()
 

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -630,8 +630,8 @@ class Gateway(AsyncUtilMixin, EventBase):
             pairing_status=DevicePairingStatus.CONFIGURED,
             **zha_device.extended_device_info.__dict__,
         )
-        await zha_device.async_initialize(from_cache=False)
         self._maybe_create_device_entities(zha_device)
+        await zha_device.async_initialize(from_cache=False)
 
         self.emit(
             ZHA_GW_MSG_DEVICE_FULL_INIT,

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -324,29 +324,17 @@ class Gateway(AsyncUtilMixin, EventBase):
             zha_group = self.get_or_create_group(group)
             # we can do this here because the entities are in the
             # entity registry tied to the devices
-            discovery.GROUP_PROBE.discover_group_entities(zha_group)
+
+            for entity in discovery.GROUP_PROBE.discover_group_entities(zha_group):
+                entity.on_add()
 
     def create_platform_entities(self) -> None:
         """Create platform entities."""
 
         for platform in discovery.PLATFORMS:
-            for platform_entity_class, args, kw_args in self.config.platforms[platform]:
-                try:
-                    platform_entity = platform_entity_class.create_platform_entity(
-                        *args, **kw_args
-                    )
-                except Exception:  # pylint: disable=broad-except
-                    _LOGGER.exception(
-                        "Failed to create platform entity: %s [args=%s, kwargs=%s]",
-                        platform_entity_class,
-                        args,
-                        kw_args,
-                    )
-                    continue
-                if platform_entity:
-                    _LOGGER.debug(
-                        "Platform entity data: %s", platform_entity.info_object
-                    )
+            for entity in self.config.platforms[platform]:
+                entity.on_add()
+
             self.config.platforms[platform].clear()
 
     @property
@@ -473,7 +461,10 @@ class Gateway(AsyncUtilMixin, EventBase):
         # need to handle endpoint correctly on groups
         zha_group = self.get_or_create_group(zigpy_group)
         zha_group.clear_caches()
-        discovery.GROUP_PROBE.discover_group_entities(zha_group)
+
+        for entity in discovery.GROUP_PROBE.discover_group_entities(zha_group):
+            entity.on_add()
+
         zha_group.info("group_member_removed - endpoint: %s", endpoint)
         self._emit_group_gateway_message(zigpy_group, ZHA_GW_MSG_GROUP_MEMBER_REMOVED)
 
@@ -484,7 +475,10 @@ class Gateway(AsyncUtilMixin, EventBase):
         # need to handle endpoint correctly on groups
         zha_group = self.get_or_create_group(zigpy_group)
         zha_group.clear_caches()
-        discovery.GROUP_PROBE.discover_group_entities(zha_group)
+
+        for entity in discovery.GROUP_PROBE.discover_group_entities(zha_group):
+            entity.on_add()
+
         zha_group.info("group_member_added - endpoint: %s", endpoint)
         self._emit_group_gateway_message(zigpy_group, ZHA_GW_MSG_GROUP_MEMBER_ADDED)
 

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -310,13 +310,7 @@ class Gateway(AsyncUtilMixin, EventBase):
                 delta_msg,
                 zha_device.consider_unavailable_time,
             )
-
-            for entity in discovery.DEVICE_PROBE.discover_device_entities(zha_device):
-                if entity is not None:
-                    entity.on_add()
-                    zha_device.platform_entities[
-                        (entity.PLATFORM, entity.unique_id)
-                    ] = entity
+            self._maybe_create_device_entities(zha_device)
 
     def load_groups(self) -> None:
         """Initialize ZHA groups."""
@@ -553,18 +547,24 @@ class Gateway(AsyncUtilMixin, EventBase):
         """Return groups."""
         return self._groups
 
+    def _maybe_create_device_entities(self, device: Device) -> None:
+        """Create entities for a device if it is already initialized."""
+        for entity in discovery.DEVICE_PROBE.discover_device_entities(device):
+            if entity is None:
+                continue
+
+            if (entity.PLATFORM, entity.unique_id) in device.platform_entities:
+                continue
+
+            entity.on_add()
+            device.platform_entities[(entity.PLATFORM, entity.unique_id)] = entity
+
     def get_or_create_device(self, zigpy_device: zigpy.device.Device) -> Device:
         """Get or create a ZHA device."""
         if (zha_device := self._devices.get(zigpy_device.ieee)) is None:
             zha_device = Device.new(zigpy_device, self)
             self._devices[zigpy_device.ieee] = zha_device
-
-            for entity in discovery.DEVICE_PROBE.discover_device_entities(zha_device):
-                if entity is not None:
-                    entity.on_add()
-                    zha_device.platform_entities[
-                        (entity.PLATFORM, entity.unique_id)
-                    ] = entity
+            self._maybe_create_device_entities(zha_device)
 
         return zha_device
 
@@ -633,13 +633,7 @@ class Gateway(AsyncUtilMixin, EventBase):
             **zha_device.extended_device_info.__dict__,
         )
         await zha_device.async_initialize(from_cache=False)
-
-        for entity in discovery.DEVICE_PROBE.discover_device_entities(zha_device):
-            if entity is not None:
-                entity.on_add()
-                zha_device.platform_entities[
-                    (entity.PLATFORM, entity.unique_id)
-                ] = entity
+        self._maybe_create_device_entities(zha_device)
 
         self.emit(
             ZHA_GW_MSG_DEVICE_FULL_INIT,

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -543,8 +543,10 @@ class Gateway(AsyncUtilMixin, EventBase):
         """Return groups."""
         return self._groups
 
-    def _maybe_create_device_entities(self, device: Device) -> None:
+    def _maybe_create_device_entities(self, device: Device) -> list:
         """Create entities for a device if it is already initialized."""
+        entities = []
+
         for entity in discovery.DEVICE_PROBE.discover_device_entities(device):
             if entity is None:
                 continue
@@ -557,6 +559,10 @@ class Gateway(AsyncUtilMixin, EventBase):
 
             entity.on_add()
             device.platform_entities[(entity.PLATFORM, entity.unique_id)] = entity
+
+            entities.append(entity)
+
+        return entities
 
     def get_or_create_device(self, zigpy_device: zigpy.device.Device) -> Device:
         """Get or create a ZHA device."""
@@ -630,8 +636,11 @@ class Gateway(AsyncUtilMixin, EventBase):
             pairing_status=DevicePairingStatus.CONFIGURED,
             **zha_device.extended_device_info.__dict__,
         )
-        self._maybe_create_device_entities(zha_device)
+        entities = self._maybe_create_device_entities(zha_device)
         await zha_device.async_initialize(from_cache=False)
+
+        for entity in entities:
+            entity.recompute_capabilities()
 
         self.emit(
             ZHA_GW_MSG_DEVICE_FULL_INIT,
@@ -651,7 +660,10 @@ class Gateway(AsyncUtilMixin, EventBase):
             pairing_status=DevicePairingStatus.CONFIGURED,
             **zha_device.extended_device_info.__dict__,
         )
-        self._maybe_create_device_entities(zha_device)
+        entities = self._maybe_create_device_entities(zha_device)
+
+        for entity in entities:
+            entity.recompute_capabilities()
 
         self.emit(
             ZHA_GW_MSG_DEVICE_FULL_INIT,

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -611,17 +611,19 @@ class Gateway(AsyncUtilMixin, EventBase):
     async def _async_device_joined(self, zha_device: Device) -> None:
         zha_device.available = True
         zha_device.on_network = True
-        await zha_device.async_configure()
-        device_info = ExtendedDeviceInfoWithPairingStatus(
-            pairing_status=DevicePairingStatus.CONFIGURED,
-            **zha_device.extended_device_info.__dict__,
-        )
 
+        await zha_device.async_configure()
         await zha_device.async_initialize()
 
         self.emit(
             ZHA_GW_MSG_DEVICE_FULL_INIT,
-            DeviceFullInitEvent(device_info=device_info, new_join=True),
+            DeviceFullInitEvent(
+                device_info=ExtendedDeviceInfoWithPairingStatus(
+                    pairing_status=DevicePairingStatus.CONFIGURED,
+                    **zha_device.extended_device_info.__dict__,
+                ),
+                new_join=True,
+            ),
         )
 
     async def _async_device_rejoined(self, zha_device: Device) -> None:
@@ -633,16 +635,16 @@ class Gateway(AsyncUtilMixin, EventBase):
         # we don't have to do this on a nwk swap
         # but we don't have a way to tell currently
         await zha_device.async_configure()
-        device_info = ExtendedDeviceInfoWithPairingStatus(
-            pairing_status=DevicePairingStatus.CONFIGURED,
-            **zha_device.extended_device_info.__dict__,
-        )
-
         await zha_device.async_initialize(from_cache=True)
 
         self.emit(
             ZHA_GW_MSG_DEVICE_FULL_INIT,
-            DeviceFullInitEvent(device_info=device_info),
+            DeviceFullInitEvent(
+                device_info=ExtendedDeviceInfoWithPairingStatus(
+                    pairing_status=DevicePairingStatus.CONFIGURED,
+                    **zha_device.extended_device_info.__dict__,
+                )
+            ),
         )
         # force async_initialize() to fire so don't explicitly call it
         zha_device.available = False

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -554,9 +554,6 @@ class Gateway(AsyncUtilMixin, EventBase):
             if (entity.PLATFORM, entity.unique_id) in device.platform_entities:
                 continue
 
-            if not entity.is_supported():
-                continue
-
             entity.on_add()
             device.platform_entities[(entity.PLATFORM, entity.unique_id)] = entity
 
@@ -641,6 +638,10 @@ class Gateway(AsyncUtilMixin, EventBase):
 
         for entity in entities:
             entity.recompute_capabilities()
+
+            if not entity.is_supported():
+                del zha_device.platform_entities[(entity.PLATFORM, entity.unique_id)]
+                await entity.on_remove()
 
         self.emit(
             ZHA_GW_MSG_DEVICE_FULL_INIT,

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -118,6 +118,7 @@ class BaseEntity(LogMixin, EventBase):
     _attr_device_class: str | None
     _attr_state_class: str | None
     _attr_enabled: bool = True
+    _attr_always_supported: bool = False
 
     def __init__(self, unique_id: str) -> None:
         """Initialize the platform entity."""
@@ -131,6 +132,12 @@ class BaseEntity(LogMixin, EventBase):
         self._on_remove_callbacks: list[Callable[[], None]] = []
 
     def is_supported(self) -> bool:
+        if self._attr_always_supported:
+            return True
+
+        return self._is_supported()
+
+    def _is_supported(self) -> bool:
         return True
 
     def recompute_capabilities(self) -> None:
@@ -333,6 +340,9 @@ class PlatformEntity(BaseEntity):
         """Init this entity from the quirks metadata."""
         if entity_metadata.initially_disabled:
             self._attr_entity_registry_enabled_default = False
+
+        # v2 quirks entities are assumed to always be supported
+        self._attr_always_supported = True
 
         has_attribute_name = hasattr(entity_metadata, "attribute_name")
         has_command_name = hasattr(entity_metadata, "command_name")

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -132,15 +132,18 @@ class BaseEntity(LogMixin, EventBase):
         self._on_remove_callbacks: list[Callable[[], None]] = []
 
     def is_supported(self) -> bool:
+        """Return if the entity is supported for the device."""
         if self._attr_always_supported:
             return True
 
         return self._is_supported()
 
     def _is_supported(self) -> bool:
+        """Return if the entity is supported for the device, internal."""
         return True
 
     def recompute_capabilities(self) -> None:
+        """Recompute capabilities and feature flags."""
         pass
 
     @property

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -323,21 +323,6 @@ class PlatformEntity(BaseEntity):
         self._device: Device = device
         self._endpoint = endpoint
 
-    @classmethod
-    def create_platform_entity(
-        cls: type[PlatformEntity],
-        unique_id: str,
-        cluster_handlers: list[ClusterHandler],
-        endpoint: Endpoint,
-        device: Device,
-        **kwargs: Any,
-    ) -> PlatformEntity | None:
-        """Entity Factory.
-
-        Return a platform entity if it is a supported configuration, otherwise return None
-        """
-        return cls(unique_id, cluster_handlers, endpoint, device, **kwargs)
-
     def _init_from_quirks_metadata(self, entity_metadata: EntityMetadata) -> None:
         """Init this entity from the quirks metadata."""
         if entity_metadata.initially_disabled:

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -133,6 +133,9 @@ class BaseEntity(LogMixin, EventBase):
     def is_supported(self) -> bool:
         return True
 
+    def recompute_capabilities(self) -> None:
+        pass
+
     @property
     def enabled(self) -> bool:
         """Return the entity enabled state."""

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -247,6 +247,10 @@ class BaseEntity(LogMixin, EventBase):
         """Disable the entity."""
         self.enabled = False
 
+    def on_add(self) -> None:
+        """Run when entity is added."""
+        pass
+
     async def on_remove(self) -> None:
         """Cancel tasks and timers this entity owns."""
         for handle in self._tracked_handles:
@@ -305,20 +309,28 @@ class PlatformEntity(BaseEntity):
 
         self._cluster_handlers: list[ClusterHandler] = cluster_handlers
         self.cluster_handlers: dict[str, ClusterHandler] = {}
+
         for cluster_handler in cluster_handlers:
             self.cluster_handlers[cluster_handler.name] = cluster_handler
+
         self._device: Device = device
         self._endpoint = endpoint
+
+    def on_add(self) -> None:
+        """Run when entity is added."""
+        super().on_add()
+
         # we double create these in discovery tests because we reissue the create calls to count and prove them out
-        if (self.PLATFORM, self.unique_id) not in self._device.platform_entities:
-            self._device.platform_entities[(self.PLATFORM, self.unique_id)] = self
-        else:
+        if (self.PLATFORM, self.unique_id) in self._device.platform_entities:
             _LOGGER.debug(
                 "Not registering entity %r, unique id %r already exists: %r",
                 self,
                 (self.PLATFORM, self.unique_id),
                 self._device.platform_entities[(self.PLATFORM, self.unique_id)],
             )
+            return
+
+        self._device.platform_entities[(self.PLATFORM, self.unique_id)] = self
 
     @classmethod
     def create_platform_entity(
@@ -444,7 +456,6 @@ class GroupEntity(BaseEntity):
             immediate=False,
             function=self.update,
         )
-        self._group.register_group_entity(self)
 
     @cached_property
     def identifiers(self) -> GroupEntityIdentifiers:
@@ -494,9 +505,16 @@ class GroupEntity(BaseEntity):
         assert self._change_listener_debouncer
         self.group.gateway.create_task(self._change_listener_debouncer.async_call())
 
+    def on_add(self) -> None:
+        """Run when entity is added."""
+        super().on_add()
+        self._group.register_group_entity(self)
+
     async def on_remove(self) -> None:
         """Cancel tasks this entity owns."""
         await super().on_remove()
+        self._group.unregister_group_entity(self)
+
         if self._change_listener_debouncer:
             self._change_listener_debouncer.async_cancel()
 

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -130,6 +130,9 @@ class BaseEntity(LogMixin, EventBase):
         self._tracked_handles: list[asyncio.Handle] = []
         self._on_remove_callbacks: list[Callable[[], None]] = []
 
+    def is_supported(self) -> bool:
+        return True
+
     @property
     def enabled(self) -> bool:
         """Return the entity enabled state."""

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 import asyncio
+from collections.abc import Callable
 from contextlib import suppress
 import dataclasses
 from enum import StrEnum
@@ -127,6 +128,7 @@ class BaseEntity(LogMixin, EventBase):
         self.__previous_state: Any = None
         self._tracked_tasks: list[asyncio.Task] = []
         self._tracked_handles: list[asyncio.Handle] = []
+        self._on_remove_callbacks: list[Callable[[], None]] = []
 
     @property
     def enabled(self) -> bool:
@@ -253,6 +255,11 @@ class BaseEntity(LogMixin, EventBase):
 
     async def on_remove(self) -> None:
         """Cancel tasks and timers this entity owns."""
+        while self._on_remove_callbacks:
+            callback = self._on_remove_callbacks.pop()
+            self.debug("Running remove callback: %s", callback)
+            callback()
+
         for handle in self._tracked_handles:
             self.debug("Cancelling handle: %s", handle)
             handle.cancel()

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -316,22 +316,6 @@ class PlatformEntity(BaseEntity):
         self._device: Device = device
         self._endpoint = endpoint
 
-    def on_add(self) -> None:
-        """Run when entity is added."""
-        super().on_add()
-
-        # we double create these in discovery tests because we reissue the create calls to count and prove them out
-        if (self.PLATFORM, self.unique_id) in self._device.platform_entities:
-            _LOGGER.debug(
-                "Not registering entity %r, unique id %r already exists: %r",
-                self,
-                (self.PLATFORM, self.unique_id),
-                self._device.platform_entities[(self.PLATFORM, self.unique_id)],
-            )
-            return
-
-        self._device.platform_entities[(self.PLATFORM, self.unique_id)] = self
-
     @classmethod
     def create_platform_entity(
         cls: type[PlatformEntity],

--- a/zha/application/platforms/alarm_control_panel/__init__.py
+++ b/zha/application/platforms/alarm_control_panel/__init__.py
@@ -78,6 +78,7 @@ class AlarmControlPanel(PlatformEntity):
         self._cluster_handler.max_invalid_tries = alarm_options.failed_tries
 
     def on_add(self) -> None:
+        """Run when entity is added."""
         super().on_add()
         self._on_remove_callbacks.append(
             self._cluster_handler.on_event(

--- a/zha/application/platforms/alarm_control_panel/__init__.py
+++ b/zha/application/platforms/alarm_control_panel/__init__.py
@@ -76,8 +76,13 @@ class AlarmControlPanel(PlatformEntity):
             alarm_options.arm_requires_code
         )
         self._cluster_handler.max_invalid_tries = alarm_options.failed_tries
-        self._cluster_handler.on_event(
-            CLUSTER_HANDLER_STATE_CHANGED, self._handle_event_protocol
+
+    def on_add(self) -> None:
+        super().on_add()
+        self._on_remove_callbacks.append(
+            self._cluster_handler.on_event(
+                CLUSTER_HANDLER_STATE_CHANGED, self._handle_event_protocol
+            )
         )
 
     @functools.cached_property

--- a/zha/application/platforms/binary_sensor/__init__.py
+++ b/zha/application/platforms/binary_sensor/__init__.py
@@ -75,9 +75,14 @@ class BinarySensor(PlatformEntity):
         self._cluster_handler = cluster_handlers[0]
         super().__init__(unique_id, cluster_handlers, endpoint, device, **kwargs)
         self._state: bool = self.is_on
-        self._cluster_handler.on_event(
-            CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
-            self.handle_cluster_handler_attribute_updated,
+
+    def on_add(self) -> None:
+        super().on_add()
+        self._on_remove_callbacks.append(
+            self._cluster_handler.on_event(
+                CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
+                self.handle_cluster_handler_attribute_updated,
+            )
         )
 
     def _init_from_quirks_metadata(self, entity_metadata: BinarySensorMetadata) -> None:

--- a/zha/application/platforms/binary_sensor/__init__.py
+++ b/zha/application/platforms/binary_sensor/__init__.py
@@ -77,6 +77,7 @@ class BinarySensor(PlatformEntity):
         self._state: bool = self.is_on
 
     def on_add(self) -> None:
+        """Run when entity is added."""
         super().on_add()
         self._on_remove_callbacks.append(
             self._cluster_handler.on_event(

--- a/zha/application/platforms/button/__init__.py
+++ b/zha/application/platforms/button/__init__.py
@@ -147,6 +147,7 @@ class WriteAttributeButton(PlatformEntity):
         if ENTITY_METADATA in kwargs:
             self._init_from_quirks_metadata(kwargs[ENTITY_METADATA])
         super().__init__(unique_id, cluster_handlers, endpoint, device, **kwargs)
+        self.recompute_capabilities()
 
     def _init_from_quirks_metadata(
         self, entity_metadata: WriteAttributeButtonMetadata

--- a/zha/application/platforms/button/__init__.py
+++ b/zha/application/platforms/button/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import functools
 import logging
-from typing import TYPE_CHECKING, Any, Self
+from typing import TYPE_CHECKING, Any
 
 from zigpy.quirks.v2 import WriteAttributeButtonMetadata, ZCLCommandButtonMetadata
 

--- a/zha/application/platforms/button/__init__.py
+++ b/zha/application/platforms/button/__init__.py
@@ -117,13 +117,13 @@ class IdentifyButton(Button):
     _kwargs = {}
     _args = [DEFAULT_DURATION]
 
-    def is_supported(self) -> bool:
+    def _is_supported(self) -> bool:
         if PLATFORM_ENTITIES.prevent_entity_creation(
             Platform.BUTTON, self.device.ieee, CLUSTER_HANDLER_IDENTIFY
         ):
             return False
 
-        return True
+        return super()._is_supported()
 
 
 class WriteAttributeButton(PlatformEntity):

--- a/zha/application/platforms/button/__init__.py
+++ b/zha/application/platforms/button/__init__.py
@@ -111,30 +111,19 @@ class Button(PlatformEntity):
 class IdentifyButton(Button):
     """Defines a ZHA identify button."""
 
-    @classmethod
-    def create_platform_entity(
-        cls: type[Self],
-        unique_id: str,
-        cluster_handlers: list[ClusterHandler],
-        endpoint: Endpoint,
-        device: Device,
-        **kwargs: Any,
-    ) -> Self | None:
-        """Entity Factory.
-
-        Return entity if it is a supported configuration, otherwise return None
-        """
-        if PLATFORM_ENTITIES.prevent_entity_creation(
-            Platform.BUTTON, device.ieee, CLUSTER_HANDLER_IDENTIFY
-        ):
-            return None
-        return cls(unique_id, cluster_handlers, endpoint, device, **kwargs)
-
     _attr_device_class = ButtonDeviceClass.IDENTIFY
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _command_name = "identify"
     _kwargs = {}
     _args = [DEFAULT_DURATION]
+
+    def is_supported(self) -> bool:
+        if PLATFORM_ENTITIES.prevent_entity_creation(
+            Platform.BUTTON, self.device.ieee, CLUSTER_HANDLER_IDENTIFY
+        ):
+            return False
+
+        return True
 
 
 class WriteAttributeButton(PlatformEntity):

--- a/zha/application/platforms/button/__init__.py
+++ b/zha/application/platforms/button/__init__.py
@@ -118,8 +118,11 @@ class IdentifyButton(Button):
     _args = [DEFAULT_DURATION]
 
     def _is_supported(self) -> bool:
-        if PLATFORM_ENTITIES.prevent_entity_creation(
-            Platform.BUTTON, self.device.ieee, CLUSTER_HANDLER_IDENTIFY
+        cls = type(self)
+        if any(
+            type(entity) is cls
+            for entity in self.device.platform_entities.values()
+            if entity is not self
         ):
             return False
 

--- a/zha/application/platforms/climate/__init__.py
+++ b/zha/application/platforms/climate/__init__.py
@@ -114,10 +114,6 @@ class Thermostat(PlatformEntity):
         self._fan_cluster_handler: ClusterHandler = self.cluster_handlers.get(
             CLUSTER_HANDLER_FAN
         )
-        self._thermostat_cluster_handler.on_event(
-            CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
-            self.handle_cluster_handler_attribute_updated,
-        )
 
         self._supported_features = (
             ClimateEntityFeature.TARGET_TEMPERATURE
@@ -128,6 +124,15 @@ class Thermostat(PlatformEntity):
             self._supported_features |= ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
         if self._fan_cluster_handler is not None:
             self._supported_features |= ClimateEntityFeature.FAN_MODE
+
+    def on_add(self) -> None:
+        super().on_add()
+        self._on_remove_callbacks.append(
+            self._thermostat_cluster_handler.on_event(
+                CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
+                self.handle_cluster_handler_attribute_updated,
+            )
+        )
 
     @functools.cached_property
     def info_object(self) -> ThermostatEntityInfo:
@@ -504,6 +509,9 @@ class SinopeTechnologiesThermostat(Thermostat):
         self._supported_features |= ClimateEntityFeature.PRESET_MODE
         self._manufacturer_ch = self.cluster_handlers["sinope_manufacturer_specific"]
         self._time_update_task: Task | None = None
+
+    def on_add(self) -> None:
+        super().on_add()
         self.start_polling()
 
     def start_polling(self) -> None:

--- a/zha/application/platforms/climate/__init__.py
+++ b/zha/application/platforms/climate/__init__.py
@@ -276,7 +276,7 @@ class Thermostat(PlatformEntity):
         """Return HVAC operation mode."""
         return SYSTEM_MODE_2_HVAC.get(self._thermostat_cluster_handler.system_mode)
 
-    @functools.cached_property
+    @property
     def hvac_modes(self) -> list[HVACMode]:
         """Return the list of available HVAC operation modes."""
         return SEQ_OF_OPERATION.get(

--- a/zha/application/platforms/climate/__init__.py
+++ b/zha/application/platforms/climate/__init__.py
@@ -119,6 +119,7 @@ class Thermostat(PlatformEntity):
         self.recompute_capabilities()
 
     def recompute_capabilities(self) -> None:
+        """Recompute capabilities and feature flags."""
         super().recompute_capabilities()
         self._supported_features = (
             ClimateEntityFeature.TARGET_TEMPERATURE
@@ -133,6 +134,7 @@ class Thermostat(PlatformEntity):
             self._supported_features |= ClimateEntityFeature.FAN_MODE
 
     def on_add(self) -> None:
+        """Run when entity is added."""
         super().on_add()
         self._on_remove_callbacks.append(
             self._thermostat_cluster_handler.on_event(
@@ -517,10 +519,12 @@ class SinopeTechnologiesThermostat(Thermostat):
         self._time_update_task: Task | None = None
 
     def recompute_capabilities(self) -> None:
+        """Recompute capabilities and feature flags."""
         super().recompute_capabilities()
         self._supported_features |= ClimateEntityFeature.PRESET_MODE
 
     def on_add(self) -> None:
+        """Run when entity is added."""
         super().on_add()
         self.start_polling()
 
@@ -640,6 +644,7 @@ class MoesThermostat(Thermostat):
     """Moes Thermostat implementation."""
 
     def recompute_capabilities(self) -> None:
+        """Recompute capabilities and feature flags."""
         super().recompute_capabilities()
         self._presets = [
             Preset.NONE,
@@ -721,6 +726,7 @@ class BecaThermostat(Thermostat):
     """Beca Thermostat implementation."""
 
     def recompute_capabilities(self) -> None:
+        """Recompute capabilities and feature flags."""
         super().recompute_capabilities()
         self._presets = [
             Preset.NONE,
@@ -824,6 +830,7 @@ class ZONNSMARTThermostat(Thermostat):
     PRESET_FROST = "frost protect"
 
     def recompute_capabilities(self) -> None:
+        """Recompute capabilities."""
         super().recompute_capabilities()
         self._presets = [
             Preset.NONE,

--- a/zha/application/platforms/climate/__init__.py
+++ b/zha/application/platforms/climate/__init__.py
@@ -115,13 +115,20 @@ class Thermostat(PlatformEntity):
             CLUSTER_HANDLER_FAN
         )
 
+        self._supported_features = ClimateEntityFeature(0)
+        self.recompute_capabilities()
+
+    def recompute_capabilities(self) -> None:
+        super().recompute_capabilities()
         self._supported_features = (
             ClimateEntityFeature.TARGET_TEMPERATURE
             | ClimateEntityFeature.TURN_OFF
             | ClimateEntityFeature.TURN_ON
         )
+
         if HVACMode.HEAT_COOL in self.hvac_modes:
             self._supported_features |= ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+
         if self._fan_cluster_handler is not None:
             self._supported_features |= ClimateEntityFeature.FAN_MODE
 
@@ -281,12 +288,12 @@ class Thermostat(PlatformEntity):
         """Return current preset mode."""
         return self._preset
 
-    @functools.cached_property
+    @property
     def preset_modes(self) -> list[str] | None:
         """Return supported preset modes."""
         return self._presets
 
-    @functools.cached_property
+    @property
     def supported_features(self) -> ClimateEntityFeature:
         """Return the list of supported features."""
         return self._supported_features
@@ -506,9 +513,12 @@ class SinopeTechnologiesThermostat(Thermostat):
         """Initialize ZHA Thermostat instance."""
         super().__init__(unique_id, cluster_handlers, endpoint, device, **kwargs)
         self._presets = [Preset.AWAY, Preset.NONE]
-        self._supported_features |= ClimateEntityFeature.PRESET_MODE
         self._manufacturer_ch = self.cluster_handlers["sinope_manufacturer_specific"]
         self._time_update_task: Task | None = None
+
+    def recompute_capabilities(self) -> None:
+        super().recompute_capabilities()
+        self._supported_features |= ClimateEntityFeature.PRESET_MODE
 
     def on_add(self) -> None:
         super().on_add()
@@ -629,16 +639,8 @@ class CentralitePearl(ZenWithinThermostat):
 class MoesThermostat(Thermostat):
     """Moes Thermostat implementation."""
 
-    def __init__(
-        self,
-        unique_id: str,
-        cluster_handlers: list[ClusterHandler],
-        endpoint: Endpoint,
-        device: Device,
-        **kwargs,
-    ):
-        """Initialize ZHA Thermostat instance."""
-        super().__init__(unique_id, cluster_handlers, endpoint, device, **kwargs)
+    def recompute_capabilities(self) -> None:
+        super().recompute_capabilities()
         self._presets = [
             Preset.NONE,
             Preset.AWAY,
@@ -718,16 +720,8 @@ class MoesThermostat(Thermostat):
 class BecaThermostat(Thermostat):
     """Beca Thermostat implementation."""
 
-    def __init__(
-        self,
-        unique_id: str,
-        cluster_handlers: list[ClusterHandler],
-        endpoint: Endpoint,
-        device: Device,
-        **kwargs,
-    ):
-        """Initialize ZHA Thermostat instance."""
-        super().__init__(unique_id, cluster_handlers, endpoint, device, **kwargs)
+    def recompute_capabilities(self) -> None:
+        super().recompute_capabilities()
         self._presets = [
             Preset.NONE,
             Preset.AWAY,
@@ -829,16 +823,8 @@ class ZONNSMARTThermostat(Thermostat):
     PRESET_HOLIDAY = "holiday"
     PRESET_FROST = "frost protect"
 
-    def __init__(
-        self,
-        unique_id: str,
-        cluster_handlers: list[ClusterHandler],
-        endpoint: Endpoint,
-        device: Device,
-        **kwargs,
-    ):
-        """Initialize ZHA Thermostat instance."""
-        super().__init__(unique_id, cluster_handlers, endpoint, device, **kwargs)
+    def recompute_capabilities(self) -> None:
+        super().recompute_capabilities()
         self._presets = [
             Preset.NONE,
             self.PRESET_HOLIDAY,

--- a/zha/application/platforms/cover/__init__.py
+++ b/zha/application/platforms/cover/__init__.py
@@ -93,9 +93,11 @@ class Cover(PlatformEntity):
 
     def on_add(self) -> None:
         super().on_add()
-        self._cover_cluster_handler.on_event(
-            CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
-            self.handle_cluster_handler_attribute_updated,
+        self._on_remove_callbacks.append(
+            self._cover_cluster_handler.on_event(
+                CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
+                self.handle_cluster_handler_attribute_updated,
+            )
         )
 
     @property
@@ -399,18 +401,25 @@ class Shade(PlatformEntity):
             position = max(0, min(255, position))
             position = int(position * 100 / 255)
         self._position: int | None = position
-        self._on_off_cluster_handler.on_event(
-            CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
-            self.handle_cluster_handler_attribute_updated,
-        )
-        self._level_cluster_handler.on_event(
-            CLUSTER_HANDLER_LEVEL_CHANGED, self.handle_cluster_handler_set_level
-        )
         self._attr_supported_features: CoverEntityFeature = (
             CoverEntityFeature.OPEN
             | CoverEntityFeature.CLOSE
             | CoverEntityFeature.STOP
             | CoverEntityFeature.SET_POSITION
+        )
+
+    def on_add(self) -> None:
+        super().on_add()
+        self._on_remove_callbacks.append(
+            self._on_off_cluster_handler.on_event(
+                CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
+                self.handle_cluster_handler_attribute_updated,
+            )
+        )
+        self._on_remove_callbacks.append(
+            self._level_cluster_handler.on_event(
+                CLUSTER_HANDLER_LEVEL_CHANGED, self.handle_cluster_handler_set_level
+            )
         )
 
     @property

--- a/zha/application/platforms/cover/__init__.py
+++ b/zha/application/platforms/cover/__init__.py
@@ -92,6 +92,7 @@ class Cover(PlatformEntity):
         self._determine_initial_state()
 
     def on_add(self) -> None:
+        """Run when entity is added."""
         super().on_add()
         self._on_remove_callbacks.append(
             self._cover_cluster_handler.on_event(
@@ -409,6 +410,7 @@ class Shade(PlatformEntity):
         )
 
     def on_add(self) -> None:
+        """Run when entity is added."""
         super().on_add()
         self._on_remove_callbacks.append(
             self._on_off_cluster_handler.on_event(

--- a/zha/application/platforms/cover/__init__.py
+++ b/zha/application/platforms/cover/__init__.py
@@ -90,6 +90,9 @@ class Cover(PlatformEntity):
         self._target_tilt_position: int | None = None
         self._state: str = STATE_OPEN
         self._determine_initial_state()
+
+    def on_add(self) -> None:
+        super().on_add()
         self._cover_cluster_handler.on_event(
             CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
             self.handle_cluster_handler_attribute_updated,

--- a/zha/application/platforms/device_tracker.py
+++ b/zha/application/platforms/device_tracker.py
@@ -68,6 +68,7 @@ class DeviceScannerEntity(PlatformEntity):
         self._battery_level: float | None = None
 
     def on_add(self) -> None:
+        """Run when entity is added."""
         super().on_add()
         self._on_remove_callbacks.append(
             self._battery_cluster_handler.on_event(

--- a/zha/application/platforms/device_tracker.py
+++ b/zha/application/platforms/device_tracker.py
@@ -66,12 +66,18 @@ class DeviceScannerEntity(PlatformEntity):
         self._keepalive_interval: int = 60
         self._should_poll: bool = True
         self._battery_level: float | None = None
-        self._battery_cluster_handler.on_event(
-            CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
-            self.handle_cluster_handler_attribute_updated,
+
+    def on_add(self) -> None:
+        super().on_add()
+        self._on_remove_callbacks.append(
+            self._battery_cluster_handler.on_event(
+                CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
+                self.handle_cluster_handler_attribute_updated,
+            )
         )
+
         self._tracked_tasks.append(
-            device.gateway.async_create_background_task(
+            self.device.gateway.async_create_background_task(
                 self._refresh(),
                 name=f"device_tracker_refresh_{self.unique_id}",
                 eager_start=True,

--- a/zha/application/platforms/fan/__init__.py
+++ b/zha/application/platforms/fan/__init__.py
@@ -217,6 +217,7 @@ class Fan(PlatformEntity, BaseFan):
         self.recompute_capabilities()
 
     def on_add(self) -> None:
+        """Run when entity is added."""
         super().on_add()
         self._on_remove_callbacks.append(
             self._fan_cluster_handler.on_event(

--- a/zha/application/platforms/fan/__init__.py
+++ b/zha/application/platforms/fan/__init__.py
@@ -214,11 +214,15 @@ class Fan(PlatformEntity, BaseFan):
         self._fan_cluster_handler: ClusterHandler = self.cluster_handlers.get(
             CLUSTER_HANDLER_FAN
         )
-        if self._fan_cluster_handler:
+
+    def on_add(self) -> None:
+        super().on_add()
+        self._on_remove_callbacks.append(
             self._fan_cluster_handler.on_event(
                 CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
                 self.handle_cluster_handler_attribute_updated,
             )
+        )
 
     @functools.cached_property
     def info_object(self) -> FanEntityInfo:

--- a/zha/application/platforms/fan/__init__.py
+++ b/zha/application/platforms/fan/__init__.py
@@ -214,6 +214,7 @@ class Fan(PlatformEntity, BaseFan):
         self._fan_cluster_handler: ClusterHandler = self.cluster_handlers.get(
             CLUSTER_HANDLER_FAN
         )
+        self.recompute_capabilities()
 
     def on_add(self) -> None:
         super().on_add()

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -722,18 +722,24 @@ class Light(PlatformEntity, BaseLight):
         self._zha_config_enable_light_transitioning_flag = (
             light_options.enable_light_transitioning_flag
         )
+        self._refresh_task: asyncio.Task | None = None
 
-        self._on_off_cluster_handler.on_event(
-            CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
-            self.handle_cluster_handler_attribute_updated,
+    def on_add(self) -> None:
+        super().on_add()
+        self._on_remove_callbacks.append(
+            self._on_off_cluster_handler.on_event(
+                CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
+                self.handle_cluster_handler_attribute_updated,
+            )
         )
 
         if self._level_cluster_handler:
-            self._level_cluster_handler.on_event(
-                CLUSTER_HANDLER_LEVEL_CHANGED, self.handle_cluster_handler_set_level
+            self._on_remove_callbacks.append(
+                self._level_cluster_handler.on_event(
+                    CLUSTER_HANDLER_LEVEL_CHANGED, self.handle_cluster_handler_set_level
+                )
             )
 
-        self._refresh_task: asyncio.Task | None = None
         self.start_polling()
 
     @functools.cached_property

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -668,9 +668,40 @@ class Light(PlatformEntity, BaseLight):
         if self._color_cluster_handler:
             self._min_mireds: int = self._color_cluster_handler.min_mireds
             self._max_mireds: int = self._color_cluster_handler.max_mireds
-        effect_list = [EFFECT_OFF]
 
-        light_options = device.gateway.config.config.light_options
+        light_options = self.device.gateway.config.config.light_options
+        self._zha_config_transition = light_options.default_light_transition
+        self._zha_config_enhanced_light_transition = (
+            light_options.enable_enhanced_light_transition
+        )
+        self._zha_config_enable_light_transitioning_flag = (
+            light_options.enable_light_transitioning_flag
+        )
+        self._refresh_task: asyncio.Task | None = None
+
+        self.recompute_capabilities()
+
+    def on_add(self) -> None:
+        super().on_add()
+        self._on_remove_callbacks.append(
+            self._on_off_cluster_handler.on_event(
+                CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
+                self.handle_cluster_handler_attribute_updated,
+            )
+        )
+
+        if self._level_cluster_handler:
+            self._on_remove_callbacks.append(
+                self._level_cluster_handler.on_event(
+                    CLUSTER_HANDLER_LEVEL_CHANGED, self.handle_cluster_handler_set_level
+                )
+            )
+
+        self.start_polling()
+
+    def recompute_capabilities(self) -> None:
+        effect_list = [EFFECT_OFF]
+        light_options = self.device.gateway.config.config.light_options
 
         self._supported_color_modes = {ColorMode.ONOFF}
         if self._level_cluster_handler:
@@ -716,35 +747,7 @@ class Light(PlatformEntity, BaseLight):
         if self._identify_cluster_handler:
             self._supported_features |= LightEntityFeature.FLASH
 
-        if effect_list:
-            self._effect_list = effect_list
-
-        self._zha_config_transition = light_options.default_light_transition
-        self._zha_config_enhanced_light_transition = (
-            light_options.enable_enhanced_light_transition
-        )
-        self._zha_config_enable_light_transitioning_flag = (
-            light_options.enable_light_transitioning_flag
-        )
-        self._refresh_task: asyncio.Task | None = None
-
-    def on_add(self) -> None:
-        super().on_add()
-        self._on_remove_callbacks.append(
-            self._on_off_cluster_handler.on_event(
-                CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
-                self.handle_cluster_handler_attribute_updated,
-            )
-        )
-
-        if self._level_cluster_handler:
-            self._on_remove_callbacks.append(
-                self._level_cluster_handler.on_event(
-                    CLUSTER_HANDLER_LEVEL_CHANGED, self.handle_cluster_handler_set_level
-                )
-            )
-
-        self.start_polling()
+        self._effect_list = effect_list
 
     @functools.cached_property
     def info_object(self) -> LightEntityInfo:

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -626,6 +626,10 @@ class BaseLight(BaseEntity, ABC):
                     "zha.light-refresh-debounced-member",
                 )
 
+    async def on_remove(self) -> None:
+        self._async_unsub_transition_listener()
+        await super().on_remove()
+
 
 @STRICT_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_ON_OFF,

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -628,6 +628,7 @@ class BaseLight(BaseEntity, ABC):
                 )
 
     async def on_remove(self) -> None:
+        """Clean up when entity is removed."""
         self._async_unsub_transition_listener()
         await super().on_remove()
 
@@ -683,6 +684,7 @@ class Light(PlatformEntity, BaseLight):
         self.recompute_capabilities()
 
     def on_add(self) -> None:
+        """Run when entity is added."""
         super().on_add()
         self._on_remove_callbacks.append(
             self._on_off_cluster_handler.on_event(
@@ -701,9 +703,9 @@ class Light(PlatformEntity, BaseLight):
         self.start_polling()
 
     def recompute_capabilities(self) -> None:
+        """Recompute capabilities."""
         super().recompute_capabilities()
         effect_list = [EFFECT_OFF]
-        light_options = self.device.gateway.config.config.light_options
 
         self._supported_color_modes = {ColorMode.ONOFF}
         if self._level_cluster_handler:
@@ -1063,6 +1065,7 @@ class LightGroup(GroupEntity, BaseLight):
         self.recompute_capabilities()
 
     def recompute_capabilities(self) -> None:
+        """Recompute capabilities."""
         super().recompute_capabilities()
         light_options = self.group.gateway.config.config.light_options
         self._zha_config_group_members_assume_state = (

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -700,6 +700,7 @@ class Light(PlatformEntity, BaseLight):
         self.start_polling()
 
     def recompute_capabilities(self) -> None:
+        super().recompute_capabilities()
         effect_list = [EFFECT_OFF]
         light_options = self.device.gateway.config.config.light_options
 
@@ -1035,16 +1036,42 @@ class LightGroup(GroupEntity, BaseLight):
         """Initialize a light group."""
         # light groups change the update_group_from_child_delay so we need to do this
         # before calling super
-        light_options = group.gateway.config.config.light_options
-        self._zha_config_group_members_assume_state = (
-            light_options.group_members_assume_state
-        )
         kwargs = {}
         if self._zha_config_group_members_assume_state:
             kwargs["update_group_from_member_delay"] = (
                 ASSUME_UPDATE_GROUP_FROM_CHILD_DELAY
             )
         super().__init__(group, **kwargs)
+
+        self._on_off_cluster_handler: ClusterHandler = group.zigpy_group.endpoint[
+            OnOff.cluster_id
+        ]
+        self._level_cluster_handler: None | (
+            ClusterHandler
+        ) = group.zigpy_group.endpoint[LevelControl.cluster_id]
+        self._color_cluster_handler: None | (
+            ClusterHandler
+        ) = group.zigpy_group.endpoint[Color.cluster_id]
+        self._identify_cluster_handler: None | (
+            ClusterHandler
+        ) = group.zigpy_group.endpoint[Identify.cluster_id]
+
+        self._debounced_member_refresh: Debouncer | None = Debouncer(
+            self.group.gateway,
+            _LOGGER,
+            cooldown=3,
+            immediate=True,
+            function=self._force_member_updates,
+        )
+
+        self.recompute_capabilities()
+
+    def recompute_capabilities(self) -> None:
+        super().recompute_capabilities()
+        light_options = self.group.gateway.config.config.light_options
+        self._zha_config_group_members_assume_state = (
+            light_options.group_members_assume_state
+        )
         self._zha_config_transition = light_options.default_light_transition
         self._zha_config_enable_light_transitioning_flag = (
             light_options.enable_light_transitioning_flag
@@ -1052,7 +1079,7 @@ class LightGroup(GroupEntity, BaseLight):
         self._zha_config_enhanced_light_transition = False
         self._GROUP_SUPPORTS_EXECUTE_IF_OFF: bool = True
 
-        for member in group.members:
+        for member in self.group.members:
             # Ensure we do not send group commands that violate the minimum transition
             # time of any members.
             if member.device.manufacturer in DEFAULT_MIN_TRANSITION_MANUFACTURERS:
@@ -1072,29 +1099,8 @@ class LightGroup(GroupEntity, BaseLight):
                         self._GROUP_SUPPORTS_EXECUTE_IF_OFF = False
                         break
 
-        self._on_off_cluster_handler: ClusterHandler = group.zigpy_group.endpoint[
-            OnOff.cluster_id
-        ]
-        self._level_cluster_handler: None | (
-            ClusterHandler
-        ) = group.zigpy_group.endpoint[LevelControl.cluster_id]
-        self._color_cluster_handler: None | (
-            ClusterHandler
-        ) = group.zigpy_group.endpoint[Color.cluster_id]
-        self._identify_cluster_handler: None | (
-            ClusterHandler
-        ) = group.zigpy_group.endpoint[Identify.cluster_id]
-
         self._color_mode = ColorMode.UNKNOWN
         self._supported_color_modes = {ColorMode.ONOFF}
-
-        self._debounced_member_refresh: Debouncer | None = Debouncer(
-            self.group.gateway,
-            _LOGGER,
-            cooldown=3,
-            immediate=True,
-            function=self._force_member_updates,
-        )
 
         if hasattr(self, "info_object"):
             delattr(self, "info_object")

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -22,6 +22,7 @@ from zigpy.zcl.foundation import Status
 
 from zha.application import Platform
 from zha.application.platforms import (
+    DEFAULT_UPDATE_GROUP_FROM_CHILD_DELAY,
     BaseEntity,
     BaseEntityInfo,
     GroupEntity,
@@ -1032,16 +1033,11 @@ class MinTransitionLight(Light):
 class LightGroup(GroupEntity, BaseLight):
     """Representation of a light group."""
 
+    _attr_always_supported = True
+
     def __init__(self, group: Group):
         """Initialize a light group."""
-        # light groups change the update_group_from_child_delay so we need to do this
-        # before calling super
-        kwargs = {}
-        if self._zha_config_group_members_assume_state:
-            kwargs["update_group_from_member_delay"] = (
-                ASSUME_UPDATE_GROUP_FROM_CHILD_DELAY
-            )
-        super().__init__(group, **kwargs)
+        super().__init__(group)
 
         self._on_off_cluster_handler: ClusterHandler = group.zigpy_group.endpoint[
             OnOff.cluster_id
@@ -1078,6 +1074,15 @@ class LightGroup(GroupEntity, BaseLight):
         )
         self._zha_config_enhanced_light_transition = False
         self._GROUP_SUPPORTS_EXECUTE_IF_OFF: bool = True
+
+        if self.group.gateway.config.config.light_options.group_members_assume_state:
+            self._change_listener_debouncer.cooldown = (
+                ASSUME_UPDATE_GROUP_FROM_CHILD_DELAY
+            )
+        else:
+            self._change_listener_debouncer.cooldown = (
+                DEFAULT_UPDATE_GROUP_FROM_CHILD_DELAY
+            )
 
         for member in self.group.members:
             # Ensure we do not send group commands that violate the minimum transition

--- a/zha/application/platforms/lock/__init__.py
+++ b/zha/application/platforms/lock/__init__.py
@@ -55,6 +55,7 @@ class DoorLock(PlatformEntity):
         )
 
     def on_add(self) -> None:
+        """Run when entity is added."""
         super().on_add()
         self._on_remove_callbacks.append(
             self._doorlock_cluster_handler.on_event(

--- a/zha/application/platforms/lock/__init__.py
+++ b/zha/application/platforms/lock/__init__.py
@@ -53,9 +53,14 @@ class DoorLock(PlatformEntity):
         self._state: str | None = VALUE_TO_STATE.get(
             self._doorlock_cluster_handler.cluster.get("lock_state"), None
         )
-        self._doorlock_cluster_handler.on_event(
-            CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
-            self.handle_cluster_handler_attribute_updated,
+
+    def on_add(self) -> None:
+        super().on_add()
+        self._on_remove_callbacks.append(
+            self._doorlock_cluster_handler.on_event(
+                CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
+                self.handle_cluster_handler_attribute_updated,
+            )
         )
 
     @property

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -205,34 +205,6 @@ class NumberConfigurationEntity(PlatformEntity):
     _attribute_name: str
     _attr_mode: NumberMode = NumberMode.AUTO
 
-    @classmethod
-    def create_platform_entity(
-        cls: type[Self],
-        unique_id: str,
-        cluster_handlers: list[ClusterHandler],
-        endpoint: Endpoint,
-        device: Device,
-        **kwargs: Any,
-    ) -> Self | None:
-        """Entity Factory.
-
-        Return entity if it is a supported configuration, otherwise return None
-        """
-        cluster_handler = cluster_handlers[0]
-        if ENTITY_METADATA not in kwargs and (
-            cls._attribute_name in cluster_handler.cluster.unsupported_attributes
-            or cls._attribute_name not in cluster_handler.cluster.attributes_by_name
-            or cluster_handler.cluster.get(cls._attribute_name) is None
-        ):
-            _LOGGER.debug(
-                "%s is not supported - skipping %s entity creation",
-                cls._attribute_name,
-                cls.__name__,
-            )
-            return None
-
-        return cls(unique_id, cluster_handlers, endpoint, device, **kwargs)
-
     def __init__(
         self,
         unique_id: str,
@@ -245,6 +217,22 @@ class NumberConfigurationEntity(PlatformEntity):
         self._cluster_handler: ClusterHandler = cluster_handlers[0]
         self._attr_device_class: NumberDeviceClass | None = None
         super().__init__(unique_id, cluster_handlers, endpoint, device, **kwargs)
+
+    def is_supported(self) -> bool:
+        if (
+            self._attribute_name in self._cluster_handler.cluster.unsupported_attributes
+            or self._attribute_name
+            not in self._cluster_handler.cluster.attributes_by_name
+            or self._cluster_handler.cluster.get(self._attribute_name) is None
+        ):
+            _LOGGER.debug(
+                "%s is not supported - skipping %s entity creation",
+                self._attribute_name,
+                self.__class__.__name__,
+            )
+            return False
+
+        return True
 
     def on_add(self) -> None:
         super().on_add()

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -218,7 +218,7 @@ class NumberConfigurationEntity(PlatformEntity):
         self._attr_device_class: NumberDeviceClass | None = None
         super().__init__(unique_id, cluster_handlers, endpoint, device, **kwargs)
 
-    def is_supported(self) -> bool:
+    def _is_supported(self) -> bool:
         if (
             self._attribute_name in self._cluster_handler.cluster.unsupported_attributes
             or self._attribute_name
@@ -232,7 +232,7 @@ class NumberConfigurationEntity(PlatformEntity):
             )
             return False
 
-        return True
+        return super()._is_supported()
 
     def on_add(self) -> None:
         super().on_add()

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -5,14 +5,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 import functools
 import logging
-from typing import TYPE_CHECKING, Any, Self
+from typing import TYPE_CHECKING, Any
 
 from zhaquirks.quirk_ids import DANFOSS_ALLY_THERMOSTAT
 from zigpy.quirks.v2 import NumberMetadata
 from zigpy.zcl.clusters.hvac import Thermostat
 
 from zha.application import Platform
-from zha.application.const import ENTITY_METADATA
 from zha.application.platforms import BaseEntityInfo, EntityCategory, PlatformEntity
 from zha.application.platforms.helpers import validate_device_class
 from zha.application.platforms.number.const import (
@@ -93,6 +92,7 @@ class Number(PlatformEntity):
         ]
 
     def on_add(self) -> None:
+        """Run when entity is added."""
         super().on_add()
         self._on_remove_callbacks.append(
             self._analog_output_cluster_handler.on_event(
@@ -219,6 +219,7 @@ class NumberConfigurationEntity(PlatformEntity):
         super().__init__(unique_id, cluster_handlers, endpoint, device, **kwargs)
 
     def _is_supported(self) -> bool:
+        """Return if the entity is supported for the device, internal."""
         if (
             self._attribute_name in self._cluster_handler.cluster.unsupported_attributes
             or self._attribute_name
@@ -235,6 +236,7 @@ class NumberConfigurationEntity(PlatformEntity):
         return super()._is_supported()
 
     def on_add(self) -> None:
+        """Initialize entity."""
         super().on_add()
         self._on_remove_callbacks.append(
             self._cluster_handler.on_event(

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -245,9 +245,14 @@ class NumberConfigurationEntity(PlatformEntity):
         self._cluster_handler: ClusterHandler = cluster_handlers[0]
         self._attr_device_class: NumberDeviceClass | None = None
         super().__init__(unique_id, cluster_handlers, endpoint, device, **kwargs)
-        self._cluster_handler.on_event(
-            CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
-            self.handle_cluster_handler_attribute_updated,
+
+    def on_add(self) -> None:
+        super().on_add()
+        self._on_remove_callbacks.append(
+            self._cluster_handler.on_event(
+                CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
+                self.handle_cluster_handler_attribute_updated,
+            )
         )
 
     def _init_from_quirks_metadata(self, entity_metadata: NumberMetadata) -> None:

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -91,9 +91,14 @@ class Number(PlatformEntity):
         self._analog_output_cluster_handler: ClusterHandler = self.cluster_handlers[
             CLUSTER_HANDLER_ANALOG_OUTPUT
         ]
-        self._analog_output_cluster_handler.on_event(
-            CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
-            self.handle_cluster_handler_attribute_updated,
+
+    def on_add(self) -> None:
+        super().on_add()
+        self._on_remove_callbacks.append(
+            self._analog_output_cluster_handler.on_event(
+                CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
+                self.handle_cluster_handler_attribute_updated,
+            )
         )
 
     @functools.cached_property

--- a/zha/application/platforms/select.py
+++ b/zha/application/platforms/select.py
@@ -186,6 +186,7 @@ class ZCLEnumSelectEntity(PlatformEntity):
         self._attr_options = [entry.name.replace("_", " ") for entry in self._enum]
 
     def on_add(self) -> None:
+        """Run when entity is added."""
         super().on_add()
         self._on_remove_callbacks.append(
             self._cluster_handler.on_event(

--- a/zha/application/platforms/select.py
+++ b/zha/application/platforms/select.py
@@ -194,7 +194,7 @@ class ZCLEnumSelectEntity(PlatformEntity):
             )
         )
 
-    def is_supported(self) -> bool:
+    def _is_supported(self) -> bool:
         if (
             self._attribute_name in self._cluster_handler.cluster.unsupported_attributes
             or self._attribute_name
@@ -208,7 +208,7 @@ class ZCLEnumSelectEntity(PlatformEntity):
             )
             return False
 
-        return True
+        return super()._is_supported()
 
     def _init_from_quirks_metadata(self, entity_metadata: ZCLEnumMetadata) -> None:
         """Init this entity from the quirks metadata."""

--- a/zha/application/platforms/select.py
+++ b/zha/application/platforms/select.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from enum import Enum
 import functools
 import logging
-from typing import TYPE_CHECKING, Any, Self
+from typing import TYPE_CHECKING, Any
 
 from zhaquirks.danfoss import thermostat as danfoss_thermostat
 from zhaquirks.quirk_ids import (
@@ -22,7 +22,7 @@ from zigpy.zcl.clusters.general import OnOff
 from zigpy.zcl.clusters.security import IasWd
 
 from zha.application import Platform
-from zha.application.const import ENTITY_METADATA, Strobe
+from zha.application.const import Strobe
 from zha.application.platforms import BaseEntityInfo, EntityCategory, PlatformEntity
 from zha.application.registries import PLATFORM_ENTITIES
 from zha.zigbee.cluster_handlers import ClusterAttributeUpdatedEvent
@@ -172,34 +172,6 @@ class ZCLEnumSelectEntity(PlatformEntity):
     _attr_entity_category = EntityCategory.CONFIG
     _enum: type[Enum]
 
-    @classmethod
-    def create_platform_entity(
-        cls: type[Self],
-        unique_id: str,
-        cluster_handlers: list[ClusterHandler],
-        endpoint: Endpoint,
-        device: Device,
-        **kwargs: Any,
-    ) -> Self | None:
-        """Entity Factory.
-
-        Return entity if it is a supported configuration, otherwise return None
-        """
-        cluster_handler = cluster_handlers[0]
-        if ENTITY_METADATA not in kwargs and (
-            cls._attribute_name in cluster_handler.cluster.unsupported_attributes
-            or cls._attribute_name not in cluster_handler.cluster.attributes_by_name
-            or cluster_handler.cluster.get(cls._attribute_name) is None
-        ):
-            _LOGGER.debug(
-                "%s is not supported - skipping %s entity creation",
-                cls._attribute_name,
-                cls.__name__,
-            )
-            return None
-
-        return cls(unique_id, cluster_handlers, endpoint, device, **kwargs)
-
     def __init__(
         self,
         unique_id: str,
@@ -221,6 +193,22 @@ class ZCLEnumSelectEntity(PlatformEntity):
                 self.handle_cluster_handler_attribute_updated,
             )
         )
+
+    def is_supported(self) -> bool:
+        if (
+            self._attribute_name in self._cluster_handler.cluster.unsupported_attributes
+            or self._attribute_name
+            not in self._cluster_handler.cluster.attributes_by_name
+            or self._cluster_handler.cluster.get(self._attribute_name) is None
+        ):
+            _LOGGER.debug(
+                "%s is not supported - skipping %s entity creation",
+                self._attribute_name,
+                self.__class__.__name__,
+            )
+            return False
+
+        return True
 
     def _init_from_quirks_metadata(self, entity_metadata: ZCLEnumMetadata) -> None:
         """Init this entity from the quirks metadata."""

--- a/zha/application/platforms/select.py
+++ b/zha/application/platforms/select.py
@@ -212,9 +212,14 @@ class ZCLEnumSelectEntity(PlatformEntity):
         super().__init__(unique_id, cluster_handlers, endpoint, device, **kwargs)
         self._cluster_handler: ClusterHandler = cluster_handlers[0]
         self._attr_options = [entry.name.replace("_", " ") for entry in self._enum]
-        self._cluster_handler.on_event(
-            CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
-            self.handle_cluster_handler_attribute_updated,
+
+    def on_add(self) -> None:
+        super().on_add()
+        self._on_remove_callbacks.append(
+            self._cluster_handler.on_event(
+                CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
+                self.handle_cluster_handler_attribute_updated,
+            )
         )
 
     def _init_from_quirks_metadata(self, entity_metadata: ZCLEnumMetadata) -> None:

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -1529,10 +1529,11 @@ class RSSISensor(Sensor):
         )
 
     def _is_supported(self) -> bool:
-        key = f"{CLUSTER_HANDLER_BASIC}_{self._unique_id_suffix}"
-
-        if PLATFORM_ENTITIES.prevent_entity_creation(
-            Platform.SENSOR, self.device.ieee, key
+        cls = type(self)
+        if any(
+            type(entity) is cls
+            for entity in self.device.platform_entities.values()
+            if entity is not self
         ):
             return False
 

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -160,38 +160,26 @@ class Sensor(PlatformEntity):
     _attr_state_class: SensorStateClass | None = None
     _skip_creation_if_no_attr_cache: bool = False
 
-    @classmethod
-    def create_platform_entity(
-        cls: type[Self],
-        unique_id: str,
-        cluster_handlers: list[ClusterHandler],
-        endpoint: Endpoint,
-        device: Device,
-        **kwargs: Any,
-    ) -> Self | None:
-        """Entity Factory.
-
-        Return entity if it is a supported configuration, otherwise return None
-        """
-        cluster_handler = cluster_handlers[0]
-        if ENTITY_METADATA not in kwargs and (
-            cls._attribute_name in cluster_handler.cluster.unsupported_attributes
-            or cls._attribute_name not in cluster_handler.cluster.attributes_by_name
+    def is_supported(self) -> bool:
+        if (
+            self._attribute_name in self._cluster_handler.cluster.unsupported_attributes
+            or self._attribute_name
+            not in self._cluster_handler.cluster.attributes_by_name
         ):
             _LOGGER.debug(
                 "%s is not supported - skipping %s entity creation",
-                cls._attribute_name,
-                cls.__name__,
+                self._attribute_name,
+                self.__name__,
             )
-            return None
+            return False
 
         if (
-            cls._skip_creation_if_no_attr_cache
-            and cluster_handlers[0].cluster.get(cls._attribute_name) is None
+            self._skip_creation_if_no_attr_cache
+            and self._cluster_handler.cluster.get(self._attribute_name) is None
         ):
-            return None
+            return False
 
-        return cls(unique_id, cluster_handlers, endpoint, device, **kwargs)
+        return True
 
     def __init__(
         self,
@@ -204,9 +192,14 @@ class Sensor(PlatformEntity):
         """Init this sensor."""
         self._cluster_handler: ClusterHandler = cluster_handlers[0]
         super().__init__(unique_id, cluster_handlers, endpoint, device, **kwargs)
-        self._cluster_handler.on_event(
-            CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
-            self.handle_cluster_handler_attribute_updated,
+
+    def on_add(self) -> None:
+        super().on_add()
+        self._on_remove_callbacks.append(
+            self._cluster_handler.on_event(
+                CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
+                self.handle_cluster_handler_attribute_updated,
+            )
         )
 
     def _validate_state_class(
@@ -397,21 +390,6 @@ class DeviceCounterSensor(BaseEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_entity_registry_enabled_default = False
 
-    @classmethod
-    def create_platform_entity(
-        cls,
-        zha_device: Device,
-        counter_groups: str,
-        counter_group: str,
-        counter: str,
-        **kwargs: Any,
-    ) -> Self | None:
-        """Entity Factory.
-
-        Return entity if it is a supported configuration, otherwise return None
-        """
-        return cls(zha_device, counter_groups, counter_group, counter, **kwargs)
-
     def __init__(
         self,
         zha_device: Device,
@@ -451,6 +429,9 @@ class DeviceCounterSensor(BaseEntity):
                 self.update
             )
         )
+
+    def is_supported(self) -> bool:
+        return True
 
     @functools.cached_property
     def identifiers(self) -> DeviceCounterSensorIdentifiers:
@@ -541,9 +522,7 @@ class EnumSensor(Sensor):
         self._attribute_name = entity_metadata.attribute_name
         self._enum = entity_metadata.enum
 
-        PlatformEntity._init_from_quirks_metadata(
-            self, entity_metadata
-        )  # pylint: disable=protected-access
+        PlatformEntity._init_from_quirks_metadata(self, entity_metadata)  # pylint: disable=protected-access
 
     def formatter(self, value: int) -> str | None:
         """Use name of enum."""
@@ -578,24 +557,11 @@ class Battery(Sensor):
         "battery_voltage",
     }
 
-    @classmethod
-    def create_platform_entity(
-        cls: type[Self],
-        unique_id: str,
-        cluster_handlers: list[ClusterHandler],
-        endpoint: Endpoint,
-        device: Device,
-        **kwargs: Any,
-    ) -> Self | None:
-        """Entity Factory.
+    def is_supported(self) -> bool:
+        if self.device.is_mains_powered:
+            return False
 
-        Unlike any other entity, PowerConfiguration cluster may not support
-        battery_percent_remaining attribute, but zha-device-handlers takes care of it
-        so create the entity regardless
-        """
-        if device.is_mains_powered:
-            return None
-        return cls(unique_id, cluster_handlers, endpoint, device, **kwargs)
+        return True
 
     @staticmethod
     def formatter(value: int) -> int | None:  # pylint: disable=arguments-differ
@@ -1414,21 +1380,8 @@ class ThermostatHVACAction(Sensor):
     _unique_id_suffix = "hvac_action"
     _attr_translation_key: str = "hvac_action"
 
-    @classmethod
-    def create_platform_entity(
-        cls: type[Self],
-        unique_id: str,
-        cluster_handlers: list[ClusterHandler],
-        endpoint: Endpoint,
-        device: Device,
-        **kwargs: Any,
-    ) -> Self | None:
-        """Entity Factory.
-
-        Return entity if it is a supported configuration, otherwise return None
-        """
-
-        return cls(unique_id, cluster_handlers, endpoint, device, **kwargs)
+    def is_supported(self) -> bool:
+        return True
 
     @property
     def state(self) -> dict:
@@ -1551,24 +1504,6 @@ class RSSISensor(Sensor):
     _attr_entity_registry_enabled_default = False
     _attr_translation_key: str = "rssi"
 
-    @classmethod
-    def create_platform_entity(
-        cls: type[Self],
-        unique_id: str,
-        cluster_handlers: list[ClusterHandler],
-        endpoint: Endpoint,
-        device: Device,
-        **kwargs: Any,
-    ) -> Self | None:
-        """Entity Factory.
-
-        Return entity if it is a supported configuration, otherwise return None
-        """
-        key = f"{CLUSTER_HANDLER_BASIC}_{cls._unique_id_suffix}"
-        if PLATFORM_ENTITIES.prevent_entity_creation(Platform.SENSOR, device.ieee, key):
-            return None
-        return cls(unique_id, cluster_handlers, endpoint, device, **kwargs)
-
     def __init__(
         self,
         unique_id: str,
@@ -1584,8 +1519,17 @@ class RSSISensor(Sensor):
         super().on_add()
         self.device.gateway.global_updater.register_update_listener(self.update)
         self._on_remove_callbacks.append(
-            lambda: self.device.gateway.global_updater.remove_update_listener(self.update)
+            lambda: self.device.gateway.global_updater.remove_update_listener(
+                self.update
+            )
         )
+
+    def is_supported(self) -> bool:
+        key = f"{CLUSTER_HANDLER_BASIC}_{cls._unique_id_suffix}"
+        if PLATFORM_ENTITIES.prevent_entity_creation(Platform.SENSOR, device.ieee, key):
+            return False
+
+        return True
 
     @property
     def state(self) -> dict:

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -171,6 +171,7 @@ class Sensor(PlatformEntity):
         """Init this sensor."""
         self._cluster_handler: ClusterHandler = cluster_handlers[0]
         super().__init__(unique_id, cluster_handlers, endpoint, device, **kwargs)
+        self.recompute_capabilities()
 
     def on_add(self) -> None:
         super().on_add()

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -557,7 +557,8 @@ class Battery(Sensor):
     }
 
     def _is_supported(self) -> bool:
-        return super()._is_supported() and not self.device.is_mains_powered
+        # XXX: We intentionally ignore the presence of this attribute
+        return PlatformEntity._is_supported(self) and not self.device.is_mains_powered
 
     @staticmethod
     def formatter(value: int) -> int | None:  # pylint: disable=arguments-differ
@@ -1380,7 +1381,7 @@ class ThermostatHVACAction(Sensor):
     _attr_translation_key: str = "hvac_action"
 
     def _is_supported(self) -> bool:
-        return PlatformEntity.is_supported(self)
+        return PlatformEntity._is_supported(self)
 
     @property
     def state(self) -> dict:
@@ -1531,7 +1532,7 @@ class RSSISensor(Sensor):
         ):
             return False
 
-        return super()._is_supported()
+        return PlatformEntity._is_supported(self)
 
     @property
     def state(self) -> dict:

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -981,7 +981,10 @@ class SmartEnergyMetering(PollableSensor):
     ) -> None:
         """Init."""
         super().__init__(unique_id, cluster_handlers, endpoint, device, **kwargs)
+        self.recompute_capabilities()
 
+    def recompute_capabilities(self) -> None:
+        super().recompute_capabilities()
         entity_description = self._ENTITY_DESCRIPTION_MAP.get(
             self._cluster_handler.unit_of_measurement
         )

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -10,7 +10,7 @@ import functools
 import logging
 import numbers
 import typing
-from typing import TYPE_CHECKING, Any, Self
+from typing import TYPE_CHECKING, Any
 
 from zhaquirks.danfoss import thermostat as danfoss_thermostat
 from zhaquirks.quirk_ids import DANFOSS_ALLY_THERMOSTAT
@@ -21,7 +21,6 @@ from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.clusters.general import Basic
 
 from zha.application import Platform
-from zha.application.const import ENTITY_METADATA
 from zha.application.platforms import (
     BaseEntity,
     BaseEntityInfo,
@@ -174,6 +173,7 @@ class Sensor(PlatformEntity):
         self.recompute_capabilities()
 
     def on_add(self) -> None:
+        """Run when entity is added."""
         super().on_add()
         self._on_remove_callbacks.append(
             self._cluster_handler.on_event(
@@ -332,6 +332,7 @@ class PollableSensor(Sensor):
         self._polling_task: Task | None = None
 
     def on_add(self) -> None:
+        """Run when entity is added."""
         super().on_add()
         self.maybe_start_polling()
 
@@ -424,6 +425,7 @@ class DeviceCounterSensor(BaseEntity):
         # self._attr_translation_key = f"counter_{self._zigpy_counter.name.lower()}"
 
     def on_add(self) -> None:
+        """Run when entity is added."""
         super().on_add()
         self._device.gateway.global_updater.register_update_listener(self.update)
         self._on_remove_callbacks.append(
@@ -980,6 +982,7 @@ class SmartEnergyMetering(PollableSensor):
         self.recompute_capabilities()
 
     def recompute_capabilities(self) -> None:
+        """Recompute capabilities and feature flags."""
         super().recompute_capabilities()
         entity_description = self._ENTITY_DESCRIPTION_MAP.get(
             self._cluster_handler.unit_of_measurement
@@ -1516,6 +1519,7 @@ class RSSISensor(Sensor):
         super().__init__(unique_id, cluster_handlers, endpoint, device, **kwargs)
 
     def on_add(self) -> None:
+        """Run when entity is added."""
         super().on_add()
         self.device.gateway.global_updater.register_update_listener(self.update)
         self._on_remove_callbacks.append(

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -182,7 +182,7 @@ class Sensor(PlatformEntity):
             )
         )
 
-    def is_supported(self) -> bool:
+    def _is_supported(self) -> bool:
         if (
             self._attribute_name in self._cluster_handler.cluster.unsupported_attributes
             or self._attribute_name
@@ -201,7 +201,7 @@ class Sensor(PlatformEntity):
         ):
             return False
 
-        return True
+        return super()._is_supported()
 
     def _validate_state_class(
         self,
@@ -416,6 +416,7 @@ class DeviceCounterSensor(BaseEntity):
         self._zigpy_counter_group: str = counter_group
 
         self._attr_fallback_name: str = self._zigpy_counter.name
+        self._always_supported: bool = True
 
         # TODO: why do entities get created with " None" as a name suffix instead of
         # falling back to `fallback_name`? We should be able to provide translation keys
@@ -430,9 +431,6 @@ class DeviceCounterSensor(BaseEntity):
                 self.update
             )
         )
-
-    def is_supported(self) -> bool:
-        return True
 
     @functools.cached_property
     def identifiers(self) -> DeviceCounterSensorIdentifiers:
@@ -558,11 +556,8 @@ class Battery(Sensor):
         "battery_voltage",
     }
 
-    def is_supported(self) -> bool:
-        if self.device.is_mains_powered:
-            return False
-
-        return True
+    def _is_supported(self) -> bool:
+        return super()._is_supported() and not self.device.is_mains_powered
 
     @staticmethod
     def formatter(value: int) -> int | None:  # pylint: disable=arguments-differ
@@ -1384,8 +1379,8 @@ class ThermostatHVACAction(Sensor):
     _unique_id_suffix = "hvac_action"
     _attr_translation_key: str = "hvac_action"
 
-    def is_supported(self) -> bool:
-        return True
+    def _is_supported(self) -> bool:
+        return PlatformEntity.is_supported(self)
 
     @property
     def state(self) -> dict:
@@ -1528,14 +1523,15 @@ class RSSISensor(Sensor):
             )
         )
 
-    def is_supported(self) -> bool:
+    def _is_supported(self) -> bool:
         key = f"{CLUSTER_HANDLER_BASIC}_{self._unique_id_suffix}"
+
         if PLATFORM_ENTITIES.prevent_entity_creation(
             Platform.SENSOR, self.device.ieee, key
         ):
             return False
 
-        return True
+        return super()._is_supported()
 
     @property
     def state(self) -> dict:

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -160,27 +160,6 @@ class Sensor(PlatformEntity):
     _attr_state_class: SensorStateClass | None = None
     _skip_creation_if_no_attr_cache: bool = False
 
-    def is_supported(self) -> bool:
-        if (
-            self._attribute_name in self._cluster_handler.cluster.unsupported_attributes
-            or self._attribute_name
-            not in self._cluster_handler.cluster.attributes_by_name
-        ):
-            _LOGGER.debug(
-                "%s is not supported - skipping %s entity creation",
-                self._attribute_name,
-                self.__class__.__name__,
-            )
-            return False
-
-        if (
-            self._skip_creation_if_no_attr_cache
-            and self._cluster_handler.cluster.get(self._attribute_name) is None
-        ):
-            return False
-
-        return True
-
     def __init__(
         self,
         unique_id: str,
@@ -201,6 +180,27 @@ class Sensor(PlatformEntity):
                 self.handle_cluster_handler_attribute_updated,
             )
         )
+
+    def is_supported(self) -> bool:
+        if (
+            self._attribute_name in self._cluster_handler.cluster.unsupported_attributes
+            or self._attribute_name
+            not in self._cluster_handler.cluster.attributes_by_name
+        ):
+            _LOGGER.debug(
+                "%s is not supported - skipping %s entity creation",
+                self._attribute_name,
+                self.__class__.__name__,
+            )
+            return False
+
+        if (
+            self._skip_creation_if_no_attr_cache
+            and self._cluster_handler.cluster.get(self._attribute_name) is None
+        ):
+            return False
+
+        return True
 
     def _validate_state_class(
         self,

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -336,6 +336,9 @@ class PollableSensor(Sensor):
         """Init this sensor."""
         super().__init__(unique_id, cluster_handlers, endpoint, device, **kwargs)
         self._polling_task: Task | None = None
+
+    def on_add(self) -> None:
+        super().on_add()
         self.maybe_start_polling()
 
     @property
@@ -440,11 +443,14 @@ class DeviceCounterSensor(BaseEntity):
         # even if they do not exist.
         # self._attr_translation_key = f"counter_{self._zigpy_counter.name.lower()}"
 
+    def on_add(self) -> None:
+        super().on_add()
         self._device.gateway.global_updater.register_update_listener(self.update)
-
-        # we double create these in discovery tests because we reissue the create calls to count and prove them out
-        if (self.PLATFORM, self.unique_id) not in self._device.platform_entities:
-            self._device.platform_entities[(self.PLATFORM, self.unique_id)] = self
+        self._on_remove_callbacks.append(
+            lambda: self._device.gateway.global_updater.remove_update_listener(
+                self.update
+            )
+        )
 
     @functools.cached_property
     def identifiers(self) -> DeviceCounterSensorIdentifiers:
@@ -508,11 +514,6 @@ class DeviceCounterSensor(BaseEntity):
                 self._device.gateway.config.allow_polling,
             )
 
-    async def on_remove(self) -> None:
-        """Cancel tasks this entity owns."""
-        self._device.gateway.global_updater.remove_update_listener(self.update)
-        await super().on_remove()
-
 
 class EnumSensor(Sensor):
     """Sensor with value from enum."""
@@ -540,7 +541,9 @@ class EnumSensor(Sensor):
         self._attribute_name = entity_metadata.attribute_name
         self._enum = entity_metadata.enum
 
-        PlatformEntity._init_from_quirks_metadata(self, entity_metadata)  # pylint: disable=protected-access
+        PlatformEntity._init_from_quirks_metadata(
+            self, entity_metadata
+        )  # pylint: disable=protected-access
 
     def formatter(self, value: int) -> str | None:
         """Use name of enum."""
@@ -1576,7 +1579,13 @@ class RSSISensor(Sensor):
     ) -> None:
         """Init."""
         super().__init__(unique_id, cluster_handlers, endpoint, device, **kwargs)
+
+    def on_add(self) -> None:
+        super().on_add()
         self.device.gateway.global_updater.register_update_listener(self.update)
+        self._on_remove_callbacks.append(
+            lambda: self.device.gateway.global_updater.remove_update_listener(self.update)
+        )
 
     @property
     def state(self) -> dict:
@@ -1611,11 +1620,6 @@ class RSSISensor(Sensor):
                 self._device.available,
                 self._device.gateway.config.allow_polling,
             )
-
-    async def on_remove(self) -> None:
-        """Cancel tasks this entity owns."""
-        self._device.gateway.global_updater.remove_update_listener(self.update)
-        await super().on_remove()
 
 
 @MULTI_MATCH(cluster_handler_names=CLUSTER_HANDLER_BASIC)

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -169,7 +169,7 @@ class Sensor(PlatformEntity):
             _LOGGER.debug(
                 "%s is not supported - skipping %s entity creation",
                 self._attribute_name,
-                self.__name__,
+                self.__class__.__name__,
             )
             return False
 
@@ -1525,8 +1525,10 @@ class RSSISensor(Sensor):
         )
 
     def is_supported(self) -> bool:
-        key = f"{CLUSTER_HANDLER_BASIC}_{cls._unique_id_suffix}"
-        if PLATFORM_ENTITIES.prevent_entity_creation(Platform.SENSOR, device.ieee, key):
+        key = f"{CLUSTER_HANDLER_BASIC}_{self._unique_id_suffix}"
+        if PLATFORM_ENTITIES.prevent_entity_creation(
+            Platform.SENSOR, self.device.ieee, key
+        ):
             return False
 
         return True

--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -226,7 +226,7 @@ class ConfigurableAttributeSwitch(PlatformEntity):
         self._off_value = entity_metadata.off_value
         self._on_value = entity_metadata.on_value
 
-    def is_supported(self) -> bool:
+    def _is_supported(self) -> bool:
         if (
             self._attribute_name in self._cluster_handler.cluster.unsupported_attributes
             or self._attribute_name
@@ -240,7 +240,7 @@ class ConfigurableAttributeSwitch(PlatformEntity):
             )
             return False
 
-        return True
+        return super()._is_supported()
 
     @functools.cached_property
     def info_object(self) -> ConfigurableAttributeSwitchInfo:
@@ -656,18 +656,14 @@ class WindowCoveringInversionSwitch(ConfigurableAttributeSwitch):
     _attribute_name = WindowCovering.AttributeDefs.config_status.name
     _attr_translation_key = "inverted"
 
-    def is_supported(self) -> bool:
+    def _is_supported(self) -> bool:
         window_covering_mode_attr = (
             WindowCovering.AttributeDefs.window_covering_mode.name
         )
 
-        # this entity needs 2 attributes to function
+        # this entity needs a second attribute to function
         if (
-            self._attribute_name in self._cluster_handler.cluster.unsupported_attributes
-            or self._attribute_name
-            not in self._cluster_handler.cluster.attributes_by_name
-            or self._cluster_handler.cluster.get(self._attribute_name) is None
-            or (
+            (
                 window_covering_mode_attr
                 in self._cluster_handler.cluster.unsupported_attributes
             )
@@ -684,7 +680,7 @@ class WindowCoveringInversionSwitch(ConfigurableAttributeSwitch):
             )
             return False
 
-        return True
+        return super()._is_supported()
 
     @property
     def is_on(self) -> bool:

--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -121,6 +121,7 @@ class Switch(PlatformEntity, BaseSwitch):
         )
 
     def on_add(self) -> None:
+        """Run when entity is added."""
         super().on_add()
         self._on_remove_callbacks.append(
             self._on_off_cluster_handler.on_event(

--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -120,9 +120,14 @@ class Switch(PlatformEntity, BaseSwitch):
         self._on_off_cluster_handler: OnOffClusterHandler = cast(
             OnOffClusterHandler, self.cluster_handlers[CLUSTER_HANDLER_ON_OFF]
         )
-        self._on_off_cluster_handler.on_event(
-            CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
-            self.handle_cluster_handler_attribute_updated,
+
+    def on_add(self) -> None:
+        super().on_add()
+        self._on_remove_callbacks.append(
+            self._on_off_cluster_handler.on_event(
+                CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
+                self.handle_cluster_handler_attribute_updated,
+            )
         )
 
     def handle_cluster_handler_attribute_updated(

--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -6,7 +6,7 @@ from abc import ABC
 from dataclasses import dataclass
 import functools
 import logging
-from typing import TYPE_CHECKING, Any, Self, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from zhaquirks.quirk_ids import DANFOSS_ALLY_THERMOSTAT, TUYA_PLUG_ONOFF
 from zigpy.quirks.v2 import SwitchMetadata
@@ -15,7 +15,6 @@ from zigpy.zcl.clusters.general import OnOff
 from zigpy.zcl.foundation import Status
 
 from zha.application import Platform
-from zha.application.const import ENTITY_METADATA
 from zha.application.platforms import (
     BaseEntity,
     BaseEntityInfo,
@@ -200,34 +199,6 @@ class ConfigurableAttributeSwitch(PlatformEntity):
     _off_value: int = 0
     _on_value: int = 1
 
-    @classmethod
-    def create_platform_entity(
-        cls: type[Self],
-        unique_id: str,
-        cluster_handlers: list[ClusterHandler],
-        endpoint: Endpoint,
-        device: Device,
-        **kwargs: Any,
-    ) -> Self | None:
-        """Entity Factory.
-
-        Return entity if it is a supported configuration, otherwise return None
-        """
-        cluster_handler = cluster_handlers[0]
-        if ENTITY_METADATA not in kwargs and (
-            cls._attribute_name in cluster_handler.cluster.unsupported_attributes
-            or cls._attribute_name not in cluster_handler.cluster.attributes_by_name
-            or cluster_handler.cluster.get(cls._attribute_name) is None
-        ):
-            _LOGGER.debug(
-                "%s is not supported - skipping %s entity creation",
-                cls._attribute_name,
-                cls.__name__,
-            )
-            return None
-
-        return cls(unique_id, cluster_handlers, endpoint, device, **kwargs)
-
     def __init__(
         self,
         unique_id: str,
@@ -254,6 +225,22 @@ class ConfigurableAttributeSwitch(PlatformEntity):
             self._force_inverted = entity_metadata.force_inverted
         self._off_value = entity_metadata.off_value
         self._on_value = entity_metadata.on_value
+
+    def is_supported(self) -> bool:
+        cluster_handler = cluster_handlers[0]
+        if (
+            self._attribute_name in cluster_handler.cluster.unsupported_attributes
+            or self._attribute_name not in cluster_handler.cluster.attributes_by_name
+            or cluster_handler.cluster.get(self._attribute_name) is None
+        ):
+            _LOGGER.debug(
+                "%s is not supported - skipping %s entity creation",
+                self._attribute_name,
+                self.__class__.__name__,
+            )
+            return False
+
+        return True
 
     @functools.cached_property
     def info_object(self) -> ConfigurableAttributeSwitchInfo:
@@ -669,42 +656,35 @@ class WindowCoveringInversionSwitch(ConfigurableAttributeSwitch):
     _attribute_name = WindowCovering.AttributeDefs.config_status.name
     _attr_translation_key = "inverted"
 
-    @classmethod
-    def create_platform_entity(
-        cls: type[Self],
-        unique_id: str,
-        cluster_handlers: list[ClusterHandler],
-        endpoint: Endpoint,
-        device: Device,
-        **kwargs: Any,
-    ) -> Self | None:
-        """Entity Factory.
-
-        Return entity if it is a supported configuration, otherwise return None
-        """
-        cluster_handler = cluster_handlers[0]
+    def is_supported(self) -> bool:
         window_covering_mode_attr = (
             WindowCovering.AttributeDefs.window_covering_mode.name
         )
+
         # this entity needs 2 attributes to function
         if (
-            cls._attribute_name in cluster_handler.cluster.unsupported_attributes
-            or cls._attribute_name not in cluster_handler.cluster.attributes_by_name
-            or cluster_handler.cluster.get(cls._attribute_name) is None
-            or window_covering_mode_attr
-            in cluster_handler.cluster.unsupported_attributes
-            or window_covering_mode_attr
-            not in cluster_handler.cluster.attributes_by_name
-            or cluster_handler.cluster.get(window_covering_mode_attr) is None
+            self._attribute_name in self._cluster_handler.cluster.unsupported_attributes
+            or self._attribute_name
+            not in self._cluster_handler.cluster.attributes_by_name
+            or self._cluster_handler.cluster.get(self._attribute_name) is None
+            or (
+                window_covering_mode_attr
+                in self._cluster_handler.cluster.unsupported_attributes
+            )
+            or (
+                window_covering_mode_attr
+                not in self._cluster_handler.cluster.attributes_by_name
+            )
+            or self._cluster_handler.cluster.get(window_covering_mode_attr) is None
         ):
             _LOGGER.debug(
                 "%s is not supported - skipping %s entity creation",
-                cls._attribute_name,
-                cls.__name__,
+                self._attribute_name,
+                self.__class__.__name__,
             )
             return None
 
-        return cls(unique_id, cluster_handlers, endpoint, device, **kwargs)
+        return self(unique_id, cluster_handlers, endpoint, device, **kwargs)
 
     @property
     def is_on(self) -> bool:

--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -227,11 +227,11 @@ class ConfigurableAttributeSwitch(PlatformEntity):
         self._on_value = entity_metadata.on_value
 
     def is_supported(self) -> bool:
-        cluster_handler = cluster_handlers[0]
         if (
-            self._attribute_name in cluster_handler.cluster.unsupported_attributes
-            or self._attribute_name not in cluster_handler.cluster.attributes_by_name
-            or cluster_handler.cluster.get(self._attribute_name) is None
+            self._attribute_name in self._cluster_handler.cluster.unsupported_attributes
+            or self._attribute_name
+            not in self._cluster_handler.cluster.attributes_by_name
+            or self._cluster_handler.cluster.get(self._attribute_name) is None
         ):
             _LOGGER.debug(
                 "%s is not supported - skipping %s entity creation",
@@ -682,9 +682,9 @@ class WindowCoveringInversionSwitch(ConfigurableAttributeSwitch):
                 self._attribute_name,
                 self.__class__.__name__,
             )
-            return None
+            return False
 
-        return self(unique_id, cluster_handlers, endpoint, device, **kwargs)
+        return True
 
     @property
     def is_on(self) -> bool:

--- a/zha/application/platforms/update.py
+++ b/zha/application/platforms/update.py
@@ -303,13 +303,17 @@ class FirmwareUpdateEntity(PlatformEntity):
         super().on_add()
 
         self.device.device.add_listener(self)
-        self._ota_cluster_handler.on_event(
-            CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
-            self.handle_cluster_handler_attribute_updated,
+        self._on_remove_callbacks.append(
+            self._ota_cluster_handler.on_event(
+                CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
+                self.handle_cluster_handler_attribute_updated,
+            )
+        )
+        self._on_remove_callbacks.append(
+            lambda: self.device.device.remove_listener(self)
         )
 
     async def on_remove(self) -> None:
         """Call when entity will be removed."""
         self._attr_in_progress = False
-        self.device.device.remove_listener(self)
         await super().on_remove()

--- a/zha/application/platforms/update.py
+++ b/zha/application/platforms/update.py
@@ -113,12 +113,6 @@ class FirmwareUpdateEntity(PlatformEntity):
             upgrades=(), downgrades=()
         )
 
-        self.device.device.add_listener(self)
-        self._ota_cluster_handler.on_event(
-            CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
-            self.handle_cluster_handler_attribute_updated,
-        )
-
     @functools.cached_property
     def info_object(self) -> UpdateEntityInfo:
         """Return a representation of the entity."""
@@ -303,6 +297,16 @@ class FirmwareUpdateEntity(PlatformEntity):
         # Clear the state
         self._attr_in_progress = False
         self.maybe_emit_state_changed_event()
+
+    def on_add(self) -> None:
+        """Call when entity is added."""
+        super().on_add()
+
+        self.device.device.add_listener(self)
+        self._ota_cluster_handler.on_event(
+            CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
+            self.handle_cluster_handler_attribute_updated,
+        )
 
     async def on_remove(self) -> None:
         """Call when entity will be removed."""

--- a/zha/application/registries.py
+++ b/zha/application/registries.py
@@ -492,8 +492,7 @@ class PlatformEntityRegistry:
 
     def prevent_entity_creation(self, platform: Platform, ieee: EUI64, key: str):
         """Return True if the entity should not be created."""
-        platform_restrictions = self.single_device_matches[platform]
-        device_restrictions = platform_restrictions[ieee]
+        device_restrictions = self.single_device_matches[platform][ieee]
         if key in device_restrictions:
             return True
         device_restrictions.append(key)

--- a/zha/application/registries.py
+++ b/zha/application/registries.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING
 from zigpy import zcl
 import zigpy.profiles.zha
 import zigpy.profiles.zll
-from zigpy.types.named import EUI64
 
 from zha.application import Platform
 
@@ -282,9 +281,6 @@ class PlatformEntityRegistry:
             lambda: collections.defaultdict(lambda: collections.defaultdict(list))
         )
         self._group_registry: dict[str, type[GroupEntity]] = {}
-        self.single_device_matches: dict[Platform, dict[EUI64, list[str]]] = (
-            collections.defaultdict(lambda: collections.defaultdict(list))
-        )
 
     def get_entity(
         self,
@@ -489,20 +485,6 @@ class PlatformEntityRegistry:
             return zha_ent
 
         return decorator
-
-    def prevent_entity_creation(self, platform: Platform, ieee: EUI64, key: str):
-        """Return True if the entity should not be created."""
-        device_restrictions = self.single_device_matches[platform][ieee]
-        if key in device_restrictions:
-            return True
-        device_restrictions.append(key)
-        return False
-
-    def clean_up(self) -> None:
-        """Clean up post discovery."""
-        self.single_device_matches = collections.defaultdict(
-            lambda: collections.defaultdict(list)
-        )
 
 
 PLATFORM_ENTITIES = PlatformEntityRegistry()

--- a/zha/zigbee/cluster_handlers/__init__.py
+++ b/zha/zigbee/cluster_handlers/__init__.py
@@ -212,9 +212,6 @@ class ClusterHandler(LogMixin, EventBase):
         self._status: ClusterHandlerStatus = ClusterHandlerStatus.CREATED
         self.data_cache: dict[str, Any] = {}
 
-        # TODO: better lifecycle!
-        self.on_add()
-
     def on_add(self) -> None:
         """Call when cluster handler is added."""
         self._cluster.add_listener(self)

--- a/zha/zigbee/cluster_handlers/__init__.py
+++ b/zha/zigbee/cluster_handlers/__init__.py
@@ -212,6 +212,9 @@ class ClusterHandler(LogMixin, EventBase):
         self._status: ClusterHandlerStatus = ClusterHandlerStatus.CREATED
         self.data_cache: dict[str, Any] = {}
 
+        # TODO: better lifecycle!
+        self.on_add()
+
     def on_add(self) -> None:
         """Call when cluster handler is added."""
         self._cluster.add_listener(self)

--- a/zha/zigbee/cluster_handlers/__init__.py
+++ b/zha/zigbee/cluster_handlers/__init__.py
@@ -210,8 +210,15 @@ class ClusterHandler(LogMixin, EventBase):
             ]
             self.value_attribute = attr_def.name
         self._status: ClusterHandlerStatus = ClusterHandlerStatus.CREATED
-        self._cluster.add_listener(self)
         self.data_cache: dict[str, Any] = {}
+
+    def on_add(self) -> None:
+        """Call when cluster handler is added."""
+        self._cluster.add_listener(self)
+
+    def on_remove(self) -> None:
+        """Call when cluster handler will be removed."""
+        self._cluster.remove_listener(self)
 
     @classmethod
     def matches(cls, cluster: zigpy.zcl.Cluster, endpoint: Endpoint) -> bool:  # pylint: disable=unused-argument
@@ -664,7 +671,14 @@ class ZDOClusterHandler(LogMixin):
         self._zha_device = device
         self._status = ClusterHandlerStatus.CREATED
         self._unique_id = f"{str(device.ieee)}:{device.name}_ZDO"
+
+    def on_add(self) -> None:
+        """Call when cluster handler is added."""
         self._cluster.add_listener(self)
+
+    def on_remove(self) -> None:
+        """Call when cluster handler will be removed."""
+        self._cluster.remove_listener(self)
 
     @property
     def unique_id(self):

--- a/zha/zigbee/cluster_handlers/__init__.py
+++ b/zha/zigbee/cluster_handlers/__init__.py
@@ -601,6 +601,7 @@ class ClusterHandler(LogMixin, EventBase):
                     only_cache=only_cache,
                     manufacturer=manufacturer,
                 )
+                self.debug("Got attributes: %s", read)
                 result.update(read)
             except (TimeoutError, zigpy.exceptions.ZigbeeException) as ex:
                 self.debug(

--- a/zha/zigbee/cluster_handlers/lighting.py
+++ b/zha/zigbee/cluster_handlers/lighting.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from functools import cached_property
-
 from zigpy.zcl.clusters.lighting import Ballast, Color
 
 from zha.zigbee.cluster_handlers import (
@@ -56,7 +54,7 @@ class ColorClusterHandler(ClusterHandler):
         Color.AttributeDefs.options.name: True,
     }
 
-    @cached_property
+    @property
     def color_capabilities(self) -> Color.ColorCapabilities:
         """Return ZCL color capabilities of the light."""
         color_capabilities = self.cluster.get(

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from enum import Enum
 from functools import cached_property
@@ -30,7 +30,7 @@ from zigpy.zcl.foundation import (
 import zigpy.zdo.types as zdo_types
 from zigpy.zdo.types import RouteStatus, _NeighborEnums
 
-from zha.application import Platform
+from zha.application import Platform, discovery
 from zha.application.const import (
     ATTR_ARGS,
     ATTR_ATTRIBUTE,
@@ -61,7 +61,7 @@ from zha.application.const import (
     ZHA_EVENT,
 )
 from zha.application.helpers import convert_to_zcl_values, convert_zcl_value
-from zha.application.platforms import BaseEntityInfo, PlatformEntity
+from zha.application.platforms import BaseEntity, BaseEntityInfo, PlatformEntity
 from zha.event import EventBase
 from zha.exceptions import ZHAException
 from zha.mixins import LogMixin
@@ -741,9 +741,6 @@ class Device(LogMixin, EventBase):
 
     async def async_configure(self) -> None:
         """Configure the device."""
-        should_identify = (
-            self.gateway.config.config.device_options.enable_identify_on_join
-        )
         self.debug("started configuration")
         await self._zdo_handler.async_configure()
         self._zdo_handler.debug("'async_configure' stage succeeded")
@@ -767,7 +764,7 @@ class Device(LogMixin, EventBase):
         self.debug("completed configuration")
 
         if (
-            should_identify
+            self.gateway.config.config.device_options.enable_identify_on_join
             and self.identify_ch is not None
             and not self.skip_configuration
         ):
@@ -776,9 +773,50 @@ class Device(LogMixin, EventBase):
                 effect_variant=Identify.EffectVariant.Default,
             )
 
+    def _maybe_add_new_entities(self) -> Sequence[BaseEntity]:
+        if self.is_active_coordinator:
+            new_entities = discovery.DEVICE_PROBE.discover_coordinator_device_entities(
+                self
+            )
+        else:
+            new_entities = discovery.DEVICE_PROBE.discover_device_entities(self)
+
+        added_entities = []
+
+        # Discover all applicable entities
+        for entity in new_entities:
+            key = (entity.PLATFORM, entity.unique_id)
+
+            if key in self.platform_entities:
+                continue
+
+            self.platform_entities[key] = entity
+            entity.on_add()
+            added_entities.append(entity)
+
+        return added_entities
+
+    async def _maybe_remove_unsupported_entities(self) -> Sequence[BaseEntity]:
+        removed_entities = []
+
+        # Finally, remove inapplicable entities
+        for key, entity in list(self.platform_entities.items()):
+            entity.recompute_capabilities()
+
+            if not entity.is_supported():
+                del self.platform_entities[key]
+                await entity.on_remove()
+
+                removed_entities.append(entity)
+
+        return removed_entities
+
     async def async_initialize(self, from_cache: bool = False) -> None:
         """Initialize cluster handlers."""
         self.debug("started initialization")
+
+        self._maybe_add_new_entities()
+
         await self._zdo_handler.async_initialize(from_cache)
         self._zdo_handler.debug("'async_initialize' stage succeeded")
 
@@ -791,6 +829,9 @@ class Device(LogMixin, EventBase):
                 await endpoint.async_initialize(from_cache)
             except Exception:  # pylint: disable=broad-exception-caught
                 self.debug("Failed to initialize endpoint", exc_info=True)
+
+        # Finally, remove inapplicable entities
+        await self._maybe_remove_unsupported_entities()
 
         self.debug("power source: %s", self.power_source)
         self.status = DeviceStatus.INITIALIZED

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -800,6 +800,9 @@ class Device(LogMixin, EventBase):
         """Cancel tasks this device owns."""
         self._zdo_handler.on_remove()
 
+        for endpoint in self._endpoints.values():
+            endpoint.on_remove()
+
         for platform_entity in self._platform_entities.values():
             await platform_entity.on_remove()
 

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -30,7 +30,7 @@ from zigpy.zcl.foundation import (
 import zigpy.zdo.types as zdo_types
 from zigpy.zdo.types import RouteStatus, _NeighborEnums
 
-from zha.application import Platform, discovery
+from zha.application import Platform
 from zha.application.const import (
     ATTR_ARGS,
     ATTR_ATTRIBUTE,
@@ -550,9 +550,7 @@ class Device(LogMixin, EventBase):
         gateway: Gateway,
     ) -> Self:
         """Create new device."""
-        zha_dev = cls(zigpy_dev, gateway)
-        discovery.DEVICE_PROBE.discover_device_entities(zha_dev)
-        return zha_dev
+        return cls(zigpy_dev, gateway)
 
     def async_update_sw_build_id(self, sw_version: int) -> None:
         """Update device sw version."""

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -799,8 +799,10 @@ class Device(LogMixin, EventBase):
     async def _maybe_remove_unsupported_entities(self) -> Sequence[BaseEntity]:
         removed_entities = []
 
-        # Finally, remove inapplicable entities
-        for key, entity in list(self.platform_entities.items()):
+        # Finally, remove inapplicable entities. We iterate backwards to give entities
+        # that have uniqueness constraints (i.e. LQI, RSSI, and Identify) to always pick
+        # the first-created entity, not the last.
+        for key, entity in reversed(list(self.platform_entities.items())):
             entity.recompute_capabilities()
 
             if not entity.is_supported():

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -236,7 +236,10 @@ class Device(LogMixin, EventBase):
 
         self._platform_entities: dict[tuple[Platform, str], PlatformEntity] = {}
         self.semaphore: asyncio.Semaphore = asyncio.Semaphore(3)
+
         self._zdo_handler: ZDOClusterHandler = ZDOClusterHandler(self)
+        self._zdo_handler.on_add()
+
         self.status: DeviceStatus = DeviceStatus.CREATED
 
         self._endpoints: dict[int, Endpoint] = {}
@@ -797,6 +800,8 @@ class Device(LogMixin, EventBase):
 
     async def on_remove(self) -> None:
         """Cancel tasks this device owns."""
+        self._zdo_handler.on_remove()
+
         for platform_entity in self._platform_entities.values():
             await platform_entity.on_remove()
 

--- a/zha/zigbee/endpoint.py
+++ b/zha/zigbee/endpoint.py
@@ -8,7 +8,7 @@ import functools
 import logging
 from typing import TYPE_CHECKING, Any, Final, TypeVar
 
-from zha.application import const, discovery
+from zha.application import const
 from zha.async_ import gather_with_limited_concurrency
 from zha.zigbee.cluster_handlers import ClusterHandler
 from zha.zigbee.cluster_handlers.const import (
@@ -160,7 +160,9 @@ class Endpoint:
                 self._device.identify_ch = cluster_handler
             elif cluster_handler.name == CLUSTER_HANDLER_BASIC:
                 self._device.basic_ch = cluster_handler
+
             self._all_cluster_handlers[cluster_handler.id] = cluster_handler
+            cluster_handler.on_add()
 
     def add_client_cluster_handlers(self) -> None:
         """Create client cluster handlers for all output clusters if in the registry."""
@@ -172,6 +174,7 @@ class Endpoint:
             if cluster is not None:
                 cluster_handler = cluster_handler_class(cluster, self)
                 self.client_cluster_handlers[cluster_handler.id] = cluster_handler
+                cluster_handler.on_add()
 
     async def async_initialize(self, from_cache: bool = False) -> None:
         """Initialize claimed cluster handlers."""

--- a/zha/zigbee/endpoint.py
+++ b/zha/zigbee/endpoint.py
@@ -50,6 +50,18 @@ class Endpoint:
         self._client_cluster_handlers: dict[str, ClientClusterHandler] = {}
         self._unique_id: str = f"{device.unique_id}-{zigpy_endpoint.endpoint_id}"
 
+    def on_remove(self) -> None:
+        """Run when endpoint is removed."""
+        for handler in self.all_cluster_handlers.values():
+            handler.on_remove()
+
+        self.all_cluster_handlers.clear()
+
+        for handler in self.client_cluster_handlers.values():
+            handler.on_remove()
+
+        self.client_cluster_handlers.clear()
+
     @functools.cached_property
     def device(self) -> Device:
         """Return the device this endpoint belongs to."""

--- a/zha/zigbee/endpoint.py
+++ b/zha/zigbee/endpoint.py
@@ -114,8 +114,7 @@ class Endpoint:
         endpoint = cls(zigpy_endpoint, device)
         endpoint.add_all_cluster_handlers()
         endpoint.add_client_cluster_handlers()
-        if not device.is_coordinator:
-            discovery.ENDPOINT_PROBE.discover_entities(endpoint)
+
         return endpoint
 
     def add_all_cluster_handlers(self) -> None:

--- a/zha/zigbee/endpoint.py
+++ b/zha/zigbee/endpoint.py
@@ -8,7 +8,7 @@ import functools
 import logging
 from typing import TYPE_CHECKING, Any, Final, TypeVar
 
-from zha.application import Platform, const, discovery
+from zha.application import const, discovery
 from zha.async_ import gather_with_limited_concurrency
 from zha.zigbee.cluster_handlers import ClusterHandler
 from zha.zigbee.cluster_handlers.const import (
@@ -209,30 +209,6 @@ class Endpoint:
                 )
             else:
                 cluster_handler.debug("'%s' stage succeeded", func_name)
-
-    def async_new_entity(
-        self,
-        platform: Platform,
-        entity_class: CALLABLE_T,
-        unique_id: str,
-        cluster_handlers: list[ClusterHandler],
-        **kwargs: Any,
-    ) -> None:
-        """Create a new entity."""
-        from zha.zigbee.device import (  # pylint: disable=import-outside-toplevel
-            DeviceStatus,
-        )
-
-        if self.device.status == DeviceStatus.INITIALIZED:
-            return
-
-        self.device.gateway.config.platforms[platform].append(
-            (
-                entity_class,
-                (unique_id, cluster_handlers, self, self.device),
-                kwargs or {},
-            )
-        )
 
     def emit_zha_event(self, event_data: dict[str, Any]) -> None:
         """Broadcast an event from this endpoint."""

--- a/zha/zigbee/group.py
+++ b/zha/zigbee/group.py
@@ -231,6 +231,12 @@ class Group(LogMixin):
             )
         self.update_entity_subscriptions()
 
+    def unregister_group_entity(self, group_entity: GroupEntity) -> None:
+        """Unregister a group entity."""
+        if group_entity.unique_id in self._group_entities:
+            self._group_entities.pop(group_entity.unique_id)
+            self._entity_unsubs.pop(group_entity.unique_id)()
+
     def _handle_maybe_update_group_members(self, event: EntityStateChangedEvent):
         """Handle the maybe update group members event."""
         self.gateway.async_create_task(self._maybe_update_group_members(event))

--- a/zha/zigbee/group.py
+++ b/zha/zigbee/group.py
@@ -353,5 +353,5 @@ class Group(LogMixin):
 
     async def on_remove(self) -> None:
         """Cancel tasks this group owns."""
-        for group_entity in self._group_entities.values():
+        for group_entity in tuple(self._group_entities.values()):
             await group_entity.on_remove()


### PR DESCRIPTION
`PlatformEntity` objects, among others, rely on implicit "registration" inside of `__init__` by mutating a global dictionary that ZHA flushes when creating new devices. This is a bit difficult to work with, in my opinion, and is somewhat preventing https://github.com/zigpy/zigpy/pull/1535 from being implemented.

This PR:
1. Construct entity objects *early*.
2. Implement an `on_add` interface to mirror `on_remove` and allow for entity object creation to not rely on any sort of global state.
3. Allow entities to explicitly indicate if they are not supported by the current device via `Entity.is_supported` (this is mostly a copy/paste of the `create_platform_entity` logic).
4. Funnel all device entity discovery explicitly via `gateway.py`.
