### PR TITLE
Add Aqara H1 with neutral features

### DIFF
--- a/zha/application/platforms/select.py
+++ b/zha/application/platforms/select.py
@@ -15,6 +15,7 @@ from zhaquirks.quirk_ids import (
     TUYA_PLUG_ONOFF,
 )
 from zhaquirks.xiaomi.aqara.magnet_ac01 import OppleCluster as MagnetAC01OppleCluster
+from zhaquirks.xiaomi.aqara.opple_switch import OppleOperationMode
 from zhaquirks.xiaomi.aqara.switch_acn047 import OppleCluster as T2RelayOppleCluster
 from zigpy import types
 from zigpy.quirks.v2 import ZCLEnumMetadata
@@ -510,6 +511,19 @@ class AqaraT2RelayDecoupledMode(ZCLEnumSelectEntity):
     _attribute_name = "decoupled_mode"
     _enum = T2RelayOppleCluster.DecoupledMode
     _attr_translation_key: str = "decoupled_mode"
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
+    cluster_handler_names="opple_cluster",
+    models={"lumi.switch.n1aeu1", "lumi.switch.n2aeu1"},
+)
+class AqaraH1OperationMode(ZCLEnumSelectEntity):
+    """Representation of a ZHA switch operation mode configuration entity."""
+
+    _unique_id_suffix = "operation_mode"
+    _attribute_name = "operation_mode"
+    _enum = OppleOperationMode
+    _attr_translation_key: str = "operation_mode"
 
 
 class InovelliOutputMode(types.enum1):

--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -374,6 +374,42 @@ class XiaomiPlugPowerOutageMemorySwitch(ConfigurableAttributeSwitch):
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
+    cluster_handler_names="opple_cluster",
+    models={"lumi.switch.n1aeu1", "lumi.switch.n2aeu1"},
+)
+class AqaraH1OutageMemorySwitch(ConfigurableAttributeSwitch):
+    """Representation of a ZHA power outage memory configuration entity."""
+
+    _unique_id_suffix = "power_outage_memory"
+    _attribute_name = "power_outage_memory"
+    _attr_translation_key = "power_outage_memory"
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
+    cluster_handler_names="opple_cluster",
+    models={"lumi.switch.n1aeu1", "lumi.switch.n2aeu1"},
+)
+class AqaraH1ReverseIndicationLightSwitch(ConfigurableAttributeSwitch):
+    """Representation of a ZHA reverse indication light."""
+
+    _unique_id_suffix = "reverse_indicator_light"
+    _attribute_name = "reverse_indicator_light"
+    _attr_translation_key = "reverse_indicator_light"
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
+    cluster_handler_names="opple_cluster",
+    models={"lumi.switch.n1aeu1", "lumi.switch.n2aeu1"},
+)
+class AqaraH1DoNotDisturbSwitch(ConfigurableAttributeSwitch):
+    """Representation of a ZHA do not disturb mode."""
+
+    _unique_id_suffix = "do_not_disturb"
+    _attribute_name = "do_not_disturb"
+    _attr_translation_key = "do_not_disturb"
+
+
+@CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_BASIC,
     manufacturers={"Philips", "Signify Netherlands B.V."},
     models={"SML001", "SML002", "SML003", "SML004"},

--- a/zha/zigbee/cluster_handlers/manufacturerspecific.py
+++ b/zha/zigbee/cluster_handlers/manufacturerspecific.py
@@ -203,6 +203,16 @@ class OppleRemoteClusterHandler(ClusterHandler):
                 "light_level": True,
                 "hand_open": True,
             }
+        elif self.cluster.endpoint.model in (
+            "lumi.switch.n1aeu1",
+            "lumi.switch.n2aeu1",
+        ):
+            self.ZCL_INIT_ATTRS = {
+                "power_outage_memory": True,
+                "reverse_indicator_light": True,
+                "operation_mode": True,
+                "do_not_disturb": True,
+            }
 
     async def async_initialize_cluster_handler_specific(self, from_cache: bool) -> None:  # pylint: disable=unused-argument
         """Initialize cluster handler specific."""


### PR DESCRIPTION
This PR implements handling of Do not disturb mode, Decoupled mode, Power outage memory and Reversed LEDs switches present in Aqara H1 with neutral ("lumi.switch.n1aeu1", "lumi.switch.n2aeu1") wall switches.