### PR TITLE
Use quirks v2 unit enums for quirks test

### DIFF
--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -30,6 +30,7 @@ from zigpy.quirks.v2 import (
     QuirkBuilder,
     ZCLSensorMetadata,
 )
+from zigpy.quirks.v2.homeassistant import UnitOfTime
 import zigpy.types
 from zigpy.zcl import ClusterType
 import zigpy.zcl.clusters.closures
@@ -316,7 +317,7 @@ async def test_quirks_v2_entity_discovery(
             min_value=1,
             max_value=100,
             step=1,
-            unit=zigpy.quirks.v2.homeassistant.UnitOfTime.SECONDS,
+            unit=UnitOfTime.SECONDS,
             multiplier=1,
             translation_key="off_wait_time",
             fallback_name="Off wait time",
@@ -517,7 +518,7 @@ def _get_test_device(
             min_value=1,
             max_value=100,
             step=1,
-            unit=zigpy.quirks.v2.homeassistant.UnitOfTime.SECONDS,
+            unit=UnitOfTime.SECONDS,
             multiplier=1,
             translation_key="on_off_transition_time",
             fallback_name="On off transition time",
@@ -528,7 +529,7 @@ def _get_test_device(
             min_value=1,
             max_value=100,
             step=1,
-            unit=zigpy.quirks.v2.homeassistant.UnitOfTime.SECONDS,
+            unit=UnitOfTime.SECONDS,
             multiplier=1,
             translation_key="on_off_transition_time",
             fallback_name="On off transition time",

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -30,7 +30,6 @@ from zigpy.quirks.v2 import (
     QuirkBuilder,
     ZCLSensorMetadata,
 )
-from zigpy.quirks.v2.homeassistant import UnitOfTime
 import zigpy.types
 from zigpy.zcl import ClusterType
 import zigpy.zcl.clusters.closures
@@ -317,7 +316,7 @@ async def test_quirks_v2_entity_discovery(
             min_value=1,
             max_value=100,
             step=1,
-            unit=UnitOfTime.SECONDS,
+            unit=zigpy.quirks.v2.homeassistant.UnitOfTime.SECONDS,
             multiplier=1,
             translation_key="off_wait_time",
             fallback_name="Off wait time",
@@ -518,7 +517,7 @@ def _get_test_device(
             min_value=1,
             max_value=100,
             step=1,
-            unit=UnitOfTime.SECONDS,
+            unit=zigpy.quirks.v2.homeassistant.UnitOfTime.SECONDS,
             multiplier=1,
             translation_key="on_off_transition_time",
             fallback_name="On off transition time",
@@ -529,7 +528,7 @@ def _get_test_device(
             min_value=1,
             max_value=100,
             step=1,
-            unit=UnitOfTime.SECONDS,
+            unit=zigpy.quirks.v2.homeassistant.UnitOfTime.SECONDS,
             multiplier=1,
             translation_key="on_off_transition_time",
             fallback_name="On off transition time",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -38,7 +38,7 @@ from zha.application import Platform
 from zha.application.const import ZCL_INIT_ATTRS, ZHA_CLUSTER_HANDLER_READS_PER_REQ
 from zha.application.gateway import Gateway
 from zha.application.platforms import PlatformEntity, sensor
-from zha.application.platforms.sensor import DanfossSoftwareErrorCode, UnitOfMass
+from zha.application.platforms.sensor import DanfossSoftwareErrorCode
 from zha.application.platforms.sensor.const import SensorDeviceClass, SensorStateClass
 from zha.units import PERCENTAGE, UnitOfEnergy, UnitOfPressure, UnitOfVolume
 from zha.zigbee.cluster_handlers import AttrReportConfig
@@ -1360,7 +1360,7 @@ class OppleCluster(CustomCluster, ManufacturerSpecificCluster):
         OppleCluster.cluster_id,
         divisor=1,
         multiplier=1,
-        unit=UnitOfMass.GRAMS,
+        unit=zigpy.quirks.v2.homeassistant.UnitOfMass.GRAMS,
         translation_key="last_feeding_size",
         fallback_name="Last feeding size",
         reporting_config=ReportingConfig(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -15,6 +15,7 @@ from zigpy.profiles import zha
 import zigpy.profiles.zha
 from zigpy.quirks import CustomCluster, DeviceRegistry, get_device
 from zigpy.quirks.v2 import CustomDeviceV2, QuirkBuilder, ReportingConfig
+from zigpy.quirks.v2.homeassistant import UnitOfMass as UnitOfMassV2
 from zigpy.quirks.v2.homeassistant.sensor import (
     SensorDeviceClass as SensorDeviceClassV2,
 )
@@ -1360,7 +1361,7 @@ class OppleCluster(CustomCluster, ManufacturerSpecificCluster):
         OppleCluster.cluster_id,
         divisor=1,
         multiplier=1,
-        unit=zigpy.quirks.v2.homeassistant.UnitOfMass.GRAMS,
+        unit=UnitOfMassV2.GRAMS,
         translation_key="last_feeding_size",
         fallback_name="Last feeding size",
         reporting_config=ReportingConfig(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -15,7 +15,7 @@ from zigpy.profiles import zha
 import zigpy.profiles.zha
 from zigpy.quirks import CustomCluster, DeviceRegistry, get_device
 from zigpy.quirks.v2 import CustomDeviceV2, QuirkBuilder, ReportingConfig
-from zigpy.quirks.v2.homeassistant import UnitOfMass as UnitOfMassV2
+from zigpy.quirks.v2.homeassistant import UnitOfMass
 from zigpy.quirks.v2.homeassistant.sensor import (
     SensorDeviceClass as SensorDeviceClassV2,
 )
@@ -1361,7 +1361,7 @@ class OppleCluster(CustomCluster, ManufacturerSpecificCluster):
         OppleCluster.cluster_id,
         divisor=1,
         multiplier=1,
-        unit=UnitOfMassV2.GRAMS,
+        unit=UnitOfMass.GRAMS,
         translation_key="last_feeding_size",
         fallback_name="Last feeding size",
         reporting_config=ReportingConfig(


### PR DESCRIPTION
## Proposed change

This fixes quirks v2 tests in ZHA to actually use quirks v2 enums from zigpy, and not ZHA units.

An alternative would be to import zigpy `UnitOfMass` as `UnitOfMassV2` to avoid mistakenly using the wrong enum, but it we only use it once in `test_sensor` (for building the quirk), so this change should be enough for now.


## Additional information

Related:
- https://github.com/zigpy/zigpy/pull/1546 (actual fix for the unit issue)
- https://github.com/zigpy/zigpy/pull/1547 (regression test in zigpy, similar to this one)