### PR TITLE
Implement quirks v2 "prevent default entity creation"

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -917,3 +917,36 @@ async def test_primary_entity_computation(
         assert primary == [
             get_entity(zha_device, primary_platform, entity_type=primary_entity_type)
         ]
+
+
+async def test_quirks_v2_prevent_default_entities(zha_gateway: Gateway) -> None:
+    """Test quirks v2 can prevent creating default entities."""
+    registry = DeviceRegistry()
+
+    (
+        QuirkBuilder("CentraLite", "3405-L", registry=registry)
+        .prevent_default_entity_creation(endpoint_id=123)
+        .prevent_default_entity_creation(cluster_id=0x4567)
+        .prevent_default_entity_creation(unique_id_suffix="_something")
+        .prevent_default_entity_creation(function=lambda entity: None)
+        .prevent_default_entity_creation(
+            function=lambda entity: entity.__class__.__name__ == "IdentifyButton"
+        )
+        .add_to_registry()
+    )
+
+    zigpy_dev = registry.get_device(
+        await zigpy_device_from_json(
+            zha_gateway.application_controller,
+            "tests/data/devices/centralite-3405-l.json",
+        )
+    )
+
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
+
+    with pytest.raises(KeyError):
+        zha_device.get_platform_entity(
+            Platform.BUTTON, unique_id="00:0d:6f:00:05:65:83:f2-1-3"
+        )
+
+    assert len(zha_device.platform_entities) == 8

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -801,7 +801,7 @@ class Device(LogMixin, EventBase):
                 continue
 
             if disabled_meta.function is not None and not disabled_meta.function(
-                self, entity
+                entity
             ):
                 continue
 

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -773,36 +773,28 @@ class Device(LogMixin, EventBase):
                 effect_variant=Identify.EffectVariant.Default,
             )
 
-    def _is_entity_disabled_by_default(self, entity: PlatformEntity) -> bool:
+    def _is_entity_removed_by_quirk(self, entity: PlatformEntity) -> bool:
         if self.quirk_metadata is None:
             return False
 
-        for disabled_meta in self.quirk_metadata.disabled_default_entities:
-            _LOGGER.debug(
-                "Checking if entity %s is disabled by %s", entity, disabled_meta
-            )
+        for meta in self.quirk_metadata.disabled_default_entities:
+            _LOGGER.debug("Checking if entity %s is removed by %s", entity, meta)
 
-            if (
-                disabled_meta.unique_id_suffix is not None
-                and not entity.unique_id.endswith(disabled_meta.unique_id_suffix)
+            if meta.unique_id_suffix is not None and not entity.unique_id.endswith(
+                meta.unique_id_suffix
             ):
                 continue
 
-            if (
-                disabled_meta.endpoint_id is not None
-                and entity.endpoint.id != disabled_meta.endpoint_id
-            ):
+            if meta.endpoint_id is not None and entity.endpoint.id != meta.endpoint_id:
                 continue
 
-            if disabled_meta.cluster_id is not None and not any(
-                cluster_handler.cluster.cluster_id == disabled_meta.cluster_id
+            if meta.cluster_id is not None and not any(
+                cluster_handler.cluster.cluster_id == meta.cluster_id
                 for cluster_handler in entity.cluster_handlers.values()
             ):
                 continue
 
-            if disabled_meta.function is not None and not disabled_meta.function(
-                entity
-            ):
+            if meta.function is not None and not meta.function(entity):
                 continue
 
             return True
@@ -825,7 +817,7 @@ class Device(LogMixin, EventBase):
             if key in self.platform_entities:
                 continue
 
-            if self._is_entity_disabled_by_default(entity):
+            if self._is_entity_removed_by_quirk(entity):
                 continue
 
             self.platform_entities[key] = entity

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -773,6 +773,42 @@ class Device(LogMixin, EventBase):
                 effect_variant=Identify.EffectVariant.Default,
             )
 
+    def _is_entity_disabled_by_default(self, entity: PlatformEntity) -> bool:
+        if self.quirk_metadata is None:
+            return False
+
+        for disabled_meta in self.quirk_metadata.disabled_default_entities:
+            _LOGGER.debug(
+                "Checking if entity %s is disabled by %s", entity, disabled_meta
+            )
+
+            if (
+                disabled_meta.unique_id_suffix is not None
+                and not entity.unique_id.endswith(disabled_meta.unique_id_suffix)
+            ):
+                continue
+
+            if (
+                disabled_meta.endpoint_id is not None
+                and entity.endpoint.id != disabled_meta.endpoint_id
+            ):
+                continue
+
+            if disabled_meta.cluster_id is not None and not any(
+                cluster_handler.cluster.cluster_id == disabled_meta.cluster_id
+                for cluster_handler in entity.cluster_handlers.values()
+            ):
+                continue
+
+            if disabled_meta.function is not None and not disabled_meta.function(
+                self, entity
+            ):
+                continue
+
+            return True
+
+        return False
+
     def _maybe_add_new_entities(self) -> Sequence[BaseEntity]:
         if self.is_active_coordinator:
             new_entities = discovery.DEVICE_PROBE.discover_coordinator_device_entities(
@@ -786,8 +822,10 @@ class Device(LogMixin, EventBase):
         # Discover all applicable entities
         for entity in new_entities:
             key = (entity.PLATFORM, entity.unique_id)
-
             if key in self.platform_entities:
+                continue
+
+            if self._is_entity_disabled_by_default(entity):
                 continue
 
             self.platform_entities[key] = entity


### PR DESCRIPTION
`prevent_default_entity_creation` is now functional.

When writing unit tests, I did run into our legacy unique ID format being slightly useless for some types of entities (namely those without a suffix, like `00:0d:6f:00:05:65:83:f2-1-3`). We should look into standardizing them all in a future release with a migration.