### PR TITLE
Update __init__.py

### DIFF
--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -509,7 +509,7 @@ class BaseLight(BaseEntity, ABC):
         if self._zha_config_enable_light_transitioning_flag:
             self.async_transition_start_timer(transition_time)
         self.debug("turned off: %s", result)
-        if result[1] is not Status.SUCCESS:
+        if not result or result[1] is not Status.SUCCESS:
             return
         self._state = False
 


### PR DESCRIPTION
If there is no response from the light, variable "result" is "None". Querying result[1] then throws the exception "NoneType object is not subscriptable".