### PR TITLE
Match v1 quirk entities before v2

### DIFF
--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -257,14 +257,14 @@ class DeviceProbe:
 
         assert not device.is_active_coordinator
 
-        yield from self.discover_quirks_v2_entities(device)
-
         for ep_id, endpoint in device.endpoints.items():
             if ep_id != 0:
                 yield from ENDPOINT_PROBE.discover_entities(
                     endpoint,
                     device.gateway.config.config.device_overrides,
                 )
+
+        yield from self.discover_quirks_v2_entities(device)
 
     def discover_quirks_v2_entities(self, device: Device) -> Iterator[PlatformEntity]:
         """Discover entities for a ZHA device exposed by quirks v2."""


### PR DESCRIPTION
Reported in https://github.com/zigpy/zha-device-handlers/pull/2808.

v1 quirk entities were implicitly loaded before v2 quirks before #365 was merged, this PR corrects it.