### PR TITLE
Update script/setup to detect current environment

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -14,9 +14,19 @@ if [ ! -f "$SETTINGS_FILE" ]; then
     cp "$SETTINGS_TEMPLATE_FILE" "$SETTINGS_FILE"
 fi
 
-curl -LsSf https://astral.sh/uv/install.sh | sh
-uv venv venv
-. venv/bin/activate
+if [ ! -n "$VIRTUAL_ENV" ]; then
+  if [ -x "$(command -v uv)" ]; then
+    uv venv venv
+  else
+    python3 -m venv venv
+  fi
+  source venv/bin/activate
+fi
+
+if ! [ -x "$(command -v uv)" ]; then
+  python3 -m pip install uv
+fi
+
 uv pip install -U pip setuptools pre-commit
 uv pip install -r requirements_test.txt
 uv pip install -e .


### PR DESCRIPTION
Check if we are already in a venv before trying to create and activate one. This allows using the script to update the requirements in an existing venv (instead of having to manually delete it first).
This also uses `pip` to install `uv`, instead of using the install script.