### PR TITLE
Claim cluster handlers during device configuration

### DIFF
--- a/tests/data/devices/espressif-zigbeecarbondioxidesensor.json
+++ b/tests/data/devices/espressif-zigbeecarbondioxidesensor.json
@@ -1,0 +1,444 @@
+{
+  "ieee": "f0:f5:bd:ff:fe:01:86:64",
+  "nwk": 58318,
+  "manufacturer": "Espressif",
+  "model": "ZigbeeCarbonDioxideSensor",
+  "name": "Espressif ZigbeeCarbonDioxideSensor",
+  "quirk_applied": false,
+  "quirk_class": "zigpy.device.Device",
+  "quirk_id": null,
+  "manufacturer_code": 4660,
+  "power_source": "Mains",
+  "lqi": 232,
+  "rssi": -42,
+  "last_seen": "2025-03-20T19:18:56",
+  "available": true,
+  "device_type": "EndDevice",
+  "signature": {
+    "node_descriptor": {
+      "logical_type": 2,
+      "complex_descriptor_available": 0,
+      "user_descriptor_available": 0,
+      "reserved": 0,
+      "aps_flags": 0,
+      "frequency_band": 8,
+      "mac_capability_flags": 140,
+      "manufacturer_code": 4660,
+      "maximum_buffer_size": 108,
+      "maximum_incoming_transfer_size": 1613,
+      "server_mask": 11264,
+      "maximum_outgoing_transfer_size": 1613,
+      "descriptor_capability_field": 0
+    },
+    "endpoints": {
+      "10": {
+        "profile_id": "0x0104",
+        "device_type": "0x000c",
+        "input_clusters": [
+          "0x0000",
+          "0x0003",
+          "0x040d"
+        ],
+        "output_clusters": []
+      }
+    },
+    "manufacturer": "Espressif",
+    "model": "ZigbeeCarbonDioxideSensor"
+  },
+  "active_coordinator": false,
+  "entities": [
+    {
+      "entity_id": "button.espressif_zigbeecarbondioxidesensor_identify",
+      "name": "Espressif ZigbeeCarbonDioxideSensor"
+    },
+    {
+      "entity_id": "sensor.espressif_zigbeecarbondioxidesensor_carbon_dioxide",
+      "name": "Espressif ZigbeeCarbonDioxideSensor"
+    }
+  ],
+  "neighbors": [],
+  "routes": [],
+  "endpoint_names": [
+    {
+      "name": "SIMPLE_SENSOR"
+    }
+  ],
+  "user_given_name": null,
+  "device_reg_id": "e15760d423c062370731e1fee41b7ccf",
+  "area_id": null,
+  "cluster_details": {
+    "10": {
+      "device_type": {
+        "name": "SIMPLE_SENSOR",
+        "id": 12
+      },
+      "profile_id": 260,
+      "in_clusters": {
+        "0x0000": {
+          "endpoint_attribute": "basic",
+          "attributes": {
+            "0x0013": {
+              "attribute": "ZCLAttributeDef(id=0x0013, name='alarm_mask', type=<flag 'AlarmMask'>, zcl_type=<DataTypeId.map8: 24>, access=<ZCLAttributeAccess.Read|Write: 3>, mandatory=False, is_manufacturer_specific=False)",
+              "value": null
+            },
+            "0x0001": {
+              "attribute": "ZCLAttributeDef(id=0x0001, name='app_version', type=<class 'zigpy.types.basic.uint8_t'>, zcl_type=<DataTypeId.uint8: 32>, access=<ZCLAttributeAccess.Read: 1>, mandatory=False, is_manufacturer_specific=False)",
+              "value": null
+            },
+            "0xfffd": {
+              "attribute": "ZCLAttributeDef(id=0xFFFD, name='cluster_revision', type=<class 'zigpy.types.basic.uint16_t'>, zcl_type=<DataTypeId.uint16: 33>, access=<ZCLAttributeAccess.Read: 1>, mandatory=True, is_manufacturer_specific=False)",
+              "value": null
+            },
+            "0x0006": {
+              "attribute": "ZCLAttributeDef(id=0x0006, name='date_code', type=<class 'zigpy.types.basic.LimitedCharString.<locals>.LimitedCharString'>, zcl_type=<DataTypeId.string: 66>, access=<ZCLAttributeAccess.Read: 1>, mandatory=False, is_manufacturer_specific=False)",
+              "value": null
+            },
+            "0x0012": {
+              "attribute": "ZCLAttributeDef(id=0x0012, name='device_enabled', type=<enum 'Bool'>, zcl_type=<DataTypeId.bool_: 16>, access=<ZCLAttributeAccess.Read|Write: 3>, mandatory=False, is_manufacturer_specific=False)",
+              "value": null
+            },
+            "0x0014": {
+              "attribute": "ZCLAttributeDef(id=0x0014, name='disable_local_config', type=<flag 'DisableLocalConfig'>, zcl_type=<DataTypeId.map8: 24>, access=<ZCLAttributeAccess.Read|Write: 3>, mandatory=False, is_manufacturer_specific=False)",
+              "value": null
+            },
+            "0x0008": {
+              "attribute": "ZCLAttributeDef(id=0x0008, name='generic_device_class', type=<enum 'GenericDeviceClass'>, zcl_type=<DataTypeId.enum8: 48>, access=<ZCLAttributeAccess.Read: 1>, mandatory=False, is_manufacturer_specific=False)",
+              "value": null
+            },
+            "0x0009": {
+              "attribute": "ZCLAttributeDef(id=0x0009, name='generic_device_type', type=<enum 'GenericLightingDeviceType'>, zcl_type=<DataTypeId.enum8: 48>, access=<ZCLAttributeAccess.Read: 1>, mandatory=False, is_manufacturer_specific=False)",
+              "value": null
+            },
+            "0x0003": {
+              "attribute": "ZCLAttributeDef(id=0x0003, name='hw_version', type=<class 'zigpy.types.basic.uint8_t'>, zcl_type=<DataTypeId.uint8: 32>, access=<ZCLAttributeAccess.Read: 1>, mandatory=False, is_manufacturer_specific=False)",
+              "value": null
+            },
+            "0x0010": {
+              "attribute": "ZCLAttributeDef(id=0x0010, name='location_desc', type=<class 'zigpy.types.basic.LimitedCharString.<locals>.LimitedCharString'>, zcl_type=<DataTypeId.string: 66>, access=<ZCLAttributeAccess.Read|Write: 3>, mandatory=False, is_manufacturer_specific=False)",
+              "value": null
+            },
+            "0x0004": {
+              "attribute": "ZCLAttributeDef(id=0x0004, name='manufacturer', type=<class 'zigpy.types.basic.LimitedCharString.<locals>.LimitedCharString'>, zcl_type=<DataTypeId.string: 66>, access=<ZCLAttributeAccess.Read: 1>, mandatory=False, is_manufacturer_specific=False)",
+              "value": "Espressif"
+            },
+            "0x000c": {
+              "attribute": "ZCLAttributeDef(id=0x000C, name='manufacturer_version_details', type=<class 'zigpy.types.basic.CharacterString'>, zcl_type=<DataTypeId.string: 66>, access=<ZCLAttributeAccess.Read: 1>, mandatory=False, is_manufacturer_specific=False)",
+              "value": null
+            },
+            "0x0005": {
+              "attribute": "ZCLAttributeDef(id=0x0005, name='model', type=<class 'zigpy.types.basic.LimitedCharString.<locals>.LimitedCharString'>, zcl_type=<DataTypeId.string: 66>, access=<ZCLAttributeAccess.Read: 1>, mandatory=False, is_manufacturer_specific=False)",
+              "value": "ZigbeeCarbonDioxideSensor"
+            },
+            "0x0011": {
+              "attribute": "ZCLAttributeDef(id=0x0011, name='physical_env', type=<enum 'PhysicalEnvironment'>, zcl_type=<DataTypeId.enum8: 48>, access=<ZCLAttributeAccess.Read|Write: 3>, mandatory=False, is_manufacturer_specific=False)",
+              "value": null
+            },
+            "0x0007": {
+              "attribute": "ZCLAttributeDef(id=0x0007, name='power_source', type=<enum 'PowerSource'>, zcl_type=<DataTypeId.enum8: 48>, access=<ZCLAttributeAccess.Read: 1>, mandatory=True, is_manufacturer_specific=False)",
+              "value": null
+            },
+            "0x000a": {
+              "attribute": "ZCLAttributeDef(id=0x000A, name='product_code', type=<class 'zigpy.types.basic.LVBytes'>, zcl_type=<DataTypeId.octstr: 65>, access=<ZCLAttributeAccess.Read: 1>, mandatory=False, is_manufacturer_specific=False)",
+              "value": null
+            },
+            "0x000e": {
+              "attribute": "ZCLAttributeDef(id=0x000E, name='product_label', type=<class 'zigpy.types.basic.CharacterString'>, zcl_type=<DataTypeId.string: 66>, access=<ZCLAttributeAccess.Read: 1>, mandatory=False, is_manufacturer_specific=False)",
+              "value": null
+            },
+            "0x000b": {
+              "attribute": "ZCLAttributeDef(id=0x000B, name='product_url', type=<class 'zigpy.types.basic.CharacterString'>, zcl_type=<DataTypeId.string: 66>, access=<ZCLAttributeAccess.Read: 1>, mandatory=False, is_manufacturer_specific=False)",
+              "value": null
+            },
+            "0xfffe": {
+              "attribute": "ZCLAttributeDef(id=0xFFFE, name='reporting_status', type=<enum 'AttributeReportingStatus'>, zcl_type=<DataTypeId.enum8: 48>, access=<ZCLAttributeAccess.Read: 1>, mandatory=False, is_manufacturer_specific=False)",
+              "value": null
+            },
+            "0x000d": {
+              "attribute": "ZCLAttributeDef(id=0x000D, name='serial_number', type=<class 'zigpy.types.basic.CharacterString'>, zcl_type=<DataTypeId.string: 66>, access=<ZCLAttributeAccess.Read: 1>, mandatory=False, is_manufacturer_specific=False)",
+              "value": null
+            },
+            "0x0002": {
+              "attribute": "ZCLAttributeDef(id=0x0002, name='stack_version', type=<class 'zigpy.types.basic.uint8_t'>, zcl_type=<DataTypeId.uint8: 32>, access=<ZCLAttributeAccess.Read: 1>, mandatory=False, is_manufacturer_specific=False)",
+              "value": null
+            },
+            "0x4000": {
+              "attribute": "ZCLAttributeDef(id=0x4000, name='sw_build_id', type=<class 'zigpy.types.basic.CharacterString'>, zcl_type=<DataTypeId.string: 66>, access=<ZCLAttributeAccess.Read: 1>, mandatory=False, is_manufacturer_specific=False)",
+              "value": null
+            },
+            "0x0000": {
+              "attribute": "ZCLAttributeDef(id=0x0000, name='zcl_version', type=<class 'zigpy.types.basic.uint8_t'>, zcl_type=<DataTypeId.uint8: 32>, access=<ZCLAttributeAccess.Read: 1>, mandatory=True, is_manufacturer_specific=False)",
+              "value": null
+            }
+          },
+          "unsupported_attributes": []
+        },
+        "0x0003": {
+          "endpoint_attribute": "identify",
+          "attributes": {
+            "0xfffd": {
+              "attribute": "ZCLAttributeDef(id=0xFFFD, name='cluster_revision', type=<class 'zigpy.types.basic.uint16_t'>, zcl_type=<DataTypeId.uint16: 33>, access=<ZCLAttributeAccess.Read: 1>, mandatory=True, is_manufacturer_specific=False)",
+              "value": null
+            },
+            "0x0000": {
+              "attribute": "ZCLAttributeDef(id=0x0000, name='identify_time', type=<class 'zigpy.types.basic.uint16_t'>, zcl_type=<DataTypeId.uint16: 33>, access=<ZCLAttributeAccess.Read|Write: 3>, mandatory=True, is_manufacturer_specific=False)",
+              "value": null
+            },
+            "0xfffe": {
+              "attribute": "ZCLAttributeDef(id=0xFFFE, name='reporting_status', type=<enum 'AttributeReportingStatus'>, zcl_type=<DataTypeId.enum8: 48>, access=<ZCLAttributeAccess.Read: 1>, mandatory=False, is_manufacturer_specific=False)",
+              "value": null
+            }
+          },
+          "unsupported_attributes": []
+        },
+        "0x040d": {
+          "endpoint_attribute": "carbon_dioxide_concentration",
+          "attributes": {
+            "0xfffd": {
+              "attribute": "ZCLAttributeDef(id=0xFFFD, name='cluster_revision', type=<class 'zigpy.types.basic.uint16_t'>, zcl_type=<DataTypeId.uint16: 33>, access=<ZCLAttributeAccess.Read: 1>, mandatory=True, is_manufacturer_specific=False)",
+              "value": null
+            },
+            "0x0002": {
+              "attribute": "ZCLAttributeDef(id=0x0002, name='max_measured_value', type=<class 'zigpy.types.basic.Single'>, zcl_type=<DataTypeId.single: 57>, access=<ZCLAttributeAccess.Read: 1>, mandatory=True, is_manufacturer_specific=False)",
+              "value": null
+            },
+            "0x0000": {
+              "attribute": "ZCLAttributeDef(id=0x0000, name='measured_value', type=<class 'zigpy.types.basic.Single'>, zcl_type=<DataTypeId.single: 57>, access=<ZCLAttributeAccess.Read|Report: 9>, mandatory=True, is_manufacturer_specific=False)",
+              "value": 0.0003239999932702631
+            },
+            "0x0001": {
+              "attribute": "ZCLAttributeDef(id=0x0001, name='min_measured_value', type=<class 'zigpy.types.basic.Single'>, zcl_type=<DataTypeId.single: 57>, access=<ZCLAttributeAccess.Read: 1>, mandatory=True, is_manufacturer_specific=False)",
+              "value": null
+            },
+            "0xfffe": {
+              "attribute": "ZCLAttributeDef(id=0xFFFE, name='reporting_status', type=<enum 'AttributeReportingStatus'>, zcl_type=<DataTypeId.enum8: 48>, access=<ZCLAttributeAccess.Read: 1>, mandatory=False, is_manufacturer_specific=False)",
+              "value": null
+            },
+            "0x0003": {
+              "attribute": "ZCLAttributeDef(id=0x0003, name='tolerance', type=<class 'zigpy.types.basic.Single'>, zcl_type=<DataTypeId.single: 57>, access=<ZCLAttributeAccess.Read: 1>, mandatory=False, is_manufacturer_specific=False)",
+              "value": null
+            }
+          },
+          "unsupported_attributes": []
+        }
+      },
+      "out_clusters": {}
+    }
+  },
+  "zha_lib_entities": {
+    "button": [
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "f0:f5:bd:ff:fe:01:86:64-10-3",
+          "platform": "button",
+          "class_name": "IdentifyButton",
+          "translation_key": null,
+          "device_class": "identify",
+          "state_class": null,
+          "entity_category": "diagnostic",
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "cluster_handlers": [
+            {
+              "class_name": "IdentifyClusterHandler",
+              "generic_id": "cluster_handler_0x0003",
+              "endpoint_id": 10,
+              "cluster": {
+                "id": 3,
+                "name": "Identify",
+                "type": "server"
+              },
+              "id": "10:0x0003",
+              "unique_id": "f0:f5:bd:ff:fe:01:86:64:10:0x0003",
+              "status": "CREATED",
+              "value_attribute": null
+            }
+          ],
+          "device_ieee": [
+            100,
+            134,
+            1,
+            254,
+            255,
+            189,
+            245,
+            240
+          ],
+          "endpoint_id": 10,
+          "available": true,
+          "group_id": null,
+          "command": "identify",
+          "args": [
+            5
+          ],
+          "kwargs": {}
+        },
+        "state": {
+          "class_name": "IdentifyButton",
+          "available": true
+        }
+      }
+    ],
+    "sensor": [
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "f0:f5:bd:ff:fe:01:86:64-10-1037",
+          "platform": "sensor",
+          "class_name": "CarbonDioxideConcentration",
+          "translation_key": null,
+          "device_class": "carbon_dioxide",
+          "state_class": "measurement",
+          "entity_category": null,
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "cluster_handlers": [
+            {
+              "class_name": "CarbonDioxideConcentrationClusterHandler",
+              "generic_id": "cluster_handler_0x040d",
+              "endpoint_id": 10,
+              "cluster": {
+                "id": 1037,
+                "name": "Carbon Dioxide (CO₂) Concentration",
+                "type": "server"
+              },
+              "id": "10:0x040d",
+              "unique_id": "f0:f5:bd:ff:fe:01:86:64:10:0x040d",
+              "status": "CREATED",
+              "value_attribute": "measured_value"
+            }
+          ],
+          "device_ieee": [
+            100,
+            134,
+            1,
+            254,
+            255,
+            189,
+            245,
+            240
+          ],
+          "endpoint_id": 10,
+          "available": true,
+          "group_id": null,
+          "attribute": "measured_value",
+          "decimals": 0,
+          "divisor": 1,
+          "multiplier": 1000000.0,
+          "unit": "ppm"
+        },
+        "state": {
+          "class_name": "CarbonDioxideConcentration",
+          "available": true,
+          "state": 324
+        }
+      },
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "f0:f5:bd:ff:fe:01:86:64-10-0-rssi",
+          "platform": "sensor",
+          "class_name": "RSSISensor",
+          "translation_key": "rssi",
+          "device_class": "signal_strength",
+          "state_class": "measurement",
+          "entity_category": "diagnostic",
+          "entity_registry_enabled_default": false,
+          "enabled": true,
+          "cluster_handlers": [
+            {
+              "class_name": "BasicClusterHandler",
+              "generic_id": "cluster_handler_0x0000",
+              "endpoint_id": 10,
+              "cluster": {
+                "id": 0,
+                "name": "Basic",
+                "type": "server"
+              },
+              "id": "10:0x0000",
+              "unique_id": "f0:f5:bd:ff:fe:01:86:64:10:0x0000",
+              "status": "CREATED",
+              "value_attribute": null
+            }
+          ],
+          "device_ieee": [
+            100,
+            134,
+            1,
+            254,
+            255,
+            189,
+            245,
+            240
+          ],
+          "endpoint_id": 10,
+          "available": true,
+          "group_id": null,
+          "attribute": null,
+          "decimals": 1,
+          "divisor": 1,
+          "multiplier": 1,
+          "unit": "dBm"
+        },
+        "state": {
+          "class_name": "RSSISensor",
+          "available": true,
+          "state": -42
+        }
+      },
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "f0:f5:bd:ff:fe:01:86:64-10-0-lqi",
+          "platform": "sensor",
+          "class_name": "LQISensor",
+          "translation_key": "lqi",
+          "device_class": null,
+          "state_class": "measurement",
+          "entity_category": "diagnostic",
+          "entity_registry_enabled_default": false,
+          "enabled": true,
+          "cluster_handlers": [
+            {
+              "class_name": "BasicClusterHandler",
+              "generic_id": "cluster_handler_0x0000",
+              "endpoint_id": 10,
+              "cluster": {
+                "id": 0,
+                "name": "Basic",
+                "type": "server"
+              },
+              "id": "10:0x0000",
+              "unique_id": "f0:f5:bd:ff:fe:01:86:64:10:0x0000",
+              "status": "CREATED",
+              "value_attribute": null
+            }
+          ],
+          "device_ieee": [
+            100,
+            134,
+            1,
+            254,
+            255,
+            189,
+            245,
+            240
+          ],
+          "endpoint_id": 10,
+          "available": true,
+          "group_id": null,
+          "attribute": null,
+          "decimals": 1,
+          "divisor": 1,
+          "multiplier": 1,
+          "unit": null
+        },
+        "state": {
+          "class_name": "LQISensor",
+          "available": true,
+          "state": 232
+        }
+      }
+    ]
+  }
+}

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -950,3 +950,27 @@ async def test_quirks_v2_prevent_default_entities(zha_gateway: Gateway) -> None:
         )
 
     assert len(zha_device.platform_entities) == 8
+
+
+async def test_join_binding_reporting(zha_gateway: Gateway) -> None:
+    """Test that new joins go through binding and attribute reporting."""
+
+    zigpy_dev = await zigpy_device_from_json(
+        zha_gateway.application_controller,
+        "tests/data/devices/espressif-zigbeecarbondioxidesensor.json",
+    )
+
+    co2 = zigpy_dev.endpoints[10].carbon_dioxide_concentration
+
+    with (
+        patch.object(co2, "bind", wraps=co2.bind) as mock_bind,
+        patch.object(
+            co2, "configure_reporting_multiple", wraps=co2.configure_reporting_multiple
+        ) as mock_reporting_config,
+    ):
+        await join_zigpy_device(zha_gateway, zigpy_dev)
+
+    assert mock_bind.mock_calls == [call()]
+    assert mock_reporting_config.mock_calls == [
+        call({"measured_value": (30, 900, 1e-6)})
+    ]

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -749,6 +749,9 @@ class Device(LogMixin, EventBase):
             self.debug("applying quirks custom device configuration")
             await self._zigpy_device.apply_custom_configuration()
 
+        # Try to add entities to claim the cluster handlers
+        self._maybe_add_new_entities()
+
         await asyncio.gather(
             *(endpoint.async_configure() for endpoint in self._endpoints.values())
         )


### PR DESCRIPTION
This bug was introduced in https://github.com/zigpy/zha/pull/365.

Cluster handlers were not being claimed during device configuration (after join), only during device initialization (on integration startup), because we did not try to add new entities.

In the future, there needs to be a better way to have entities *themselves* specify the reporting configuration they require to function. The ZHA device or endpoint object then would figure out the correct binding and reporting config. This would allow entities deriving from the same attribute to all independently be able to specify reporting config and to continue to be reusable. It would also allow prospective entities to be aggregated during device join and for their corresponding attributes/commands to be read. This would eliminate the need for cluster handlers.

Related: https://github.com/home-assistant/core/issues/140880