### PR TITLE
Verify cover supported features per window covering type

### DIFF
--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -26,6 +26,7 @@ from tests.common import (
 from zha.application import Platform
 from zha.application.const import ATTR_COMMAND
 from zha.application.gateway import Gateway
+from zha.application.platforms.cover import Cover
 from zha.application.platforms.cover.const import (
     ATTR_CURRENT_POSITION,
     ATTR_CURRENT_TILT_POSITION,
@@ -211,13 +212,6 @@ async def test_cover(
     zha_gateway: Gateway,
 ) -> None:
     """Test zha cover platform."""
-
-    # Timeout for device movement following a position attribute update
-    DEFAULT_MOVEMENT_TIMEOUT: float = 5
-
-    # Upper limit for dynamic timeout
-    LIFT_MOVEMENT_TIMEOUT_RANGE: float = 300
-    TILT_MOVEMENT_TIMEOUT_RANGE: float = 30
 
     zigpy_cover_device = create_mock_zigpy_device(zha_gateway, ZIGPY_COVER_DEVICE)
     cluster = zigpy_cover_device.endpoints.get(1).window_covering
@@ -431,7 +425,7 @@ async def test_cover(
         assert entity.state["state"] == CoverState.OPEN
 
         # wait for transition timeout to clear the target
-        await asyncio.sleep(DEFAULT_MOVEMENT_TIMEOUT)
+        await asyncio.sleep(Cover.DEFAULT_MOVEMENT_TIMEOUT)
         assert entity.state["state"] == CoverState.OPEN
 
     # test set tilt position command, starting at 100 % / 0 ZCL (open) from previous tilt test
@@ -472,7 +466,7 @@ async def test_cover(
         assert entity.state["state"] == CoverState.OPEN
 
         # wait for transition timeout to clear the target
-        await asyncio.sleep(DEFAULT_MOVEMENT_TIMEOUT)
+        await asyncio.sleep(Cover.DEFAULT_MOVEMENT_TIMEOUT)
         assert entity.state["state"] == CoverState.OPEN
 
     # test interrupted movement (e.g. device button press), starting from 47 %
@@ -498,7 +492,7 @@ async def test_cover(
         assert entity.state["state"] == CoverState.CLOSING
 
         # wait the timer duration
-        await asyncio.sleep(DEFAULT_MOVEMENT_TIMEOUT)
+        await asyncio.sleep(Cover.DEFAULT_MOVEMENT_TIMEOUT)
         assert entity.state["state"] == CoverState.OPEN
 
     # test interrupted tilt movement (e.g. device button press), starting from 47 %
@@ -526,7 +520,7 @@ async def test_cover(
         assert entity.state["state"] == CoverState.CLOSING
 
         # wait the timer duration
-        await asyncio.sleep(DEFAULT_MOVEMENT_TIMEOUT)
+        await asyncio.sleep(Cover.DEFAULT_MOVEMENT_TIMEOUT)
         assert entity.state["state"] == CoverState.OPEN
 
     # test device instigated movement (e.g. device button press), starting from 30 %
@@ -542,7 +536,7 @@ async def test_cover(
         assert entity.state["state"] == CoverState.OPENING
 
         # wait the default timer duration
-        await asyncio.sleep(DEFAULT_MOVEMENT_TIMEOUT)
+        await asyncio.sleep(Cover.DEFAULT_MOVEMENT_TIMEOUT)
         assert entity.state["state"] == CoverState.OPEN
 
     # test device instigated tilt movement (e.g. device button press), starting from 30 %
@@ -558,7 +552,7 @@ async def test_cover(
         assert entity.state["state"] == CoverState.OPENING
 
         # wait the default timer duration
-        await asyncio.sleep(DEFAULT_MOVEMENT_TIMEOUT)
+        await asyncio.sleep(Cover.DEFAULT_MOVEMENT_TIMEOUT)
         assert entity.state["state"] == CoverState.OPEN
 
     # test dynamic movement timeout, starting from 40 % and moving to 90 %
@@ -578,12 +572,12 @@ async def test_cover(
         assert entity.state["state"] == CoverState.OPENING
 
         # wait the default timer duration and verify status is still opening
-        await asyncio.sleep(DEFAULT_MOVEMENT_TIMEOUT)
+        await asyncio.sleep(Cover.DEFAULT_MOVEMENT_TIMEOUT)
         assert entity.state["state"] == CoverState.OPENING
 
         # wait the remainder of the dynamic timeout and check if the movement timed out: (50% * 300 seconds) - default
         await asyncio.sleep(
-            (50 * 0.01 * LIFT_MOVEMENT_TIMEOUT_RANGE) - DEFAULT_MOVEMENT_TIMEOUT
+            (50 * 0.01 * Cover.LIFT_MOVEMENT_TIMEOUT_RANGE) - Cover.DEFAULT_MOVEMENT_TIMEOUT
         )
         assert entity.state[ATTR_CURRENT_POSITION] == 40
         assert entity.state["state"] == CoverState.OPEN
@@ -607,12 +601,12 @@ async def test_cover(
         assert entity.state["state"] == CoverState.OPENING
 
         # wait the default timer duration and verify status is still opening
-        await asyncio.sleep(DEFAULT_MOVEMENT_TIMEOUT)
+        await asyncio.sleep(Cover.DEFAULT_MOVEMENT_TIMEOUT)
         assert entity.state["state"] == CoverState.OPENING
 
         # wait the remainder of the dynamic timeout and check if the movement timed out: (50% * 30 seconds) - default
         await asyncio.sleep(
-            (50 * 0.01 * TILT_MOVEMENT_TIMEOUT_RANGE) - DEFAULT_MOVEMENT_TIMEOUT
+            (50 * 0.01 * Cover.TILT_MOVEMENT_TIMEOUT_RANGE) - Cover.DEFAULT_MOVEMENT_TIMEOUT
         )
         assert entity.state[ATTR_CURRENT_TILT_POSITION] == 40
         assert entity.state["state"] == CoverState.OPEN

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -577,7 +577,8 @@ async def test_cover(
 
         # wait the remainder of the dynamic timeout and check if the movement timed out: (50% * 300 seconds) - default
         await asyncio.sleep(
-            (50 * 0.01 * Cover.LIFT_MOVEMENT_TIMEOUT_RANGE) - Cover.DEFAULT_MOVEMENT_TIMEOUT
+            (50 * 0.01 * Cover.LIFT_MOVEMENT_TIMEOUT_RANGE)
+            - Cover.DEFAULT_MOVEMENT_TIMEOUT
         )
         assert entity.state[ATTR_CURRENT_POSITION] == 40
         assert entity.state["state"] == CoverState.OPEN
@@ -606,7 +607,8 @@ async def test_cover(
 
         # wait the remainder of the dynamic timeout and check if the movement timed out: (50% * 30 seconds) - default
         await asyncio.sleep(
-            (50 * 0.01 * Cover.TILT_MOVEMENT_TIMEOUT_RANGE) - Cover.DEFAULT_MOVEMENT_TIMEOUT
+            (50 * 0.01 * Cover.TILT_MOVEMENT_TIMEOUT_RANGE)
+            - Cover.DEFAULT_MOVEMENT_TIMEOUT
         )
         assert entity.state[ATTR_CURRENT_TILT_POSITION] == 40
         assert entity.state["state"] == CoverState.OPEN

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -28,6 +28,7 @@ from zha.application.const import ATTR_COMMAND
 from zha.application.gateway import Gateway
 from zha.application.platforms.cover.const import (
     ATTR_CURRENT_POSITION,
+    ATTR_CURRENT_TILT_POSITION,
     CoverEntityFeature,
     CoverState,
 )
@@ -96,16 +97,19 @@ async def test_cover_non_tilt_initial_state(  # pylint: disable=unused-argument
     cluster = zigpy_cover_device.endpoints[1].window_covering
     cluster.PLUGGED_ATTR_READS = {
         WCAttrs.current_position_lift_percentage.name: 0,
+        WCAttrs.current_position_tilt_percentage.name: 0,  # to validate that this is overridden to None in the state attribute
         WCAttrs.window_covering_type.name: WCT.Drapery,
         WCAttrs.config_status.name: WCCS(~WCCS.Open_up_commands_reversed),
     }
     update_attribute_cache(cluster)
     zha_device = await join_zigpy_device(zha_gateway, zigpy_cover_device)
+
     assert (
         not zha_device.endpoints[1]
         .all_cluster_handlers[f"1:0x{cluster.cluster_id:04x}"]
         .inverted
     )
+
     assert cluster.read_attributes.call_count == 3
     assert (
         WCAttrs.current_position_lift_percentage.name
@@ -120,6 +124,13 @@ async def test_cover_non_tilt_initial_state(  # pylint: disable=unused-argument
     state = entity.state
     assert state["state"] == CoverState.OPEN
     assert state[ATTR_CURRENT_POSITION] == 100
+    assert state[ATTR_CURRENT_TILT_POSITION] is None
+    assert entity.supported_features == (
+        CoverEntityFeature.OPEN
+        | CoverEntityFeature.CLOSE
+        | CoverEntityFeature.STOP
+        | CoverEntityFeature.SET_POSITION
+    )
 
     # test update
     cluster.PLUGGED_ATTR_READS = {
@@ -134,6 +145,66 @@ async def test_cover_non_tilt_initial_state(  # pylint: disable=unused-argument
 
     assert entity.state["state"] == CoverState.CLOSED
     assert entity.state[ATTR_CURRENT_POSITION] == 0
+
+
+async def test_cover_non_lift_initial_state(  # pylint: disable=unused-argument
+    zha_gateway: Gateway,
+) -> None:
+    """Test ZHA cover platform."""
+
+    # load up cover domain
+    zigpy_cover_device = create_mock_zigpy_device(zha_gateway, ZIGPY_COVER_DEVICE)
+    cluster = zigpy_cover_device.endpoints[1].window_covering
+    cluster.PLUGGED_ATTR_READS = {
+        WCAttrs.current_position_lift_percentage.name: 0,  # to validate that this is overridden to None in the state attribute
+        WCAttrs.current_position_tilt_percentage.name: 0,
+        WCAttrs.window_covering_type.name: WCT.Tilt_blind_tilt_only,
+        WCAttrs.config_status.name: WCCS(~WCCS.Open_up_commands_reversed),
+    }
+    update_attribute_cache(cluster)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_cover_device)
+
+    assert (
+        not zha_device.endpoints[1]
+        .all_cluster_handlers[f"1:0x{cluster.cluster_id:04x}"]
+        .inverted
+    )
+
+    assert cluster.read_attributes.call_count == 3
+    assert (
+        WCAttrs.current_position_lift_percentage.name
+        in cluster.read_attributes.call_args[0][0]
+    )
+    assert (
+        WCAttrs.current_position_tilt_percentage.name
+        in cluster.read_attributes.call_args[0][0]
+    )
+
+    entity = get_entity(zha_device, platform=Platform.COVER)
+    state = entity.state
+    assert state["state"] == CoverState.OPEN
+    assert state[ATTR_CURRENT_POSITION] is None
+    assert state[ATTR_CURRENT_TILT_POSITION] == 100
+    assert entity.supported_features == (
+        CoverEntityFeature.OPEN_TILT
+        | CoverEntityFeature.CLOSE_TILT
+        | CoverEntityFeature.STOP_TILT
+        | CoverEntityFeature.SET_TILT_POSITION
+    )
+
+    # test update
+    cluster.PLUGGED_ATTR_READS = {
+        WCAttrs.current_position_tilt_percentage.name: 100,
+        WCAttrs.window_covering_type.name: WCT.Tilt_blind_tilt_only,
+        WCAttrs.config_status.name: WCCS(~WCCS.Open_up_commands_reversed),
+    }
+    update_attribute_cache(cluster)
+    prev_call_count = cluster.read_attributes.call_count
+    await entity.async_update()
+    assert cluster.read_attributes.call_count == prev_call_count + 1
+
+    assert entity.state["state"] == CoverState.CLOSED
+    assert entity.state[ATTR_CURRENT_TILT_POSITION] == 0
 
 
 async def test_cover(
@@ -329,7 +400,7 @@ async def test_cover(
 
     # test set position command, starting at 100 % / 0 ZCL (open) from previous lift test
     with patch("zigpy.zcl.Cluster.request", return_value=[0x5, zcl_f.Status.SUCCESS]):
-        assert entity.state["current_position"] == 100
+        assert entity.state[ATTR_CURRENT_POSITION] == 100
         await entity.async_set_cover_position(position=47)  # 53 when inverted for ZCL
         await zha_gateway.async_block_till_done()
         assert cluster.request.call_count == 1
@@ -345,14 +416,14 @@ async def test_cover(
             zha_gateway, cluster, {WCAttrs.current_position_lift_percentage.id: 35}
         )
 
-        assert entity.state["current_position"] == 65
+        assert entity.state[ATTR_CURRENT_POSITION] == 65
         assert entity.state["state"] == CoverState.CLOSING
 
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_lift_percentage.id: 53}
         )
 
-        assert entity.state["current_position"] == 47
+        assert entity.state[ATTR_CURRENT_POSITION] == 47
         assert entity.state["state"] == CoverState.OPEN
 
         # verify that a subsequent go_to command does not change the state to closing/opening
@@ -365,7 +436,7 @@ async def test_cover(
 
     # test set tilt position command, starting at 100 % / 0 ZCL (open) from previous tilt test
     with patch("zigpy.zcl.Cluster.request", return_value=[0x5, zcl_f.Status.SUCCESS]):
-        assert entity.state["current_tilt_position"] == 100
+        assert entity.state[ATTR_CURRENT_TILT_POSITION] == 100
         await entity.async_set_cover_tilt_position(
             tilt_position=47
         )  # 53 when inverted for ZCL
@@ -386,14 +457,14 @@ async def test_cover(
             zha_gateway, cluster, {WCAttrs.current_position_tilt_percentage.id: 35}
         )
 
-        assert entity.state["current_tilt_position"] == 65
+        assert entity.state[ATTR_CURRENT_TILT_POSITION] == 65
         assert entity.state["state"] == CoverState.CLOSING
 
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_tilt_percentage.id: 53}
         )
 
-        assert entity.state["current_tilt_position"] == 47
+        assert entity.state[ATTR_CURRENT_TILT_POSITION] == 47
         assert entity.state["state"] == CoverState.OPEN
 
         # verify that a subsequent go_to command does not change the state to closing/opening
@@ -415,7 +486,7 @@ async def test_cover(
         assert cluster.request.call_args[0][3] == 100
         assert cluster.request.call_args[1]["expect_reply"] is True
 
-        assert entity.state["current_position"] == 47
+        assert entity.state[ATTR_CURRENT_POSITION] == 47
         assert entity.state["state"] == CoverState.CLOSING
 
         # simulate a device position update to set timer to the default duration rather than dynamic
@@ -423,7 +494,7 @@ async def test_cover(
             zha_gateway, cluster, {WCAttrs.current_position_lift_percentage.id: 70}
         )
 
-        assert entity.state["current_position"] == 30
+        assert entity.state[ATTR_CURRENT_POSITION] == 30
         assert entity.state["state"] == CoverState.CLOSING
 
         # wait the timer duration
@@ -443,7 +514,7 @@ async def test_cover(
         assert cluster.request.call_args[0][3] == 100
         assert cluster.request.call_args[1]["expect_reply"] is True
 
-        assert entity.state["current_tilt_position"] == 47
+        assert entity.state[ATTR_CURRENT_TILT_POSITION] == 47
         assert entity.state["state"] == CoverState.CLOSING
 
         # simulate a device position update to set timer to the default duration rather than dynamic
@@ -451,7 +522,7 @@ async def test_cover(
             zha_gateway, cluster, {WCAttrs.current_position_tilt_percentage.id: 70}
         )
 
-        assert entity.state["current_tilt_position"] == 30
+        assert entity.state[ATTR_CURRENT_TILT_POSITION] == 30
         assert entity.state["state"] == CoverState.CLOSING
 
         # wait the timer duration
@@ -460,14 +531,14 @@ async def test_cover(
 
     # test device instigated movement (e.g. device button press), starting from 30 %
     with patch("zigpy.zcl.Cluster.request", return_value=[0x5, zcl_f.Status.SUCCESS]):
-        assert entity.state["current_position"] == 30
+        assert entity.state[ATTR_CURRENT_POSITION] == 30
         assert entity.state["state"] == CoverState.OPEN
 
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_lift_percentage.id: 60}
         )
 
-        assert entity.state["current_position"] == 40
+        assert entity.state[ATTR_CURRENT_POSITION] == 40
         assert entity.state["state"] == CoverState.OPENING
 
         # wait the default timer duration
@@ -476,14 +547,14 @@ async def test_cover(
 
     # test device instigated tilt movement (e.g. device button press), starting from 30 %
     with patch("zigpy.zcl.Cluster.request", return_value=[0x5, zcl_f.Status.SUCCESS]):
-        assert entity.state["current_tilt_position"] == 30
+        assert entity.state[ATTR_CURRENT_TILT_POSITION] == 30
         assert entity.state["state"] == CoverState.OPEN
 
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_tilt_percentage.id: 60}
         )
 
-        assert entity.state["current_tilt_position"] == 40
+        assert entity.state[ATTR_CURRENT_TILT_POSITION] == 40
         assert entity.state["state"] == CoverState.OPENING
 
         # wait the default timer duration
@@ -492,7 +563,7 @@ async def test_cover(
 
     # test dynamic movement timeout, starting from 40 % and moving to 90 %
     with patch("zigpy.zcl.Cluster.request", return_value=[0x5, zcl_f.Status.SUCCESS]):
-        assert entity.state["current_position"] == 40
+        assert entity.state[ATTR_CURRENT_POSITION] == 40
         assert entity.state["state"] == CoverState.OPEN
 
         await entity.async_set_cover_position(position=90)  # 10 when inverted for ZCL
@@ -514,12 +585,12 @@ async def test_cover(
         await asyncio.sleep(
             (50 * 0.01 * LIFT_MOVEMENT_TIMEOUT_RANGE) - DEFAULT_MOVEMENT_TIMEOUT
         )
-        assert entity.state["current_position"] == 40
+        assert entity.state[ATTR_CURRENT_POSITION] == 40
         assert entity.state["state"] == CoverState.OPEN
 
     # test dynamic tilt movement timeout, starting from 40 % and moving to 90 %
     with patch("zigpy.zcl.Cluster.request", return_value=[0x5, zcl_f.Status.SUCCESS]):
-        assert entity.state["current_tilt_position"] == 40
+        assert entity.state[ATTR_CURRENT_TILT_POSITION] == 40
         assert entity.state["state"] == CoverState.OPEN
 
         await entity.async_set_cover_tilt_position(
@@ -543,13 +614,13 @@ async def test_cover(
         await asyncio.sleep(
             (50 * 0.01 * TILT_MOVEMENT_TIMEOUT_RANGE) - DEFAULT_MOVEMENT_TIMEOUT
         )
-        assert entity.state["current_tilt_position"] == 40
+        assert entity.state[ATTR_CURRENT_TILT_POSITION] == 40
         assert entity.state["state"] == CoverState.OPEN
 
     # test concurrent movement of both axis, lift and tilt starting at 40 %
     with patch("zigpy.zcl.Cluster.request", return_value=[0x5, zcl_f.Status.SUCCESS]):
-        assert entity.state["current_position"] == 40
-        assert entity.state["current_tilt_position"] == 40
+        assert entity.state[ATTR_CURRENT_POSITION] == 40
+        assert entity.state[ATTR_CURRENT_TILT_POSITION] == 40
 
         await entity.async_set_cover_position(position=90)  # 10 when inverted for ZCL
         await zha_gateway.async_block_till_done()
@@ -581,7 +652,7 @@ async def test_cover(
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_tilt_percentage.id: 99}
         )
-        assert entity.state["current_tilt_position"] == 1
+        assert entity.state[ATTR_CURRENT_TILT_POSITION] == 1
 
         # state should have reverted to opening because there is still an active lift target transition
         assert entity.state["state"] == CoverState.OPENING
@@ -590,7 +661,7 @@ async def test_cover(
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_lift_percentage.id: 10}
         )
-        assert entity.state["current_position"] == 90
+        assert entity.state[ATTR_CURRENT_POSITION] == 90
 
         # the state should now be open (static)
         assert entity.state["state"] == CoverState.OPEN
@@ -889,7 +960,7 @@ async def test_shade(
         assert cluster_level.request.call_args[0][0] is False
         assert cluster_level.request.call_args[0][1] == 0x0004
         assert int(cluster_level.request.call_args[0][3] * 100 / 255) == 47
-        assert entity.state["current_position"] == 0
+        assert entity.state[ATTR_CURRENT_POSITION] == 0
 
     # set position UI success
     with patch(
@@ -901,11 +972,11 @@ async def test_shade(
         assert cluster_level.request.call_args[0][0] is False
         assert cluster_level.request.call_args[0][1] == 0x0004
         assert int(cluster_level.request.call_args[0][3] * 100 / 255) == 47
-        assert entity.state["current_position"] == 47
+        assert entity.state[ATTR_CURRENT_POSITION] == 47
 
     # report position change
     await send_attributes_report(zha_gateway, cluster_level, {8: 0, 0: 100, 1: 1})
-    assert entity.state["current_position"] == int(100 * 100 / 255)
+    assert entity.state[ATTR_CURRENT_POSITION] == int(100 * 100 / 255)
 
     # stop command fails
     with (
@@ -998,7 +1069,7 @@ async def test_keen_vent(
         assert cluster_on_off.request.call_args[0][1] == 0x0001
         assert cluster_level.request.call_count == 1
         assert entity.state["state"] == CoverState.OPEN
-        assert entity.state["current_position"] == 100
+        assert entity.state[ATTR_CURRENT_POSITION] == 100
 
 
 async def test_cover_remote(zha_gateway: Gateway) -> None:

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -26,7 +26,11 @@ from tests.common import (
 from zha.application import Platform
 from zha.application.const import ATTR_COMMAND
 from zha.application.gateway import Gateway
-from zha.application.platforms.cover import Cover
+from zha.application.platforms.cover import (
+    DEFAULT_MOVEMENT_TIMEOUT,
+    LIFT_MOVEMENT_TIMEOUT_RANGE,
+    TILT_MOVEMENT_TIMEOUT_RANGE,
+)
 from zha.application.platforms.cover.const import (
     ATTR_CURRENT_POSITION,
     ATTR_CURRENT_TILT_POSITION,
@@ -425,7 +429,7 @@ async def test_cover(
         assert entity.state["state"] == CoverState.OPEN
 
         # wait for transition timeout to clear the target
-        await asyncio.sleep(Cover.DEFAULT_MOVEMENT_TIMEOUT)
+        await asyncio.sleep(DEFAULT_MOVEMENT_TIMEOUT)
         assert entity.state["state"] == CoverState.OPEN
 
     # test set tilt position command, starting at 100 % / 0 ZCL (open) from previous tilt test
@@ -466,7 +470,7 @@ async def test_cover(
         assert entity.state["state"] == CoverState.OPEN
 
         # wait for transition timeout to clear the target
-        await asyncio.sleep(Cover.DEFAULT_MOVEMENT_TIMEOUT)
+        await asyncio.sleep(DEFAULT_MOVEMENT_TIMEOUT)
         assert entity.state["state"] == CoverState.OPEN
 
     # test interrupted movement (e.g. device button press), starting from 47 %
@@ -492,7 +496,7 @@ async def test_cover(
         assert entity.state["state"] == CoverState.CLOSING
 
         # wait the timer duration
-        await asyncio.sleep(Cover.DEFAULT_MOVEMENT_TIMEOUT)
+        await asyncio.sleep(DEFAULT_MOVEMENT_TIMEOUT)
         assert entity.state["state"] == CoverState.OPEN
 
     # test interrupted tilt movement (e.g. device button press), starting from 47 %
@@ -520,7 +524,7 @@ async def test_cover(
         assert entity.state["state"] == CoverState.CLOSING
 
         # wait the timer duration
-        await asyncio.sleep(Cover.DEFAULT_MOVEMENT_TIMEOUT)
+        await asyncio.sleep(DEFAULT_MOVEMENT_TIMEOUT)
         assert entity.state["state"] == CoverState.OPEN
 
     # test device instigated movement (e.g. device button press), starting from 30 %
@@ -536,7 +540,7 @@ async def test_cover(
         assert entity.state["state"] == CoverState.OPENING
 
         # wait the default timer duration
-        await asyncio.sleep(Cover.DEFAULT_MOVEMENT_TIMEOUT)
+        await asyncio.sleep(DEFAULT_MOVEMENT_TIMEOUT)
         assert entity.state["state"] == CoverState.OPEN
 
     # test device instigated tilt movement (e.g. device button press), starting from 30 %
@@ -552,7 +556,7 @@ async def test_cover(
         assert entity.state["state"] == CoverState.OPENING
 
         # wait the default timer duration
-        await asyncio.sleep(Cover.DEFAULT_MOVEMENT_TIMEOUT)
+        await asyncio.sleep(DEFAULT_MOVEMENT_TIMEOUT)
         assert entity.state["state"] == CoverState.OPEN
 
     # test dynamic movement timeout, starting from 40 % and moving to 90 %
@@ -572,13 +576,12 @@ async def test_cover(
         assert entity.state["state"] == CoverState.OPENING
 
         # wait the default timer duration and verify status is still opening
-        await asyncio.sleep(Cover.DEFAULT_MOVEMENT_TIMEOUT)
+        await asyncio.sleep(DEFAULT_MOVEMENT_TIMEOUT)
         assert entity.state["state"] == CoverState.OPENING
 
         # wait the remainder of the dynamic timeout and check if the movement timed out: (50% * 300 seconds) - default
         await asyncio.sleep(
-            (50 * 0.01 * Cover.LIFT_MOVEMENT_TIMEOUT_RANGE)
-            - Cover.DEFAULT_MOVEMENT_TIMEOUT
+            (50 * 0.01 * LIFT_MOVEMENT_TIMEOUT_RANGE) - DEFAULT_MOVEMENT_TIMEOUT
         )
         assert entity.state[ATTR_CURRENT_POSITION] == 40
         assert entity.state["state"] == CoverState.OPEN
@@ -602,13 +605,12 @@ async def test_cover(
         assert entity.state["state"] == CoverState.OPENING
 
         # wait the default timer duration and verify status is still opening
-        await asyncio.sleep(Cover.DEFAULT_MOVEMENT_TIMEOUT)
+        await asyncio.sleep(DEFAULT_MOVEMENT_TIMEOUT)
         assert entity.state["state"] == CoverState.OPENING
 
         # wait the remainder of the dynamic timeout and check if the movement timed out: (50% * 30 seconds) - default
         await asyncio.sleep(
-            (50 * 0.01 * Cover.TILT_MOVEMENT_TIMEOUT_RANGE)
-            - Cover.DEFAULT_MOVEMENT_TIMEOUT
+            (50 * 0.01 * TILT_MOVEMENT_TIMEOUT_RANGE) - DEFAULT_MOVEMENT_TIMEOUT
         )
         assert entity.state[ATTR_CURRENT_TILT_POSITION] == 40
         assert entity.state["state"] == CoverState.OPEN

--- a/zha/application/platforms/cover/__init__.py
+++ b/zha/application/platforms/cover/__init__.py
@@ -51,10 +51,10 @@ _LOGGER = logging.getLogger(__name__)
 
 MULTI_MATCH = functools.partial(PLATFORM_ENTITIES.multipass_match, Platform.COVER)
 
-# Upper limit for dynamic timeout
+# Timeout for device transition state following a position attribute update
 DEFAULT_MOVEMENT_TIMEOUT: float = 5
 
-# Timeout for device transition state following a position attribute update
+# Upper limit for dynamic timeout
 LIFT_MOVEMENT_TIMEOUT_RANGE: float = 300
 TILT_MOVEMENT_TIMEOUT_RANGE: float = 30
 

--- a/zha/application/platforms/cover/__init__.py
+++ b/zha/application/platforms/cover/__init__.py
@@ -90,6 +90,7 @@ class Cover(PlatformEntity):
                 )
             )
         self._supported_features: CoverEntityFeature = CoverEntityFeature(0)
+        self.recompute_capabilities()
 
         self._target_lift_position: int | None = None
         self._target_tilt_position: int | None = None
@@ -106,7 +107,6 @@ class Cover(PlatformEntity):
         self._tilt_transition_timer: asyncio.TimerHandle | None = None
 
         self._state: CoverState | None = CoverState.OPEN
-        self.recompute_capabilities()
         self._determine_cover_state(refresh=True)
 
     def recompute_capabilities(self) -> None:

--- a/zha/application/platforms/cover/__init__.py
+++ b/zha/application/platforms/cover/__init__.py
@@ -49,6 +49,10 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+DEFAULT_MOVEMENT_TIMEOUT: float = 5
+LIFT_MOVEMENT_TIMEOUT_RANGE: float = 300
+TILT_MOVEMENT_TIMEOUT_RANGE: float = 30
+
 MULTI_MATCH = functools.partial(PLATFORM_ENTITIES.multipass_match, Platform.COVER)
 
 
@@ -115,10 +119,6 @@ class BaseCover(PlatformEntity, ABC):
 @MULTI_MATCH(cluster_handler_names=CLUSTER_HANDLER_COVER)
 class Cover(BaseCover):
     """Representation of a ZHA cover."""
-
-    DEFAULT_MOVEMENT_TIMEOUT: float = 5
-    LIFT_MOVEMENT_TIMEOUT_RANGE: float = 300
-    TILT_MOVEMENT_TIMEOUT_RANGE: float = 30
 
     _attr_translation_key: str = "cover"
 
@@ -430,15 +430,15 @@ class Cover(BaseCover):
             or self.current_cover_position is None
             or self._target_lift_position == self.current_cover_position
         ):
-            duration = self.DEFAULT_MOVEMENT_TIMEOUT
+            duration = DEFAULT_MOVEMENT_TIMEOUT
         else:
             duration = (
                 abs(self._target_lift_position - self.current_cover_position)
                 * 0.01
-                * self.LIFT_MOVEMENT_TIMEOUT_RANGE
+                * LIFT_MOVEMENT_TIMEOUT_RANGE
             )
         if is_position_update:
-            duration = min(self.DEFAULT_MOVEMENT_TIMEOUT, duration)
+            duration = min(DEFAULT_MOVEMENT_TIMEOUT, duration)
         assert duration > 0
 
         if not transition_update:
@@ -461,15 +461,15 @@ class Cover(BaseCover):
             or self.current_cover_tilt_position is None
             or self._target_tilt_position == self.current_cover_tilt_position
         ):
-            duration = self.DEFAULT_MOVEMENT_TIMEOUT
+            duration = DEFAULT_MOVEMENT_TIMEOUT
         else:
             duration = (
                 abs(self._target_tilt_position - self.current_cover_tilt_position)
                 * 0.01
-                * self.TILT_MOVEMENT_TIMEOUT_RANGE
+                * TILT_MOVEMENT_TIMEOUT_RANGE
             )
         if is_position_update:
-            duration = min(self.DEFAULT_MOVEMENT_TIMEOUT, duration)
+            duration = min(DEFAULT_MOVEMENT_TIMEOUT, duration)
         assert duration > 0
 
         if not transition_update:

--- a/zha/application/platforms/cover/__init__.py
+++ b/zha/application/platforms/cover/__init__.py
@@ -206,7 +206,7 @@ class Cover(PlatformEntity):
         Keep in mind the values have already been flipped to match HA
         in the WindowCovering cluster handler.
         """
-        if not self._attr_supported_features & CoverEntityFeature.OPEN:
+        if not self.supported_features & CoverEntityFeature.OPEN:
             return None
         return self._cover_cluster_handler.current_position_lift_percentage
 
@@ -219,7 +219,7 @@ class Cover(PlatformEntity):
         Keep in mind the values have already been flipped to match HA
         in the WindowCovering cluster handler.
         """
-        if not self._attr_supported_features & CoverEntityFeature.OPEN_TILT:
+        if not self.supported_features & CoverEntityFeature.OPEN_TILT:
             return None
         return self._cover_cluster_handler.current_position_tilt_percentage
 

--- a/zha/application/platforms/cover/__init__.py
+++ b/zha/application/platforms/cover/__init__.py
@@ -50,19 +50,16 @@ _LOGGER = logging.getLogger(__name__)
 
 MULTI_MATCH = functools.partial(PLATFORM_ENTITIES.multipass_match, Platform.COVER)
 
-# Timeout for device transition state following a position attribute update
-DEFAULT_MOVEMENT_TIMEOUT: float = 5
-
-# Upper limit for dynamic timeout
-LIFT_MOVEMENT_TIMEOUT_RANGE: float = 300
-TILT_MOVEMENT_TIMEOUT_RANGE: float = 30
-
 
 @MULTI_MATCH(cluster_handler_names=CLUSTER_HANDLER_COVER)
 class Cover(PlatformEntity):
     """Representation of a ZHA cover."""
 
     PLATFORM = Platform.COVER
+
+    DEFAULT_MOVEMENT_TIMEOUT: float = 5
+    LIFT_MOVEMENT_TIMEOUT_RANGE: float = 300
+    TILT_MOVEMENT_TIMEOUT_RANGE: float = 30
 
     _attr_translation_key: str = "cover"
     _attr_primary_weight = 10
@@ -373,15 +370,15 @@ class Cover(PlatformEntity):
             or self.current_cover_position is None
             or self._target_lift_position == self.current_cover_position
         ):
-            duration = DEFAULT_MOVEMENT_TIMEOUT
+            duration = self.DEFAULT_MOVEMENT_TIMEOUT
         else:
             duration = (
                 abs(self._target_lift_position - self.current_cover_position)
                 * 0.01
-                * LIFT_MOVEMENT_TIMEOUT_RANGE
+                * self.LIFT_MOVEMENT_TIMEOUT_RANGE
             )
         if is_position_update:
-            duration = min(DEFAULT_MOVEMENT_TIMEOUT, duration)
+            duration = min(self.DEFAULT_MOVEMENT_TIMEOUT, duration)
         assert duration > 0
 
         if not transition_update:
@@ -404,15 +401,15 @@ class Cover(PlatformEntity):
             or self.current_cover_tilt_position is None
             or self._target_tilt_position == self.current_cover_tilt_position
         ):
-            duration = DEFAULT_MOVEMENT_TIMEOUT
+            duration = self.DEFAULT_MOVEMENT_TIMEOUT
         else:
             duration = (
                 abs(self._target_tilt_position - self.current_cover_tilt_position)
                 * 0.01
-                * TILT_MOVEMENT_TIMEOUT_RANGE
+                * self.TILT_MOVEMENT_TIMEOUT_RANGE
             )
         if is_position_update:
-            duration = min(DEFAULT_MOVEMENT_TIMEOUT, duration)
+            duration = min(self.DEFAULT_MOVEMENT_TIMEOUT, duration)
         assert duration > 0
 
         if not transition_update:

--- a/zha/application/platforms/cover/__init__.py
+++ b/zha/application/platforms/cover/__init__.py
@@ -49,11 +49,14 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+MULTI_MATCH = functools.partial(PLATFORM_ENTITIES.multipass_match, Platform.COVER)
+
+# Upper limit for dynamic timeout
 DEFAULT_MOVEMENT_TIMEOUT: float = 5
+
+# Timeout for device transition state following a position attribute update
 LIFT_MOVEMENT_TIMEOUT_RANGE: float = 300
 TILT_MOVEMENT_TIMEOUT_RANGE: float = 30
-
-MULTI_MATCH = functools.partial(PLATFORM_ENTITIES.multipass_match, Platform.COVER)
 
 
 class BaseCover(PlatformEntity, ABC):

--- a/zha/application/platforms/cover/__init__.py
+++ b/zha/application/platforms/cover/__init__.py
@@ -110,28 +110,35 @@ class Cover(PlatformEntity):
         self._determine_cover_state(refresh=True)
 
     def recompute_capabilities(self) -> None:
-        """Recompute capabilities and feature flags."""
+        """Recompute capabilities and feature flags based on the window covering type."""
         super().recompute_capabilities()
 
-        self._attr_supported_features = (
-            CoverEntityFeature.OPEN
-            | CoverEntityFeature.CLOSE
-            | CoverEntityFeature.STOP
-            | CoverEntityFeature.SET_POSITION
-        )
-        if (
-            self._cover_cluster_handler.window_covering_type
-            and self._cover_cluster_handler.window_covering_type
-            in (
-                WCT.Shutter,
-                WCT.Tilt_blind_tilt_only,
-                WCT.Tilt_blind_tilt_and_lift,
-            )
+        # Enable lift features if the window covering type is not tilt only
+        if self._cover_cluster_handler.window_covering_type not in (
+            WCT.Shutter,
+            WCT.Tilt_blind_tilt_only,
         ):
-            self._attr_supported_features |= CoverEntityFeature.SET_TILT_POSITION
-            self._attr_supported_features |= CoverEntityFeature.OPEN_TILT
-            self._attr_supported_features |= CoverEntityFeature.CLOSE_TILT
-            self._attr_supported_features |= CoverEntityFeature.STOP_TILT
+            self._attr_supported_features = (
+                CoverEntityFeature.OPEN
+                | CoverEntityFeature.CLOSE
+                | CoverEntityFeature.STOP
+                | CoverEntityFeature.SET_POSITION
+            )
+        else:
+            self._attr_supported_features = CoverEntityFeature(0)
+
+        # Enable tilt features if the window covering type supports tilt
+        if self._cover_cluster_handler.window_covering_type in (
+            WCT.Shutter,
+            WCT.Tilt_blind_tilt_only,
+            WCT.Tilt_blind_tilt_and_lift,
+        ):
+            self._attr_supported_features |= (
+                CoverEntityFeature.OPEN_TILT
+                | CoverEntityFeature.CLOSE_TILT
+                | CoverEntityFeature.STOP_TILT
+                | CoverEntityFeature.SET_TILT_POSITION
+            )
 
     def on_add(self) -> None:
         """Run when entity is added."""
@@ -199,6 +206,8 @@ class Cover(PlatformEntity):
         Keep in mind the values have already been flipped to match HA
         in the WindowCovering cluster handler.
         """
+        if not self._attr_supported_features & CoverEntityFeature.OPEN:
+            return None
         return self._cover_cluster_handler.current_position_lift_percentage
 
     @property
@@ -210,6 +219,8 @@ class Cover(PlatformEntity):
         Keep in mind the values have already been flipped to match HA
         in the WindowCovering cluster handler.
         """
+        if not self._attr_supported_features & CoverEntityFeature.OPEN_TILT:
+            return None
         return self._cover_cluster_handler.current_position_tilt_percentage
 
     @property

--- a/zha/application/platforms/cover/__init__.py
+++ b/zha/application/platforms/cover/__init__.py
@@ -86,7 +86,7 @@ class Cover(PlatformEntity):
                     self._cover_cluster_handler.window_covering_type
                 )
             )
-        self._supported_features: CoverEntityFeature = CoverEntityFeature(0)
+        self._attr_supported_features: CoverEntityFeature = CoverEntityFeature(0)
         self.recompute_capabilities()
 
         self._target_lift_position: int | None = None
@@ -109,14 +109,14 @@ class Cover(PlatformEntity):
     def recompute_capabilities(self) -> None:
         """Recompute capabilities and feature flags based on the window covering type."""
         super().recompute_capabilities()
-        self._supported_features = CoverEntityFeature(0)
+        supported_features = CoverEntityFeature(0)
 
         # Enable lift features if the window covering type is not tilt only
         if self._cover_cluster_handler.window_covering_type not in (
             WCT.Shutter,
             WCT.Tilt_blind_tilt_only,
         ):
-            self._supported_features |= (
+            supported_features |= (
                 CoverEntityFeature.OPEN
                 | CoverEntityFeature.CLOSE
                 | CoverEntityFeature.STOP
@@ -129,12 +129,14 @@ class Cover(PlatformEntity):
             WCT.Tilt_blind_tilt_only,
             WCT.Tilt_blind_tilt_and_lift,
         ):
-            self._supported_features |= (
+            supported_features |= (
                 CoverEntityFeature.OPEN_TILT
                 | CoverEntityFeature.CLOSE_TILT
                 | CoverEntityFeature.STOP_TILT
                 | CoverEntityFeature.SET_TILT_POSITION
             )
+
+        self._attr_supported_features = supported_features
 
     def on_add(self) -> None:
         """Run when entity is added."""
@@ -160,7 +162,7 @@ class Cover(PlatformEntity):
     @property
     def supported_features(self) -> CoverEntityFeature:
         """Return supported features."""
-        return self._supported_features
+        return self._attr_supported_features
 
     @property
     def state(self) -> dict[str, Any]:
@@ -611,7 +613,7 @@ class Shade(PlatformEntity):
 
     _attr_device_class = CoverDeviceClass.SHADE
     _attr_translation_key: str = "shade"
-    _supported_features: CoverEntityFeature = (
+    _attr_supported_features: CoverEntityFeature = (
         CoverEntityFeature.OPEN
         | CoverEntityFeature.CLOSE
         | CoverEntityFeature.STOP
@@ -676,7 +678,7 @@ class Shade(PlatformEntity):
     @functools.cached_property
     def supported_features(self) -> CoverEntityFeature:
         """Return supported features."""
-        return self._supported_features
+        return self._attr_supported_features
 
     @property
     def current_cover_position(self) -> int | None:

--- a/zha/application/platforms/cover/__init__.py
+++ b/zha/application/platforms/cover/__init__.py
@@ -89,7 +89,7 @@ class Cover(PlatformEntity):
                     self._cover_cluster_handler.window_covering_type
                 )
             )
-        self._attr_supported_features: CoverEntityFeature = CoverEntityFeature(0)
+        self._supported_features: CoverEntityFeature = CoverEntityFeature(0)
 
         self._target_lift_position: int | None = None
         self._target_tilt_position: int | None = None
@@ -112,20 +112,19 @@ class Cover(PlatformEntity):
     def recompute_capabilities(self) -> None:
         """Recompute capabilities and feature flags based on the window covering type."""
         super().recompute_capabilities()
+        self._supported_features = CoverEntityFeature(0)
 
         # Enable lift features if the window covering type is not tilt only
         if self._cover_cluster_handler.window_covering_type not in (
             WCT.Shutter,
             WCT.Tilt_blind_tilt_only,
         ):
-            self._attr_supported_features = (
+            self._supported_features |= (
                 CoverEntityFeature.OPEN
                 | CoverEntityFeature.CLOSE
                 | CoverEntityFeature.STOP
                 | CoverEntityFeature.SET_POSITION
             )
-        else:
-            self._attr_supported_features = CoverEntityFeature(0)
 
         # Enable tilt features if the window covering type supports tilt
         if self._cover_cluster_handler.window_covering_type in (
@@ -133,7 +132,7 @@ class Cover(PlatformEntity):
             WCT.Tilt_blind_tilt_only,
             WCT.Tilt_blind_tilt_and_lift,
         ):
-            self._attr_supported_features |= (
+            self._supported_features |= (
                 CoverEntityFeature.OPEN_TILT
                 | CoverEntityFeature.CLOSE_TILT
                 | CoverEntityFeature.STOP_TILT
@@ -164,7 +163,7 @@ class Cover(PlatformEntity):
     @property
     def supported_features(self) -> CoverEntityFeature:
         """Return supported features."""
-        return self._attr_supported_features
+        return self._supported_features
 
     @property
     def state(self) -> dict[str, Any]:
@@ -615,7 +614,7 @@ class Shade(PlatformEntity):
 
     _attr_device_class = CoverDeviceClass.SHADE
     _attr_translation_key: str = "shade"
-    _attr_supported_features: CoverEntityFeature = (
+    _supported_features: CoverEntityFeature = (
         CoverEntityFeature.OPEN
         | CoverEntityFeature.CLOSE
         | CoverEntityFeature.STOP
@@ -680,7 +679,7 @@ class Shade(PlatformEntity):
     @functools.cached_property
     def supported_features(self) -> CoverEntityFeature:
         """Return supported features."""
-        return self._attr_supported_features
+        return self._supported_features
 
     @property
     def current_cover_position(self) -> int | None:


### PR DESCRIPTION
## What's changed
- The `current_position` and `current_tilt_position` state attributes now report `None` if their features are not supported by the device, resolves [#142352](https://github.com/home-assistant/core/issues/142352)
  - This is required because some devices are reporting a position of 0 rather than null
- Revise `supported_features` logic so it _excludes_ tilt only window covering types when enabling lift features
  - This means that lift features will still be enabled as a fallback if the `window_covering_type` attribute value is undefined by the device
  - Previously lift features were enabled for all devices, they should not be enabled for `WCT.Shutter` or `WCT.Tilt_blind_tilt_only` types, see _Table 7-41. Window Covering Type_ from the [Cluster Library Specification 07-5123 Revision 8](https://zigbeealliance.org/wp-content/uploads/2021/10/07-5123-08-Zigbee-Cluster-Library.pdf)
<img alt="image" width="544" src="https://private-user-images.githubusercontent.com/32534428/431515604-4d9c6bd9-ab1f-4ed5-8a98-3ef301af61f0.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDQxODYxMTYsIm5iZiI6MTc0NDE4NTgxNiwicGF0aCI6Ii8zMjUzNDQyOC80MzE1MTU2MDQtNGQ5YzZiZDktYWIxZi00ZWQ1LThhOTgtM2VmMzAxYWY2MWYwLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA0MDklMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwNDA5VDA4MDMzNlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWRhZDNjYTZmNGQ4OWZiNTg4NjVhYmM4MTAwMWExZjBhZmYxYWZiNTQ1OWEwZjE2Y2ExMjcyYzUzNzgxNDUxMGMmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.I4rHEKyuJZkZfnpzq6inZybVxfmttandBPvTje_oRBU">

- Updates to cover platform tests
  - Check lift only devices don't have tilt features enabled and that state attribute `current_tilt_position` is always None
  - Check tilt only devices don't have lift features enabled and that state attribute `current_position` is always None

## Fixes issue
- Some devices report 0 (open) rather than null values for non-functional tilt/lift position attributes
https://github.com/home-assistant/core/issues/142352


## Related
- https://github.com/zigpy/zha/pull/376


FYI @TheJulianJES, @puddly, @dmulcahey 