### PR TITLE
Ignore endpoint profiles other than ZHA or ZLL

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ import zigpy.config
 import zigpy.device
 import zigpy.group
 import zigpy.profiles
+from zigpy.profiles.zha import PROFILE_ID as ZHA_PROFILE_ID
 import zigpy.types
 from zigpy.zcl.clusters.general import Basic, Groups
 from zigpy.zcl.foundation import Status
@@ -237,6 +238,7 @@ async def zigpy_app_controller_fixture():
     ep = dev.add_endpoint(1)
     ep.add_input_cluster(Basic.cluster_id)
     ep.add_input_cluster(Groups.cluster_id)
+    ep.profile_id = ZHA_PROFILE_ID
 
     with patch("zigpy.device.Device.request", return_value=[Status.SUCCESS]):
         yield app

--- a/tests/data/devices/frient-a-s-aqszb-110.json
+++ b/tests/data/devices/frient-a-s-aqszb-110.json
@@ -836,7 +836,7 @@
       {
         "info_object": {
           "fallback_name": null,
-          "unique_id": "00:15:bc:00:36:00:1f:ee-1-3",
+          "unique_id": "00:15:bc:00:36:00:1f:ee-38-3",
           "platform": "button",
           "class_name": "IdentifyButton",
           "translation_key": null,
@@ -849,14 +849,14 @@
             {
               "class_name": "IdentifyClusterHandler",
               "generic_id": "cluster_handler_0x0003",
-              "endpoint_id": 1,
+              "endpoint_id": 38,
               "cluster": {
                 "id": 3,
                 "name": "Identify",
                 "type": "server"
               },
-              "id": "1:0x0003",
-              "unique_id": "00:15:bc:00:36:00:1f:ee:1:0x0003",
+              "id": "38:0x0003",
+              "unique_id": "00:15:bc:00:36:00:1f:ee:38:0x0003",
               "status": "CREATED",
               "value_attribute": null
             }
@@ -871,7 +871,7 @@
             21,
             0
           ],
-          "endpoint_id": 1,
+          "endpoint_id": 38,
           "available": false,
           "group_id": null,
           "command": "identify",
@@ -1151,56 +1151,6 @@
           "class_name": "Humidity",
           "available": false,
           "state": 21.8
-        }
-      }
-    ],
-    "switch": [
-      {
-        "info_object": {
-          "fallback_name": null,
-          "unique_id": "00:15:bc:00:36:00:1f:ee-1-6",
-          "platform": "switch",
-          "class_name": "Switch",
-          "translation_key": "switch",
-          "device_class": null,
-          "state_class": null,
-          "entity_category": null,
-          "entity_registry_enabled_default": true,
-          "enabled": true,
-          "cluster_handlers": [
-            {
-              "class_name": "OnOffClusterHandler",
-              "generic_id": "cluster_handler_0x0006",
-              "endpoint_id": 1,
-              "cluster": {
-                "id": 6,
-                "name": "On/Off",
-                "type": "server"
-              },
-              "id": "1:0x0006",
-              "unique_id": "00:15:bc:00:36:00:1f:ee:1:0x0006",
-              "status": "CREATED",
-              "value_attribute": "on_off"
-            }
-          ],
-          "device_ieee": [
-            238,
-            31,
-            0,
-            54,
-            0,
-            188,
-            21,
-            0
-          ],
-          "endpoint_id": 1,
-          "available": false,
-          "group_id": null
-        },
-        "state": {
-          "class_name": "Switch",
-          "state": false,
-          "available": false
         }
       }
     ],

--- a/tests/data/devices/frient-a-s-flszb-110.json
+++ b/tests/data/devices/frient-a-s-flszb-110.json
@@ -1162,7 +1162,7 @@
       {
         "info_object": {
           "fallback_name": null,
-          "unique_id": "00:15:bc:00:33:00:76:9a-1-3",
+          "unique_id": "00:15:bc:00:33:00:76:9a-35-3",
           "platform": "button",
           "class_name": "IdentifyButton",
           "translation_key": null,
@@ -1175,14 +1175,14 @@
             {
               "class_name": "IdentifyClusterHandler",
               "generic_id": "cluster_handler_0x0003",
-              "endpoint_id": 1,
+              "endpoint_id": 35,
               "cluster": {
                 "id": 3,
                 "name": "Identify",
                 "type": "server"
               },
-              "id": "1:0x0003",
-              "unique_id": "00:15:bc:00:33:00:76:9a:1:0x0003",
+              "id": "35:0x0003",
+              "unique_id": "00:15:bc:00:33:00:76:9a:35:0x0003",
               "status": "CREATED",
               "value_attribute": null
             }
@@ -1706,56 +1706,6 @@
           "class_name": "Siren",
           "available": false,
           "state": false
-        }
-      }
-    ],
-    "switch": [
-      {
-        "info_object": {
-          "fallback_name": null,
-          "unique_id": "00:15:bc:00:33:00:76:9a-1-6",
-          "platform": "switch",
-          "class_name": "Switch",
-          "translation_key": "switch",
-          "device_class": null,
-          "state_class": null,
-          "entity_category": null,
-          "entity_registry_enabled_default": true,
-          "enabled": true,
-          "cluster_handlers": [
-            {
-              "class_name": "OnOffClusterHandler",
-              "generic_id": "cluster_handler_0x0006",
-              "endpoint_id": 1,
-              "cluster": {
-                "id": 6,
-                "name": "On/Off",
-                "type": "server"
-              },
-              "id": "1:0x0006",
-              "unique_id": "00:15:bc:00:33:00:76:9a:1:0x0006",
-              "status": "CREATED",
-              "value_attribute": "on_off"
-            }
-          ],
-          "device_ieee": [
-            154,
-            118,
-            0,
-            51,
-            0,
-            188,
-            21,
-            0
-          ],
-          "endpoint_id": 1,
-          "available": false,
-          "group_id": null
-        },
-        "state": {
-          "class_name": "Switch",
-          "state": false,
-          "available": false
         }
       }
     ],

--- a/tests/data/devices/frient-a-s-splzb-141.json
+++ b/tests/data/devices/frient-a-s-splzb-141.json
@@ -2520,54 +2520,6 @@
       {
         "info_object": {
           "fallback_name": null,
-          "unique_id": "00:15:bc:00:2f:02:19:79-1-6",
-          "platform": "switch",
-          "class_name": "Switch",
-          "translation_key": "switch",
-          "device_class": null,
-          "state_class": null,
-          "entity_category": null,
-          "entity_registry_enabled_default": true,
-          "enabled": true,
-          "cluster_handlers": [
-            {
-              "class_name": "OnOffClusterHandler",
-              "generic_id": "cluster_handler_0x0006",
-              "endpoint_id": 1,
-              "cluster": {
-                "id": 6,
-                "name": "On/Off",
-                "type": "server"
-              },
-              "id": "1:0x0006",
-              "unique_id": "00:15:bc:00:2f:02:19:79:1:0x0006",
-              "status": "CREATED",
-              "value_attribute": "on_off"
-            }
-          ],
-          "device_ieee": [
-            121,
-            25,
-            2,
-            47,
-            0,
-            188,
-            21,
-            0
-          ],
-          "endpoint_id": 1,
-          "available": false,
-          "group_id": null
-        },
-        "state": {
-          "class_name": "Switch",
-          "state": false,
-          "available": false
-        }
-      },
-      {
-        "info_object": {
-          "fallback_name": null,
           "unique_id": "00:15:bc:00:2f:02:19:79-2",
           "platform": "switch",
           "class_name": "Switch",

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -223,6 +223,7 @@ async def test_quirks_binary_sensor_attr_converter(zha_gateway: Gateway) -> None
                 SIG_EP_INPUT: [general.Basic.cluster_id, general.OnOff.cluster_id],
                 SIG_EP_OUTPUT: [],
                 SIG_EP_TYPE: zha.DeviceType.SIMPLE_SENSOR,
+                SIG_EP_PROFILE: zha.PROFILE_ID,
             }
         },
         manufacturer="manufacturer",

--- a/tests/test_cluster_handlers.py
+++ b/tests/test_cluster_handlers.py
@@ -1077,7 +1077,14 @@ async def test_cluster_no_ep_attribute(
         zha_gateway,
         create_mock_zigpy_device(
             zha_gateway,
-            {1: {SIG_EP_INPUT: [0x042E], SIG_EP_OUTPUT: [], SIG_EP_TYPE: 0x1234}},
+            {
+                1: {
+                    SIG_EP_INPUT: [0x042E],
+                    SIG_EP_OUTPUT: [],
+                    SIG_EP_TYPE: 0x1234,
+                    SIG_EP_PROFILE: zigpy.profiles.zha.PROFILE_ID,
+                }
+            },
         ),
     )
 
@@ -1104,6 +1111,7 @@ async def test_configure_reporting(zha_gateway: Gateway) -> None:
         )
 
     mock_ep = mock.AsyncMock(spec_set=zigpy.endpoint.Endpoint)
+    mock_ep.profile_id = zigpy.profiles.zha.PROFILE_ID
     mock_ep.device.zdo = AsyncMock()
 
     cluster = zigpy.zcl.clusters.lighting.Color(mock_ep)
@@ -1150,6 +1158,7 @@ async def test_invalid_cluster_handler(zha_gateway: Gateway, caplog) -> None:  #
 
     mock_device = mock.AsyncMock(spec_set=zigpy.device.Device)
     zigpy_ep = zigpy.endpoint.Endpoint(mock_device, endpoint_id=1)
+    zigpy_ep.profile_id = zigpy.profiles.zha.PROFILE_ID
 
     cluster = zigpy_ep.add_input_cluster(zigpy.zcl.clusters.lighting.Color.cluster_id)
     cluster.configure_reporting_multiple = AsyncMock(
@@ -1194,6 +1203,7 @@ async def test_standard_cluster_handler(
 
     mock_device = mock.AsyncMock(spec_set=zigpy.device.Device)
     zigpy_ep = zigpy.endpoint.Endpoint(mock_device, endpoint_id=1)
+    zigpy_ep.profile_id = zigpy.profiles.zha.PROFILE_ID
 
     cluster = zigpy_ep.add_input_cluster(zigpy.zcl.clusters.lighting.Color.cluster_id)
     cluster.configure_reporting_multiple = AsyncMock(
@@ -1233,6 +1243,7 @@ async def test_quirk_id_cluster_handler(
 
     mock_device = mock.AsyncMock(spec_set=zigpy.device.Device)
     zigpy_ep = zigpy.endpoint.Endpoint(mock_device, endpoint_id=1)
+    zigpy_ep.profile_id = zigpy.profiles.zha.PROFILE_ID
 
     cluster = zigpy_ep.add_input_cluster(zigpy.zcl.clusters.lighting.Color.cluster_id)
     cluster.configure_reporting_multiple = AsyncMock(

--- a/tests/test_cluster_handlers.py
+++ b/tests/test_cluster_handlers.py
@@ -1110,7 +1110,7 @@ async def test_configure_reporting(zha_gateway: Gateway) -> None:
             AttrReportConfig(attr="current_y", config=(1, 60, 4)),
         )
 
-    mock_ep = mock.AsyncMock(spec_set=zigpy.endpoint.Endpoint)
+    mock_ep = mock.AsyncMock()
     mock_ep.profile_id = zigpy.profiles.zha.PROFILE_ID
     mock_ep.device.zdo = AsyncMock()
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -19,6 +19,7 @@ import zigpy.zdo.types as zdo_t
 from tests.common import (
     SIG_EP_INPUT,
     SIG_EP_OUTPUT,
+    SIG_EP_PROFILE,
     SIG_EP_TYPE,
     create_mock_zigpy_device,
     get_entity,
@@ -74,6 +75,7 @@ def zigpy_device_mains(zha_gateway: Gateway, with_basic_cluster_handler: bool = 
             SIG_EP_INPUT: in_clusters,
             SIG_EP_OUTPUT: [],
             SIG_EP_TYPE: zigpy.profiles.zha.DeviceType.ON_OFF_SWITCH,
+            SIG_EP_PROFILE: zigpy.profiles.zha.PROFILE_ID,
         }
     }
     return create_mock_zigpy_device(

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -59,6 +59,7 @@ def zigpy_device(
             SIG_EP_INPUT: in_clusters,
             SIG_EP_OUTPUT: [],
             SIG_EP_TYPE: zigpy.profiles.zha.DeviceType.ON_OFF_SWITCH,
+            SIG_EP_PROFILE: zigpy.profiles.zha.PROFILE_ID,
         }
     }
     return create_mock_zigpy_device(zha_gateway, endpoints, **kwargs)

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -320,6 +320,7 @@ async def test_quirks_v2_entity_discovery(
                     zigpy.zcl.clusters.general.Scenes.cluster_id,
                 ],
                 SIG_EP_TYPE: zigpy.profiles.zha.DeviceType.NON_COLOR_CONTROLLER,
+                SIG_EP_PROFILE: zigpy.profiles.zha.PROFILE_ID,
             }
         },
         ieee="01:2d:6f:00:0a:90:69:e8",
@@ -440,6 +441,7 @@ async def test_quirks_v2_entity_discovery_e1_curtain(
                     zigpy.zcl.clusters.general.Ota.cluster_id,
                     XiaomiAqaraDriverE1.cluster_id,
                 ],
+                SIG_EP_PROFILE: zigpy.profiles.zha.PROFILE_ID,
             }
         },
         ieee="01:2d:6f:00:0a:90:69:e8",
@@ -522,6 +524,7 @@ def _get_test_device(
                     zigpy.zcl.clusters.general.Scenes.cluster_id,
                 ],
                 SIG_EP_TYPE: zigpy.profiles.zha.DeviceType.NON_COLOR_CONTROLLER,
+                SIG_EP_PROFILE: zigpy.profiles.zha.PROFILE_ID,
             }
         },
         ieee="01:2d:6f:00:0a:90:69:e8",

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -175,6 +175,7 @@ async def test_on_off_select_attribute_report_v2(
                 ],
                 SIG_EP_OUTPUT: [],
                 SIG_EP_TYPE: zha.DeviceType.OCCUPANCY_SENSOR,
+                SIG_EP_PROFILE: zha.PROFILE_ID,
             }
         },
         manufacturer="Fake_Manufacturer",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1319,6 +1319,7 @@ async def zigpy_device_timestamp_sensor_v2_mock(
                 ],
                 SIG_EP_OUTPUT: [],
                 SIG_EP_TYPE: zigpy.profiles.zha.DeviceType.ON_OFF_SWITCH,
+                SIG_EP_PROFILE: zigpy.profiles.zha.PROFILE_ID,
             }
         },
         manufacturer="Fake_Timestamp_sensor",
@@ -1420,6 +1421,7 @@ async def zigpy_device_aqara_sensor_v2_mock(
                 ],
                 SIG_EP_OUTPUT: [],
                 SIG_EP_TYPE: zigpy.profiles.zha.DeviceType.OCCUPANCY_SENSOR,
+                SIG_EP_PROFILE: zigpy.profiles.zha.PROFILE_ID,
             }
         },
         manufacturer="Fake_Manufacturer_sensor",
@@ -1663,6 +1665,7 @@ async def zigpy_device_danfoss_thermostat_mock(
                 ],
                 SIG_EP_OUTPUT: [general.Basic.cluster_id, general.Ota.cluster_id],
                 SIG_EP_TYPE: zigpy.profiles.zha.DeviceType.THERMOSTAT,
+                SIG_EP_PROFILE: zigpy.profiles.zha.PROFILE_ID,
             }
         },
         manufacturer="Danfoss",
@@ -1717,6 +1720,7 @@ async def test_quirks_sensor_attr_converter(zha_gateway: Gateway) -> None:
                 ],
                 SIG_EP_OUTPUT: [],
                 SIG_EP_TYPE: zha.DeviceType.SIMPLE_SENSOR,
+                SIG_EP_PROFILE: zigpy.profiles.zha.PROFILE_ID,
             }
         },
         manufacturer="manufacturer",

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -381,6 +381,7 @@ async def test_switch_configurable(
                 SIG_EP_INPUT: [general.Basic.cluster_id],
                 SIG_EP_OUTPUT: [],
                 SIG_EP_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                SIG_EP_PROFILE: zha.PROFILE_ID,
             }
         },
         manufacturer="_TZE200_b6wax7g0",
@@ -492,6 +493,7 @@ async def test_switch_configurable_custom_on_off_values(zha_gateway: Gateway) ->
                 SIG_EP_INPUT: [general.Basic.cluster_id],
                 SIG_EP_OUTPUT: [],
                 SIG_EP_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                SIG_EP_PROFILE: zha.PROFILE_ID,
             }
         },
         manufacturer="manufacturer",
@@ -571,6 +573,7 @@ async def test_switch_configurable_custom_on_off_values_force_inverted(
                 SIG_EP_INPUT: [general.Basic.cluster_id],
                 SIG_EP_OUTPUT: [],
                 SIG_EP_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                SIG_EP_PROFILE: zha.PROFILE_ID,
             }
         },
         manufacturer="manufacturer2",
@@ -651,6 +654,7 @@ async def test_switch_configurable_custom_on_off_values_inverter_attribute(
                 SIG_EP_INPUT: [general.Basic.cluster_id],
                 SIG_EP_OUTPUT: [],
                 SIG_EP_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                SIG_EP_PROFILE: zha.PROFILE_ID,
             }
         },
         manufacturer="manufacturer3",

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -17,6 +17,7 @@ import zigpy.zdo.types as zdo_t
 from tests.common import (
     SIG_EP_INPUT,
     SIG_EP_OUTPUT,
+    SIG_EP_PROFILE,
     SIG_EP_TYPE,
     create_mock_zigpy_device,
     get_entity,
@@ -41,6 +42,7 @@ def zigpy_device_mock(zha_gateway: Gateway):
             SIG_EP_INPUT: [general.Basic.cluster_id, general.OnOff.cluster_id],
             SIG_EP_OUTPUT: [general.Ota.cluster_id],
             SIG_EP_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+            SIG_EP_PROFILE: zha.PROFILE_ID,
         }
     }
     return create_mock_zigpy_device(

--- a/zha/zigbee/endpoint.py
+++ b/zha/zigbee/endpoint.py
@@ -8,6 +8,9 @@ import functools
 import logging
 from typing import TYPE_CHECKING, Any, Final, TypeVar
 
+from zigpy.profiles.zha import PROFILE_ID as ZHA_PROFILE_ID
+from zigpy.profiles.zll import PROFILE_ID as ZLL_PROFILE_ID
+
 from zha.application import const
 from zha.async_ import gather_with_limited_concurrency
 from zha.zigbee.cluster_handlers import ClusterHandler
@@ -131,6 +134,14 @@ class Endpoint:
 
     def add_all_cluster_handlers(self) -> None:
         """Create and add cluster handlers for all input clusters."""
+        profile_id = self._zigpy_endpoint.profile_id
+        if profile_id not in (ZLL_PROFILE_ID, ZHA_PROFILE_ID):
+            _LOGGER.debug(
+                "Skipping endpoint, profile is not ZLL or ZHA: 0x%04X",
+                self._zigpy_endpoint.profile_id,
+            )
+            return
+
         for cluster_id, cluster in self.zigpy_endpoint.in_clusters.items():
             cluster_handler_classes = CLUSTER_HANDLER_REGISTRY.get(
                 cluster_id, {None: ClusterHandler}


### PR DESCRIPTION
I believe our current behavior of creating entities for any endpoint may not be correct. Develco/Frient, for example, has a "special" endpoint on their devices that has a custom profile but does not conform to the ZCL and results in useless entities being created.

According to the (limited) diagnostics database, no devices lose functionality with this change.