### PR TITLE
Ignore "non-value" attribute values for sensors

### DIFF
--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -34,12 +34,13 @@ from tests.common import (
     get_entity,
     join_zigpy_device,
     send_attributes_report,
+    zigpy_device_from_json,
 )
 from zha.application import Platform
 from zha.application.const import ZCL_INIT_ATTRS, ZHA_CLUSTER_HANDLER_READS_PER_REQ
 from zha.application.gateway import Gateway
 from zha.application.platforms import PlatformEntity, sensor
-from zha.application.platforms.sensor import DanfossSoftwareErrorCode
+from zha.application.platforms.sensor import DanfossSoftwareErrorCode, Temperature
 from zha.application.platforms.sensor.const import SensorDeviceClass, SensorStateClass
 from zha.units import PERCENTAGE, UnitOfEnergy, UnitOfPressure, UnitOfVolume
 from zha.zigbee.cluster_handlers import AttrReportConfig
@@ -1748,3 +1749,34 @@ async def test_quirks_sensor_attr_converter(zha_gateway: Gateway) -> None:
 
     await send_attributes_report(zha_gateway, cluster, {"present_value": 0})
     assert entity.state["state"] == 100.0
+
+
+async def test_ignore_non_value(zha_gateway: Gateway) -> None:
+    """Test ZHA quirks v2 sensor with attribute_converter."""
+
+    zigpy_dev = await zigpy_device_from_json(
+        zha_gateway.application_controller,
+        "tests/data/devices/third-reality-inc-3rsm0147z.json",
+    )
+
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
+    cluster = zha_device.device.endpoints[1].temperature
+    entity = get_entity(zha_device, platform=Platform.SENSOR, entity_type=Temperature)
+
+    assert entity.state["state"] == 22.3
+
+    # Normal attribute report
+    await send_attributes_report(
+        zha_gateway,
+        cluster,
+        {measurement.TemperatureMeasurement.AttributeDefs.measured_value.id: 3000},
+    )
+    assert entity.state["state"] == 30.0
+
+    # Invalid attribute value, ignored
+    await send_attributes_report(
+        zha_gateway,
+        cluster,
+        {measurement.TemperatureMeasurement.AttributeDefs.measured_value.id: -0x8000},
+    )
+    assert entity.state["state"] is None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1752,7 +1752,7 @@ async def test_quirks_sensor_attr_converter(zha_gateway: Gateway) -> None:
 
 
 async def test_ignore_non_value(zha_gateway: Gateway) -> None:
-    """Test ZHA quirks v2 sensor with attribute_converter."""
+    """Test sensor updates ignoring ZCL datatype non-values."""
 
     zigpy_dev = await zigpy_device_from_json(
         zha_gateway.application_controller,

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -17,6 +17,7 @@ from zhaquirks.quirk_ids import DANFOSS_ALLY_THERMOSTAT
 from zigpy import types
 from zigpy.quirks.v2 import ZCLEnumMetadata, ZCLSensorMetadata
 from zigpy.state import Counter, State
+from zigpy.zcl import foundation
 from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.clusters.general import Basic
 
@@ -297,10 +298,25 @@ class Sensor(PlatformEntity):
         ):
             self.maybe_emit_state_changed_event()
 
+    def _is_non_value(self, value: int) -> bool:
+        # Ignore "non-value" values
+        try:
+            attr_def = self._cluster_handler.cluster.find_attribute(
+                self._attribute_name
+            )
+        except ValueError:
+            return False
+
+        data_type = foundation.DataType.from_type_id(attr_def.zcl_type)
+        return value == data_type.non_value
+
     def formatter(
         self, value: int | enum.IntEnum
     ) -> datetime | int | float | str | None:
         """Numeric pass-through formatter."""
+        if self._is_non_value(value):
+            return None
+
         if self._decimals > 0:
             return round(
                 float(value * self._multiplier) / self._divisor, self._decimals
@@ -885,10 +901,10 @@ class Illuminance(Sensor):
 
     def formatter(self, value: int) -> int | None:
         """Convert illumination data."""
+        if self._is_non_value(value):
+            return None
         if value == 0:
             return 0
-        if value == 0xFFFF:
-            return None
         return round(pow(10, ((value - 1) / 10000)))
 
 
@@ -1243,12 +1259,6 @@ class Flow(Sensor):
     _divisor = 10
     _attr_native_unit_of_measurement = UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR
     _attr_primary_weight = 1
-
-    def formatter(self, value: int) -> datetime | int | float | str | None:
-        """Handle unknown value state."""
-        if value == 0xFFFF:
-            return None
-        return super().formatter(value)
 
 
 @MULTI_MATCH(cluster_handler_names=CLUSTER_HANDLER_TEMPERATURE)

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -174,6 +174,13 @@ class Sensor(PlatformEntity):
     ) -> None:
         """Init this sensor."""
         self._cluster_handler: ClusterHandler = cluster_handlers[0]
+        self._attr_def: foundation.ZCLAttributeDef | None = None
+
+        if self._attribute_name is not None:
+            self._attr_def = self._cluster_handler.cluster.find_attribute(
+                self._attribute_name
+            )
+
         super().__init__(unique_id, cluster_handlers, endpoint, device, **kwargs)
         self.recompute_capabilities()
 
@@ -300,14 +307,10 @@ class Sensor(PlatformEntity):
 
     def _is_non_value(self, value: int | float) -> bool:
         """Ignore non-value numerical values."""
-        try:
-            attr_def = self._cluster_handler.cluster.find_attribute(
-                self._attribute_name
-            )
-        except ValueError:
+        if self._attr_def is None:
             return False
 
-        data_type = foundation.DataType.from_type_id(attr_def.zcl_type)
+        data_type = foundation.DataType.from_type_id(self._attr_def.zcl_type)
         return value == data_type.non_value
 
     def formatter(

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -298,8 +298,8 @@ class Sensor(PlatformEntity):
         ):
             self.maybe_emit_state_changed_event()
 
-    def _is_non_value(self, value: int) -> bool:
-        # Ignore "non-value" values
+    def _is_non_value(self, value: int | float) -> bool:
+        """Ignore non-value numerical values."""
         try:
             attr_def = self._cluster_handler.cluster.find_attribute(
                 self._attribute_name


### PR DESCRIPTION
Zigpy currently provides a way to determine if a value is a "non-value" for a type. This is easily supported for numeric types but not so much for more complex ones, like arrays and such. This PR will globally fix invalid sensor readings showing up in the frontend.

https://github.com/home-assistant/core/issues/96894