### PR TITLE
Fix `current_cover_tilt_position` for shades, add base class

### DIFF
--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -795,6 +795,7 @@ async def test_shade(
     # coverage (these are always None for now)
     assert entity.is_opening is None
     assert entity.is_closing is None
+    assert entity.current_cover_tilt_position is None
 
     # test that the state has changed from unavailable to off
     await send_attributes_report(

--- a/zha/application/platforms/cover/__init__.py
+++ b/zha/application/platforms/cover/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 import asyncio
 from collections import deque
 import functools
@@ -58,14 +59,81 @@ LIFT_MOVEMENT_TIMEOUT_RANGE: float = 300
 TILT_MOVEMENT_TIMEOUT_RANGE: float = 30
 
 
-@MULTI_MATCH(cluster_handler_names=CLUSTER_HANDLER_COVER)
-class Cover(PlatformEntity):
-    """Representation of a ZHA cover."""
+class BaseCover(PlatformEntity, ABC):
+    """Abstract base class for ZHA covers."""
 
     PLATFORM = Platform.COVER
 
-    _attr_translation_key: str = "cover"
     _attr_primary_weight = 10
+
+    @property
+    @abstractmethod
+    def supported_features(self) -> CoverEntityFeature:
+        """Return supported features."""
+        pass
+
+    @property
+    @abstractmethod
+    def is_closed(self) -> bool | None:
+        """Return True if the cover is closed."""
+        pass
+
+    @property
+    @abstractmethod
+    def is_opening(self) -> bool | None:
+        """Return if the cover is opening or not."""
+        pass
+
+    @property
+    @abstractmethod
+    def is_closing(self) -> bool | None:
+        """Return if the cover is closing or not."""
+        pass
+
+    @property
+    @abstractmethod
+    def current_cover_position(self) -> int | None:
+        """Return the current position of ZHA cover.
+
+        In HA, None is unknown, 0 is closed, 100 is fully open.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def current_cover_tilt_position(self) -> int | None:
+        """Return the current tilt position of the cover.
+
+        In HA, None is unknown, 0 is closed, 100 is fully open.
+        """
+        pass
+
+    @abstractmethod
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        """Open the cover."""
+        pass
+
+    @abstractmethod
+    async def async_close_cover(self, **kwargs: Any) -> None:
+        """Close the cover."""
+        pass
+
+    @abstractmethod
+    async def async_set_cover_position(self, **kwargs: Any) -> None:
+        """Move the cover to a specific position."""
+        pass
+
+    @abstractmethod
+    async def async_stop_cover(self, **kwargs: Any) -> None:
+        """Stop the cover."""
+        pass
+
+
+@MULTI_MATCH(cluster_handler_names=CLUSTER_HANDLER_COVER)
+class Cover(BaseCover):
+    """Representation of a ZHA cover."""
+
+    _attr_translation_key: str = "cover"
 
     def __init__(
         self,
@@ -597,10 +665,8 @@ class Cover(PlatformEntity):
         CLUSTER_HANDLER_SHADE,
     }
 )
-class Shade(PlatformEntity):
+class Shade(BaseCover):
     """ZHA Shade."""
-
-    PLATFORM = Platform.COVER
 
     _attr_device_class = CoverDeviceClass.SHADE
     _attr_translation_key: str = "shade"
@@ -610,7 +676,6 @@ class Shade(PlatformEntity):
         | CoverEntityFeature.STOP
         | CoverEntityFeature.SET_POSITION
     )
-    _attr_primary_weight = 10
 
     def __init__(
         self,

--- a/zha/application/platforms/cover/__init__.py
+++ b/zha/application/platforms/cover/__init__.py
@@ -679,6 +679,11 @@ class Shade(PlatformEntity):
         """
         return self._position
 
+    @property
+    def current_cover_tilt_position(self) -> int | None:
+        """Return the current tilt position of the cover."""
+        return None
+
     @functools.cached_property
     def is_opening(self) -> bool | None:
         """Return if the cover is opening or not."""

--- a/zha/application/platforms/cover/__init__.py
+++ b/zha/application/platforms/cover/__init__.py
@@ -70,25 +70,21 @@ class BaseCover(PlatformEntity, ABC):
     @abstractmethod
     def supported_features(self) -> CoverEntityFeature:
         """Return supported features."""
-        pass
 
     @property
     @abstractmethod
     def is_closed(self) -> bool | None:
         """Return True if the cover is closed."""
-        pass
 
     @property
     @abstractmethod
     def is_opening(self) -> bool | None:
         """Return if the cover is opening or not."""
-        pass
 
     @property
     @abstractmethod
     def is_closing(self) -> bool | None:
         """Return if the cover is closing or not."""
-        pass
 
     @property
     @abstractmethod
@@ -97,7 +93,6 @@ class BaseCover(PlatformEntity, ABC):
 
         In HA, None is unknown, 0 is closed, 100 is fully open.
         """
-        pass
 
     @property
     @abstractmethod
@@ -106,27 +101,22 @@ class BaseCover(PlatformEntity, ABC):
 
         In HA, None is unknown, 0 is closed, 100 is fully open.
         """
-        pass
 
     @abstractmethod
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
-        pass
 
     @abstractmethod
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
-        pass
 
     @abstractmethod
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
-        pass
 
     @abstractmethod
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
-        pass
 
 
 @MULTI_MATCH(cluster_handler_names=CLUSTER_HANDLER_COVER)


### PR DESCRIPTION
## Proposed change

This PR fixes an issue where the `current_cover_tilt_position` property was removed for the `Shade` implementation, based on the `LevelControl` cluster (in https://github.com/zigpy/zha/pull/376).

The Home Assistant integration does not differentiate between our `Cover` and `Shade` implementation, so tries to access the `current_cover_tilt_position` attribute/property regardless: https://github.com/home-assistant/core/blob/d23c9f715e1f7772ec8ae176f3db4b9afa7db95d/homeassistant/components/zha/cover.py#L122-L125

We need to make sure we provide it in all our cover implementations, so this PR adds it back, returning `None` by default, as a `Shade` cannot support tilt.

A new abstract `BaseCover` class is also added to make sure all relevant methods are implemented by the `Cover` and `Shade` implementations.

## Additional information

Should address:
- https://github.com/home-assistant/core/issues/142815
- https://github.com/home-assistant/core/issues/142601

We should likely add tests for this in HA in the future. I'm guessing `Shade` is not covered at all.