### PR TITLE
RFC: Event platform

### DIFF
--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -90,6 +90,7 @@ PLATFORMS = (
     Platform.CLIMATE,
     Platform.COVER,
     Platform.DEVICE_TRACKER,
+    Platform.EVENT,
     Platform.FAN,
     Platform.LIGHT,
     Platform.LOCK,

--- a/zha/application/platforms/event/__init__.py
+++ b/zha/application/platforms/event/__init__.py
@@ -1,0 +1,65 @@
+"""Support for the ZHA event platform."""
+
+from __future__ import annotations
+
+import dataclasses
+import functools
+import logging
+from typing import Any, Final
+
+from zigpy.quirks.v2 import EventMetadata
+
+from zha.application import Platform
+from zha.application.platforms import PlatformEntity
+from zha.application.platforms.helpers import validate_device_class
+
+from .const import EventDeviceClass
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class EventPlatformEvent:
+    """Event for the event platform trigger."""
+
+    event: Final[str] = "trigger_event"
+    event_type: str
+    event_attributes: dict[str, Any] | None
+
+
+class EventEntity(PlatformEntity):
+    """Represent an event entity."""
+
+    PLATFORM = Platform.EVENT
+    _attr_event_types: tuple[str] = ()
+
+    def _init_from_quirks_metadata(self, entity_metadata: EventMetadata) -> None:
+        """Init this entity from the quirks metadata."""
+        super()._init_from_quirks_metadata(entity_metadata)
+
+        self._attr_event_types = entity_metadata.event_types
+
+        if entity_metadata.device_class is not None:
+            self._attr_device_class = validate_device_class(
+                EventDeviceClass,
+                entity_metadata.device_class,
+                Platform.EVENT.value,
+                _LOGGER,
+            )
+
+    @functools.cached_property
+    def event_types(self) -> list[str]:
+        """Return a list of possible events."""
+        return list(self._attr_event_types)
+
+    def trigger_event(
+        self, event_type: str, event_attributes: dict[str, Any] | None = None
+    ) -> None:
+        """Trigger an event."""
+        self.emit(
+            EventPlatformEvent.event_type,
+            EventPlatformEvent(
+                event_type=event_type,
+                event_attributes=event_attributes,
+            ),
+        )

--- a/zha/application/platforms/event/const.py
+++ b/zha/application/platforms/event/const.py
@@ -1,0 +1,11 @@
+"""Constants for the ZHA event platform."""
+
+from enum import StrEnum
+
+
+class EventDeviceClass(StrEnum):
+    """Device class for event entities."""
+
+    DOORBELL = "doorbell"
+    BUTTON = "button"
+    MOTION = "motion"

--- a/zha/application/platforms/helpers.py
+++ b/zha/application/platforms/helpers.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, overload
 
 if TYPE_CHECKING:
     from zha.application.platforms.binary_sensor.const import BinarySensorDeviceClass
+    from zha.application.platforms.event.const import EventDeviceClass
     from zha.application.platforms.number.const import NumberDeviceClass
     from zha.application.platforms.sensor.const import SensorDeviceClass
 
@@ -78,16 +79,32 @@ def validate_device_class(
 ) -> NumberDeviceClass | None: ...
 
 
+@overload
+def validate_device_class(
+    device_class_enum: type[EventDeviceClass],
+    metadata_value: enum.Enum,
+    platform: str,
+    logger: logging.Logger,
+) -> EventDeviceClass | None: ...
+
+
 def validate_device_class(
     device_class_enum: (
         type[BinarySensorDeviceClass]
         | type[SensorDeviceClass]
         | type[NumberDeviceClass]
+        | type[EventDeviceClass]
     ),
     metadata_value: enum.Enum,
     platform: str,
     logger: logging.Logger,
-) -> BinarySensorDeviceClass | SensorDeviceClass | NumberDeviceClass | None:
+) -> (
+    BinarySensorDeviceClass
+    | SensorDeviceClass
+    | NumberDeviceClass
+    | EventDeviceClass
+    | None
+):
     """Validate and return a device class."""
     try:
         return device_class_enum(metadata_value.value)


### PR DESCRIPTION
This is a stub PR that explores implementing the Home Assistant Core "event" platform for ZHA. This platform is a little different from the others in that it does not expose state but rather expects events to be triggered at runtime via `core_entity.trigger_event(event_type)`.

The functionality exposed by this platform has always been a pain point for ZHA (since we rely on device automation triggers at the moment) and I think brings up the first difficulty with quirks v2. Below is a sample implementation that fits within the constraints of quirks v2:

```python
class DevelcoButtonEventTypes(StrEnum):
    PRESSED = "pressed"
    RELEASED = "released"


def setup_triggers(device: Device, trigger_event: Callable[[str], None]) -> None:
    """Map device events to event entity triggers."""

    class Listener:
        def attribute_updated(
            self, attribute_id: int, value: Any, timestamp: datetime
        ) -> None:
            if attribute_id != BinaryInput.present_value:
                return

            if value:
                trigger_event(DevelcoButtonEventTypes.PRESSED)
            else:
                trigger_event(DevelcoButtonEventTypes.RELEASED)

    device.endpoints[1].binary_input.add_listener(Listener())


# Quirk defined here
(
    QuirkBuilder("develco", "button")
    .event(
        unique_id_suffix="button",
        translation_key="button",
        fallback_name="Button",
        event_types=DevelcoButtonEventTypes,
        setup_triggers=setup_triggers,
    )
    .add_to_registry()
)
```

An alternative implementation that relies on quirks directly creating ZHA entities is something that I somewhat prefer:

```python
from zha.platforms.event import EventEntity

class DevelcoButtonEntity(EventEntity):
    _attr_event_types = DevelcoButtonEventTypes
    _attr_translation_key = "button"
    _unique_id_suffix = "button"
    _fallback_name = "Button"

    def on_add(self):
        self.device.endpoints[1].binary_input.add_listener(self)  # TODO: make this better in zigpy...
        self._on_remove_callbacks.append(lambda: self.device.remove_listener(self))

    def attribute_updated(
        self, attribute_id: int, value: Any, timestamp: datetime
    ) -> None:
        if attribute_id != BinaryInput.present_value:
            return

        if value:
            self.trigger_event(DevelcoButtonEventTypes.PRESSED)
        else:
            self.trigger_event(DevelcoButtonEventTypes.RELEASED)

(
    QuirkBuilder("develco", "button")
    .prevent_default_entity_creation(...)
    .register_entity(DevelcoButtonEntity)
    .add_to_registry()
)
```