### PR TITLE
Fix printing log message for `None` profile id

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -961,18 +961,5 @@ async def test_endpoint_none_profile(
     zigpy_dev.endpoints[3].profile_id = None
     zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
 
-    assert zha_device.async_get_clusters() == {
-        3: {
-            CLUSTER_TYPE_IN: {
-                general.Basic.cluster_id: zigpy_dev.endpoints[3].in_clusters[
-                    general.Basic.cluster_id
-                ],
-                general.OnOff.cluster_id: zigpy_dev.endpoints[3].in_clusters[
-                    general.OnOff.cluster_id
-                ],
-            },
-            CLUSTER_TYPE_OUT: {},
-        }
-    }
     assert zha_device.async_get_std_clusters() == {}
     assert "Skipping endpoint, profile is None" in caplog.text

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -950,3 +950,29 @@ async def test_join_binding_reporting(zha_gateway: Gateway) -> None:
     assert mock_reporting_config.mock_calls == [
         call({"measured_value": (30, 900, 1e-6)})
     ]
+
+
+async def test_endpoint_none_profile(
+    zha_gateway: Gateway,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test endpoint with None profile id being skipped."""
+    zigpy_dev = zigpy_device(zha_gateway, with_basic_cluster_handler=True)
+    zigpy_dev.endpoints[3].profile_id = None
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
+
+    assert zha_device.async_get_clusters() == {
+        3: {
+            CLUSTER_TYPE_IN: {
+                general.Basic.cluster_id: zigpy_dev.endpoints[3].in_clusters[
+                    general.Basic.cluster_id
+                ],
+                general.OnOff.cluster_id: zigpy_dev.endpoints[3].in_clusters[
+                    general.OnOff.cluster_id
+                ],
+            },
+            CLUSTER_TYPE_OUT: {},
+        }
+    }
+    assert zha_device.async_get_std_clusters() == {}
+    assert "Skipping endpoint, profile is None" in caplog.text

--- a/zha/zigbee/endpoint.py
+++ b/zha/zigbee/endpoint.py
@@ -135,10 +135,13 @@ class Endpoint:
     def add_all_cluster_handlers(self) -> None:
         """Create and add cluster handlers for all input clusters."""
         profile_id = self._zigpy_endpoint.profile_id
-        if profile_id not in (ZLL_PROFILE_ID, ZHA_PROFILE_ID):
+        if profile_id is None:
+            _LOGGER.debug("Skipping endpoint, profile is None")
+            return
+        elif profile_id not in (ZLL_PROFILE_ID, ZHA_PROFILE_ID):
             _LOGGER.debug(
                 "Skipping endpoint, profile is not ZLL or ZHA: 0x%04X",
-                self._zigpy_endpoint.profile_id,
+                profile_id,
             )
             return
 


### PR DESCRIPTION
## Proposed change

This fixes an issue where we error out on if `ep.profile_id` is `None` when trying to print a log message whilst formatting the int into a hex representation.
This PR adds another message if the `profile_id` is `None` (which it can be according to typing and apparently is in some HA Core tests).

Or are there better ideas?


## Additional information

This is what should be needed to get some HA Core tests passing. Apparently we do have some `None` `profile_id` in tests there.
I think I've also seen some devices doing (or quirks?) doing this, so we should account for this.