### PR TITLE
Clean up `number` platform

### DIFF
--- a/tests/data/devices/adurosmart-eria-ad-rgbw3001.json
+++ b/tests/data/devices/adurosmart-eria-ad-rgbw3001.json
@@ -1226,10 +1226,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 153,
-          "max_value": 500,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 500,
+          "native_min_value": 153,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpColorTemperatureConfigurationEntity",
@@ -1280,10 +1281,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 65534,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 65534,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OffTransitionTimeConfigurationEntity",
@@ -1334,10 +1336,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnLevelConfigurationEntity",
@@ -1388,10 +1391,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 65535,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 65535,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnOffTransitionTimeConfigurationEntity",
@@ -1442,10 +1446,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 65534,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 65534,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnTransitionTimeConfigurationEntity",
@@ -1496,10 +1501,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/centralite-systems-3156105.json
+++ b/tests/data/devices/centralite-systems-3156105.json
@@ -1513,10 +1513,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": -2.5,
-          "max_value": 2.5,
-          "step": 0.1,
-          "multiplier": 0.1
+          "mode": "box",
+          "native_max_value": 2.5,
+          "native_min_value": -2.5,
+          "native_step": 0.1,
+          "native_unit_of_measurement": "\u00b0C"
         },
         "state": {
           "class_name": "ThermostatLocalTempCalibration",
@@ -1567,10 +1568,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0.0,
-          "max_value": 100.0,
-          "step": 0.5,
-          "multiplier": 0.01
+          "mode": "box",
+          "native_max_value": 30.0,
+          "native_min_value": 7.0,
+          "native_step": 0.5,
+          "native_unit_of_measurement": "\u00b0C"
         },
         "state": {
           "class_name": "MaxHeatSetpointLimit",
@@ -1621,10 +1623,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0.0,
-          "max_value": 100.0,
-          "step": 0.5,
-          "multiplier": 0.01
+          "mode": "box",
+          "native_max_value": 30.0,
+          "native_min_value": 7.0,
+          "native_step": 0.5,
+          "native_unit_of_measurement": "\u00b0C"
         },
         "state": {
           "class_name": "MinHeatSetpointLimit",

--- a/tests/data/devices/ericsity-gl-c-008p.json
+++ b/tests/data/devices/ericsity-gl-c-008p.json
@@ -1211,10 +1211,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 158,
-          "max_value": 500,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 500,
+          "native_min_value": 158,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpColorTemperatureConfigurationEntity",
@@ -1265,10 +1266,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/ericsity-gl-c-009p.json
+++ b/tests/data/devices/ericsity-gl-c-009p.json
@@ -1205,10 +1205,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 158,
-          "max_value": 500,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 500,
+          "native_min_value": 158,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpColorTemperatureConfigurationEntity",
@@ -1259,10 +1260,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/espressif-zigbeeanalogdevice.json
+++ b/tests/data/devices/espressif-zigbeeanalogdevice.json
@@ -527,11 +527,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "engineering_units": null,
-          "application_type": 17235967,
-          "min_value": 0,
-          "max_value": 1023,
-          "step": null
+          "mode": "auto",
+          "native_max_value": 1023,
+          "native_min_value": 0,
+          "native_step": null,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "Number",

--- a/tests/data/devices/espressif-zigbeeanalogdevice.json
+++ b/tests/data/devices/espressif-zigbeeanalogdevice.json
@@ -490,7 +490,7 @@
           "unique_id": "ab:cd:ef:12:39:a2:73:55-1-13",
           "migrate_unique_ids": [],
           "platform": "number",
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "translation_key": null,
           "device_class": null,
           "state_class": null,
@@ -534,7 +534,7 @@
           "native_unit_of_measurement": null
         },
         "state": {
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "available": true,
           "state": 0.0
         }

--- a/tests/data/devices/ewelink-ck-bl702-al-01-7009-z102lg03-1.json
+++ b/tests/data/devices/ewelink-ck-bl702-al-01-7009-z102lg03-1.json
@@ -1226,10 +1226,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 142,
-          "max_value": 500,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 500,
+          "native_min_value": 142,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpColorTemperatureConfigurationEntity",
@@ -1280,10 +1281,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnLevelConfigurationEntity",
@@ -1334,10 +1336,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 65535,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 65535,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnOffTransitionTimeConfigurationEntity",
@@ -1388,10 +1391,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/gledopto-gl-b-008p.json
+++ b/tests/data/devices/gledopto-gl-b-008p.json
@@ -1226,10 +1226,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 158,
-          "max_value": 495,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 495,
+          "native_min_value": 158,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpColorTemperatureConfigurationEntity",
@@ -1280,10 +1281,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/homr-hrmsn01.json
+++ b/tests/data/devices/homr-hrmsn01.json
@@ -2332,10 +2332,11 @@
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
-          "min_value": 153,
-          "max_value": 500,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 500,
+          "native_min_value": 153,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpColorTemperatureConfigurationEntity",

--- a/tests/data/devices/ikea-of-sweden-starkvind-air-purifier.json
+++ b/tests/data/devices/ikea-of-sweden-starkvind-air-purifier.json
@@ -893,10 +893,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 4294967295,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 4294967295,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": "Minutes"
         },
         "state": {
           "class_name": "FilterLifeTime",

--- a/tests/data/devices/ikea-of-sweden-starkvind-air-purifier.json
+++ b/tests/data/devices/ikea-of-sweden-starkvind-air-purifier.json
@@ -897,7 +897,7 @@
           "native_max_value": 4294967295,
           "native_min_value": 0,
           "native_step": 1.0,
-          "native_unit_of_measurement": "Minutes"
+          "native_unit_of_measurement": "min"
         },
         "state": {
           "class_name": "FilterLifeTime",

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-w-op-ch-400lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-w-op-ch-400lm.json
@@ -1186,10 +1186,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnLevelConfigurationEntity",
@@ -1240,10 +1241,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 65535,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 65535,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnOffTransitionTimeConfigurationEntity",
@@ -1294,10 +1296,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-ws-opal-400lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-ws-opal-400lm.json
@@ -1362,10 +1362,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 250,
-          "max_value": 454,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 454,
+          "native_min_value": 250,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpColorTemperatureConfigurationEntity",
@@ -1416,10 +1417,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnLevelConfigurationEntity",
@@ -1470,10 +1472,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 65535,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 65535,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnOffTransitionTimeConfigurationEntity",
@@ -1524,10 +1527,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-opal-1000lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-opal-1000lm.json
@@ -968,10 +968,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnLevelConfigurationEntity",
@@ -1022,10 +1023,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 65535,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 65535,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnOffTransitionTimeConfigurationEntity",
@@ -1076,10 +1078,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-w-opal-1000lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-w-opal-1000lm.json
@@ -1186,10 +1186,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnLevelConfigurationEntity",
@@ -1240,10 +1241,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 65535,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 65535,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnOffTransitionTimeConfigurationEntity",
@@ -1294,10 +1296,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-ws-opal-980lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-ws-opal-980lm.json
@@ -1361,10 +1361,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 250,
-          "max_value": 454,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 454,
+          "native_min_value": 250,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpColorTemperatureConfigurationEntity",
@@ -1415,10 +1416,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnLevelConfigurationEntity",
@@ -1469,10 +1471,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 65535,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 65535,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnOffTransitionTimeConfigurationEntity",
@@ -1523,10 +1526,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-gu10-ws-400lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-gu10-ws-400lm.json
@@ -1367,10 +1367,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 250,
-          "max_value": 454,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 454,
+          "native_min_value": 250,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpColorTemperatureConfigurationEntity",
@@ -1421,10 +1422,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnLevelConfigurationEntity",
@@ -1475,10 +1477,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 65535,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 65535,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnOffTransitionTimeConfigurationEntity",
@@ -1529,10 +1532,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/ikea-of-sweden-vallhorn-wireless-motion-sensor.json
+++ b/tests/data/devices/ikea-of-sweden-vallhorn-wireless-motion-sensor.json
@@ -2049,10 +2049,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 10,
-          "max_value": 65534,
-          "step": 1,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 65534,
+          "native_min_value": 10,
+          "native_step": 1,
+          "native_unit_of_measurement": "s"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",

--- a/tests/data/devices/innr-ae-280-c.json
+++ b/tests/data/devices/innr-ae-280-c.json
@@ -1206,10 +1206,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 153,
-          "max_value": 555,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 555,
+          "native_min_value": 153,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpColorTemperatureConfigurationEntity",
@@ -1260,10 +1261,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnLevelConfigurationEntity",
@@ -1314,10 +1316,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 65535,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 65535,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnOffTransitionTimeConfigurationEntity",
@@ -1368,10 +1371,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/innr-rb-285-c.json
+++ b/tests/data/devices/innr-rb-285-c.json
@@ -1226,10 +1226,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 153,
-          "max_value": 555,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 555,
+          "native_min_value": 153,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpColorTemperatureConfigurationEntity",
@@ -1280,10 +1281,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/innr-sp-120.json
+++ b/tests/data/devices/innr-sp-120.json
@@ -2834,10 +2834,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 65535,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 65535,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnOffTransitionTimeConfigurationEntity",

--- a/tests/data/devices/isilentllc-dog-feeder.json
+++ b/tests/data/devices/isilentllc-dog-feeder.json
@@ -1124,7 +1124,7 @@
           "unique_id": "00:13:a2:00:41:67:1f:d7-1-13",
           "migrate_unique_ids": [],
           "platform": "number",
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "translation_key": "number",
           "device_class": null,
           "state_class": null,
@@ -1168,7 +1168,7 @@
           "native_unit_of_measurement": null
         },
         "state": {
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "available": true,
           "state": 3.0
         }

--- a/tests/data/devices/isilentllc-dog-feeder.json
+++ b/tests/data/devices/isilentllc-dog-feeder.json
@@ -1161,11 +1161,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "engineering_units": 95,
-          "application_type": null,
-          "min_value": 1.0,
-          "max_value": 12.0,
-          "step": null
+          "mode": "auto",
+          "native_max_value": 12.0,
+          "native_min_value": 1.0,
+          "native_step": null,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "Number",

--- a/tests/data/devices/isilentllc-masterbed-light-controller.json
+++ b/tests/data/devices/isilentllc-masterbed-light-controller.json
@@ -1689,11 +1689,11 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "engineering_units": 5,
-          "application_type": null,
-          "min_value": 0,
-          "max_value": 1023,
-          "step": 0.009999999776482582
+          "mode": "auto",
+          "native_max_value": 1023,
+          "native_min_value": 0,
+          "native_step": 0.009999999776482582,
+          "native_unit_of_measurement": "Volts"
         },
         "state": {
           "class_name": "Number",
@@ -1744,11 +1744,11 @@
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
-          "engineering_units": 5,
-          "application_type": null,
-          "min_value": 0,
-          "max_value": 1023,
-          "step": 0.009999999776482582
+          "mode": "auto",
+          "native_max_value": 1023,
+          "native_min_value": 0,
+          "native_step": 0.009999999776482582,
+          "native_unit_of_measurement": "Volts"
         },
         "state": {
           "class_name": "Number",

--- a/tests/data/devices/isilentllc-masterbed-light-controller.json
+++ b/tests/data/devices/isilentllc-masterbed-light-controller.json
@@ -1652,7 +1652,7 @@
           "unique_id": "00:13:a2:00:40:b1:90:06-2-13",
           "migrate_unique_ids": [],
           "platform": "number",
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "translation_key": "number",
           "device_class": null,
           "state_class": null,
@@ -1693,10 +1693,10 @@
           "native_max_value": 1023,
           "native_min_value": 0,
           "native_step": 0.009999999776482582,
-          "native_unit_of_measurement": "Volts"
+          "native_unit_of_measurement": "V"
         },
         "state": {
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "available": true,
           "state": 1.5
         }
@@ -1707,7 +1707,7 @@
           "unique_id": "00:13:a2:00:40:b1:90:06-3-13",
           "migrate_unique_ids": [],
           "platform": "number",
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "translation_key": "number",
           "device_class": null,
           "state_class": null,
@@ -1748,10 +1748,10 @@
           "native_max_value": 1023,
           "native_min_value": 0,
           "native_step": 0.009999999776482582,
-          "native_unit_of_measurement": "Volts"
+          "native_unit_of_measurement": "V"
         },
         "state": {
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "available": true,
           "state": 1.5
         }

--- a/tests/data/devices/jasco-products-45857.json
+++ b/tests/data/devices/jasco-products-45857.json
@@ -2721,10 +2721,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnLevelConfigurationEntity",

--- a/tests/data/devices/king-of-fans-inc-hbuniversalcfremote.json
+++ b/tests/data/devices/king-of-fans-inc-hbuniversalcfremote.json
@@ -937,10 +937,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnLevelConfigurationEntity",

--- a/tests/data/devices/king-of-fans-inc-hdc52eastwindfan.json
+++ b/tests/data/devices/king-of-fans-inc-hdc52eastwindfan.json
@@ -937,10 +937,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnLevelConfigurationEntity",

--- a/tests/data/devices/ledvance-flex-rgbw.json
+++ b/tests/data/devices/ledvance-flex-rgbw.json
@@ -1481,10 +1481,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 254,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 254,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "DefaultMoveRateConfigurationEntity",
@@ -1535,10 +1536,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 65534,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 65534,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OffTransitionTimeConfigurationEntity",
@@ -1589,10 +1591,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnLevelConfigurationEntity",
@@ -1643,10 +1646,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 65535,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 65535,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnOffTransitionTimeConfigurationEntity",
@@ -1697,10 +1701,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 65534,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 65534,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnTransitionTimeConfigurationEntity",

--- a/tests/data/devices/ledvance-outdoor-accent-light-rgb.json
+++ b/tests/data/devices/ledvance-outdoor-accent-light-rgb.json
@@ -1453,10 +1453,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 254,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 254,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "DefaultMoveRateConfigurationEntity",
@@ -1507,10 +1508,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 65534,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 65534,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OffTransitionTimeConfigurationEntity",
@@ -1561,10 +1563,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnLevelConfigurationEntity",
@@ -1615,10 +1618,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 65535,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 65535,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnOffTransitionTimeConfigurationEntity",
@@ -1669,10 +1673,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 65534,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 65534,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnTransitionTimeConfigurationEntity",

--- a/tests/data/devices/lk-zbt-onoffplug-d0001.json
+++ b/tests/data/devices/lk-zbt-onoffplug-d0001.json
@@ -1073,10 +1073,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnLevelConfigurationEntity",
@@ -1127,10 +1128,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 65535,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 65535,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnOffTransitionTimeConfigurationEntity",
@@ -1181,10 +1183,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/lumi-lumi-light-aqcn02.json
+++ b/tests/data/devices/lumi-lumi-light-aqcn02.json
@@ -1806,10 +1806,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 65535,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 65535,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnOffTransitionTimeConfigurationEntity",

--- a/tests/data/devices/lumi-lumi-motion-ac02.json
+++ b/tests/data/devices/lumi-lumi-motion-ac02.json
@@ -1288,10 +1288,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 2,
-          "max_value": 65535,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 65535,
+          "native_min_value": 2,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "AqaraMotionDetectionInterval",

--- a/tests/data/devices/lumi-lumi-motion-agl04.json
+++ b/tests/data/devices/lumi-lumi-motion-agl04.json
@@ -1281,10 +1281,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 2,
-          "max_value": 65535,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 65535,
+          "native_min_value": 2,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "AqaraMotionDetectionInterval",

--- a/tests/data/devices/philips-7602031u7.json
+++ b/tests/data/devices/philips-7602031u7.json
@@ -1237,10 +1237,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 153,
-          "max_value": 500,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 500,
+          "native_min_value": 153,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpColorTemperatureConfigurationEntity",
@@ -1291,10 +1292,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/philips-lct014.json
+++ b/tests/data/devices/philips-lct014.json
@@ -1237,10 +1237,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 153,
-          "max_value": 500,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 500,
+          "native_min_value": 153,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpColorTemperatureConfigurationEntity",
@@ -1291,10 +1292,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/philips-llc020.json
+++ b/tests/data/devices/philips-llc020.json
@@ -1237,10 +1237,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 153,
-          "max_value": 500,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 500,
+          "native_min_value": 153,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpColorTemperatureConfigurationEntity",
@@ -1291,10 +1292,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/plaid-systems-ps-sprzms-slp3.json
+++ b/tests/data/devices/plaid-systems-ps-sprzms-slp3.json
@@ -8,7 +8,7 @@
   "friendly_model": "PS-SPRZMS-SLP3",
   "name": "PLAID SYSTEMS PS-SPRZMS-SLP3",
   "quirk_applied": true,
-  "quirk_class": "zhaquirks.plaid.soil.SoilMoisture",
+  "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
   "quirk_id": null,
   "manufacturer_code": 4098,
   "power_source": "Battery or Unknown",
@@ -893,31 +893,7 @@
       ]
     }
   },
-  "original_signature": {
-    "models_info": [
-      [
-        "PLAID SYSTEMS",
-        "PS-SPRZMS-SLP3"
-      ]
-    ],
-    "endpoints": {
-      "1": {
-        "profile_id": "0x0104",
-        "device_type": "0x0405",
-        "input_clusters": [
-          "0x0000",
-          "0x0001",
-          "0x0003",
-          "0x0402",
-          "0x0405"
-        ],
-        "output_clusters": [
-          "0x0003",
-          "0x0019"
-        ]
-      }
-    }
-  },
+  "original_signature": {},
   "zha_lib_entities": {
     "button": [
       {
@@ -1112,7 +1088,7 @@
               },
               "id": "1:0x0001",
               "unique_id": "00:0d:6f:00:0e:6e:82:87:1:0x0001",
-              "status": "CONFIGURED",
+              "status": "INITIALIZED",
               "value_attribute": "battery_voltage"
             }
           ],

--- a/tests/data/devices/plaid-systems-ps-sprzms-slp3.json
+++ b/tests/data/devices/plaid-systems-ps-sprzms-slp3.json
@@ -8,7 +8,7 @@
   "friendly_model": "PS-SPRZMS-SLP3",
   "name": "PLAID SYSTEMS PS-SPRZMS-SLP3",
   "quirk_applied": true,
-  "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
+  "quirk_class": "zhaquirks.plaid.soil.SoilMoisture",
   "quirk_id": null,
   "manufacturer_code": 4098,
   "power_source": "Battery or Unknown",
@@ -893,7 +893,31 @@
       ]
     }
   },
-  "original_signature": {},
+  "original_signature": {
+    "models_info": [
+      [
+        "PLAID SYSTEMS",
+        "PS-SPRZMS-SLP3"
+      ]
+    ],
+    "endpoints": {
+      "1": {
+        "profile_id": "0x0104",
+        "device_type": "0x0405",
+        "input_clusters": [
+          "0x0000",
+          "0x0001",
+          "0x0003",
+          "0x0402",
+          "0x0405"
+        ],
+        "output_clusters": [
+          "0x0003",
+          "0x0019"
+        ]
+      }
+    }
+  },
   "zha_lib_entities": {
     "button": [
       {
@@ -1088,7 +1112,7 @@
               },
               "id": "1:0x0001",
               "unique_id": "00:0d:6f:00:0e:6e:82:87:1:0x0001",
-              "status": "INITIALIZED",
+              "status": "CONFIGURED",
               "value_attribute": "battery_voltage"
             }
           ],

--- a/tests/data/devices/sengled-e11-g13.json
+++ b/tests/data/devices/sengled-e11-g13.json
@@ -1982,10 +1982,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnLevelConfigurationEntity",

--- a/tests/data/devices/sengled-e12-n14.json
+++ b/tests/data/devices/sengled-e12-n14.json
@@ -1982,10 +1982,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnLevelConfigurationEntity",

--- a/tests/data/devices/sengled-e1f-n9g.json
+++ b/tests/data/devices/sengled-e1f-n9g.json
@@ -1997,10 +1997,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnLevelConfigurationEntity",

--- a/tests/data/devices/sengled-e21-n1ea.json
+++ b/tests/data/devices/sengled-e21-n1ea.json
@@ -2405,10 +2405,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 154,
-          "max_value": 500,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 500,
+          "native_min_value": 154,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpColorTemperatureConfigurationEntity",
@@ -2459,10 +2460,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnLevelConfigurationEntity",
@@ -2513,10 +2515,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/sengled-z01-a19nae26.json
+++ b/tests/data/devices/sengled-z01-a19nae26.json
@@ -2381,10 +2381,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnLevelConfigurationEntity",

--- a/tests/data/devices/signify-netherlands-b-v-lca001.json
+++ b/tests/data/devices/signify-netherlands-b-v-lca001.json
@@ -1241,10 +1241,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 153,
-          "max_value": 500,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 500,
+          "native_min_value": 153,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpColorTemperatureConfigurationEntity",
@@ -1295,10 +1296,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/signify-netherlands-b-v-lca005.json
+++ b/tests/data/devices/signify-netherlands-b-v-lca005.json
@@ -1236,10 +1236,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 153,
-          "max_value": 500,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 500,
+          "native_min_value": 153,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpColorTemperatureConfigurationEntity",
@@ -1290,10 +1291,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/signify-netherlands-b-v-lca007.json
+++ b/tests/data/devices/signify-netherlands-b-v-lca007.json
@@ -1236,10 +1236,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 153,
-          "max_value": 500,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 500,
+          "native_min_value": 153,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpColorTemperatureConfigurationEntity",
@@ -1290,10 +1291,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/signify-netherlands-b-v-lcb001.json
+++ b/tests/data/devices/signify-netherlands-b-v-lcb001.json
@@ -1236,10 +1236,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 153,
-          "max_value": 500,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 500,
+          "native_min_value": 153,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpColorTemperatureConfigurationEntity",
@@ -1290,10 +1291,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/signify-netherlands-b-v-lcb002.json
+++ b/tests/data/devices/signify-netherlands-b-v-lcb002.json
@@ -1236,10 +1236,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 153,
-          "max_value": 500,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 500,
+          "native_min_value": 153,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpColorTemperatureConfigurationEntity",
@@ -1290,10 +1291,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/signify-netherlands-b-v-lce001.json
+++ b/tests/data/devices/signify-netherlands-b-v-lce001.json
@@ -1241,10 +1241,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 153,
-          "max_value": 500,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 500,
+          "native_min_value": 153,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpColorTemperatureConfigurationEntity",
@@ -1295,10 +1296,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/signify-netherlands-b-v-lcx004.json
+++ b/tests/data/devices/signify-netherlands-b-v-lcx004.json
@@ -1236,10 +1236,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 153,
-          "max_value": 500,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 500,
+          "native_min_value": 153,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpColorTemperatureConfigurationEntity",
@@ -1290,10 +1291,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/signify-netherlands-b-v-lta010.json
+++ b/tests/data/devices/signify-netherlands-b-v-lta010.json
@@ -1225,10 +1225,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 153,
-          "max_value": 454,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 454,
+          "native_min_value": 153,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpColorTemperatureConfigurationEntity",
@@ -1279,10 +1280,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/signify-netherlands-b-v-ltb003.json
+++ b/tests/data/devices/signify-netherlands-b-v-ltb003.json
@@ -1226,10 +1226,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 153,
-          "max_value": 454,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 454,
+          "native_min_value": 153,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpColorTemperatureConfigurationEntity",
@@ -1280,10 +1281,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/signify-netherlands-b-v-lwa003.json
+++ b/tests/data/devices/signify-netherlands-b-v-lwa003.json
@@ -826,10 +826,11 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/sinope-technologies-va4220zb.json
+++ b/tests/data/devices/sinope-technologies-va4220zb.json
@@ -2656,10 +2656,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnLevelConfigurationEntity",

--- a/tests/data/devices/sunricher-hk-ln-dim-a.json
+++ b/tests/data/devices/sunricher-hk-ln-dim-a.json
@@ -1071,10 +1071,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnLevelConfigurationEntity",
@@ -1125,10 +1126,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 65535,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 65535,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnOffTransitionTimeConfigurationEntity",
@@ -1179,10 +1181,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/texasinstruments-ti-router.json
+++ b/tests/data/devices/texasinstruments-ti-router.json
@@ -566,10 +566,11 @@
           "endpoint_id": 8,
           "available": true,
           "group_id": null,
-          "min_value": -20,
-          "max_value": 20,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 20,
+          "native_min_value": -20,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "TiRouterTransmitPower",

--- a/tests/data/devices/the-home-depot-ecosmart-zbt-a19-cct-bulb.json
+++ b/tests/data/devices/the-home-depot-ecosmart-zbt-a19-cct-bulb.json
@@ -1559,10 +1559,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 153,
-          "max_value": 370,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 370,
+          "native_min_value": 153,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpColorTemperatureConfigurationEntity",
@@ -1613,10 +1614,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnLevelConfigurationEntity",
@@ -1667,10 +1669,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 65535,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 65535,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnOffTransitionTimeConfigurationEntity",
@@ -1721,10 +1724,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/third-reality-inc-3rms16bz.json
+++ b/tests/data/devices/third-reality-inc-3rms16bz.json
@@ -910,10 +910,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 5,
-          "max_value": 3600,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 3600,
+          "native_min_value": 5,
+          "native_step": 1.0,
+          "native_unit_of_measurement": "s"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",

--- a/tests/data/devices/third-reality-inc-3rsnl02043z.json
+++ b/tests/data/devices/third-reality-inc-3rsnl02043z.json
@@ -1507,10 +1507,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 153,
-          "max_value": 65279,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 65279,
+          "native_min_value": 153,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpColorTemperatureConfigurationEntity",
@@ -1561,10 +1562,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnLevelConfigurationEntity",
@@ -1615,10 +1617,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 65535,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 65535,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "OnOffTransitionTimeConfigurationEntity",
@@ -1669,10 +1672,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpCurrentLevelConfigurationEntity",

--- a/tests/data/devices/third-reality-inc-3rws18bz.json
+++ b/tests/data/devices/third-reality-inc-3rws18bz.json
@@ -1023,10 +1023,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 255,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": "min"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",

--- a/tests/data/devices/tz3210-09hzmirw-ts0502b.json
+++ b/tests/data/devices/tz3210-09hzmirw-ts0502b.json
@@ -1315,10 +1315,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 153,
-          "max_value": 500,
-          "step": 1.0,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 500,
+          "native_min_value": 153,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "StartUpColorTemperatureConfigurationEntity",

--- a/tests/data/devices/tz3210-j4pdtz9v-ts0001.json
+++ b/tests/data/devices/tz3210-j4pdtz9v-ts0001.json
@@ -972,7 +972,7 @@
               },
               "id": "1:0xef00",
               "unique_id": "ab:cd:ef:12:c8:12:1d:0b:1:0xef00",
-              "status": "INITIALIZED",
+              "status": "CONFIGURED",
               "value_attribute": null
             }
           ],
@@ -989,10 +989,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 50,
-          "max_value": 100,
-          "step": 1,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 100,
+          "native_min_value": 50,
+          "native_step": 1,
+          "native_unit_of_measurement": "%"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -1026,7 +1027,7 @@
               },
               "id": "1:0xef00",
               "unique_id": "ab:cd:ef:12:c8:12:1d:0b:1:0xef00",
-              "status": "INITIALIZED",
+              "status": "CONFIGURED",
               "value_attribute": null
             }
           ],
@@ -1043,10 +1044,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 10,
-          "step": 1,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 10,
+          "native_min_value": 0,
+          "native_step": 1,
+          "native_unit_of_measurement": "s"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -1080,7 +1082,7 @@
               },
               "id": "1:0xef00",
               "unique_id": "ab:cd:ef:12:c8:12:1d:0b:1:0xef00",
-              "status": "INITIALIZED",
+              "status": "CONFIGURED",
               "value_attribute": null
             }
           ],
@@ -1097,10 +1099,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 50,
-          "step": 1,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 50,
+          "native_min_value": 0,
+          "native_step": 1,
+          "native_unit_of_measurement": "%"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -1136,7 +1139,7 @@
               },
               "id": "1:0xef00",
               "unique_id": "ab:cd:ef:12:c8:12:1d:0b:1:0xef00",
-              "status": "INITIALIZED",
+              "status": "CONFIGURED",
               "value_attribute": null
             }
           ],
@@ -1192,7 +1195,7 @@
               },
               "id": "1:0xef00",
               "unique_id": "ab:cd:ef:12:c8:12:1d:0b:1:0xef00",
-              "status": "INITIALIZED",
+              "status": "CONFIGURED",
               "value_attribute": null
             }
           ],
@@ -1468,7 +1471,7 @@
               },
               "id": "1:0xef00",
               "unique_id": "ab:cd:ef:12:c8:12:1d:0b:1:0xef00",
-              "status": "INITIALIZED",
+              "status": "CONFIGURED",
               "value_attribute": null
             }
           ],

--- a/tests/data/devices/tz3210-j4pdtz9v-ts0001.json
+++ b/tests/data/devices/tz3210-j4pdtz9v-ts0001.json
@@ -972,7 +972,7 @@
               },
               "id": "1:0xef00",
               "unique_id": "ab:cd:ef:12:c8:12:1d:0b:1:0xef00",
-              "status": "CONFIGURED",
+              "status": "INITIALIZED",
               "value_attribute": null
             }
           ],
@@ -1027,7 +1027,7 @@
               },
               "id": "1:0xef00",
               "unique_id": "ab:cd:ef:12:c8:12:1d:0b:1:0xef00",
-              "status": "CONFIGURED",
+              "status": "INITIALIZED",
               "value_attribute": null
             }
           ],
@@ -1082,7 +1082,7 @@
               },
               "id": "1:0xef00",
               "unique_id": "ab:cd:ef:12:c8:12:1d:0b:1:0xef00",
-              "status": "CONFIGURED",
+              "status": "INITIALIZED",
               "value_attribute": null
             }
           ],
@@ -1139,7 +1139,7 @@
               },
               "id": "1:0xef00",
               "unique_id": "ab:cd:ef:12:c8:12:1d:0b:1:0xef00",
-              "status": "CONFIGURED",
+              "status": "INITIALIZED",
               "value_attribute": null
             }
           ],
@@ -1195,7 +1195,7 @@
               },
               "id": "1:0xef00",
               "unique_id": "ab:cd:ef:12:c8:12:1d:0b:1:0xef00",
-              "status": "CONFIGURED",
+              "status": "INITIALIZED",
               "value_attribute": null
             }
           ],
@@ -1471,7 +1471,7 @@
               },
               "id": "1:0xef00",
               "unique_id": "ab:cd:ef:12:c8:12:1d:0b:1:0xef00",
-              "status": "CONFIGURED",
+              "status": "INITIALIZED",
               "value_attribute": null
             }
           ],

--- a/tests/data/devices/tz6210-duv6fhwt-ts0601.json
+++ b/tests/data/devices/tz6210-duv6fhwt-ts0601.json
@@ -1026,10 +1026,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 1,
-          "max_value": 30,
-          "step": 1,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 30,
+          "native_min_value": 1,
+          "native_step": 1,
+          "native_unit_of_measurement": "min"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -1080,10 +1081,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 100,
-          "step": 1,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 100,
+          "native_min_value": 0,
+          "native_step": 1,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "NumberConfigurationEntity",

--- a/tests/data/devices/tze200-2aaelwxk-ts0225.json
+++ b/tests/data/devices/tze200-2aaelwxk-ts0225.json
@@ -1885,7 +1885,7 @@
           "unique_id": "ab:cd:ef:12:94:85:f7:5f-2-13",
           "migrate_unique_ids": [],
           "platform": "number",
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "translation_key": null,
           "device_class": null,
           "state_class": null,
@@ -1926,10 +1926,10 @@
           "native_max_value": 600,
           "native_min_value": 0,
           "native_step": 1,
-          "native_unit_of_measurement": "Seconds"
+          "native_unit_of_measurement": "s"
         },
         "state": {
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "available": true,
           "state": null
         }
@@ -1940,7 +1940,7 @@
           "unique_id": "ab:cd:ef:12:94:85:f7:5f-3-13",
           "migrate_unique_ids": [],
           "platform": "number",
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "translation_key": null,
           "device_class": null,
           "state_class": null,
@@ -1984,7 +1984,7 @@
           "native_unit_of_measurement": null
         },
         "state": {
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "available": true,
           "state": null
         }
@@ -1995,7 +1995,7 @@
           "unique_id": "ab:cd:ef:12:94:85:f7:5f-4-13",
           "migrate_unique_ids": [],
           "platform": "number",
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "translation_key": null,
           "device_class": null,
           "state_class": null,
@@ -2036,10 +2036,10 @@
           "native_max_value": 1000,
           "native_min_value": 0,
           "native_step": 10,
-          "native_unit_of_measurement": "Centimeters"
+          "native_unit_of_measurement": "cm"
         },
         "state": {
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "available": true,
           "state": null
         }
@@ -2050,7 +2050,7 @@
           "unique_id": "ab:cd:ef:12:94:85:f7:5f-5-13",
           "migrate_unique_ids": [],
           "platform": "number",
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "translation_key": null,
           "device_class": null,
           "state_class": null,
@@ -2094,7 +2094,7 @@
           "native_unit_of_measurement": null
         },
         "state": {
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "available": true,
           "state": null
         }
@@ -2105,7 +2105,7 @@
           "unique_id": "ab:cd:ef:12:94:85:f7:5f-6-13",
           "migrate_unique_ids": [],
           "platform": "number",
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "translation_key": null,
           "device_class": null,
           "state_class": null,
@@ -2146,10 +2146,10 @@
           "native_max_value": 600,
           "native_min_value": 0,
           "native_step": 10,
-          "native_unit_of_measurement": "Centimeters"
+          "native_unit_of_measurement": "cm"
         },
         "state": {
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "available": true,
           "state": null
         }
@@ -2160,7 +2160,7 @@
           "unique_id": "ab:cd:ef:12:94:85:f7:5f-7-13",
           "migrate_unique_ids": [],
           "platform": "number",
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "translation_key": null,
           "device_class": null,
           "state_class": null,
@@ -2204,7 +2204,7 @@
           "native_unit_of_measurement": null
         },
         "state": {
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "available": true,
           "state": null
         }
@@ -2215,7 +2215,7 @@
           "unique_id": "ab:cd:ef:12:94:85:f7:5f-8-13",
           "migrate_unique_ids": [],
           "platform": "number",
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "translation_key": null,
           "device_class": null,
           "state_class": null,
@@ -2256,10 +2256,10 @@
           "native_max_value": 600,
           "native_min_value": 0,
           "native_step": 10,
-          "native_unit_of_measurement": "Centimeters"
+          "native_unit_of_measurement": "cm"
         },
         "state": {
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "available": true,
           "state": null
         }

--- a/tests/data/devices/tze200-2aaelwxk-ts0225.json
+++ b/tests/data/devices/tze200-2aaelwxk-ts0225.json
@@ -1537,10 +1537,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 10,
-          "step": 1,
-          "multiplier": 0.01
+          "mode": "auto",
+          "native_max_value": 10,
+          "native_min_value": 0,
+          "native_step": 1,
+          "native_unit_of_measurement": "m"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -1591,10 +1592,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 10,
-          "step": 1,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 10,
+          "native_min_value": 0,
+          "native_step": 1,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -1645,10 +1647,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 6,
-          "step": 0.01,
-          "multiplier": 0.01
+          "mode": "auto",
+          "native_max_value": 6,
+          "native_min_value": 0,
+          "native_step": 0.01,
+          "native_unit_of_measurement": "m"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -1699,10 +1702,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 10,
-          "step": 1,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 10,
+          "native_min_value": 0,
+          "native_step": 1,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -1753,10 +1757,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 28800,
-          "step": 1,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 28800,
+          "native_min_value": 0,
+          "native_step": 1,
+          "native_unit_of_measurement": "s"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -1807,10 +1812,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 6,
-          "step": 0.01,
-          "multiplier": 0.01
+          "mode": "auto",
+          "native_max_value": 6,
+          "native_min_value": 0,
+          "native_step": 0.01,
+          "native_unit_of_measurement": "m"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -1861,10 +1867,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 10,
-          "step": 1,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 10,
+          "native_min_value": 0,
+          "native_step": 1,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -1915,11 +1922,11 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "engineering_units": 73,
-          "application_type": null,
-          "min_value": 0,
-          "max_value": 600,
-          "step": 1
+          "mode": "auto",
+          "native_max_value": 600,
+          "native_min_value": 0,
+          "native_step": 1,
+          "native_unit_of_measurement": "Seconds"
         },
         "state": {
           "class_name": "Number",
@@ -1970,11 +1977,11 @@
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
-          "engineering_units": null,
-          "application_type": null,
-          "min_value": 0,
-          "max_value": 10,
-          "step": 1
+          "mode": "auto",
+          "native_max_value": 10,
+          "native_min_value": 0,
+          "native_step": 1,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "Number",
@@ -2025,11 +2032,11 @@
           "endpoint_id": 4,
           "available": true,
           "group_id": null,
-          "engineering_units": 118,
-          "application_type": null,
-          "min_value": 0,
-          "max_value": 1000,
-          "step": 10
+          "mode": "auto",
+          "native_max_value": 1000,
+          "native_min_value": 0,
+          "native_step": 10,
+          "native_unit_of_measurement": "Centimeters"
         },
         "state": {
           "class_name": "Number",
@@ -2080,11 +2087,11 @@
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
-          "engineering_units": null,
-          "application_type": null,
-          "min_value": 0,
-          "max_value": 10,
-          "step": 1
+          "mode": "auto",
+          "native_max_value": 10,
+          "native_min_value": 0,
+          "native_step": 1,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "Number",
@@ -2135,11 +2142,11 @@
           "endpoint_id": 6,
           "available": true,
           "group_id": null,
-          "engineering_units": 118,
-          "application_type": null,
-          "min_value": 0,
-          "max_value": 600,
-          "step": 10
+          "mode": "auto",
+          "native_max_value": 600,
+          "native_min_value": 0,
+          "native_step": 10,
+          "native_unit_of_measurement": "Centimeters"
         },
         "state": {
           "class_name": "Number",
@@ -2190,11 +2197,11 @@
           "endpoint_id": 7,
           "available": true,
           "group_id": null,
-          "engineering_units": null,
-          "application_type": null,
-          "min_value": 0,
-          "max_value": 10,
-          "step": 1
+          "mode": "auto",
+          "native_max_value": 10,
+          "native_min_value": 0,
+          "native_step": 1,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "Number",
@@ -2245,11 +2252,11 @@
           "endpoint_id": 8,
           "available": true,
           "group_id": null,
-          "engineering_units": 118,
-          "application_type": null,
-          "min_value": 0,
-          "max_value": 600,
-          "step": 10
+          "mode": "auto",
+          "native_max_value": 600,
+          "native_min_value": 0,
+          "native_step": 10,
+          "native_unit_of_measurement": "Centimeters"
         },
         "state": {
           "class_name": "Number",

--- a/tests/data/devices/tze200-locansqn-ts0601.json
+++ b/tests/data/devices/tze200-locansqn-ts0601.json
@@ -8,7 +8,7 @@
   "friendly_model": "TS0601",
   "name": "_TZE200_locansqn TS0601",
   "quirk_applied": true,
-  "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
+  "quirk_class": "zhaquirks.tuya.builder.EnchantedDeviceV2",
   "quirk_id": null,
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",

--- a/tests/data/devices/tze200-locansqn-ts0601.json
+++ b/tests/data/devices/tze200-locansqn-ts0601.json
@@ -8,7 +8,7 @@
   "friendly_model": "TS0601",
   "name": "_TZE200_locansqn TS0601",
   "quirk_applied": true,
-  "quirk_class": "zhaquirks.tuya.builder.EnchantedDeviceV2",
+  "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
   "quirk_id": null,
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
@@ -1154,10 +1154,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 100,
-          "step": 1,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 100,
+          "native_min_value": 0,
+          "native_step": 1,
+          "native_unit_of_measurement": "%"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -1208,10 +1209,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 100,
-          "step": 1,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 100,
+          "native_min_value": 0,
+          "native_step": 1,
+          "native_unit_of_measurement": "%"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -1262,10 +1264,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": -20,
-          "max_value": 60,
-          "step": 1,
-          "multiplier": 0.1
+          "mode": "auto",
+          "native_max_value": 60,
+          "native_min_value": -20,
+          "native_step": 1,
+          "native_unit_of_measurement": "\u00b0C"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -1316,10 +1319,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": -20,
-          "max_value": 60,
-          "step": 1,
-          "multiplier": 0.1
+          "mode": "auto",
+          "native_max_value": 60,
+          "native_min_value": -20,
+          "native_step": 1,
+          "native_unit_of_measurement": "\u00b0C"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -1370,10 +1374,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 5,
-          "max_value": 120,
-          "step": 5,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 120,
+          "native_min_value": 5,
+          "native_step": 5,
+          "native_unit_of_measurement": "min"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -1424,10 +1429,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 1,
-          "max_value": 100,
-          "step": 1,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 100,
+          "native_min_value": 1,
+          "native_step": 1,
+          "native_unit_of_measurement": "%"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -1478,10 +1484,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 5,
-          "max_value": 120,
-          "step": 5,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 120,
+          "native_min_value": 5,
+          "native_step": 5,
+          "native_unit_of_measurement": "min"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -1532,10 +1539,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0.1,
-          "max_value": 50,
-          "step": 0.1,
-          "multiplier": 0.1
+          "mode": "auto",
+          "native_max_value": 50,
+          "native_min_value": 0.1,
+          "native_step": 0.1,
+          "native_unit_of_measurement": "\u00b0C"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",

--- a/tests/data/devices/tze204-iaeejhvf-ts0601.json
+++ b/tests/data/devices/tze204-iaeejhvf-ts0601.json
@@ -1502,11 +1502,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "engineering_units": null,
-          "application_type": null,
-          "min_value": 1,
-          "max_value": 9,
-          "step": 1
+          "mode": "auto",
+          "native_max_value": 9,
+          "native_min_value": 1,
+          "native_step": 1,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "Number",
@@ -1557,10 +1557,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 10,
-          "step": 0.1,
-          "multiplier": 0.1
+          "mode": "auto",
+          "native_max_value": 10,
+          "native_min_value": 0,
+          "native_step": 0.1,
+          "native_unit_of_measurement": "s"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -1611,10 +1612,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 1,
-          "max_value": 10,
-          "step": 0.1,
-          "multiplier": 0.1
+          "mode": "auto",
+          "native_max_value": 10,
+          "native_min_value": 1,
+          "native_step": 0.1,
+          "native_unit_of_measurement": "s"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -1665,10 +1667,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0.75,
-          "max_value": 9.0,
-          "step": 0.75,
-          "multiplier": 0.01
+          "mode": "auto",
+          "native_max_value": 9.0,
+          "native_min_value": 0.75,
+          "native_step": 0.75,
+          "native_unit_of_measurement": "m"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -1719,10 +1722,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 8.25,
-          "step": 0.75,
-          "multiplier": 0.01
+          "mode": "auto",
+          "native_max_value": 8.25,
+          "native_min_value": 0,
+          "native_step": 0.75,
+          "native_unit_of_measurement": "m"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -1773,10 +1777,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 9,
-          "step": 0.1,
-          "multiplier": 0.01
+          "mode": "auto",
+          "native_max_value": 9,
+          "native_min_value": 0,
+          "native_step": 0.1,
+          "native_unit_of_measurement": "m"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -1827,10 +1832,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 9,
-          "step": 1,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 9,
+          "native_min_value": 0,
+          "native_step": 1,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -1881,10 +1887,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 600,
-          "step": 1,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 600,
+          "native_min_value": 0,
+          "native_step": 1,
+          "native_unit_of_measurement": "s"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -1935,10 +1942,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 420,
-          "step": 0.1,
-          "multiplier": 0.1
+          "mode": "auto",
+          "native_max_value": 420,
+          "native_min_value": 0,
+          "native_step": 0.1,
+          "native_unit_of_measurement": "lx"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -1989,10 +1997,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 10,
-          "step": 1,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 10,
+          "native_min_value": 0,
+          "native_step": 1,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -2043,11 +2052,11 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "engineering_units": 118,
-          "application_type": null,
-          "min_value": 0,
-          "max_value": 950,
-          "step": 10
+          "mode": "auto",
+          "native_max_value": 950,
+          "native_min_value": 0,
+          "native_step": 10,
+          "native_unit_of_measurement": "Centimeters"
         },
         "state": {
           "class_name": "Number",
@@ -2098,11 +2107,11 @@
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
-          "engineering_units": 118,
-          "application_type": null,
-          "min_value": 10,
-          "max_value": 950,
-          "step": 10
+          "mode": "auto",
+          "native_max_value": 950,
+          "native_min_value": 10,
+          "native_step": 10,
+          "native_unit_of_measurement": "Centimeters"
         },
         "state": {
           "class_name": "Number",
@@ -2153,11 +2162,11 @@
           "endpoint_id": 4,
           "available": true,
           "group_id": null,
-          "engineering_units": 159,
-          "application_type": null,
-          "min_value": 0,
-          "max_value": 20000,
-          "step": 100
+          "mode": "auto",
+          "native_max_value": 20000,
+          "native_min_value": 0,
+          "native_step": 100,
+          "native_unit_of_measurement": "Milliseconds"
         },
         "state": {
           "class_name": "Number",
@@ -2208,11 +2217,11 @@
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
-          "engineering_units": 159,
-          "application_type": null,
-          "min_value": 2000,
-          "max_value": 200000,
-          "step": 1000
+          "mode": "auto",
+          "native_max_value": 200000,
+          "native_min_value": 2000,
+          "native_step": 1000,
+          "native_unit_of_measurement": "Milliseconds"
         },
         "state": {
           "class_name": "Number",

--- a/tests/data/devices/tze204-iaeejhvf-ts0601.json
+++ b/tests/data/devices/tze204-iaeejhvf-ts0601.json
@@ -1465,7 +1465,7 @@
           "unique_id": "ab:cd:ef:12:52:88:1c:b0-1-13",
           "migrate_unique_ids": [],
           "platform": "number",
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "translation_key": null,
           "device_class": null,
           "state_class": null,
@@ -1509,7 +1509,7 @@
           "native_unit_of_measurement": null
         },
         "state": {
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "available": true,
           "state": 5
         }
@@ -2015,7 +2015,7 @@
           "unique_id": "ab:cd:ef:12:52:88:1c:b0-2-13",
           "migrate_unique_ids": [],
           "platform": "number",
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "translation_key": null,
           "device_class": null,
           "state_class": null,
@@ -2056,10 +2056,10 @@
           "native_max_value": 950,
           "native_min_value": 0,
           "native_step": 10,
-          "native_unit_of_measurement": "Centimeters"
+          "native_unit_of_measurement": "cm"
         },
         "state": {
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "available": true,
           "state": 40.0
         }
@@ -2070,7 +2070,7 @@
           "unique_id": "ab:cd:ef:12:52:88:1c:b0-3-13",
           "migrate_unique_ids": [],
           "platform": "number",
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "translation_key": null,
           "device_class": null,
           "state_class": null,
@@ -2111,10 +2111,10 @@
           "native_max_value": 950,
           "native_min_value": 10,
           "native_step": 10,
-          "native_unit_of_measurement": "Centimeters"
+          "native_unit_of_measurement": "cm"
         },
         "state": {
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "available": true,
           "state": 140.0
         }
@@ -2125,7 +2125,7 @@
           "unique_id": "ab:cd:ef:12:52:88:1c:b0-4-13",
           "migrate_unique_ids": [],
           "platform": "number",
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "translation_key": null,
           "device_class": null,
           "state_class": null,
@@ -2166,10 +2166,10 @@
           "native_max_value": 20000,
           "native_min_value": 0,
           "native_step": 100,
-          "native_unit_of_measurement": "Milliseconds"
+          "native_unit_of_measurement": "ms"
         },
         "state": {
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "available": true,
           "state": 500.0
         }
@@ -2180,7 +2180,7 @@
           "unique_id": "ab:cd:ef:12:52:88:1c:b0-5-13",
           "migrate_unique_ids": [],
           "platform": "number",
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "translation_key": null,
           "device_class": null,
           "state_class": null,
@@ -2221,10 +2221,10 @@
           "native_max_value": 200000,
           "native_min_value": 2000,
           "native_step": 1000,
-          "native_unit_of_measurement": "Milliseconds"
+          "native_unit_of_measurement": "ms"
         },
         "state": {
-          "class_name": "Number",
+          "class_name": "AnalogOutputNumber",
           "available": true,
           "state": 2000.0
         }

--- a/tests/data/devices/tze204-nlrfgpny-ts0601.json
+++ b/tests/data/devices/tze204-nlrfgpny-ts0601.json
@@ -1211,10 +1211,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 1,
-          "max_value": 60,
-          "step": 1,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 60,
+          "native_min_value": 1,
+          "native_step": 1,
+          "native_unit_of_measurement": "min"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",

--- a/tests/data/devices/tze204-qasjif9e-ts0601.json
+++ b/tests/data/devices/tze204-qasjif9e-ts0601.json
@@ -824,10 +824,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 1,
-          "max_value": 10,
-          "step": 0.1,
-          "multiplier": 0.1
+          "mode": "auto",
+          "native_max_value": 10,
+          "native_min_value": 1,
+          "native_step": 0.1,
+          "native_unit_of_measurement": "s"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -878,10 +879,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0.75,
-          "max_value": 9.0,
-          "step": 0.75,
-          "multiplier": 0.01
+          "mode": "auto",
+          "native_max_value": 9.0,
+          "native_min_value": 0.75,
+          "native_step": 0.75,
+          "native_unit_of_measurement": "m"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -932,10 +934,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 8.25,
-          "step": 0.75,
-          "multiplier": 0.01
+          "mode": "auto",
+          "native_max_value": 8.25,
+          "native_min_value": 0,
+          "native_step": 0.75,
+          "native_unit_of_measurement": "m"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -986,10 +989,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 1,
-          "max_value": 1500,
-          "step": 0.1,
-          "multiplier": 0.1
+          "mode": "auto",
+          "native_max_value": 1500,
+          "native_min_value": 1,
+          "native_step": 0.1,
+          "native_unit_of_measurement": "s"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",
@@ -1040,10 +1044,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": 0,
-          "max_value": 10,
-          "step": 1,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 10,
+          "native_min_value": 0,
+          "native_step": 1,
+          "native_unit_of_measurement": null
         },
         "state": {
           "class_name": "NumberConfigurationEntity",

--- a/tests/data/devices/tze284-ne4pikwm-ts0601.json
+++ b/tests/data/devices/tze284-ne4pikwm-ts0601.json
@@ -1109,10 +1109,11 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "min_value": -6,
-          "max_value": 6,
-          "step": 1,
-          "multiplier": 1
+          "mode": "auto",
+          "native_max_value": 6,
+          "native_min_value": -6,
+          "native_step": 1,
+          "native_unit_of_measurement": "\u00b0C"
         },
         "state": {
           "class_name": "NumberConfigurationEntity",

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1623,10 +1623,10 @@ async def test_thermostat_default_local_temperature_calibration_config(
     ]
     assert local_temperature_calibration_entity
     assert isinstance(local_temperature_calibration_entity, NumberConfigurationEntity)
-    assert local_temperature_calibration_entity.info_object.min_value == -2.5
-    assert local_temperature_calibration_entity.info_object.max_value == 2.5
-    assert local_temperature_calibration_entity.info_object.step == 0.1
-    assert local_temperature_calibration_entity.info_object.multiplier == 0.1
+    assert local_temperature_calibration_entity.info_object.native_min_value == -2.5
+    assert local_temperature_calibration_entity.info_object.native_max_value == 2.5
+    assert local_temperature_calibration_entity.info_object.native_step == 0.1
+    assert local_temperature_calibration_entity._multiplier == 0.1
 
 
 async def test_thermostat_quirkv2_local_temperature_calibration_config_overwrite(
@@ -1667,7 +1667,7 @@ async def test_thermostat_quirkv2_local_temperature_calibration_config_overwrite
     ]
     assert local_temperature_calibration_entity
     assert isinstance(local_temperature_calibration_entity, NumberConfigurationEntity)
-    assert local_temperature_calibration_entity.info_object.min_value == -5.0
-    assert local_temperature_calibration_entity.info_object.max_value == 5.0
-    assert local_temperature_calibration_entity.info_object.step == 0.1
-    assert local_temperature_calibration_entity.info_object.multiplier == 0.1
+    assert local_temperature_calibration_entity.info_object.native_min_value == -5.0
+    assert local_temperature_calibration_entity.info_object.native_max_value == 5.0
+    assert local_temperature_calibration_entity.info_object.native_step == 0.1
+    assert local_temperature_calibration_entity._multiplier == 0.1

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -120,21 +120,19 @@ async def test_number(
 
     assert cluster.read_attributes.call_count == 3
 
-    assert entity.description == "PWM1"
     assert entity.fallback_name == "PWM1"
-    assert entity.translation_key is None
 
     # test that the state is 15.0
     assert entity.state["state"] == 15.0
 
     # test attributes
-    assert entity.info_object.min_value == 1.0
-    assert entity.info_object.max_value == 100.0
-    assert entity.info_object.step == 1.1
+    assert entity.info_object.native_min_value == 1.0
+    assert entity.info_object.native_max_value == 100.0
+    assert entity.info_object.native_step == 1.1
+    assert entity.info_object.mode == NumberMode.AUTO
 
     assert entity.icon == "mdi:percent"
     assert entity.native_unit_of_measurement == "%"
-    assert entity.mode == NumberMode.AUTO
     assert entity.native_min_value == 1.0
     assert entity.native_max_value == 100.0
     assert entity.native_step == 1.1
@@ -151,7 +149,7 @@ async def test_number(
     assert entity.state["state"] == 20.0
 
     # change value from client
-    await entity.async_set_value(30.0)
+    await entity.async_set_native_value(30.0)
     await zha_gateway.async_block_till_done()
 
     assert len(cluster.write_attributes.mock_calls) == 1
@@ -272,7 +270,7 @@ async def test_level_control_number(
     assert entity._attr_entity_category == EntityCategory.CONFIG
 
     assert entity.icon is None
-    assert entity.description is None
+    assert entity.fallback_name is None
     assert entity.native_unit_of_measurement is None
     assert entity.mode == NumberMode.AUTO
     assert entity.native_min_value == 0

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -203,7 +203,6 @@ async def test_number_missing_description_attr(
     entity: PlatformEntity = get_entity(zha_device, platform=Platform.NUMBER)
     assert isinstance(entity, PlatformEntity)
 
-    assert entity.description is None
     assert entity.fallback_name is None
     assert entity.translation_key == "number"
 

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -560,20 +560,18 @@ def test_entity_names() -> None:
 
     for _, entity_classes in iter_all_rules():
         for entity_class in entity_classes:
-            if hasattr(entity_class, "_attr_fallback_name"):
-                # The entity has a name
+            if entity_class._attr_fallback_name is not None:
                 assert (
                     isinstance(entity_class._attr_fallback_name, str)
                     and entity_class._attr_fallback_name
                 )
-            elif hasattr(entity_class, "_attr_translation_key"):
+            elif entity_class._attr_translation_key is not None:
                 assert (
                     isinstance(entity_class._attr_translation_key, str)
                     and entity_class._attr_translation_key
                 )
-            elif hasattr(entity_class, "_attr_device_class"):
-                if entity_class is not AnalogInputSensor:
-                    assert entity_class._attr_device_class
+            elif entity_class._attr_device_class is not None:
+                pass
             else:
                 # The only exceptions
                 assert (

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -574,7 +574,8 @@ def test_entity_names() -> None:
                 pass
             else:
                 # The only exceptions
-                assert (
-                    entity_class is IASZone
-                    or entity_class is BinaryInputWithDescription
+                assert entity_class in (
+                    IASZone,
+                    BinaryInputWithDescription,
+                    AnalogInputSensor,
                 )

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -197,12 +197,12 @@ QUIRKS_ENTITY_META_TO_ENTITY_CLASS = {
         Platform.NUMBER,
         NumberMetadata,
         EntityType.DIAGNOSTIC,
-    ): number.Number,
+    ): number.AnalogOutputNumber,
     (
         Platform.NUMBER,
         NumberMetadata,
         EntityType.STANDARD,
-    ): number.Number,
+    ): number.AnalogOutputNumber,
     (
         Platform.SWITCH,
         SwitchMetadata,

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -197,12 +197,12 @@ QUIRKS_ENTITY_META_TO_ENTITY_CLASS = {
         Platform.NUMBER,
         NumberMetadata,
         EntityType.DIAGNOSTIC,
-    ): number.AnalogOutputNumber,
+    ): number.NumberConfigurationEntity,
     (
         Platform.NUMBER,
         NumberMetadata,
         EntityType.STANDARD,
-    ): number.AnalogOutputNumber,
+    ): number.NumberConfigurationEntity,
     (
         Platform.SWITCH,
         SwitchMetadata,

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -114,12 +114,13 @@ class BaseEntity(LogMixin, EventBase):
 
     PLATFORM: Platform = Platform.UNKNOWN
 
-    _attr_fallback_name: str | None
-    _attr_translation_key: str | None
-    _attr_entity_category: EntityCategory | None
+    _attr_fallback_name: str | None = None
+    _attr_icon: str | None = None
+    _attr_translation_key: str | None = None
+    _attr_entity_category: EntityCategory | None = None
     _attr_entity_registry_enabled_default: bool = True
-    _attr_device_class: str | None
-    _attr_state_class: str | None
+    _attr_device_class: str | None = None
+    _attr_state_class: str | None = None
     _attr_enabled: bool = True
     _attr_always_supported: bool = False
     _attr_primary: bool = False
@@ -187,14 +188,12 @@ class BaseEntity(LogMixin, EventBase):
     @property
     def fallback_name(self) -> str | None:
         """Return the entity fallback name for when a translation key is unavailable."""
-        if hasattr(self, "_attr_fallback_name"):
-            return self._attr_fallback_name
-        return None
+        return self._attr_fallback_name
 
     @property
     def icon(self) -> str | None:
         """Return the entity icon."""
-        return None
+        return self._attr_icon
 
     @property
     def translation_key(self) -> str | None:
@@ -218,16 +217,12 @@ class BaseEntity(LogMixin, EventBase):
     @property
     def device_class(self) -> str | None:
         """Return the device class."""
-        if hasattr(self, "_attr_device_class"):
-            return self._attr_device_class
-        return None
+        return self._attr_device_class
 
     @property
     def state_class(self) -> str | None:
         """Return the state class."""
-        if hasattr(self, "_attr_state_class"):
-            return self._attr_state_class
-        return None
+        return self._attr_state_class
 
     @final
     @property

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -51,7 +51,6 @@ class NumberEntityInfo(BaseEntityInfo):
     native_max_value: float
     native_min_value: float
     native_step: float | None
-    native_value: float | None
     native_unit_of_measurement: str | None
 
 
@@ -83,7 +82,6 @@ class BaseNumber(PlatformEntity):
             native_max_value=self.native_max_value,
             native_min_value=self.native_min_value,
             native_step=self.native_step,
-            native_value=self.native_value,
             native_unit_of_measurement=self.native_unit_of_measurement,
         )
 
@@ -154,7 +152,11 @@ class Number(BaseNumber):
         self._attr_native_unit_of_measurement = UNITS.get(
             analog_output.engineering_units
         )
-        self._attr_icon = ICONS.get(analog_output.application_type >> 16)
+
+        if analog_output.application_type is not None:
+            self._attr_icon = ICONS.get(analog_output.application_type >> 16)
+        else:
+            self._attr_icon = None
 
         if analog_output.description is not None:
             self._attr_fallback_name = analog_output.description

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -123,7 +123,7 @@ class BaseNumber(PlatformEntity):
 
 
 @STRICT_MATCH(cluster_handler_names=CLUSTER_HANDLER_ANALOG_OUTPUT)
-class Number(BaseNumber):
+class AnalogOutputNumber(BaseNumber):
     """Representation of a ZHA Number entity."""
 
     _attr_translation_key: str = "number"

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -47,31 +47,88 @@ CONFIG_DIAGNOSTIC_MATCH = functools.partial(
 class NumberEntityInfo(BaseEntityInfo):
     """Number entity info."""
 
-    engineering_units: int
-    application_type: int
-    min_value: float | None
-    max_value: float | None
-    step: float | None
+    mode: NumberMode
+    native_max_value: float
+    native_min_value: float
+    native_step: float | None
+    native_value: float | None
+    native_unit_of_measurement: str | None
 
 
-@dataclass(frozen=True, kw_only=True)
-class NumberConfigurationEntityInfo(BaseEntityInfo):
-    """Number configuration entity info."""
-
-    min_value: float | None
-    max_value: float | None
-    step: float | None
-    multiplier: float | None
-    device_class: str | None
-
-
-@STRICT_MATCH(cluster_handler_names=CLUSTER_HANDLER_ANALOG_OUTPUT)
-class Number(PlatformEntity):
+class BaseNumber(PlatformEntity):
     """Representation of a ZHA Number entity."""
 
     PLATFORM = Platform.NUMBER
-    _attr_translation_key: str = "number"
+
+    _attr_device_class: NumberDeviceClass | None = None
+
     _attr_mode: NumberMode = NumberMode.AUTO
+    _attr_native_max_value: float
+    _attr_native_min_value: float
+    _attr_native_step: float | None = None
+    _attr_native_value: float | None
+    _attr_native_unit_of_measurement: str | None = None
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current value."""
+        raise NotImplementedError
+
+    @functools.cached_property
+    def info_object(self) -> NumberEntityInfo:
+        """Return a representation of the number entity."""
+        return NumberEntityInfo(
+            **super().info_object.__dict__,
+            mode=self.mode,
+            native_max_value=self.native_max_value,
+            native_min_value=self.native_min_value,
+            native_step=self.native_step,
+            native_value=self.native_value,
+            native_unit_of_measurement=self.native_unit_of_measurement,
+        )
+
+    @property
+    def state(self) -> dict[str, Any]:
+        """Return the state of the entity."""
+        response = super().state
+        response["state"] = self.native_value
+        return response
+
+    @property
+    def native_min_value(self) -> float:
+        """Return the minimum value."""
+        return self._attr_native_min_value
+
+    @property
+    def native_max_value(self) -> float:
+        """Return the maximum value."""
+        return self._attr_native_max_value
+
+    @property
+    def native_step(self) -> float | None:
+        """Return the value step."""
+        return self._attr_native_step
+
+    @functools.cached_property
+    def native_unit_of_measurement(self) -> str | None:
+        """Return the unit the value is expressed in."""
+        return self._attr_native_unit_of_measurement
+
+    @functools.cached_property
+    def mode(self) -> NumberMode:
+        """Return the mode of the entity."""
+        return self._attr_mode
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the current value from HA."""
+        raise NotImplementedError
+
+
+@STRICT_MATCH(cluster_handler_names=CLUSTER_HANDLER_ANALOG_OUTPUT)
+class Number(BaseNumber):
+    """Representation of a ZHA Number entity."""
+
+    _attr_translation_key: str = "number"
 
     def __init__(
         self,
@@ -85,6 +142,24 @@ class Number(PlatformEntity):
         self._analog_output_cluster_handler: ClusterHandler = self.cluster_handlers[
             CLUSTER_HANDLER_ANALOG_OUTPUT
         ]
+
+    def recompute_capabilities(self) -> None:
+        """Recompute capabilities."""
+        super().recompute_capabilities()
+
+        analog_output = self._analog_output_cluster_handler
+        self._attr_native_min_value = analog_output.min_present_value or 0
+        self._attr_native_max_value = analog_output.max_present_value or 1023
+        self._attr_native_step = analog_output.resolution
+        self._attr_native_unit_of_measurement = UNITS.get(
+            analog_output.engineering_units
+        )
+        self._attr_icon = ICONS.get(analog_output.application_type >> 16)
+
+        if analog_output.description is not None:
+            self._attr_fallback_name = analog_output.description
+        else:
+            self._attr_fallback_name = None
 
     def on_add(self) -> None:
         """Run when entity is added."""
@@ -104,77 +179,10 @@ class Number(PlatformEntity):
                 self._analog_output_cluster_handler.description
             )
 
-    @functools.cached_property
-    def info_object(self) -> NumberEntityInfo:
-        """Return a representation of the number entity."""
-        return NumberEntityInfo(
-            **super().info_object.__dict__,
-            engineering_units=self._analog_output_cluster_handler.engineering_units,
-            application_type=self._analog_output_cluster_handler.application_type,
-            min_value=self.native_min_value,
-            max_value=self.native_max_value,
-            step=self.native_step,
-        )
-
-    @property
-    def state(self) -> dict[str, Any]:
-        """Return the state of the entity."""
-        response = super().state
-        response["state"] = self.native_value
-        return response
-
     @property
     def native_value(self) -> float | None:
         """Return the current value."""
         return self._analog_output_cluster_handler.present_value
-
-    @property
-    def native_min_value(self) -> float:
-        """Return the minimum value."""
-        min_present_value = self._analog_output_cluster_handler.min_present_value
-        if min_present_value is not None:
-            return min_present_value
-        return 0
-
-    @property
-    def native_max_value(self) -> float:
-        """Return the maximum value."""
-        max_present_value = self._analog_output_cluster_handler.max_present_value
-        if max_present_value is not None:
-            return max_present_value
-        return 1023
-
-    @property
-    def native_step(self) -> float | None:
-        """Return the value step."""
-        return self._analog_output_cluster_handler.resolution
-
-    @functools.cached_property
-    def description(self) -> str | None:
-        """Return the description of the number entity."""
-        description = self._analog_output_cluster_handler.description
-        if not description:
-            return None
-        return description
-
-    @functools.cached_property
-    def icon(self) -> str | None:
-        """Return the icon to be used for this entity."""
-        application_type = self._analog_output_cluster_handler.application_type
-        if application_type is not None:
-            return ICONS.get(application_type >> 16, None)
-        return None
-
-    @functools.cached_property
-    def native_unit_of_measurement(self) -> str | None:
-        """Return the unit the value is expressed in."""
-        engineering_units = self._analog_output_cluster_handler.engineering_units
-        return BACNET_UNITS_TO_HA_UNITS.get(engineering_units)
-
-    @functools.cached_property
-    def mode(self) -> NumberMode:
-        """Return the mode of the entity."""
-        return self._attr_mode
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value from HA."""
@@ -188,25 +196,16 @@ class Number(PlatformEntity):
         """Handle value update from cluster handler."""
         self.maybe_emit_state_changed_event()
 
-    async def async_set_value(self, value: Any, **kwargs: Any) -> None:  # pylint: disable=unused-argument
-        """Update the current value from service."""
-        num_value = float(value)
-        if await self._analog_output_cluster_handler.async_set_present_value(num_value):
-            self.maybe_emit_state_changed_event()
 
-
-class NumberConfigurationEntity(PlatformEntity):
+class NumberConfigurationEntity(BaseNumber):
     """Representation of a ZHA number configuration entity."""
 
-    PLATFORM = Platform.NUMBER
     _attr_entity_category = EntityCategory.CONFIG
-    _attr_native_unit_of_measurement: str | None
     _attr_native_min_value: float = 0.0
     _attr_native_max_value: float = 100.0
     _attr_native_step: float = 1.0
-    _attr_multiplier: float = 1
+    _multiplier: float = 1
     _attribute_name: str
-    _attr_mode: NumberMode = NumberMode.AUTO
 
     def __init__(
         self,
@@ -217,15 +216,16 @@ class NumberConfigurationEntity(PlatformEntity):
     ) -> None:
         """Init this number configuration entity."""
         self._cluster_handler: ClusterHandler = cluster_handlers[0]
-        self._attr_device_class: NumberDeviceClass | None = None
         super().__init__(cluster_handlers, endpoint, device, **kwargs)
 
     def _is_supported(self) -> bool:
         """Return if the entity is supported for the device, internal."""
         if (
             self._attribute_name in self._cluster_handler.cluster.unsupported_attributes
-            or self._attribute_name
-            not in self._cluster_handler.cluster.attributes_by_name
+            or (
+                self._attribute_name
+                not in self._cluster_handler.cluster.attributes_by_name
+            )
             or self._cluster_handler.cluster.get(self._attribute_name) is None
         ):
             _LOGGER.debug(
@@ -259,7 +259,7 @@ class NumberConfigurationEntity(PlatformEntity):
         if entity_metadata.step is not None:
             self._attr_native_step = entity_metadata.step
         if entity_metadata.multiplier is not None:
-            self._attr_multiplier = entity_metadata.multiplier
+            self._multiplier = entity_metadata.multiplier
         if entity_metadata.device_class is not None:
             self._attr_device_class = validate_device_class(
                 NumberDeviceClass,
@@ -269,17 +269,6 @@ class NumberConfigurationEntity(PlatformEntity):
             )
         if entity_metadata.unit is not None:
             self._attr_native_unit_of_measurement = entity_metadata.unit
-
-    @functools.cached_property
-    def info_object(self) -> NumberConfigurationEntityInfo:
-        """Return a representation of the number entity."""
-        return NumberConfigurationEntityInfo(
-            **super().info_object.__dict__,
-            min_value=self._attr_native_min_value,
-            max_value=self._attr_native_max_value,
-            step=self._attr_native_step,
-            multiplier=self._attr_multiplier,
-        )
 
     @property
     def state(self) -> dict[str, Any]:
@@ -294,45 +283,12 @@ class NumberConfigurationEntity(PlatformEntity):
         value = self._cluster_handler.cluster.get(self._attribute_name)
         if value is None:
             return None
-        return value * self._attr_multiplier
-
-    @property
-    def native_min_value(self) -> float:
-        """Return the minimum value."""
-        return self._attr_native_min_value
-
-    @property
-    def native_max_value(self) -> float:
-        """Return the maximum value."""
-        return self._attr_native_max_value
-
-    @property
-    def native_step(self) -> float | None:
-        """Return the value step."""
-        return self._attr_native_step
-
-    @functools.cached_property
-    def description(self) -> str | None:
-        """Return the description of the number entity."""
-        # To maintain parity with `Number`
-        return None
-
-    @functools.cached_property
-    def native_unit_of_measurement(self) -> str | None:
-        """Return the unit the value is expressed in."""
-        if hasattr(self, "_attr_native_unit_of_measurement"):
-            return self._attr_native_unit_of_measurement
-        return None
-
-    @functools.cached_property
-    def mode(self) -> NumberMode:
-        """Return the mode of the entity."""
-        return self._attr_mode
+        return value * self._multiplier
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value from HA."""
         await self._cluster_handler.write_attributes_safe(
-            {self._attribute_name: int(value / self._attr_multiplier)}
+            {self._attribute_name: int(value / self._multiplier)}
         )
         self.maybe_emit_state_changed_event()
 
@@ -345,6 +301,7 @@ class NumberConfigurationEntity(PlatformEntity):
                 self._attribute_name, from_cache=False
             )
             _LOGGER.debug("read value=%s", value)
+            # The attribute update handler below takes care of the rest
 
     def handle_cluster_handler_attribute_updated(
         self,
@@ -445,18 +402,11 @@ class StartUpColorTemperatureConfigurationEntity(NumberConfigurationEntity):
     _attribute_name = "start_up_color_temperature"
     _attr_translation_key: str = "start_up_color_temperature"
 
-    def __init__(
-        self,
-        cluster_handlers: list[ClusterHandler],
-        endpoint: Endpoint,
-        device: Device,
-        **kwargs: Any,
-    ) -> None:
-        """Init this ZHA startup color temperature entity."""
-        super().__init__(cluster_handlers, endpoint, device, **kwargs)
-        if self._cluster_handler:
-            self._attr_native_min_value: float = self._cluster_handler.min_mireds
-            self._attr_native_max_value: float = self._cluster_handler.max_mireds
+    def recompute_capabilities(self) -> None:
+        """Recompute capabilities."""
+        super().recompute_capabilities()
+        self._attr_native_min_value = self._cluster_handler.min_mireds
+        self._attr_native_max_value = self._cluster_handler.max_mireds
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
@@ -826,7 +776,7 @@ class AqaraThermostatAwayTemp(NumberConfigurationEntity):
     _attr_entity_category = EntityCategory.CONFIG
     _attr_native_min_value: float = 5
     _attr_native_max_value: float = 30
-    _attr_multiplier: float = 0.01
+    _multiplier: float = 0.01
     _attribute_name = "away_preset_temperature"
     _attr_translation_key: str = "away_preset_temperature"
 
@@ -845,7 +795,7 @@ class ThermostatLocalTempCalibration(NumberConfigurationEntity):
     _attr_native_min_value: float = -2.5
     _attr_native_max_value: float = 2.5
     _attr_native_step: float = 0.1
-    _attr_multiplier: float = 0.1
+    _multiplier: float = 0.1
     _attribute_name = "local_temperature_calibration"
     _attr_translation_key: str = "local_temperature_calibration"
 
@@ -906,7 +856,7 @@ class ZCLTemperatureEntity(NumberConfigurationEntity):
     _attr_native_unit_of_measurement: str = UnitOfTemperature.CELSIUS
     _attr_mode: NumberMode = NumberMode.BOX
     _attr_native_step: float = 0.01
-    _attr_multiplier: float = 0.01
+    _multiplier: float = 0.01
 
 
 class ZCLHeatSetpointLimitEntity(ZCLTemperatureEntity):
@@ -914,21 +864,21 @@ class ZCLHeatSetpointLimitEntity(ZCLTemperatureEntity):
 
     _attr_native_step: float = 0.5
 
-    _min_source = Thermostat.AttributeDefs.abs_min_heat_setpoint_limit.name
-    _max_source = Thermostat.AttributeDefs.abs_max_heat_setpoint_limit.name
-
-    @property
-    def native_min_value(self) -> float:
-        """Return the minimum value."""
-        # The spec says 0x954D, which is a signed integer, therefore the value is in decimals
-        min_present_value = self._cluster_handler.cluster.get(self._min_source, -27315)
-        return min_present_value * self._attr_multiplier
-
-    @property
-    def native_max_value(self) -> float:
-        """Return the maximum value."""
-        max_present_value = self._cluster_handler.cluster.get(self._max_source, 0x7FFF)
-        return max_present_value * self._attr_multiplier
+    def recompute_capabilities(self) -> None:
+        """Recompute capabilities."""
+        super().recompute_capabilities()
+        self._attr_native_min_value = (
+            self._cluster_handler.cluster.get(
+                Thermostat.AttributeDefs.abs_min_heat_setpoint_limit.name, -27315
+            )
+            * self._multiplier
+        )
+        self._attr_native_max_value = (
+            self._cluster_handler.cluster.get(
+                Thermostat.AttributeDefs.abs_max_heat_setpoint_limit.name, 0x7FFF
+            )
+            * self._multiplier
+        )
 
 
 @CONFIG_DIAGNOSTIC_MATCH(cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT)
@@ -943,7 +893,15 @@ class MaxHeatSetpointLimit(ZCLHeatSetpointLimitEntity):
     _attr_translation_key: str = "max_heat_setpoint_limit"
     _attr_entity_category = EntityCategory.CONFIG
 
-    _min_source = Thermostat.AttributeDefs.min_heat_setpoint_limit.name
+    def recompute_capabilities(self) -> None:
+        """Recompute capabilities."""
+        super().recompute_capabilities()
+        self._attr_native_min_value = (
+            self._cluster_handler.cluster.get(
+                Thermostat.AttributeDefs.min_heat_setpoint_limit.name, -27315
+            )
+            * self._multiplier
+        )
 
 
 @CONFIG_DIAGNOSTIC_MATCH(cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT)
@@ -958,7 +916,15 @@ class MinHeatSetpointLimit(ZCLHeatSetpointLimitEntity):
     _attr_translation_key: str = "min_heat_setpoint_limit"
     _attr_entity_category = EntityCategory.CONFIG
 
-    _max_source = Thermostat.AttributeDefs.max_heat_setpoint_limit.name
+    def recompute_capabilities(self) -> None:
+        """Recompute capabilities."""
+        super().recompute_capabilities()
+        self._attr_native_max_value = (
+            self._cluster_handler.cluster.get(
+                Thermostat.AttributeDefs.max_heat_setpoint_limit.name, 0x7FFF
+            )
+            * self._multiplier
+        )
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
@@ -1021,7 +987,7 @@ class DanfossRegulationSetpointOffset(NumberConfigurationEntity):
     _attr_native_min_value: float = -2.5
     _attr_native_max_value: float = 2.5
     _attr_native_step: float = 0.1
-    _attr_multiplier = 1 / 10
+    _multiplier = 1 / 10
 
 
 @CONFIG_DIAGNOSTIC_MATCH(

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -149,7 +149,7 @@ class AnalogOutputNumber(BaseNumber):
         self._attr_native_min_value = analog_output.min_present_value or 0
         self._attr_native_max_value = analog_output.max_present_value or 1023
         self._attr_native_step = analog_output.resolution
-        self._attr_native_unit_of_measurement = UNITS.get(
+        self._attr_native_unit_of_measurement = BACNET_UNITS_TO_HA_UNITS.get(
             analog_output.engineering_units
         )
 


### PR DESCRIPTION
Should resolve https://github.com/zigpy/zha-device-handlers/pull/3821#issuecomment-2842596655.

- I've reorganized the platform code to use a `BaseNumber` entity, with subclasses implementing `native_value` and `async_set_native_value`.
- All entity metadata is set in `recompute_capabilities()`.
- `_init_from_quirks_metadata` is implemented on `NumberConfigurationEntity`. Should we move it up in the hierarchy?
- We use `fallback_name` instead of `description` for standardization.