### PR TITLE
Remove `EntityType` from quirks v2 entity metadata handling

### DIFF
--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -614,6 +614,15 @@ async def test_quirks_v2_entity_discovery_errors(
     zigpy_device = _get_test_device(
         zha_gateway, "Ikea of Sweden3", "TRADFRI remote control3"
     )
+
+    # Inject unknown quirks v2 entity metadata
+    class UnknownEntityMetadata:
+        entity_platform = Platform.UPDATE
+
+    zigpy_device._exposes_metadata[
+        (1, zigpy.zcl.clusters.general.OnOff.cluster_id, ClusterType.Server)
+    ].append(UnknownEntityMetadata())
+
     zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
 
     assert (
@@ -732,9 +741,7 @@ async def test_quirks_v2_metadata_bad_device_classes(
     zigpy.quirks._DEVICE_REGISTRY.remove(zigpy_device)
 
 
-async def test_quirks_v2_fallback_name(
-    zha_gateway: Gateway,  # pylint: disable=unused-argument
-) -> None:
+async def test_quirks_v2_fallback_name(zha_gateway: Gateway) -> None:
     """Test quirks v2 fallback name."""
 
     zigpy_device = _get_test_device(
@@ -742,7 +749,7 @@ async def test_quirks_v2_fallback_name(
         "Ikea of Sweden6",
         "TRADFRI remote control6",
         augment_method=lambda builder: builder.sensor(
-            attribute_name=zigpy.zcl.clusters.general.OnOff.AttributeDefs.off_wait_time.name,
+            attribute_name=zigpy.zcl.clusters.general.OnOff.AttributeDefs.global_scene_control.name,
             cluster_id=zigpy.zcl.clusters.general.OnOff.cluster_id,
             translation_key="some_sensor",
             fallback_name="Fallback name",

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, ParamSpec, TypeVar, cast
 from zigpy.quirks.v2 import (
     BinarySensorMetadata,
     CustomDeviceV2,
-    EntityType,
     NumberMetadata,
     SwitchMetadata,
     WriteAttributeButtonMetadata,
@@ -108,111 +107,14 @@ GROUP_PLATFORMS = (
 )
 
 QUIRKS_ENTITY_META_TO_ENTITY_CLASS = {
-    (
-        Platform.BUTTON,
-        WriteAttributeButtonMetadata,
-        EntityType.CONFIG,
-    ): button.WriteAttributeButton,
-    (
-        Platform.BUTTON,
-        WriteAttributeButtonMetadata,
-        EntityType.STANDARD,
-    ): button.WriteAttributeButton,
-    (
-        Platform.BUTTON,
-        WriteAttributeButtonMetadata,
-        EntityType.DIAGNOSTIC,
-    ): button.WriteAttributeButton,
-    (
-        Platform.BUTTON,
-        ZCLCommandButtonMetadata,
-        EntityType.CONFIG,
-    ): button.Button,
-    (
-        Platform.BUTTON,
-        ZCLCommandButtonMetadata,
-        EntityType.DIAGNOSTIC,
-    ): button.Button,
-    (
-        Platform.BUTTON,
-        ZCLCommandButtonMetadata,
-        EntityType.STANDARD,
-    ): button.Button,
-    (
-        Platform.BINARY_SENSOR,
-        BinarySensorMetadata,
-        EntityType.CONFIG,
-    ): binary_sensor.BinarySensor,
-    (
-        Platform.BINARY_SENSOR,
-        BinarySensorMetadata,
-        EntityType.DIAGNOSTIC,
-    ): binary_sensor.BinarySensor,
-    (
-        Platform.BINARY_SENSOR,
-        BinarySensorMetadata,
-        EntityType.STANDARD,
-    ): binary_sensor.BinarySensor,
-    (
-        Platform.SENSOR,
-        ZCLEnumMetadata,
-        EntityType.DIAGNOSTIC,
-    ): sensor.EnumSensor,
-    (
-        Platform.SENSOR,
-        ZCLEnumMetadata,
-        EntityType.STANDARD,
-    ): sensor.EnumSensor,
-    (
-        Platform.SENSOR,
-        ZCLSensorMetadata,
-        EntityType.DIAGNOSTIC,
-    ): sensor.Sensor,
-    (
-        Platform.SENSOR,
-        ZCLSensorMetadata,
-        EntityType.STANDARD,
-    ): sensor.Sensor,
-    (
-        Platform.SELECT,
-        ZCLEnumMetadata,
-        EntityType.CONFIG,
-    ): select.ZCLEnumSelectEntity,
-    (
-        Platform.SELECT,
-        ZCLEnumMetadata,
-        EntityType.STANDARD,
-    ): select.ZCLEnumSelectEntity,
-    (
-        Platform.SELECT,
-        ZCLEnumMetadata,
-        EntityType.DIAGNOSTIC,
-    ): select.ZCLEnumSelectEntity,
-    (
-        Platform.NUMBER,
-        NumberMetadata,
-        EntityType.CONFIG,
-    ): number.NumberConfigurationEntity,
-    (
-        Platform.NUMBER,
-        NumberMetadata,
-        EntityType.DIAGNOSTIC,
-    ): number.NumberConfigurationEntity,
-    (
-        Platform.NUMBER,
-        NumberMetadata,
-        EntityType.STANDARD,
-    ): number.NumberConfigurationEntity,
-    (
-        Platform.SWITCH,
-        SwitchMetadata,
-        EntityType.CONFIG,
-    ): switch.ConfigurableAttributeSwitch,
-    (
-        Platform.SWITCH,
-        SwitchMetadata,
-        EntityType.STANDARD,
-    ): switch.ConfigurableAttributeSwitch,
+    (Platform.BUTTON, WriteAttributeButtonMetadata): button.WriteAttributeButton,
+    (Platform.BUTTON, ZCLCommandButtonMetadata): button.Button,
+    (Platform.BINARY_SENSOR, BinarySensorMetadata): binary_sensor.BinarySensor,
+    (Platform.SENSOR, ZCLEnumMetadata): sensor.EnumSensor,
+    (Platform.SENSOR, ZCLSensorMetadata): sensor.Sensor,
+    (Platform.SELECT, ZCLEnumMetadata): select.ZCLEnumSelectEntity,
+    (Platform.NUMBER, NumberMetadata): number.NumberConfigurationEntity,
+    (Platform.SWITCH, SwitchMetadata): switch.ConfigurableAttributeSwitch,
 }
 
 QUIRKS_SENSOR_DEV_CLASS_TO_ENTITY_CLASS = {
@@ -343,7 +245,7 @@ class DeviceProbe:
                 platform = Platform(entity_metadata.entity_platform.value)
                 metadata_type = type(entity_metadata)
                 entity_class = QUIRKS_ENTITY_META_TO_ENTITY_CLASS.get(
-                    (platform, metadata_type, entity_metadata.entity_type)
+                    (platform, metadata_type)
                 )
 
                 if entity_class is None:


### PR DESCRIPTION
I don't see any regressions with existing devices so I think this change is good to go. We had only a few entity types without all three `EntityType` mappings already in place.