### PR TITLE
Make integer structs immutable in unit tests

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -111,7 +111,7 @@ def update_attribute_cache(cluster: zigpy.zcl.Cluster) -> None:
         attrs.append(make_attribute(attrid, value))
 
     hdr = make_zcl_header(zcl_f.GeneralCommand.Report_Attributes)
-    hdr.frame_control.disable_default_response = True
+    hdr.frame_control = hdr.frame_control.replace(disable_default_response=True)
     msg = zcl_f.GENERAL_COMMANDS[zcl_f.GeneralCommand.Report_Attributes].schema(
         attribute_reports=attrs
     )
@@ -150,7 +150,7 @@ async def send_attributes_report(
     )
 
     hdr = make_zcl_header(zcl_f.GeneralCommand.Report_Attributes)
-    hdr.frame_control.disable_default_response = True
+    hdr.frame_control = hdr.frame_control.replace(disable_default_response=True)
     cluster.handle_message(hdr, msg)
     await zha_gateway.async_block_till_done()
 


### PR DESCRIPTION
Related to https://github.com/zigpy/zigpy/pull/1596. This doesn't use a new API so this can be merged without bumping zigpy.