### PR TITLE
Allow passing `datetime` objects to sensors

### DIFF
--- a/tests/data/devices/adurosmart-eria-ad-rgbw3001.json
+++ b/tests/data/devices/adurosmart-eria-ad-rgbw3001.json
@@ -1617,10 +1617,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1672,10 +1669,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/adurosmart-eria-vms-adurolight.json
+++ b/tests/data/devices/adurosmart-eria-vms-adurolight.json
@@ -872,10 +872,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -927,10 +924,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -982,10 +976,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/aqara-lumi-lunar-acn01.json
+++ b/tests/data/devices/aqara-lumi-lunar-acn01.json
@@ -484,10 +484,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -539,10 +536,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/aqara-lumi-motion-ac01.json
+++ b/tests/data/devices/aqara-lumi-motion-ac01.json
@@ -996,10 +996,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1051,10 +1048,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1106,10 +1100,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_temperature",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {

--- a/tests/data/devices/aug-winkhaus-gmbh-co-kg-fm-v-zb.json
+++ b/tests/data/devices/aug-winkhaus-gmbh-co-kg-fm-v-zb.json
@@ -1075,10 +1075,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1130,10 +1127,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1185,10 +1179,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/awox-tlsr82xx.json
+++ b/tests/data/devices/awox-tlsr82xx.json
@@ -1249,10 +1249,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1304,10 +1301,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/bosch-rbsh-mms-zb-eu.json
+++ b/tests/data/devices/bosch-rbsh-mms-zb-eu.json
@@ -3573,10 +3573,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -3628,10 +3625,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -3683,10 +3677,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "instantaneous_demand",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -3741,10 +3732,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {
@@ -3799,10 +3787,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "window_covering_type",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -3854,10 +3839,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {

--- a/tests/data/devices/centralite-3320-l.json
+++ b/tests/data/devices/centralite-3320-l.json
@@ -1889,10 +1889,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1944,10 +1941,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1999,10 +1993,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -2057,10 +2048,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {

--- a/tests/data/devices/centralite-3326-l.json
+++ b/tests/data/devices/centralite-3326-l.json
@@ -1869,10 +1869,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1924,10 +1921,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1979,10 +1973,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -2037,10 +2028,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {

--- a/tests/data/devices/centralite-3405-l.json
+++ b/tests/data/devices/centralite-3405-l.json
@@ -1493,10 +1493,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1548,10 +1545,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1603,10 +1597,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1661,10 +1652,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {

--- a/tests/data/devices/centralite-systems-3156105.json
+++ b/tests/data/devices/centralite-systems-3156105.json
@@ -1740,10 +1740,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1795,10 +1792,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1850,10 +1844,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1906,10 +1897,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1961,10 +1949,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "setpoint_change_source_timestamp",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {

--- a/tests/data/devices/climaxtechnology-sd8sc-00-00-03-12tc.json
+++ b/tests/data/devices/climaxtechnology-sd8sc-00-00-03-12tc.json
@@ -874,10 +874,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -929,10 +926,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/ecolink-4655bc0-r.json
+++ b/tests/data/devices/ecolink-4655bc0-r.json
@@ -1366,10 +1366,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1421,10 +1418,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1476,10 +1470,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1534,10 +1525,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {

--- a/tests/data/devices/enktro-acmidea.json
+++ b/tests/data/devices/enktro-acmidea.json
@@ -840,10 +840,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -895,10 +892,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -950,10 +944,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1005,10 +996,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "setpoint_change_source_timestamp",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {

--- a/tests/data/devices/ericsity-gl-c-008p.json
+++ b/tests/data/devices/ericsity-gl-c-008p.json
@@ -1382,10 +1382,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1437,10 +1434,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/ericsity-gl-c-009p.json
+++ b/tests/data/devices/ericsity-gl-c-009p.json
@@ -1376,10 +1376,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1431,10 +1428,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/espressif-zigbeeanalogdevice.json
+++ b/tests/data/devices/espressif-zigbeeanalogdevice.json
@@ -584,10 +584,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -639,10 +636,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -694,10 +688,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "present_value",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {

--- a/tests/data/devices/espressif-zigbeecarbondioxidesensor.json
+++ b/tests/data/devices/espressif-zigbeecarbondioxidesensor.json
@@ -388,10 +388,7 @@
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -443,10 +440,7 @@
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -498,10 +492,7 @@
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1000000.0,
           "unit": "ppm"
         },
         "state": {

--- a/tests/data/devices/ewelink-ck-bl702-al-01-7009-z102lg03-1.json
+++ b/tests/data/devices/ewelink-ck-bl702-al-01-7009-z102lg03-1.json
@@ -1507,10 +1507,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1562,10 +1559,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/ewelink-sa-003-zigbee.json
+++ b/tests/data/devices/ewelink-sa-003-zigbee.json
@@ -652,10 +652,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -707,10 +704,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/ewelink-snzb-01p.json
+++ b/tests/data/devices/ewelink-snzb-01p.json
@@ -1028,10 +1028,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1083,10 +1080,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1138,10 +1132,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/ewelink-snzb-02p.json
+++ b/tests/data/devices/ewelink-snzb-02p.json
@@ -1046,10 +1046,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1101,10 +1098,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1156,10 +1150,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1211,10 +1202,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -1266,10 +1254,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/ewelink-wb01.json
+++ b/tests/data/devices/ewelink-wb01.json
@@ -843,10 +843,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -898,10 +895,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -953,10 +947,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/ewelink-zb-sw02.json
+++ b/tests/data/devices/ewelink-zb-sw02.json
@@ -1310,10 +1310,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1365,10 +1362,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/feibit-inc-co-fzb56-zcw27lx1-0.json
+++ b/tests/data/devices/feibit-inc-co-fzb56-zcw27lx1-0.json
@@ -1115,10 +1115,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1170,10 +1167,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/frient-a-s-aqszb-110.json
+++ b/tests/data/devices/frient-a-s-aqszb-110.json
@@ -1317,10 +1317,7 @@
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1372,10 +1369,7 @@
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1427,10 +1421,7 @@
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1485,10 +1476,7 @@
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -1540,10 +1528,7 @@
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/frient-a-s-emizb-141.json
+++ b/tests/data/devices/frient-a-s-emizb-141.json
@@ -2469,10 +2469,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2524,10 +2521,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2579,10 +2573,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -2637,10 +2628,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "instantaneous_demand",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -2695,10 +2683,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {

--- a/tests/data/devices/frient-a-s-emizb-151.json
+++ b/tests/data/devices/frient-a-s-emizb-151.json
@@ -8489,10 +8489,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -8544,10 +8541,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -8599,10 +8593,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -8654,10 +8645,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "instantaneous_demand",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -8712,10 +8700,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {
@@ -8770,10 +8755,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_received",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {
@@ -8828,10 +8810,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -8884,10 +8863,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "active_power_ph_b",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -8940,10 +8916,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "active_power_ph_c",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -8996,10 +8969,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -9052,10 +9022,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current_ph_b",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -9108,10 +9075,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current_ph_c",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -9164,10 +9128,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -9220,10 +9181,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage_ph_b",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -9276,10 +9234,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage_ph_c",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -9332,10 +9287,7 @@
           "endpoint_id": 64,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "m\u00b3"
         },
         "state": {

--- a/tests/data/devices/frient-a-s-flszb-110.json
+++ b/tests/data/devices/frient-a-s-flszb-110.json
@@ -1964,10 +1964,7 @@
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2019,10 +2016,7 @@
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2074,10 +2068,7 @@
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -2130,10 +2121,7 @@
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {

--- a/tests/data/devices/frient-a-s-hmszb-120.json
+++ b/tests/data/devices/frient-a-s-hmszb-120.json
@@ -1307,10 +1307,7 @@
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1362,10 +1359,7 @@
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1417,10 +1411,7 @@
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1475,10 +1466,7 @@
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -1530,10 +1518,7 @@
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/frient-a-s-iomzb-110.json
+++ b/tests/data/devices/frient-a-s-iomzb-110.json
@@ -3107,10 +3107,7 @@
           "endpoint_id": 112,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -3162,10 +3159,7 @@
           "endpoint_id": 112,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/frient-a-s-kepzb-110.json
+++ b/tests/data/devices/frient-a-s-kepzb-110.json
@@ -1611,10 +1611,7 @@
           "endpoint_id": 44,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1666,10 +1663,7 @@
           "endpoint_id": 44,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1721,10 +1715,7 @@
           "endpoint_id": 44,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/frient-a-s-moszb-153.json
+++ b/tests/data/devices/frient-a-s-moszb-153.json
@@ -3377,10 +3377,7 @@
           "endpoint_id": 34,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -3432,10 +3429,7 @@
           "endpoint_id": 34,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -3487,10 +3481,7 @@
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -3545,10 +3536,7 @@
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -3600,10 +3588,7 @@
           "endpoint_id": 39,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "lx"
         },
         "state": {

--- a/tests/data/devices/frient-a-s-sbtzb-110.json
+++ b/tests/data/devices/frient-a-s-sbtzb-110.json
@@ -1670,10 +1670,7 @@
           "endpoint_id": 32,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1725,10 +1722,7 @@
           "endpoint_id": 32,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1780,10 +1774,7 @@
           "endpoint_id": 32,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/frient-a-s-sirzb-111.json
+++ b/tests/data/devices/frient-a-s-sirzb-111.json
@@ -1523,10 +1523,7 @@
           "endpoint_id": 43,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1578,10 +1575,7 @@
           "endpoint_id": 43,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/frient-a-s-smszb-120.json
+++ b/tests/data/devices/frient-a-s-smszb-120.json
@@ -2017,10 +2017,7 @@
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2072,10 +2069,7 @@
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2127,10 +2121,7 @@
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -2185,10 +2176,7 @@
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {

--- a/tests/data/devices/frient-a-s-splzb-141.json
+++ b/tests/data/devices/frient-a-s-splzb-141.json
@@ -3166,10 +3166,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -3221,10 +3218,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -3276,10 +3270,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "instantaneous_demand",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -3334,10 +3325,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {
@@ -3392,10 +3380,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "current_temperature",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -3447,10 +3432,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -3503,10 +3485,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -3559,10 +3538,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -3616,10 +3592,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {

--- a/tests/data/devices/frient-a-s-wiszb-131.json
+++ b/tests/data/devices/frient-a-s-wiszb-131.json
@@ -1923,10 +1923,7 @@
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1978,10 +1975,7 @@
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2033,10 +2027,7 @@
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -2091,10 +2082,7 @@
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {

--- a/tests/data/devices/gledopto-gl-b-008p.json
+++ b/tests/data/devices/gledopto-gl-b-008p.json
@@ -1397,10 +1397,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1452,10 +1449,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/homr-hrmsn01.json
+++ b/tests/data/devices/homr-hrmsn01.json
@@ -2620,10 +2620,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2675,10 +2672,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2730,10 +2724,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "lx"
         },
         "state": {
@@ -2785,10 +2776,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -2840,16 +2828,13 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "hPa"
         },
         "state": {
           "class_name": "Pressure",
           "available": true,
-          "state": 997.0
+          "state": 997
         }
       },
       {
@@ -2895,10 +2880,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/ikea-of-sweden-fyrtur-block-out-roller-blind.json
+++ b/tests/data/devices/ikea-of-sweden-fyrtur-block-out-roller-blind.json
@@ -1288,10 +1288,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1343,10 +1340,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1398,10 +1392,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1454,10 +1445,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "window_covering_type",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {

--- a/tests/data/devices/ikea-of-sweden-inspelning-smart-plug.json
+++ b/tests/data/devices/ikea-of-sweden-inspelning-smart-plug.json
@@ -2552,10 +2552,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2607,10 +2604,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2662,10 +2656,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {
@@ -2720,10 +2711,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -2776,10 +2764,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -2832,10 +2817,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {

--- a/tests/data/devices/ikea-of-sweden-parasoll-door-window-sensor.json
+++ b/tests/data/devices/ikea-of-sweden-parasoll-door-window-sensor.json
@@ -1653,10 +1653,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1708,10 +1705,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1763,10 +1757,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/ikea-of-sweden-praktlysing-cellular-blind.json
+++ b/tests/data/devices/ikea-of-sweden-praktlysing-cellular-blind.json
@@ -1288,10 +1288,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1343,10 +1340,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1398,10 +1392,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1454,10 +1445,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "window_covering_type",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {

--- a/tests/data/devices/ikea-of-sweden-rodret-dimmer.json
+++ b/tests/data/devices/ikea-of-sweden-rodret-dimmer.json
@@ -1212,10 +1212,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1267,10 +1264,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1322,10 +1316,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/ikea-of-sweden-starkvind-air-purifier.json
+++ b/tests/data/devices/ikea-of-sweden-starkvind-air-purifier.json
@@ -950,10 +950,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1005,10 +1002,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1060,16 +1054,13 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "\u00b5g/m\u00b3"
         },
         "state": {
           "class_name": "PM25",
           "available": true,
-          "state": 16.0
+          "state": 16
         }
       },
       {
@@ -1115,16 +1106,13 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "device_run_time",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "min"
         },
         "state": {
           "class_name": "IkeaDeviceRunTime",
           "available": true,
-          "state": 118729.0
+          "state": 118729
         }
       },
       {
@@ -1170,16 +1158,13 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "filter_run_time",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "min"
         },
         "state": {
           "class_name": "IkeaFilterRunTime",
           "available": true,
-          "state": 118729.0
+          "state": 118729
         }
       }
     ],

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-w-op-ch-400lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-w-op-ch-400lm.json
@@ -1412,10 +1412,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1467,10 +1464,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-ws-opal-400lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-ws-opal-400lm.json
@@ -1643,10 +1643,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1698,10 +1695,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-opal-1000lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-opal-1000lm.json
@@ -1194,10 +1194,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1249,10 +1246,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-w-opal-1000lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-w-opal-1000lm.json
@@ -1412,10 +1412,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1467,10 +1464,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-ws-opal-980lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-ws-opal-980lm.json
@@ -1642,10 +1642,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1697,10 +1694,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-gu10-ws-400lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-gu10-ws-400lm.json
@@ -1648,10 +1648,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1703,10 +1700,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/ikea-of-sweden-tradfri-control-outlet.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-control-outlet.json
@@ -823,10 +823,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -878,10 +875,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/ikea-of-sweden-tradfri-motion-sensor.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-motion-sensor.json
@@ -1293,10 +1293,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1348,10 +1345,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1403,10 +1397,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/ikea-of-sweden-tradfri-on-off-switch.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-on-off-switch.json
@@ -1387,10 +1387,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1442,10 +1439,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1497,10 +1491,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/ikea-of-sweden-tradfri-open-close-remote.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-open-close-remote.json
@@ -1336,10 +1336,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1391,10 +1388,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1446,10 +1440,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/ikea-of-sweden-tradfri-remote-control.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-remote-control.json
@@ -1472,10 +1472,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1527,10 +1524,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1582,10 +1576,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/ikea-of-sweden-tradfri-wireless-dimmer.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-wireless-dimmer.json
@@ -1206,10 +1206,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1261,10 +1258,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1316,10 +1310,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/ikea-of-sweden-vallhorn-wireless-motion-sensor.json
+++ b/tests/data/devices/ikea-of-sweden-vallhorn-wireless-motion-sensor.json
@@ -2106,10 +2106,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2161,10 +2158,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2216,10 +2210,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -2274,10 +2265,7 @@
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "lx"
         },
         "state": {

--- a/tests/data/devices/innr-ae-280-c.json
+++ b/tests/data/devices/innr-ae-280-c.json
@@ -1487,10 +1487,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1542,10 +1539,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/innr-rb-285-c.json
+++ b/tests/data/devices/innr-rb-285-c.json
@@ -1397,10 +1397,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1452,10 +1449,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/innr-sp-120.json
+++ b/tests/data/devices/innr-sp-120.json
@@ -2891,10 +2891,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2946,10 +2943,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -3001,10 +2995,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {
@@ -3059,10 +3050,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -3115,10 +3103,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -3171,10 +3156,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {

--- a/tests/data/devices/innr-sp-234.json
+++ b/tests/data/devices/innr-sp-234.json
@@ -2946,10 +2946,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -3001,10 +2998,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -3056,10 +3050,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {
@@ -3114,10 +3105,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -3170,10 +3158,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -3226,10 +3211,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {

--- a/tests/data/devices/isilentllc-dog-feeder.json
+++ b/tests/data/devices/isilentllc-dog-feeder.json
@@ -1218,10 +1218,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1273,10 +1270,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/isilentllc-doorbell.json
+++ b/tests/data/devices/isilentllc-doorbell.json
@@ -666,10 +666,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -721,10 +718,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -776,10 +770,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -831,10 +822,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/isilentllc-freezer-monitor.json
+++ b/tests/data/devices/isilentllc-freezer-monitor.json
@@ -577,10 +577,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -632,10 +629,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -687,10 +681,7 @@
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {

--- a/tests/data/devices/isilentllc-home-energy-monitor.json
+++ b/tests/data/devices/isilentllc-home-energy-monitor.json
@@ -23582,10 +23582,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -23637,10 +23634,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -23692,10 +23686,7 @@
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -23748,10 +23739,7 @@
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -23804,10 +23792,7 @@
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -23860,16 +23845,13 @@
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
-          "attribute": "power_factor",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
-          "state": 55.0,
+          "state": 55,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         }
       },
@@ -23916,10 +23898,7 @@
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -23972,10 +23951,7 @@
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -24028,10 +24004,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -24084,10 +24057,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -24140,10 +24110,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -24196,16 +24163,13 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": "power_factor",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
-          "state": 30.0,
+          "state": 30,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         }
       },
@@ -24252,10 +24216,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -24308,10 +24269,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -24364,10 +24322,7 @@
           "endpoint_id": 12,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -24420,10 +24375,7 @@
           "endpoint_id": 12,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -24476,10 +24428,7 @@
           "endpoint_id": 12,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -24532,16 +24481,13 @@
           "endpoint_id": 12,
           "available": true,
           "group_id": null,
-          "attribute": "power_factor",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
-          "state": 56.0,
+          "state": 56,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         }
       },
@@ -24588,10 +24534,7 @@
           "endpoint_id": 12,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -24644,10 +24587,7 @@
           "endpoint_id": 12,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -24700,10 +24640,7 @@
           "endpoint_id": 13,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -24756,10 +24693,7 @@
           "endpoint_id": 13,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -24812,10 +24746,7 @@
           "endpoint_id": 13,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -24868,16 +24799,13 @@
           "endpoint_id": 13,
           "available": true,
           "group_id": null,
-          "attribute": "power_factor",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
-          "state": 63.0,
+          "state": 63,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         }
       },
@@ -24924,10 +24852,7 @@
           "endpoint_id": 13,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -24980,10 +24905,7 @@
           "endpoint_id": 13,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -25036,10 +24958,7 @@
           "endpoint_id": 14,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -25092,10 +25011,7 @@
           "endpoint_id": 14,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -25148,10 +25064,7 @@
           "endpoint_id": 14,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -25204,16 +25117,13 @@
           "endpoint_id": 14,
           "available": true,
           "group_id": null,
-          "attribute": "power_factor",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
-          "state": 18.0,
+          "state": 18,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         }
       },
@@ -25260,10 +25170,7 @@
           "endpoint_id": 14,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -25316,10 +25223,7 @@
           "endpoint_id": 14,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -25372,10 +25276,7 @@
           "endpoint_id": 15,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -25428,10 +25329,7 @@
           "endpoint_id": 15,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -25484,10 +25382,7 @@
           "endpoint_id": 15,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -25540,16 +25435,13 @@
           "endpoint_id": 15,
           "available": true,
           "group_id": null,
-          "attribute": "power_factor",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
-          "state": 99.0,
+          "state": 99,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         }
       },
@@ -25596,10 +25488,7 @@
           "endpoint_id": 15,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -25652,10 +25541,7 @@
           "endpoint_id": 15,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -25708,10 +25594,7 @@
           "endpoint_id": 16,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -25764,10 +25647,7 @@
           "endpoint_id": 16,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -25820,10 +25700,7 @@
           "endpoint_id": 16,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -25876,16 +25753,13 @@
           "endpoint_id": 16,
           "available": true,
           "group_id": null,
-          "attribute": "power_factor",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
-          "state": 44.0,
+          "state": 44,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         }
       },
@@ -25932,10 +25806,7 @@
           "endpoint_id": 16,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -25988,10 +25859,7 @@
           "endpoint_id": 16,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -26044,10 +25912,7 @@
           "endpoint_id": 17,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -26100,10 +25965,7 @@
           "endpoint_id": 17,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -26156,10 +26018,7 @@
           "endpoint_id": 17,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -26212,16 +26071,13 @@
           "endpoint_id": 17,
           "available": true,
           "group_id": null,
-          "attribute": "power_factor",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
-          "state": 95.0,
+          "state": 95,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         }
       },
@@ -26268,10 +26124,7 @@
           "endpoint_id": 17,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -26324,10 +26177,7 @@
           "endpoint_id": 17,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -26380,10 +26230,7 @@
           "endpoint_id": 18,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -26436,10 +26283,7 @@
           "endpoint_id": 18,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -26492,10 +26336,7 @@
           "endpoint_id": 18,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -26548,16 +26389,13 @@
           "endpoint_id": 18,
           "available": true,
           "group_id": null,
-          "attribute": "power_factor",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
-          "state": 24.0,
+          "state": 24,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         }
       },
@@ -26604,10 +26442,7 @@
           "endpoint_id": 18,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -26660,10 +26495,7 @@
           "endpoint_id": 18,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -26716,10 +26548,7 @@
           "endpoint_id": 19,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -26772,10 +26601,7 @@
           "endpoint_id": 19,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -26828,10 +26654,7 @@
           "endpoint_id": 19,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -26884,16 +26707,13 @@
           "endpoint_id": 19,
           "available": true,
           "group_id": null,
-          "attribute": "power_factor",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
-          "state": 34.0,
+          "state": 34,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         }
       },
@@ -26940,10 +26760,7 @@
           "endpoint_id": 19,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -26996,10 +26813,7 @@
           "endpoint_id": 19,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -27052,10 +26866,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -27108,10 +26919,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -27164,10 +26972,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -27220,16 +27025,13 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "power_factor",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
-          "state": 85.0,
+          "state": 85,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         }
       },
@@ -27276,10 +27078,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -27332,10 +27131,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -27388,10 +27184,7 @@
           "endpoint_id": 20,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -27444,10 +27237,7 @@
           "endpoint_id": 20,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -27500,10 +27290,7 @@
           "endpoint_id": 20,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -27556,16 +27343,13 @@
           "endpoint_id": 20,
           "available": true,
           "group_id": null,
-          "attribute": "power_factor",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
-          "state": 91.0,
+          "state": 91,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         }
       },
@@ -27612,10 +27396,7 @@
           "endpoint_id": 20,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -27668,10 +27449,7 @@
           "endpoint_id": 20,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -27724,10 +27502,7 @@
           "endpoint_id": 21,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -27780,10 +27555,7 @@
           "endpoint_id": 21,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -27836,10 +27608,7 @@
           "endpoint_id": 21,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -27892,16 +27661,13 @@
           "endpoint_id": 21,
           "available": true,
           "group_id": null,
-          "attribute": "power_factor",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
-          "state": 51.0,
+          "state": 51,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         }
       },
@@ -27948,10 +27714,7 @@
           "endpoint_id": 21,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -28004,10 +27767,7 @@
           "endpoint_id": 21,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -28060,10 +27820,7 @@
           "endpoint_id": 22,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -28116,10 +27873,7 @@
           "endpoint_id": 22,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -28172,10 +27926,7 @@
           "endpoint_id": 22,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -28228,16 +27979,13 @@
           "endpoint_id": 22,
           "available": true,
           "group_id": null,
-          "attribute": "power_factor",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
-          "state": 97.0,
+          "state": 97,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         }
       },
@@ -28284,10 +28032,7 @@
           "endpoint_id": 22,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -28340,10 +28085,7 @@
           "endpoint_id": 22,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -28396,10 +28138,7 @@
           "endpoint_id": 23,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -28452,10 +28191,7 @@
           "endpoint_id": 23,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -28508,10 +28244,7 @@
           "endpoint_id": 23,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -28564,16 +28297,13 @@
           "endpoint_id": 23,
           "available": true,
           "group_id": null,
-          "attribute": "power_factor",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
-          "state": 21.0,
+          "state": 21,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         }
       },
@@ -28620,10 +28350,7 @@
           "endpoint_id": 23,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -28676,10 +28403,7 @@
           "endpoint_id": 23,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -28732,10 +28456,7 @@
           "endpoint_id": 24,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -28788,10 +28509,7 @@
           "endpoint_id": 24,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -28844,10 +28562,7 @@
           "endpoint_id": 24,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -28900,16 +28615,13 @@
           "endpoint_id": 24,
           "available": true,
           "group_id": null,
-          "attribute": "power_factor",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
-          "state": 55.0,
+          "state": 55,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         }
       },
@@ -28956,10 +28668,7 @@
           "endpoint_id": 24,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -29012,10 +28721,7 @@
           "endpoint_id": 24,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -29068,10 +28774,7 @@
           "endpoint_id": 25,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -29124,10 +28827,7 @@
           "endpoint_id": 25,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -29180,10 +28880,7 @@
           "endpoint_id": 25,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -29236,16 +28933,13 @@
           "endpoint_id": 25,
           "available": true,
           "group_id": null,
-          "attribute": "power_factor",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
-          "state": 0.0,
+          "state": 0,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         }
       },
@@ -29292,10 +28986,7 @@
           "endpoint_id": 25,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -29348,10 +29039,7 @@
           "endpoint_id": 25,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -29404,10 +29092,7 @@
           "endpoint_id": 26,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -29460,10 +29145,7 @@
           "endpoint_id": 26,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -29516,10 +29198,7 @@
           "endpoint_id": 26,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -29572,16 +29251,13 @@
           "endpoint_id": 26,
           "available": true,
           "group_id": null,
-          "attribute": "power_factor",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
-          "state": 41.0,
+          "state": 41,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         }
       },
@@ -29628,10 +29304,7 @@
           "endpoint_id": 26,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -29684,10 +29357,7 @@
           "endpoint_id": 26,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -29740,10 +29410,7 @@
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -29796,10 +29463,7 @@
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -29852,10 +29516,7 @@
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -29908,16 +29569,13 @@
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
-          "attribute": "power_factor",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
-          "state": 27.0,
+          "state": 27,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         }
       },
@@ -29964,10 +29622,7 @@
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -30020,10 +29675,7 @@
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -30076,10 +29728,7 @@
           "endpoint_id": 4,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -30132,10 +29781,7 @@
           "endpoint_id": 4,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -30188,10 +29834,7 @@
           "endpoint_id": 4,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -30244,16 +29887,13 @@
           "endpoint_id": 4,
           "available": true,
           "group_id": null,
-          "attribute": "power_factor",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
-          "state": 93.0,
+          "state": 93,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         }
       },
@@ -30300,10 +29940,7 @@
           "endpoint_id": 4,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -30356,10 +29993,7 @@
           "endpoint_id": 4,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -30412,10 +30046,7 @@
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -30468,10 +30099,7 @@
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -30524,10 +30152,7 @@
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -30580,16 +30205,13 @@
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
-          "attribute": "power_factor",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
-          "state": 93.0,
+          "state": 93,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         }
       },
@@ -30636,10 +30258,7 @@
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -30692,10 +30311,7 @@
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -30748,10 +30364,7 @@
           "endpoint_id": 6,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -30804,10 +30417,7 @@
           "endpoint_id": 6,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -30860,10 +30470,7 @@
           "endpoint_id": 6,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -30916,16 +30523,13 @@
           "endpoint_id": 6,
           "available": true,
           "group_id": null,
-          "attribute": "power_factor",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
-          "state": 23.0,
+          "state": 23,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         }
       },
@@ -30972,10 +30576,7 @@
           "endpoint_id": 6,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -31028,10 +30629,7 @@
           "endpoint_id": 6,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -31084,10 +30682,7 @@
           "endpoint_id": 7,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -31140,10 +30735,7 @@
           "endpoint_id": 7,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -31196,10 +30788,7 @@
           "endpoint_id": 7,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -31252,16 +30841,13 @@
           "endpoint_id": 7,
           "available": true,
           "group_id": null,
-          "attribute": "power_factor",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
-          "state": 52.0,
+          "state": 52,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         }
       },
@@ -31308,10 +30894,7 @@
           "endpoint_id": 7,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -31364,10 +30947,7 @@
           "endpoint_id": 7,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -31420,10 +31000,7 @@
           "endpoint_id": 8,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -31476,10 +31053,7 @@
           "endpoint_id": 8,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -31532,10 +31106,7 @@
           "endpoint_id": 8,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -31588,16 +31159,13 @@
           "endpoint_id": 8,
           "available": true,
           "group_id": null,
-          "attribute": "power_factor",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
-          "state": 77.0,
+          "state": 77,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         }
       },
@@ -31644,10 +31212,7 @@
           "endpoint_id": 8,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -31700,10 +31265,7 @@
           "endpoint_id": 8,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -31756,10 +31318,7 @@
           "endpoint_id": 9,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -31812,10 +31371,7 @@
           "endpoint_id": 9,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -31868,10 +31424,7 @@
           "endpoint_id": 9,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -31924,16 +31477,13 @@
           "endpoint_id": 9,
           "available": true,
           "group_id": null,
-          "attribute": "power_factor",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
-          "state": 37.0,
+          "state": 37,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         }
       },
@@ -31980,10 +31530,7 @@
           "endpoint_id": 9,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -32036,10 +31583,7 @@
           "endpoint_id": 9,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {

--- a/tests/data/devices/isilentllc-masterbed-light-controller.json
+++ b/tests/data/devices/isilentllc-masterbed-light-controller.json
@@ -1801,10 +1801,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1856,10 +1853,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1911,10 +1905,7 @@
           "endpoint_id": 4,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -1966,10 +1957,7 @@
           "endpoint_id": 4,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/isilentllc-safe.json
+++ b/tests/data/devices/isilentllc-safe.json
@@ -1788,10 +1788,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1843,10 +1840,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1898,10 +1892,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -1953,10 +1944,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/isilentllc-test-device.json
+++ b/tests/data/devices/isilentllc-test-device.json
@@ -654,10 +654,7 @@
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -709,10 +706,7 @@
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/isilentllc-test-mule.json
+++ b/tests/data/devices/isilentllc-test-mule.json
@@ -519,10 +519,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -574,10 +571,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/isilentllc-water-heater.json
+++ b/tests/data/devices/isilentllc-water-heater.json
@@ -1685,10 +1685,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1740,10 +1737,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1795,10 +1789,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -1852,10 +1843,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -1908,10 +1896,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -1965,10 +1950,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -2020,10 +2002,7 @@
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {

--- a/tests/data/devices/jasco-products-45856.json
+++ b/tests/data/devices/jasco-products-45856.json
@@ -2470,10 +2470,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2525,10 +2522,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2580,10 +2574,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "instantaneous_demand",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -2638,10 +2629,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {

--- a/tests/data/devices/jasco-products-45857.json
+++ b/tests/data/devices/jasco-products-45857.json
@@ -2778,10 +2778,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2833,10 +2830,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2888,10 +2882,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "instantaneous_demand",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -2946,10 +2937,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {

--- a/tests/data/devices/ke-tradfri-open-close-remote.json
+++ b/tests/data/devices/ke-tradfri-open-close-remote.json
@@ -1336,10 +1336,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1391,10 +1388,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1446,10 +1440,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/keen-home-inc-sv01-410-mp-1-1.json
+++ b/tests/data/devices/keen-home-inc-sv01-410-mp-1-1.json
@@ -1727,10 +1727,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1782,10 +1779,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1837,10 +1831,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1895,10 +1886,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -1950,16 +1938,13 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "hPa"
         },
         "state": {
           "class_name": "Pressure",
           "available": true,
-          "state": 991.0
+          "state": 991
         }
       }
     ],

--- a/tests/data/devices/keen-home-inc-sv02-610-mp-1-3.json
+++ b/tests/data/devices/keen-home-inc-sv02-610-mp-1-3.json
@@ -1727,10 +1727,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1782,10 +1779,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1837,10 +1831,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1895,10 +1886,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -1950,16 +1938,13 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "hPa"
         },
         "state": {
           "class_name": "Pressure",
           "available": true,
-          "state": 994.0
+          "state": 994
         }
       }
     ],

--- a/tests/data/devices/keen-home-inc-sv02-612-mp-1-3.json
+++ b/tests/data/devices/keen-home-inc-sv02-612-mp-1-3.json
@@ -1727,10 +1727,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1782,10 +1779,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1837,10 +1831,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1895,10 +1886,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -1950,16 +1938,13 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "hPa"
         },
         "state": {
           "class_name": "Pressure",
           "available": true,
-          "state": 1004.0
+          "state": 1004
         }
       }
     ],

--- a/tests/data/devices/king-of-fans-inc-hbuniversalcfremote.json
+++ b/tests/data/devices/king-of-fans-inc-hbuniversalcfremote.json
@@ -994,10 +994,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1049,10 +1046,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/king-of-fans-inc-hdc52eastwindfan.json
+++ b/tests/data/devices/king-of-fans-inc-hdc52eastwindfan.json
@@ -994,10 +994,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1049,10 +1046,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/konke-3afe140103020000.json
+++ b/tests/data/devices/konke-3afe140103020000.json
@@ -911,10 +911,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -966,10 +963,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1021,10 +1015,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1078,10 +1069,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -1133,10 +1121,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/konke-3afe220103020000.json
+++ b/tests/data/devices/konke-3afe220103020000.json
@@ -911,10 +911,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -966,10 +963,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1021,10 +1015,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1078,10 +1069,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -1133,10 +1121,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/konke-3afe270104020015.json
+++ b/tests/data/devices/konke-3afe270104020015.json
@@ -934,10 +934,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -989,10 +986,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1044,10 +1038,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/konke-3afe280100510001.json
+++ b/tests/data/devices/konke-3afe280100510001.json
@@ -877,10 +877,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -932,10 +929,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -987,10 +981,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/konke-3afe28010402000d.json
+++ b/tests/data/devices/konke-3afe28010402000d.json
@@ -1086,10 +1086,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1141,10 +1138,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1196,10 +1190,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/kwikset-smartcode-convert-gen1.json
+++ b/tests/data/devices/kwikset-smartcode-convert-gen1.json
@@ -1802,10 +1802,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1857,10 +1854,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1912,10 +1906,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1970,10 +1961,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {

--- a/tests/data/devices/lds-zb-onoffplug-d0005.json
+++ b/tests/data/devices/lds-zb-onoffplug-d0005.json
@@ -2652,10 +2652,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2707,10 +2704,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2762,10 +2756,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2819,10 +2810,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -2875,10 +2863,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -2931,10 +2916,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {

--- a/tests/data/devices/lds-zbt-cctswitch-d0001.json
+++ b/tests/data/devices/lds-zbt-cctswitch-d0001.json
@@ -1527,10 +1527,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1582,10 +1579,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1637,10 +1631,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/ledvance-flex-rgbw.json
+++ b/tests/data/devices/ledvance-flex-rgbw.json
@@ -1758,10 +1758,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1813,10 +1810,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/ledvance-outdoor-accent-light-rgb.json
+++ b/tests/data/devices/ledvance-outdoor-accent-light-rgb.json
@@ -1730,10 +1730,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1785,10 +1782,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/ledvance-plug.json
+++ b/tests/data/devices/ledvance-plug.json
@@ -877,10 +877,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -932,10 +929,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/level-home-b2.json
+++ b/tests/data/devices/level-home-b2.json
@@ -1476,10 +1476,7 @@
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1534,10 +1531,7 @@
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1589,10 +1583,7 @@
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/level-home-bolt.json
+++ b/tests/data/devices/level-home-bolt.json
@@ -1476,10 +1476,7 @@
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1534,10 +1531,7 @@
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1589,10 +1583,7 @@
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/lk-zb-doorsensor-d0003.json
+++ b/tests/data/devices/lk-zb-doorsensor-d0003.json
@@ -1292,10 +1292,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1347,10 +1344,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1402,10 +1396,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/lk-zbt-dimswitch-d0001.json
+++ b/tests/data/devices/lk-zbt-dimswitch-d0001.json
@@ -1357,10 +1357,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1412,10 +1409,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1467,10 +1461,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/lk-zbt-onoffplug-d0001.json
+++ b/tests/data/devices/lk-zbt-onoffplug-d0001.json
@@ -1299,10 +1299,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1354,10 +1351,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-airmonitor-acn01.json
+++ b/tests/data/devices/lumi-lumi-airmonitor-acn01.json
@@ -1108,10 +1108,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1163,10 +1160,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1218,10 +1212,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1276,10 +1267,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -1331,10 +1319,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1386,16 +1371,13 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "ppb"
         },
         "state": {
           "class_name": "PPBVOCLevel",
           "available": true,
-          "state": 42.0
+          "state": 42
         }
       }
     ],

--- a/tests/data/devices/lumi-lumi-curtain-agl001.json
+++ b/tests/data/devices/lumi-lumi-curtain-agl001.json
@@ -1465,10 +1465,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1520,10 +1517,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "power_source",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1575,10 +1569,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1630,10 +1621,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1688,10 +1676,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "lx"
         },
         "state": {
@@ -1743,10 +1728,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "window_covering_type",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1798,10 +1780,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "hooks_state",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-flood-acn001.json
+++ b/tests/data/devices/lumi-lumi-flood-acn001.json
@@ -1036,10 +1036,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1091,10 +1088,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1146,10 +1140,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-flood-agl02.json
+++ b/tests/data/devices/lumi-lumi-flood-agl02.json
@@ -1007,10 +1007,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1062,10 +1059,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1117,10 +1111,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-light-aqcn02.json
+++ b/tests/data/devices/lumi-lumi-light-aqcn02.json
@@ -1863,10 +1863,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1918,10 +1915,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-magnet-ac01.json
+++ b/tests/data/devices/lumi-lumi-magnet-ac01.json
@@ -1073,10 +1073,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1128,10 +1125,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1183,10 +1177,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-magnet-acn001.json
+++ b/tests/data/devices/lumi-lumi-magnet-acn001.json
@@ -1036,10 +1036,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1091,10 +1088,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1146,10 +1140,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-motion-ac02.json
+++ b/tests/data/devices/lumi-lumi-motion-ac02.json
@@ -1403,10 +1403,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1458,10 +1455,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1513,10 +1507,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1571,10 +1562,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "lx"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-motion-agl02.json
+++ b/tests/data/devices/lumi-lumi-motion-agl02.json
@@ -1238,10 +1238,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1293,10 +1290,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1348,10 +1342,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1406,10 +1397,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "lx"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-motion-agl04.json
+++ b/tests/data/devices/lumi-lumi-motion-agl04.json
@@ -1396,10 +1396,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1451,10 +1448,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1506,10 +1500,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1564,10 +1555,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_temperature",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-plug-maus01.json
+++ b/tests/data/devices/lumi-lumi-plug-maus01.json
@@ -3979,10 +3979,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -4034,10 +4031,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -4089,10 +4083,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "instantaneous_demand",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -4146,10 +4137,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {
@@ -4203,10 +4191,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_temperature",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -4258,10 +4243,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -4313,10 +4295,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -4368,10 +4347,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -4423,10 +4399,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -4478,10 +4451,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-relay-c2acn01.json
+++ b/tests/data/devices/lumi-lumi-relay-c2acn01.json
@@ -3788,10 +3788,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -3843,10 +3840,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -3898,10 +3892,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "instantaneous_demand",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -3955,10 +3946,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {
@@ -4012,10 +4000,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_temperature",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -4067,10 +4052,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -4122,10 +4104,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "power_factor",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-remote-b286opcn01.json
+++ b/tests/data/devices/lumi-lumi-remote-b286opcn01.json
@@ -2385,10 +2385,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2440,10 +2437,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2495,10 +2489,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-remote-b486opcn01.json
+++ b/tests/data/devices/lumi-lumi-remote-b486opcn01.json
@@ -1826,10 +1826,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1881,10 +1878,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1936,10 +1930,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-remote-b686opcn01.json
+++ b/tests/data/devices/lumi-lumi-remote-b686opcn01.json
@@ -2385,10 +2385,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2440,10 +2437,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2495,10 +2489,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-remote-cagl02.json
+++ b/tests/data/devices/lumi-lumi-remote-cagl02.json
@@ -1652,10 +1652,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1707,10 +1704,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1762,10 +1756,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-sen-ill-mgl01.json
+++ b/tests/data/devices/lumi-lumi-sen-ill-mgl01.json
@@ -869,10 +869,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -924,10 +921,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -979,10 +973,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1037,10 +1028,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "lx"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-sensor-86sw2.json
+++ b/tests/data/devices/lumi-lumi-sensor-86sw2.json
@@ -2443,10 +2443,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2498,10 +2495,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2553,10 +2547,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -2611,10 +2602,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_temperature",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-sensor-ht-agl02.json
+++ b/tests/data/devices/lumi-lumi-sensor-ht-agl02.json
@@ -1080,10 +1080,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1135,10 +1132,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1190,10 +1184,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1248,10 +1239,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -1303,16 +1291,13 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "hPa"
         },
         "state": {
           "class_name": "Pressure",
           "available": true,
-          "state": 1013.0
+          "state": 1013
         }
       },
       {
@@ -1358,10 +1343,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-sensor-magnet-aq2.json
+++ b/tests/data/devices/lumi-lumi-sensor-magnet-aq2.json
@@ -1195,10 +1195,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1250,10 +1247,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1305,10 +1299,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1363,10 +1354,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_temperature",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-sensor-motion-aq2.json
+++ b/tests/data/devices/lumi-lumi-sensor-motion-aq2.json
@@ -1479,10 +1479,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1534,10 +1531,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1589,10 +1583,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1647,10 +1638,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "lx"
         },
         "state": {
@@ -1702,10 +1690,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_temperature",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-sensor-smoke-acn03.json
+++ b/tests/data/devices/lumi-lumi-sensor-smoke-acn03.json
@@ -1180,10 +1180,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1235,10 +1232,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1290,10 +1284,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1348,16 +1339,13 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "smoke_density_dbm",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dB/m"
         },
         "state": {
           "class_name": "AqaraSmokeDensityDbm",
           "available": true,
-          "state": 0.0
+          "state": 0
         }
       }
     ],

--- a/tests/data/devices/lumi-lumi-sensor-smoke.json
+++ b/tests/data/devices/lumi-lumi-sensor-smoke.json
@@ -1282,10 +1282,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1337,10 +1334,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1392,10 +1386,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1450,10 +1441,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_temperature",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-sensor-switch-aq2.json
+++ b/tests/data/devices/lumi-lumi-sensor-switch-aq2.json
@@ -1058,10 +1058,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1113,10 +1110,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1168,10 +1162,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1226,10 +1217,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_temperature",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-sensor-switch-aq3.json
+++ b/tests/data/devices/lumi-lumi-sensor-switch-aq3.json
@@ -1085,10 +1085,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1140,10 +1137,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1195,10 +1189,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1253,10 +1244,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_temperature",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-sensor-switch.json
+++ b/tests/data/devices/lumi-lumi-sensor-switch.json
@@ -1344,10 +1344,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1399,10 +1396,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1454,10 +1448,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-switch-b1laus01.json
+++ b/tests/data/devices/lumi-lumi-switch-b1laus01.json
@@ -883,10 +883,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -938,10 +935,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -993,10 +987,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_temperature",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-switch-b1naus01.json
+++ b/tests/data/devices/lumi-lumi-switch-b1naus01.json
@@ -2743,10 +2743,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2798,10 +2795,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2853,10 +2847,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {
@@ -2911,10 +2902,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_temperature",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -2966,10 +2954,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-vibration-aq1.json
+++ b/tests/data/devices/lumi-lumi-vibration-aq1.json
@@ -1833,10 +1833,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1888,10 +1885,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1943,10 +1937,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -2001,10 +1992,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_temperature",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-weather.json
+++ b/tests/data/devices/lumi-lumi-weather.json
@@ -1185,10 +1185,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1240,10 +1237,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1295,10 +1289,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1353,10 +1344,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -1408,16 +1396,13 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "hPa"
         },
         "state": {
           "class_name": "Pressure",
           "available": true,
-          "state": 1009.0
+          "state": 1009
         }
       },
       {
@@ -1463,10 +1448,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/lutron-lzl4bwhl01-remote.json
+++ b/tests/data/devices/lutron-lzl4bwhl01-remote.json
@@ -773,10 +773,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -828,10 +825,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/lutron-z3-1brl.json
+++ b/tests/data/devices/lutron-z3-1brl.json
@@ -1113,10 +1113,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1168,10 +1165,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1223,10 +1217,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/osram-switch-4x-lightify.json
+++ b/tests/data/devices/osram-switch-4x-lightify.json
@@ -6594,10 +6594,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -6649,10 +6646,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -6704,10 +6698,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/philips-7602031u7.json
+++ b/tests/data/devices/philips-7602031u7.json
@@ -1408,10 +1408,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1463,10 +1460,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/philips-lct014.json
+++ b/tests/data/devices/philips-lct014.json
@@ -1408,10 +1408,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1463,10 +1460,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/philips-llc020.json
+++ b/tests/data/devices/philips-llc020.json
@@ -1408,10 +1408,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1463,10 +1460,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/philips-lst002.json
+++ b/tests/data/devices/philips-lst002.json
@@ -1232,10 +1232,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1287,10 +1284,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/philips-rom001.json
+++ b/tests/data/devices/philips-rom001.json
@@ -1388,10 +1388,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1443,10 +1440,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1498,10 +1492,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/philips-rwl020.json
+++ b/tests/data/devices/philips-rwl020.json
@@ -1704,10 +1704,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1759,10 +1756,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1814,10 +1808,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/philips-sml001.json
+++ b/tests/data/devices/philips-sml001.json
@@ -2303,10 +2303,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2358,10 +2355,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2413,10 +2407,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -2469,10 +2460,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "lx"
         },
         "state": {
@@ -2524,10 +2512,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {

--- a/tests/data/devices/plaid-systems-ps-sprzms-slp3.json
+++ b/tests/data/devices/plaid-systems-ps-sprzms-slp3.json
@@ -995,10 +995,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1050,10 +1047,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1105,10 +1099,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1163,10 +1154,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -1218,10 +1206,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/samjin-button.json
+++ b/tests/data/devices/samjin-button.json
@@ -1394,10 +1394,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1449,10 +1446,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1504,10 +1498,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1560,10 +1551,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {

--- a/tests/data/devices/samjin-multi.json
+++ b/tests/data/devices/samjin-multi.json
@@ -1243,10 +1243,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1298,10 +1295,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1353,10 +1347,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1409,10 +1400,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {

--- a/tests/data/devices/securifi-ltd-unk-model.json
+++ b/tests/data/devices/securifi-ltd-unk-model.json
@@ -4106,10 +4106,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -4161,10 +4158,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -4216,10 +4210,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -4272,10 +4263,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -4328,16 +4316,13 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "power_factor",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
-          "state": 0.0,
+          "state": 0,
           "measurement_type": "PHASE_A_MEASUREMENT"
         }
       },
@@ -4384,10 +4369,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -4440,10 +4422,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {

--- a/tests/data/devices/sengled-e11-g13.json
+++ b/tests/data/devices/sengled-e11-g13.json
@@ -2039,10 +2039,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2094,10 +2091,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2149,10 +2143,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "instantaneous_demand",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -2207,10 +2198,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {

--- a/tests/data/devices/sengled-e12-n14.json
+++ b/tests/data/devices/sengled-e12-n14.json
@@ -2039,10 +2039,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2094,10 +2091,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2149,10 +2143,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "instantaneous_demand",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -2207,10 +2198,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {

--- a/tests/data/devices/sengled-e12-n1e.json
+++ b/tests/data/devices/sengled-e12-n1e.json
@@ -2400,10 +2400,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2455,10 +2452,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2510,10 +2504,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "instantaneous_demand",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -2568,10 +2559,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {

--- a/tests/data/devices/sengled-e1c-nb6.json
+++ b/tests/data/devices/sengled-e1c-nb6.json
@@ -840,10 +840,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -895,10 +892,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/sengled-e1c-nb7.json
+++ b/tests/data/devices/sengled-e1c-nb7.json
@@ -1851,10 +1851,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1906,10 +1903,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1961,10 +1955,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "instantaneous_demand",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -2019,10 +2010,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {

--- a/tests/data/devices/sengled-e1f-n9g.json
+++ b/tests/data/devices/sengled-e1f-n9g.json
@@ -2054,10 +2054,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2109,10 +2106,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2164,10 +2158,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "instantaneous_demand",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -2222,10 +2213,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {

--- a/tests/data/devices/sengled-e1g-g8e.json
+++ b/tests/data/devices/sengled-e1g-g8e.json
@@ -2405,10 +2405,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2460,10 +2457,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2515,10 +2509,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "instantaneous_demand",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -2573,10 +2564,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {

--- a/tests/data/devices/sengled-e21-n1ea.json
+++ b/tests/data/devices/sengled-e21-n1ea.json
@@ -2572,10 +2572,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2627,10 +2624,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2682,10 +2676,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "instantaneous_demand",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -2740,10 +2731,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {

--- a/tests/data/devices/sengled-z01-a19nae26.json
+++ b/tests/data/devices/sengled-z01-a19nae26.json
@@ -2438,10 +2438,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2493,10 +2490,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2548,10 +2542,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "instantaneous_demand",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -2606,10 +2597,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {

--- a/tests/data/devices/signify-netherlands-b-v-lca001.json
+++ b/tests/data/devices/signify-netherlands-b-v-lca001.json
@@ -1412,10 +1412,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1467,10 +1464,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/signify-netherlands-b-v-lca005.json
+++ b/tests/data/devices/signify-netherlands-b-v-lca005.json
@@ -1407,10 +1407,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1462,10 +1459,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/signify-netherlands-b-v-lca007.json
+++ b/tests/data/devices/signify-netherlands-b-v-lca007.json
@@ -1407,10 +1407,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1462,10 +1459,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/signify-netherlands-b-v-lcb001.json
+++ b/tests/data/devices/signify-netherlands-b-v-lcb001.json
@@ -1407,10 +1407,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1462,10 +1459,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/signify-netherlands-b-v-lcb002.json
+++ b/tests/data/devices/signify-netherlands-b-v-lcb002.json
@@ -1407,10 +1407,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1462,10 +1459,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/signify-netherlands-b-v-lce001.json
+++ b/tests/data/devices/signify-netherlands-b-v-lce001.json
@@ -1412,10 +1412,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1467,10 +1464,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/signify-netherlands-b-v-lcx004.json
+++ b/tests/data/devices/signify-netherlands-b-v-lcx004.json
@@ -1407,10 +1407,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1462,10 +1459,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/signify-netherlands-b-v-lta010.json
+++ b/tests/data/devices/signify-netherlands-b-v-lta010.json
@@ -1396,10 +1396,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1451,10 +1448,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/signify-netherlands-b-v-ltb003.json
+++ b/tests/data/devices/signify-netherlands-b-v-ltb003.json
@@ -1397,10 +1397,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1452,10 +1449,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/signify-netherlands-b-v-lwa003.json
+++ b/tests/data/devices/signify-netherlands-b-v-lwa003.json
@@ -942,10 +942,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -997,10 +994,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/signify-netherlands-b-v-rdm001.json
+++ b/tests/data/devices/signify-netherlands-b-v-rdm001.json
@@ -1156,10 +1156,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1211,10 +1208,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1266,10 +1260,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/signify-netherlands-b-v-rdm002.json
+++ b/tests/data/devices/signify-netherlands-b-v-rdm002.json
@@ -1384,10 +1384,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1439,10 +1436,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1494,10 +1488,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/signify-netherlands-b-v-rwl022.json
+++ b/tests/data/devices/signify-netherlands-b-v-rwl022.json
@@ -1380,10 +1380,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1435,10 +1432,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1490,10 +1484,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/signify-netherlands-b-v-sml004.json
+++ b/tests/data/devices/signify-netherlands-b-v-sml004.json
@@ -1523,10 +1523,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1578,10 +1575,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1633,10 +1627,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1689,10 +1680,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "lx"
         },
         "state": {
@@ -1744,10 +1732,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {

--- a/tests/data/devices/sinope-technologies-va4220zb.json
+++ b/tests/data/devices/sinope-technologies-va4220zb.json
@@ -2713,10 +2713,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2768,10 +2765,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2823,10 +2817,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -2878,10 +2869,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 10,
-          "multiplier": 1,
           "unit": "m\u00b3/h"
         },
         "state": {
@@ -2933,10 +2921,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "instantaneous_demand",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "l/h"
         },
         "state": {
@@ -2991,10 +2976,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "L"
         },
         "state": {

--- a/tests/data/devices/smartthings-tagv4.json
+++ b/tests/data/devices/smartthings-tagv4.json
@@ -1175,10 +1175,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1230,10 +1227,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/smartwings-wm25-l-z.json
+++ b/tests/data/devices/smartwings-wm25-l-z.json
@@ -1216,10 +1216,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1271,10 +1268,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1326,10 +1320,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1382,10 +1373,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "window_covering_type",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {

--- a/tests/data/devices/sonoff-01minizb.json
+++ b/tests/data/devices/sonoff-01minizb.json
@@ -688,10 +688,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -743,10 +740,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/sonoff-s31-lite-zb.json
+++ b/tests/data/devices/sonoff-s31-lite-zb.json
@@ -652,10 +652,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -707,10 +704,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/sonoff-swv.json
+++ b/tests/data/devices/sonoff-swv.json
@@ -1509,10 +1509,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1564,10 +1561,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1619,10 +1613,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1675,10 +1666,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 10,
-          "multiplier": 1,
           "unit": "m\u00b3/h"
         },
         "state": {

--- a/tests/data/devices/sonoff-zbmicro.json
+++ b/tests/data/devices/sonoff-zbmicro.json
@@ -618,10 +618,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -673,10 +670,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/sunricher-hk-ln-dim-a.json
+++ b/tests/data/devices/sunricher-hk-ln-dim-a.json
@@ -1297,10 +1297,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1352,10 +1349,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/texasinstruments-ti-router.json
+++ b/tests/data/devices/texasinstruments-ti-router.json
@@ -623,10 +623,7 @@
           "endpoint_id": 8,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -678,10 +675,7 @@
           "endpoint_id": 8,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/the-home-depot-ecosmart-zbt-a19-cct-bulb.json
+++ b/tests/data/devices/the-home-depot-ecosmart-zbt-a19-cct-bulb.json
@@ -1840,10 +1840,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1895,10 +1892,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/third-reality-inc-3rds17bz.json
+++ b/tests/data/devices/third-reality-inc-3rds17bz.json
@@ -896,10 +896,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -951,10 +948,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1006,10 +1000,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/third-reality-inc-3rms16bz.json
+++ b/tests/data/devices/third-reality-inc-3rms16bz.json
@@ -967,10 +967,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1022,10 +1019,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1077,10 +1071,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/third-reality-inc-3rsb015bz.json
+++ b/tests/data/devices/third-reality-inc-3rsb015bz.json
@@ -1300,10 +1300,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1355,10 +1352,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1410,10 +1404,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1466,10 +1457,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "window_covering_type",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {

--- a/tests/data/devices/third-reality-inc-3rsb22bz.json
+++ b/tests/data/devices/third-reality-inc-3rsb22bz.json
@@ -1061,10 +1061,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1116,10 +1113,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1171,10 +1165,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/third-reality-inc-3rsm0147z.json
+++ b/tests/data/devices/third-reality-inc-3rsm0147z.json
@@ -889,10 +889,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -944,10 +941,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -999,10 +993,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1055,10 +1046,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -1110,10 +1098,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/third-reality-inc-3rsnl02043z.json
+++ b/tests/data/devices/third-reality-inc-3rsnl02043z.json
@@ -1788,10 +1788,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1843,10 +1840,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1898,10 +1892,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "lx"
         },
         "state": {

--- a/tests/data/devices/third-reality-inc-3rsp019bz.json
+++ b/tests/data/devices/third-reality-inc-3rsp019bz.json
@@ -1598,10 +1598,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1653,10 +1650,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/third-reality-inc-3rsp02028bz.json
+++ b/tests/data/devices/third-reality-inc-3rsp02028bz.json
@@ -1663,10 +1663,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1718,10 +1715,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1773,10 +1767,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -1828,10 +1819,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -1883,10 +1871,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -1938,10 +1923,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {

--- a/tests/data/devices/third-reality-inc-3rss007z.json
+++ b/tests/data/devices/third-reality-inc-3rss007z.json
@@ -595,10 +595,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -650,10 +647,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/third-reality-inc-3rss009z.json
+++ b/tests/data/devices/third-reality-inc-3rss009z.json
@@ -908,10 +908,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -963,10 +960,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1018,10 +1012,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/third-reality-inc-3rths24bz.json
+++ b/tests/data/devices/third-reality-inc-3rths24bz.json
@@ -884,10 +884,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -939,10 +936,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -994,10 +988,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1050,10 +1041,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -1105,10 +1093,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/third-reality-inc-3rvs01031z.json
+++ b/tests/data/devices/third-reality-inc-3rvs01031z.json
@@ -946,10 +946,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1001,10 +998,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1056,10 +1050,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/third-reality-inc-3rws18bz.json
+++ b/tests/data/devices/third-reality-inc-3rws18bz.json
@@ -1080,10 +1080,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1135,10 +1132,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1190,10 +1184,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/tubeszb-tubeszb-router.json
+++ b/tests/data/devices/tubeszb-tubeszb-router.json
@@ -523,10 +523,7 @@
           "endpoint_id": 8,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -578,10 +575,7 @@
           "endpoint_id": 8,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/tuyatec-gqhxixyk-rh3052.json
+++ b/tests/data/devices/tuyatec-gqhxixyk-rh3052.json
@@ -979,10 +979,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1034,10 +1031,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1089,10 +1083,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1145,10 +1136,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -1200,10 +1188,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/tuyatec-r9hgssol-rh3001.json
+++ b/tests/data/devices/tuyatec-r9hgssol-rh3001.json
@@ -895,10 +895,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -950,10 +947,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1005,10 +999,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/tuyatec-rkqiqvcs-rh3001.json
+++ b/tests/data/devices/tuyatec-rkqiqvcs-rh3001.json
@@ -895,10 +895,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -950,10 +947,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1005,10 +999,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/tuyatec-yg5dcbfu-rh3052.json
+++ b/tests/data/devices/tuyatec-yg5dcbfu-rh3052.json
@@ -979,10 +979,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1034,10 +1031,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1089,10 +1083,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1145,10 +1136,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -1200,10 +1188,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/tyst11-i5j6ifxj-5j6ifxj.json
+++ b/tests/data/devices/tyst11-i5j6ifxj-5j6ifxj.json
@@ -601,10 +601,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -656,10 +653,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/tyzb01-o63ssaah-ts0207.json
+++ b/tests/data/devices/tyzb01-o63ssaah-ts0207.json
@@ -1011,10 +1011,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1066,10 +1063,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1121,10 +1115,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/tyzb01-qm6djpta-ts0215.json
+++ b/tests/data/devices/tyzb01-qm6djpta-ts0215.json
@@ -1394,10 +1394,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1449,10 +1446,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1504,10 +1498,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/tyzb01-rifa0wlb-ts0011.json
+++ b/tests/data/devices/tyzb01-rifa0wlb-ts0011.json
@@ -585,10 +585,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -640,10 +637,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/tyzb01-vkwryfdr-ts0115.json
+++ b/tests/data/devices/tyzb01-vkwryfdr-ts0115.json
@@ -1219,10 +1219,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1274,10 +1271,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/tyzb01-zanh6v1o-ts0121.json
+++ b/tests/data/devices/tyzb01-zanh6v1o-ts0121.json
@@ -2456,10 +2456,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2511,10 +2508,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2566,10 +2560,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {
@@ -2624,10 +2615,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -2679,10 +2667,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -2734,10 +2719,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {

--- a/tests/data/devices/tz3000-8yhypbo7-ts0203.json
+++ b/tests/data/devices/tz3000-8yhypbo7-ts0203.json
@@ -1414,10 +1414,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1469,10 +1466,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1524,10 +1518,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/tz3000-bguser20-ts0201.json
+++ b/tests/data/devices/tz3000-bguser20-ts0201.json
@@ -1084,10 +1084,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1139,10 +1136,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1194,10 +1188,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1250,10 +1241,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -1305,10 +1293,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/tz3000-cehuw1lw-ts011f.json
+++ b/tests/data/devices/tz3000-cehuw1lw-ts011f.json
@@ -2556,10 +2556,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2611,10 +2608,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2666,10 +2660,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {
@@ -2724,10 +2715,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -2779,10 +2767,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -2834,10 +2819,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {

--- a/tests/data/devices/tz3000-f2bw0b6k-ts0201.json
+++ b/tests/data/devices/tz3000-f2bw0b6k-ts0201.json
@@ -1084,10 +1084,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1139,10 +1136,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1194,10 +1188,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1250,10 +1241,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -1305,10 +1293,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/tz3000-itnrsufe-ts0201.json
+++ b/tests/data/devices/tz3000-itnrsufe-ts0201.json
@@ -1160,10 +1160,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1215,10 +1212,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1270,10 +1264,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1326,10 +1317,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -1381,10 +1369,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/tz3000-kjfzuycl-ts004f.json
+++ b/tests/data/devices/tz3000-kjfzuycl-ts004f.json
@@ -1679,10 +1679,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1734,10 +1731,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1789,10 +1783,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/tz3000-uwkja6z1-ts011f.json
+++ b/tests/data/devices/tz3000-uwkja6z1-ts011f.json
@@ -4622,10 +4622,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -4677,10 +4674,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -4732,10 +4726,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {
@@ -4790,10 +4781,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -4845,10 +4833,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -4900,10 +4885,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -4955,10 +4937,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {
@@ -5013,10 +4992,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -5068,10 +5044,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -5123,10 +5096,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {

--- a/tests/data/devices/tz3000-w0qqde0g-ts011f.json
+++ b/tests/data/devices/tz3000-w0qqde0g-ts011f.json
@@ -2519,10 +2519,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2574,10 +2571,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2629,10 +2623,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {
@@ -2685,10 +2676,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -2740,10 +2728,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -2795,10 +2780,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {

--- a/tests/data/devices/tz3000-zw7yf6yk-ts0001.json
+++ b/tests/data/devices/tz3000-zw7yf6yk-ts0001.json
@@ -2628,10 +2628,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2683,10 +2680,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2738,10 +2732,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {
@@ -2796,10 +2787,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -2851,10 +2839,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -2906,10 +2891,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {

--- a/tests/data/devices/tz3210-09hzmirw-ts0502b.json
+++ b/tests/data/devices/tz3210-09hzmirw-ts0502b.json
@@ -1372,10 +1372,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1427,10 +1424,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/tz3210-j4pdtz9v-ts0001.json
+++ b/tests/data/devices/tz3210-j4pdtz9v-ts0001.json
@@ -1269,10 +1269,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1324,10 +1321,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1379,10 +1373,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/tz3210-jaap6jeb-ts0505b.json
+++ b/tests/data/devices/tz3210-jaap6jeb-ts0505b.json
@@ -1319,10 +1319,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1374,10 +1371,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/tz3210-tgvtvdoc-ts0207.json
+++ b/tests/data/devices/tz3210-tgvtvdoc-ts0207.json
@@ -1232,10 +1232,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1287,10 +1284,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1342,10 +1336,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1400,10 +1391,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "lx"
         },
         "state": {
@@ -1455,10 +1443,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "average_light_intensity_20mins",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "lx"
         },
         "state": {
@@ -1510,10 +1495,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rain_intensity",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "mV"
         },
         "state": {
@@ -1565,10 +1547,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "todays_max_light_intensity",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "lx"
         },
         "state": {

--- a/tests/data/devices/tz3290-7v1k4vufotpowp9z-ts1201.json
+++ b/tests/data/devices/tz3290-7v1k4vufotpowp9z-ts1201.json
@@ -766,10 +766,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -821,10 +818,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/tz6210-duv6fhwt-ts0601.json
+++ b/tests/data/devices/tz6210-duv6fhwt-ts0601.json
@@ -1138,10 +1138,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1193,10 +1190,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1248,10 +1242,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "lx"
         },
         "state": {

--- a/tests/data/devices/tze200-2aaelwxk-ts0225.json
+++ b/tests/data/devices/tze200-2aaelwxk-ts0225.json
@@ -2370,10 +2370,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2425,10 +2422,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2480,10 +2474,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "lx"
         },
         "state": {

--- a/tests/data/devices/tze200-9caxna4s-ts0301.json
+++ b/tests/data/devices/tze200-9caxna4s-ts0301.json
@@ -1258,10 +1258,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1313,10 +1310,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1368,10 +1362,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1424,10 +1415,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "window_covering_type",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {

--- a/tests/data/devices/tze200-akjefhj5-ts0601.json
+++ b/tests/data/devices/tze200-akjefhj5-ts0601.json
@@ -553,10 +553,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -608,10 +605,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/tze200-ijey4q29-ts0601.json
+++ b/tests/data/devices/tze200-ijey4q29-ts0601.json
@@ -941,10 +941,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -996,10 +993,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1051,10 +1045,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1107,10 +1098,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "lx"
         },
         "state": {

--- a/tests/data/devices/tze200-laqjm8qd-ts0601.json
+++ b/tests/data/devices/tze200-laqjm8qd-ts0601.json
@@ -568,10 +568,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -623,10 +620,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/tze200-locansqn-ts0601.json
+++ b/tests/data/devices/tze200-locansqn-ts0601.json
@@ -1653,10 +1653,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1708,10 +1705,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1763,10 +1757,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1820,10 +1811,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -1875,10 +1863,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1930,10 +1915,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "humidity_alarm",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1985,10 +1967,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "temperature_alarm",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {

--- a/tests/data/devices/tze200-myd45weu-ts0601.json
+++ b/tests/data/devices/tze200-myd45weu-ts0601.json
@@ -1077,10 +1077,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1132,10 +1129,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1187,10 +1181,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1244,10 +1235,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -1299,10 +1287,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/tze200-ny94onlb-ts0601.json
+++ b/tests/data/devices/tze200-ny94onlb-ts0601.json
@@ -5212,10 +5212,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -5267,10 +5264,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -5322,10 +5316,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {
@@ -5378,10 +5369,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -5433,10 +5421,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "active_power_ph_b",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -5488,10 +5473,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "active_power_ph_c",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -5543,10 +5525,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -5598,10 +5577,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current_ph_b",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -5653,10 +5629,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current_ph_c",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -5708,10 +5681,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -5763,10 +5733,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage_ph_b",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -5818,10 +5785,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage_ph_c",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -5873,10 +5837,7 @@
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -5928,10 +5889,7 @@
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -5983,10 +5941,7 @@
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -6038,10 +5993,7 @@
           "endpoint_id": 20,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -6093,10 +6045,7 @@
           "endpoint_id": 20,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -6148,10 +6097,7 @@
           "endpoint_id": 20,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -6203,10 +6149,7 @@
           "endpoint_id": 30,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -6258,10 +6201,7 @@
           "endpoint_id": 30,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -6313,10 +6253,7 @@
           "endpoint_id": 30,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {

--- a/tests/data/devices/tze200-pay2byax-ts0601.json
+++ b/tests/data/devices/tze200-pay2byax-ts0601.json
@@ -936,10 +936,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -991,10 +988,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1046,10 +1040,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1104,10 +1095,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "lx"
         },
         "state": {

--- a/tests/data/devices/tze200-yjjdcqsq-ts0601.json
+++ b/tests/data/devices/tze200-yjjdcqsq-ts0601.json
@@ -1141,10 +1141,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1196,10 +1193,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1251,10 +1245,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1308,10 +1299,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -1363,10 +1351,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/tze204-81yrt3lo-ts0601.json
+++ b/tests/data/devices/tze204-81yrt3lo-ts0601.json
@@ -6168,10 +6168,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -6223,10 +6220,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -6278,10 +6272,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "instantaneous_demand",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -6335,10 +6326,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {
@@ -6392,10 +6380,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_received",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {
@@ -6449,10 +6434,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -6505,10 +6487,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "ac_frequency",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "Hz"
         },
         "state": {
@@ -6561,10 +6540,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -6617,10 +6593,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -6673,10 +6646,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "rms_voltage",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "V"
         },
         "state": {
@@ -6729,10 +6699,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "instantaneous_demand",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -6786,10 +6753,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {
@@ -6843,10 +6807,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_received",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {
@@ -6900,10 +6861,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -6956,10 +6914,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -7012,10 +6967,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {
@@ -7068,10 +7020,7 @@
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
-          "attribute": "instantaneous_demand",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -7125,10 +7074,7 @@
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_delivered",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {
@@ -7182,10 +7128,7 @@
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
-          "attribute": "current_summ_received",
           "suggested_display_precision": 3,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "kWh"
         },
         "state": {
@@ -7239,10 +7182,7 @@
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
-          "attribute": "active_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "W"
         },
         "state": {
@@ -7295,10 +7235,7 @@
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
-          "attribute": "apparent_power",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "VA"
         },
         "state": {
@@ -7351,10 +7288,7 @@
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
-          "attribute": "rms_current",
           "suggested_display_precision": 1,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tze204-ai4rqhky-ts0601.json
+++ b/tests/data/devices/tze204-ai4rqhky-ts0601.json
@@ -553,10 +553,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -608,10 +605,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/tze204-iaeejhvf-ts0601.json
+++ b/tests/data/devices/tze204-iaeejhvf-ts0601.json
@@ -2553,10 +2553,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -2608,10 +2605,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -2663,10 +2657,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "lx"
         },
         "state": {
@@ -2718,10 +2709,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "present_value",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "m"
         },
         "state": {
@@ -2773,10 +2761,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "distance",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "m"
         },
         "state": {

--- a/tests/data/devices/tze204-nklqjk62-ts0601.json
+++ b/tests/data/devices/tze204-nklqjk62-ts0601.json
@@ -568,10 +568,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -623,10 +620,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/tze204-nlrfgpny-ts0601.json
+++ b/tests/data/devices/tze204-nlrfgpny-ts0601.json
@@ -1383,10 +1383,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1438,10 +1435,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1493,10 +1487,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1550,10 +1541,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "alarm_state",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {

--- a/tests/data/devices/tze204-qasjif9e-ts0601.json
+++ b/tests/data/devices/tze204-qasjif9e-ts0601.json
@@ -1101,10 +1101,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1156,10 +1153,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1211,10 +1205,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "lx"
         },
         "state": {
@@ -1266,10 +1257,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "distance",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "m"
         },
         "state": {

--- a/tests/data/devices/tze204-qtnjuoae-ts0601.json
+++ b/tests/data/devices/tze204-qtnjuoae-ts0601.json
@@ -553,10 +553,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -608,10 +605,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {

--- a/tests/data/devices/tze284-ne4pikwm-ts0601.json
+++ b/tests/data/devices/tze284-ne4pikwm-ts0601.json
@@ -1166,10 +1166,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1221,10 +1218,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1276,10 +1270,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {

--- a/tests/data/devices/tze284-qyflbnbj-ts0601.json
+++ b/tests/data/devices/tze284-qyflbnbj-ts0601.json
@@ -1082,10 +1082,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1137,10 +1134,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1192,10 +1186,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1249,10 +1240,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -1304,10 +1292,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/xiaomi-lywsd03mmc.json
+++ b/tests/data/devices/xiaomi-lywsd03mmc.json
@@ -1036,10 +1036,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1091,10 +1088,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1146,10 +1140,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1202,10 +1193,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "\u00b0C"
         },
         "state": {
@@ -1257,10 +1245,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "measured_value",
           "suggested_display_precision": null,
-          "divisor": 100,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/xiaoyan-terncy-sd01.json
+++ b/tests/data/devices/xiaoyan-terncy-sd01.json
@@ -973,10 +973,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1028,10 +1025,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1083,10 +1077,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/yale-yrd256-tsdb.json
+++ b/tests/data/devices/yale-yrd256-tsdb.json
@@ -1750,10 +1750,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1805,10 +1802,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1860,10 +1854,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/data/devices/yooksmart-d10110.json
+++ b/tests/data/devices/yooksmart-d10110.json
@@ -1259,10 +1259,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1314,10 +1311,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1369,10 +1363,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {
@@ -1424,10 +1415,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "window_covering_type",
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {

--- a/tests/data/devices/yunding-ford.json
+++ b/tests/data/devices/yunding-ford.json
@@ -1643,10 +1643,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": null
         },
         "state": {
@@ -1698,10 +1695,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": null,
           "suggested_display_precision": null,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "dBm"
         },
         "state": {
@@ -1753,10 +1747,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "attribute": "battery_percentage_remaining",
           "suggested_display_precision": 0,
-          "divisor": 1,
-          "multiplier": 1,
           "unit": "%"
         },
         "state": {

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -459,7 +459,7 @@ async def async_test_change_source_timestamp(
     await send_attributes_report(
         zha_gateway,
         cluster,
-        {hvac.Thermostat.AttributeDefs.setpoint_change_source_timestamp.id: 2674725315},
+        {hvac.Thermostat.AttributeDefs.setpoint_change_source_timestamp.id: 781355715},
     )
     assert entity.state["state"] == datetime(2024, 10, 4, 11, 15, 15, tzinfo=UTC)
 
@@ -1409,6 +1409,7 @@ class TimestampCluster(CustomCluster, ManufacturerSpecificCluster):
         "start_time",
         TimestampCluster.cluster_id,
         device_class=SensorDeviceClassV2.TIMESTAMP,  # Use the zigpy enum
+        attribute_converter=lambda x: datetime.fromtimestamp(x + 946684800, tz=UTC),
         translation_key="start_time",
         fallback_name="Start Time",
     )
@@ -1451,7 +1452,7 @@ async def test_timestamp_sensor_v2(zha_gateway: Gateway) -> None:
     assert isinstance(zha_device.device, CustomDeviceV2)
     entity = get_entity(zha_device, platform=Platform.SENSOR, qualifier="start_time")
 
-    await send_attributes_report(zha_gateway, cluster, {0xEF65: 2674725315})
+    await send_attributes_report(zha_gateway, cluster, {0xEF65: 781355715})
     assert entity.state["state"] == datetime(2024, 10, 4, 11, 15, 15, tzinfo=UTC)
 
 

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -45,7 +45,6 @@ from zha.application.platforms import (  # noqa: F401 pylint: disable=unused-imp
     switch,
     update,
 )
-from zha.application.platforms.sensor.const import SensorDeviceClass
 from zha.application.registries import (
     DEVICE_CLASS,
     PLATFORM_ENTITIES,
@@ -215,10 +214,6 @@ QUIRKS_ENTITY_META_TO_ENTITY_CLASS = {
     ): switch.ConfigurableAttributeSwitch,
 }
 
-QUIRKS_SENSOR_DEV_CLASS_TO_ENTITY_CLASS = {
-    SensorDeviceClass.TIMESTAMP: sensor.TimestampSensor
-}
-
 
 P = ParamSpec("P")
 T = TypeVar("T")
@@ -358,14 +353,6 @@ class DeviceProbe:
                         },
                     )
                     continue
-
-                if (
-                    entity_class is sensor.Sensor
-                    and entity_metadata.device_class is not None
-                ):
-                    entity_class = QUIRKS_SENSOR_DEV_CLASS_TO_ENTITY_CLASS.get(
-                        entity_metadata.device_class.value, entity_class
-                    )
 
                 # process the entity metadata for ZCL_INIT_ATTRS and REPORT_CONFIG
                 if attr_name := getattr(entity_metadata, "attribute_name", None):

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from asyncio import Task
 import contextlib
 from dataclasses import dataclass
-from datetime import UTC, date, datetime
+from datetime import date, datetime, timedelta
 import enum
 import functools
 import logging
@@ -37,7 +37,7 @@ from zha.application.platforms.number.bacnet import BACNET_UNITS_TO_HA_UNITS
 from zha.application.platforms.sensor.const import (
     ANALOG_INPUT_APPTYPE_DEV_CLASS,
     ANALOG_INPUT_APPTYPE_UNITS,
-    UNIX_EPOCH_TO_ZCL_EPOCH,
+    ZCL_EPOCH,
     SensorDeviceClass,
     SensorStateClass,
 )
@@ -128,10 +128,7 @@ CONFIG_DIAGNOSTIC_MATCH = functools.partial(
 class SensorEntityInfo(BaseEntityInfo):
     """Sensor entity info."""
 
-    attribute: str
     suggested_display_precision: int | None = None
-    divisor: int
-    multiplier: int
     unit: str | None = None
     device_class: SensorDeviceClass | None = None
     state_class: SensorStateClass | None = None
@@ -163,8 +160,8 @@ class Sensor(PlatformEntity):
     PLATFORM = Platform.SENSOR
     _attribute_name: int | str | None = None
     _attribute_converter: typing.Callable[[typing.Any], typing.Any] | None = None
-    _divisor: int = 1
-    _multiplier: int | float = 1
+    _divisor: int | float | None = None
+    _multiplier: int | float | None = None
     _attr_suggested_display_precision: int | None = None
     _attr_native_unit_of_measurement: str | None = None
     _attr_device_class: SensorDeviceClass | None = None
@@ -268,10 +265,7 @@ class Sensor(PlatformEntity):
         """Return a representation of the sensor."""
         return SensorEntityInfo(
             **super().info_object.__dict__,
-            attribute=self._attribute_name,
             suggested_display_precision=self._attr_suggested_display_precision,
-            divisor=self._divisor,
-            multiplier=self._multiplier,
             unit=(
                 getattr(self, "entity_description").native_unit_of_measurement
                 if getattr(self, "entity_description", None) is not None
@@ -293,6 +287,8 @@ class Sensor(PlatformEntity):
         assert self._attribute_name is not None
         raw_state = self._cluster_handler.cluster.get(self._attribute_name)
         if raw_state is None:
+            return None
+        if self._is_non_value(raw_state):
             return None
         if self._attribute_converter:
             return self._attribute_converter(raw_state)
@@ -327,22 +323,19 @@ class Sensor(PlatformEntity):
         data_type = foundation.DataType.from_type_id(attr_def.zcl_type)
         return value == data_type.non_value
 
-    def formatter(
-        self, value: int | enum.IntEnum
-    ) -> datetime | int | float | str | None:
+    def formatter(self, value: Any) -> date | datetime | int | float | str | None:
         """Numeric pass-through formatter."""
-        if self._is_non_value(value):
-            return None
+        if self._multiplier is not None:
+            value *= self._multiplier
 
-        return float(value * self._multiplier) / self._divisor
+        if self._divisor is not None:
+            value /= self._divisor
+
+        return value
 
 
 class TimestampSensor(Sensor):
     """Timestamp ZHA sensor."""
-
-    def formatter(self, value: int | enum.IntEnum) -> datetime | None:
-        """Pass-through formatter."""
-        return datetime.fromtimestamp(value - UNIX_EPOCH_TO_ZCL_EPOCH, tz=UTC)
 
 
 class PollableSensor(Sensor):
@@ -717,19 +710,27 @@ class BaseElectricalMeasurement(PollableSensor):
 
         return response
 
-    def formatter(self, value: int) -> int | float:
-        """Return 'normalized' value."""
-        if self._multiplier_attribute_name:
-            multiplier = getattr(self._cluster_handler, self._multiplier_attribute_name)
-        else:
-            multiplier = self._multiplier
+    @property
+    def _multiplier(self) -> int | float | None:
+        if not self._multiplier_attribute_name:
+            return super()._multiplier
 
-        if self._divisor_attribute_name:
-            divisor = getattr(self._cluster_handler, self._divisor_attribute_name)
-        else:
-            divisor = self._divisor
+        return getattr(self._cluster_handler, self._multiplier_attribute_name)
 
-        return float(value * multiplier) / divisor
+    @_multiplier.setter
+    def _multiplier(self, value: int | None) -> None:
+        raise AttributeError("Cannot set multiplier directly")
+
+    @property
+    def _divisor(self) -> int | float | None:
+        if not self._divisor_attribute_name:
+            return super()._divisor
+
+        return getattr(self._cluster_handler, self._divisor_attribute_name)
+
+    @_divisor.setter
+    def _divisor(self, value: int | None) -> None:
+        raise AttributeError("Cannot set divisor directly")
 
 
 @MULTI_MATCH(
@@ -1860,6 +1861,10 @@ class SetpointChangeSourceTimestamp(TimestampSensor):
     _attr_translation_key: str = "setpoint_change_source_timestamp"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_device_class = SensorDeviceClass.TIMESTAMP
+
+    def formatter(self, value: types.UTCTime) -> datetime:
+        """Pass-through formatter."""
+        return ZCL_EPOCH + timedelta(seconds=value)
 
 
 @CONFIG_DIAGNOSTIC_MATCH(cluster_handler_names=CLUSTER_HANDLER_COVER)

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -242,9 +242,9 @@ class Sensor(PlatformEntity):
         self._attribute_name = entity_metadata.attribute_name
         if entity_metadata.attribute_converter is not None:
             self._attribute_converter = entity_metadata.attribute_converter
-        if entity_metadata.divisor is not None:
+        if entity_metadata.divisor is not None and entity_metadata.divisor != 1:
             self._divisor = entity_metadata.divisor
-        if entity_metadata.multiplier is not None:
+        if entity_metadata.multiplier is not None and entity_metadata.multiplier != 1:
             self._multiplier = entity_metadata.multiplier
         if entity_metadata.device_class is not None:
             self._attr_device_class = validate_device_class(

--- a/zha/application/platforms/sensor/const.py
+++ b/zha/application/platforms/sensor/const.py
@@ -1,5 +1,6 @@
 """Constants for the sensor platform."""
 
+from datetime import UTC, datetime
 import enum
 
 from zigpy.zcl.clusters.general_const import AnalogInputType
@@ -450,4 +451,4 @@ ANALOG_INPUT_APPTYPE_UNITS = {
     AnalogInputType.Time_Seconds: UnitOfTime.SECONDS,
 }
 
-UNIX_EPOCH_TO_ZCL_EPOCH = 946684800
+ZCL_EPOCH = datetime(2000, 1, 1, tzinfo=UTC)


### PR DESCRIPTION
This PR removes the `QUIRKS_SENSOR_DEV_CLASS_TO_ENTITY_CLASS` discovery special case. Due to the base class `Sensor` entity now being used for all sensor types, I've removed `_multiplier` and `_divisor` from the entity info, since they had to be defaulted to `None` instead of `1`. This required a diagnostics regeneration, unfortunately inflating the diff for this PR.

Requires https://github.com/zigpy/zha-device-handlers/pull/4047.

We use `divisor=1` and `multiplier=1` in zigpy for quirks v2 sensors, which I think should be corrected. For now this PR handles both cases.

Due to the `divisor` and `multiplier` handling being changed, this also fixes an issue where ZHA always converted every int state into a float for sensors, causing `100.0` instead of just `100` as HA state.