### PR TITLE
Fix device diagnostics not regenerating with changed quirks

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -387,9 +387,18 @@ def zigpy_device_from_device_data(
 
         for cluster_type in ("in_clusters", "out_clusters"):
             for cluster in ep[cluster_type]:
-                real_cluster = getattr(endpoint, cluster_type)[
+                real_cluster = getattr(endpoint, cluster_type).get(
                     int(cluster["cluster_id"], 16)
-                ]
+                )
+
+                if real_cluster is None:
+                    _LOGGER.warning(
+                        "Cluster %s not found in endpoint %s of device %s",
+                        cluster["cluster_id"],
+                        epid,
+                        device.ieee,
+                    )
+                    continue
 
                 if patch_cluster:
                     patch_cluster_for_testing(real_cluster)

--- a/tools/import_legacy_diagnostics.py
+++ b/tools/import_legacy_diagnostics.py
@@ -105,6 +105,7 @@ def zigpy_device_from_legacy_diagnostics(
     for epid, ep in cluster_data.items():
         endpoint.request = AsyncMock(return_value=[0])
         for cluster_id, cluster in ep["in_clusters"].items():
+            # todo: likely also add here?
             real_cluster = device.endpoints[int(epid)].in_clusters[int(cluster_id, 16)]
             if patch_cluster:
                 patch_cluster_for_testing(real_cluster)


### PR DESCRIPTION
## Proposed change

This fixes an issue where regenerating device diagnostics or importing legacy device diagnostics might not work if `cluster_details` still contains clusters that are no longer present on the `Device` object.

## Additional information

This can be caused when a quirk no longer exposes a certain cluster.
Noticed here: https://github.com/zigpy/zha-device-handlers/pull/3232#issuecomment-2908002330


Draft until this is ready, as I've also had the same issue not just when regenerating diagnostics, but also when importing legacy diagnostics, though I just removed the clusters from the JSON for now.
I'll come back to this later.