### PR TITLE
Restore `latest_version` for update entity

### DIFF
--- a/tests/data/devices/adurosmart-eria-ad-rgbw3001.json
+++ b/tests/data/devices/adurosmart-eria-ad-rgbw3001.json
@@ -1731,7 +1731,7 @@
           "installed_version": "0x00000001",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000001",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/aqara-lumi-motion-ac01.json
+++ b/tests/data/devices/aqara-lumi-motion-ac01.json
@@ -1162,7 +1162,7 @@
           "installed_version": "0x00000035",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000035",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/aug-winkhaus-gmbh-co-kg-fm-v-zb.json
+++ b/tests/data/devices/aug-winkhaus-gmbh-co-kg-fm-v-zb.json
@@ -1241,7 +1241,7 @@
           "installed_version": "0x00000011",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000011",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/bosch-rbsh-mms-zb-eu.json
+++ b/tests/data/devices/bosch-rbsh-mms-zb-eu.json
@@ -3960,7 +3960,7 @@
           "installed_version": "0x11136760",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x11136760",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/centralite-3405-l.json
+++ b/tests/data/devices/centralite-3405-l.json
@@ -1714,7 +1714,7 @@
           "installed_version": "0x10025310",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x10025310",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/centralite-systems-3156105.json
+++ b/tests/data/devices/centralite-systems-3156105.json
@@ -2011,7 +2011,7 @@
           "installed_version": "0x1418468c",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x1418468c",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/ecolink-4655bc0-r.json
+++ b/tests/data/devices/ecolink-4655bc0-r.json
@@ -1587,7 +1587,7 @@
           "installed_version": "0x20160921",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x20160921",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/ericsity-gl-c-008p.json
+++ b/tests/data/devices/ericsity-gl-c-008p.json
@@ -1496,7 +1496,7 @@
           "installed_version": "0x25013001",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x25013001",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/ericsity-gl-c-009p.json
+++ b/tests/data/devices/ericsity-gl-c-009p.json
@@ -1490,7 +1490,7 @@
           "installed_version": "0x25013001",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x25013001",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/ewelink-ck-bl702-al-01-7009-z102lg03-1.json
+++ b/tests/data/devices/ewelink-ck-bl702-al-01-7009-z102lg03-1.json
@@ -1621,7 +1621,7 @@
           "installed_version": "0x00001200",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00001200",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/ewelink-snzb-01p.json
+++ b/tests/data/devices/ewelink-snzb-01p.json
@@ -1195,7 +1195,7 @@
           "installed_version": "0x00002000",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00002000",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/ewelink-snzb-02p.json
+++ b/tests/data/devices/ewelink-snzb-02p.json
@@ -1316,7 +1316,7 @@
           "installed_version": "0x00002100",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00002100",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/frient-a-s-aqszb-110.json
+++ b/tests/data/devices/frient-a-s-aqszb-110.json
@@ -1590,7 +1590,7 @@
           "installed_version": "0x00040001",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00040001",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/frient-a-s-emizb-141.json
+++ b/tests/data/devices/frient-a-s-emizb-141.json
@@ -2748,7 +2748,7 @@
           "installed_version": "0x00030102",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00030102",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/frient-a-s-emizb-151.json
+++ b/tests/data/devices/frient-a-s-emizb-151.json
@@ -9352,7 +9352,7 @@
           "installed_version": "0x00030107",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00030107",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/frient-a-s-flszb-110.json
+++ b/tests/data/devices/frient-a-s-flszb-110.json
@@ -2244,7 +2244,7 @@
           "installed_version": "0x00040001",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00040001",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/frient-a-s-hmszb-120.json
+++ b/tests/data/devices/frient-a-s-hmszb-120.json
@@ -1580,7 +1580,7 @@
           "installed_version": "0x00040001",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00040001",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/frient-a-s-iomzb-110.json
+++ b/tests/data/devices/frient-a-s-iomzb-110.json
@@ -3323,7 +3323,7 @@
           "installed_version": "0x00020001",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00020001",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/frient-a-s-kepzb-110.json
+++ b/tests/data/devices/frient-a-s-kepzb-110.json
@@ -1780,7 +1780,7 @@
           "installed_version": "0x00020005",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00020005",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/frient-a-s-moszb-153.json
+++ b/tests/data/devices/frient-a-s-moszb-153.json
@@ -3650,7 +3650,7 @@
           "installed_version": "0x00020006",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00020006",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/frient-a-s-sbtzb-110.json
+++ b/tests/data/devices/frient-a-s-sbtzb-110.json
@@ -1839,7 +1839,7 @@
           "installed_version": "0x00020002",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00020002",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/frient-a-s-sirzb-111.json
+++ b/tests/data/devices/frient-a-s-sirzb-111.json
@@ -1698,7 +1698,7 @@
           "installed_version": "0x00020004",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00020004",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/frient-a-s-smszb-120.json
+++ b/tests/data/devices/frient-a-s-smszb-120.json
@@ -2299,7 +2299,7 @@
           "installed_version": "0x00040008",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00040008",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/frient-a-s-splzb-141.json
+++ b/tests/data/devices/frient-a-s-splzb-141.json
@@ -3708,7 +3708,7 @@
           "installed_version": "0x00020009",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00020009",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/frient-a-s-wiszb-131.json
+++ b/tests/data/devices/frient-a-s-wiszb-131.json
@@ -2144,7 +2144,7 @@
           "installed_version": "0x00020006",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00020006",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/gledopto-gl-b-008p.json
+++ b/tests/data/devices/gledopto-gl-b-008p.json
@@ -1511,7 +1511,7 @@
           "installed_version": "0x00000006",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000006",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/ikea-of-sweden-fyrtur-block-out-roller-blind.json
+++ b/tests/data/devices/ikea-of-sweden-fyrtur-block-out-roller-blind.json
@@ -1565,7 +1565,7 @@
           "installed_version": "0x23088631",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x23088631",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/ikea-of-sweden-inspelning-smart-plug.json
+++ b/tests/data/devices/ikea-of-sweden-inspelning-smart-plug.json
@@ -2932,7 +2932,7 @@
           "installed_version": "0x02040045",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x02040045",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/ikea-of-sweden-parasoll-door-window-sensor.json
+++ b/tests/data/devices/ikea-of-sweden-parasoll-door-window-sensor.json
@@ -1822,7 +1822,7 @@
           "installed_version": "0x01000019",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x01000019",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/ikea-of-sweden-praktlysing-cellular-blind.json
+++ b/tests/data/devices/ikea-of-sweden-praktlysing-cellular-blind.json
@@ -1565,7 +1565,7 @@
           "installed_version": "0x23088631",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x23088631",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/ikea-of-sweden-rodret-dimmer.json
+++ b/tests/data/devices/ikea-of-sweden-rodret-dimmer.json
@@ -1381,7 +1381,7 @@
           "installed_version": "0x01000047",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x01000047",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/ikea-of-sweden-starkvind-air-purifier.json
+++ b/tests/data/devices/ikea-of-sweden-starkvind-air-purifier.json
@@ -1334,7 +1334,7 @@
           "installed_version": "0x00011001",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00011001",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-w-op-ch-400lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-w-op-ch-400lm.json
@@ -1526,7 +1526,7 @@
           "installed_version": "0x23094631",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x23094631",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-ws-opal-400lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-ws-opal-400lm.json
@@ -1757,7 +1757,7 @@
           "installed_version": "0x23087631",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x23087631",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-opal-1000lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-opal-1000lm.json
@@ -1308,7 +1308,7 @@
           "installed_version": "0x23094631",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x23094631",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-w-opal-1000lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-w-opal-1000lm.json
@@ -1526,7 +1526,7 @@
           "installed_version": "0x23094631",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x23094631",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-ws-opal-980lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-ws-opal-980lm.json
@@ -1756,7 +1756,7 @@
           "installed_version": "0x23095631",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x23095631",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-gu10-ws-400lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-gu10-ws-400lm.json
@@ -1762,7 +1762,7 @@
           "installed_version": "0x23095631",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x23095631",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/ikea-of-sweden-tradfri-control-outlet.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-control-outlet.json
@@ -989,7 +989,7 @@
           "installed_version": "0x23089631",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x23089631",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/ikea-of-sweden-tradfri-open-close-remote.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-open-close-remote.json
@@ -1505,7 +1505,7 @@
           "installed_version": "0x23079631",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x23079631",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/ikea-of-sweden-vallhorn-wireless-motion-sensor.json
+++ b/tests/data/devices/ikea-of-sweden-vallhorn-wireless-motion-sensor.json
@@ -2385,7 +2385,7 @@
           "installed_version": "0x01000064",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x01000064",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/innr-ae-280-c.json
+++ b/tests/data/devices/innr-ae-280-c.json
@@ -1601,7 +1601,7 @@
           "installed_version": "0x20026a30",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x20026a30",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/innr-rb-285-c.json
+++ b/tests/data/devices/innr-rb-285-c.json
@@ -1511,7 +1511,7 @@
           "installed_version": "0x10051567",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x10051567",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/innr-sp-120.json
+++ b/tests/data/devices/innr-sp-120.json
@@ -3271,7 +3271,7 @@
           "installed_version": "0x11040002",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x11040002",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/innr-sp-234.json
+++ b/tests/data/devices/innr-sp-234.json
@@ -3326,7 +3326,7 @@
           "installed_version": "0x31016610",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x31016610",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/jasco-products-45856.json
+++ b/tests/data/devices/jasco-products-45856.json
@@ -2694,7 +2694,7 @@
           "installed_version": "0x00000006",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000006",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/jasco-products-45857.json
+++ b/tests/data/devices/jasco-products-45857.json
@@ -3002,7 +3002,7 @@
           "installed_version": "0x00000006",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000006",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/ke-tradfri-open-close-remote.json
+++ b/tests/data/devices/ke-tradfri-open-close-remote.json
@@ -1505,7 +1505,7 @@
           "installed_version": "0x22010631",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x22010631",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/keen-home-inc-sv01-410-mp-1-1.json
+++ b/tests/data/devices/keen-home-inc-sv01-410-mp-1-1.json
@@ -2000,7 +2000,7 @@
           "installed_version": "0x10235121",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x10235121",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/king-of-fans-inc-hbuniversalcfremote.json
+++ b/tests/data/devices/king-of-fans-inc-hbuniversalcfremote.json
@@ -1108,7 +1108,7 @@
           "installed_version": "0x0000000f",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x0000000f",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/king-of-fans-inc-hdc52eastwindfan.json
+++ b/tests/data/devices/king-of-fans-inc-hdc52eastwindfan.json
@@ -1108,7 +1108,7 @@
           "installed_version": "0x0000000f",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x0000000f",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/kwikset-smartcode-convert-gen1.json
+++ b/tests/data/devices/kwikset-smartcode-convert-gen1.json
@@ -2023,7 +2023,7 @@
           "installed_version": "0x30a07a06",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x30a07a06",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/lds-zb-onoffplug-d0005.json
+++ b/tests/data/devices/lds-zb-onoffplug-d0005.json
@@ -3031,7 +3031,7 @@
           "installed_version": "0x21186230",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x21186230",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/lds-zbt-cctswitch-d0001.json
+++ b/tests/data/devices/lds-zbt-cctswitch-d0001.json
@@ -1696,7 +1696,7 @@
           "installed_version": "0x21000006",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x21000006",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/ledvance-flex-rgbw.json
+++ b/tests/data/devices/ledvance-flex-rgbw.json
@@ -1872,7 +1872,7 @@
           "installed_version": "0x00102428",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00102428",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/ledvance-outdoor-accent-light-rgb.json
+++ b/tests/data/devices/ledvance-outdoor-accent-light-rgb.json
@@ -1844,7 +1844,7 @@
           "installed_version": "0x00102428",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00102428",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/ledvance-plug.json
+++ b/tests/data/devices/ledvance-plug.json
@@ -1043,7 +1043,7 @@
           "installed_version": "0x00102101",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00102101",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/level-home-b2.json
+++ b/tests/data/devices/level-home-b2.json
@@ -1645,7 +1645,7 @@
           "installed_version": "0x0300001a",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x0300001a",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/level-home-bolt.json
+++ b/tests/data/devices/level-home-bolt.json
@@ -1645,7 +1645,7 @@
           "installed_version": "0x03020006",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x03020006",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/lk-zbt-dimswitch-d0001.json
+++ b/tests/data/devices/lk-zbt-dimswitch-d0001.json
@@ -1526,7 +1526,7 @@
           "installed_version": "0x22166500",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x22166500",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/lk-zbt-onoffplug-d0001.json
+++ b/tests/data/devices/lk-zbt-onoffplug-d0001.json
@@ -1465,7 +1465,7 @@
           "installed_version": "0x22036610",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x22036610",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/lumi-lumi-curtain-agl001.json
+++ b/tests/data/devices/lumi-lumi-curtain-agl001.json
@@ -1956,7 +1956,7 @@
           "installed_version": "0x00000018",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000018",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/lumi-lumi-flood-acn001.json
+++ b/tests/data/devices/lumi-lumi-flood-acn001.json
@@ -1205,7 +1205,7 @@
           "installed_version": "0x00000004",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000004",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/lumi-lumi-flood-agl02.json
+++ b/tests/data/devices/lumi-lumi-flood-agl02.json
@@ -1176,7 +1176,7 @@
           "installed_version": "0x00000020",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000020",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/lumi-lumi-light-aqcn02.json
+++ b/tests/data/devices/lumi-lumi-light-aqcn02.json
@@ -1977,7 +1977,7 @@
           "installed_version": "0x00000017",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000017",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/lumi-lumi-magnet-acn001.json
+++ b/tests/data/devices/lumi-lumi-magnet-acn001.json
@@ -1205,7 +1205,7 @@
           "installed_version": "0x00000004",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000004",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/lumi-lumi-motion-agl04.json
+++ b/tests/data/devices/lumi-lumi-motion-agl04.json
@@ -1617,7 +1617,7 @@
           "installed_version": "0x00000019",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000019",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/lumi-lumi-plug-maus01.json
+++ b/tests/data/devices/lumi-lumi-plug-maus01.json
@@ -4565,7 +4565,7 @@
           "installed_version": "0x0000000b",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x0000000b",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/lumi-lumi-relay-c2acn01.json
+++ b/tests/data/devices/lumi-lumi-relay-c2acn01.json
@@ -4166,7 +4166,7 @@
           "installed_version": "0x00000024",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000024",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/lumi-lumi-sensor-smoke-acn03.json
+++ b/tests/data/devices/lumi-lumi-sensor-smoke-acn03.json
@@ -1627,7 +1627,7 @@
           "installed_version": "0x00000011",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000011",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/lumi-lumi-switch-b1laus01.json
+++ b/tests/data/devices/lumi-lumi-switch-b1laus01.json
@@ -1049,7 +1049,7 @@
           "installed_version": "0x00000020",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000020",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/lumi-lumi-switch-b1naus01.json
+++ b/tests/data/devices/lumi-lumi-switch-b1naus01.json
@@ -3017,7 +3017,7 @@
           "installed_version": "0x0000001f",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x0000001f",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/lutron-z3-1brl.json
+++ b/tests/data/devices/lutron-z3-1brl.json
@@ -1280,7 +1280,7 @@
           "installed_version": "0x00000c08",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000c08",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/osram-switch-4x-lightify.json
+++ b/tests/data/devices/osram-switch-4x-lightify.json
@@ -6761,7 +6761,7 @@
           "installed_version": "0x01000000",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x01000000",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/philips-7602031u7.json
+++ b/tests/data/devices/philips-7602031u7.json
@@ -1522,7 +1522,7 @@
           "installed_version": "0x01001d00",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x01001d00",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/philips-lct014.json
+++ b/tests/data/devices/philips-lct014.json
@@ -1522,7 +1522,7 @@
           "installed_version": "0x01001a02",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x01001a02",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/philips-llc020.json
+++ b/tests/data/devices/philips-llc020.json
@@ -1522,7 +1522,7 @@
           "installed_version": "0x42006734",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x42006734",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/philips-lst002.json
+++ b/tests/data/devices/philips-lst002.json
@@ -1346,7 +1346,7 @@
           "installed_version": "0x01001700",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x01001700",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/philips-rom001.json
+++ b/tests/data/devices/philips-rom001.json
@@ -1555,7 +1555,7 @@
           "installed_version": "0x02002f08",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x02002f08",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/philips-sml001.json
+++ b/tests/data/devices/philips-sml001.json
@@ -2632,7 +2632,7 @@
           "installed_version": "0x42006bb7",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x42006bb7",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/plaid-systems-ps-sprzms-slp3.json
+++ b/tests/data/devices/plaid-systems-ps-sprzms-slp3.json
@@ -1268,7 +1268,7 @@
           "installed_version": "0x00000001",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000001",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/samjin-button.json
+++ b/tests/data/devices/samjin-button.json
@@ -1613,7 +1613,7 @@
           "installed_version": "0x00000011",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000011",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/samjin-multi.json
+++ b/tests/data/devices/samjin-multi.json
@@ -1462,7 +1462,7 @@
           "installed_version": "0x0000000b",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x0000000b",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/sengled-e11-g13.json
+++ b/tests/data/devices/sengled-e11-g13.json
@@ -2263,7 +2263,7 @@
           "installed_version": "0x00000009",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000009",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/sengled-e12-n14.json
+++ b/tests/data/devices/sengled-e12-n14.json
@@ -2263,7 +2263,7 @@
           "installed_version": "0x00000004",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000004",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/sengled-e12-n1e.json
+++ b/tests/data/devices/sengled-e12-n1e.json
@@ -2624,7 +2624,7 @@
           "installed_version": "0x0000001e",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x0000001e",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/sengled-e1c-nb7.json
+++ b/tests/data/devices/sengled-e1c-nb7.json
@@ -2127,7 +2127,7 @@
           "installed_version": "0x0000001a",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x0000001a",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/sengled-e1f-n9g.json
+++ b/tests/data/devices/sengled-e1f-n9g.json
@@ -2278,7 +2278,7 @@
           "installed_version": "0x00000020",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000020",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/sengled-e1g-g8e.json
+++ b/tests/data/devices/sengled-e1g-g8e.json
@@ -2629,7 +2629,7 @@
           "installed_version": "0x0000000e",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x0000000e",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/sengled-e21-n1ea.json
+++ b/tests/data/devices/sengled-e21-n1ea.json
@@ -2796,7 +2796,7 @@
           "installed_version": "0x00000026",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000026",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/sengled-z01-a19nae26.json
+++ b/tests/data/devices/sengled-z01-a19nae26.json
@@ -2662,7 +2662,7 @@
           "installed_version": "0x00000020",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000020",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/signify-netherlands-b-v-lca001.json
+++ b/tests/data/devices/signify-netherlands-b-v-lca001.json
@@ -1526,7 +1526,7 @@
           "installed_version": "0x01002802",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x01002802",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/signify-netherlands-b-v-lca005.json
+++ b/tests/data/devices/signify-netherlands-b-v-lca005.json
@@ -1521,7 +1521,7 @@
           "installed_version": "0x01002402",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x01002402",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/signify-netherlands-b-v-lca007.json
+++ b/tests/data/devices/signify-netherlands-b-v-lca007.json
@@ -1521,7 +1521,7 @@
           "installed_version": "0x01001f0a",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x01001f0a",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/signify-netherlands-b-v-lcb001.json
+++ b/tests/data/devices/signify-netherlands-b-v-lcb001.json
@@ -1521,7 +1521,7 @@
           "installed_version": "0x01002800",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x01002800",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/signify-netherlands-b-v-lcb002.json
+++ b/tests/data/devices/signify-netherlands-b-v-lcb002.json
@@ -1521,7 +1521,7 @@
           "installed_version": "0x01001f0a",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x01001f0a",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/signify-netherlands-b-v-lce001.json
+++ b/tests/data/devices/signify-netherlands-b-v-lce001.json
@@ -1526,7 +1526,7 @@
           "installed_version": "0x01002404",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x01002404",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/signify-netherlands-b-v-lcx004.json
+++ b/tests/data/devices/signify-netherlands-b-v-lcx004.json
@@ -1521,7 +1521,7 @@
           "installed_version": "0x01001802",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x01001802",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/signify-netherlands-b-v-lta010.json
+++ b/tests/data/devices/signify-netherlands-b-v-lta010.json
@@ -1510,7 +1510,7 @@
           "installed_version": "0x01002402",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x01002402",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/signify-netherlands-b-v-ltb003.json
+++ b/tests/data/devices/signify-netherlands-b-v-ltb003.json
@@ -1511,7 +1511,7 @@
           "installed_version": "0x01001f0a",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x01001f0a",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/signify-netherlands-b-v-lwa003.json
+++ b/tests/data/devices/signify-netherlands-b-v-lwa003.json
@@ -1056,7 +1056,7 @@
           "installed_version": "0x01001f0a",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x01001f0a",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/signify-netherlands-b-v-rdm001.json
+++ b/tests/data/devices/signify-netherlands-b-v-rdm001.json
@@ -1323,7 +1323,7 @@
           "installed_version": "0x0000041a",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x0000041a",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/signify-netherlands-b-v-rdm002.json
+++ b/tests/data/devices/signify-netherlands-b-v-rdm002.json
@@ -1551,7 +1551,7 @@
           "installed_version": "0x02003b19",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x02003b19",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/signify-netherlands-b-v-rwl022.json
+++ b/tests/data/devices/signify-netherlands-b-v-rwl022.json
@@ -1547,7 +1547,7 @@
           "installed_version": "0x02002d02",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x02002d02",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/signify-netherlands-b-v-sml004.json
+++ b/tests/data/devices/signify-netherlands-b-v-sml004.json
@@ -1852,7 +1852,7 @@
           "installed_version": "0x02003506",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x02003506",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/smartthings-tagv4.json
+++ b/tests/data/devices/smartthings-tagv4.json
@@ -1289,7 +1289,7 @@
           "installed_version": "0x00000019",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000019",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/smartwings-wm25-l-z.json
+++ b/tests/data/devices/smartwings-wm25-l-z.json
@@ -1493,7 +1493,7 @@
           "installed_version": "0x00000002",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000002",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/sonoff-swv.json
+++ b/tests/data/devices/sonoff-swv.json
@@ -1780,7 +1780,7 @@
           "installed_version": "0x00001002",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00001002",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/sonoff-zbmicro.json
+++ b/tests/data/devices/sonoff-zbmicro.json
@@ -784,7 +784,7 @@
           "installed_version": "0x00001005",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00001005",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/sunricher-hk-ln-dim-a.json
+++ b/tests/data/devices/sunricher-hk-ln-dim-a.json
@@ -1411,7 +1411,7 @@
           "installed_version": "0x00000039",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000039",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/the-home-depot-ecosmart-zbt-a19-cct-bulb.json
+++ b/tests/data/devices/the-home-depot-ecosmart-zbt-a19-cct-bulb.json
@@ -1954,7 +1954,7 @@
           "installed_version": "0x21036500",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x21036500",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/third-reality-inc-3rms16bz.json
+++ b/tests/data/devices/third-reality-inc-3rms16bz.json
@@ -1134,7 +1134,7 @@
           "installed_version": "0x0000004f",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x0000004f",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/third-reality-inc-3rsb015bz.json
+++ b/tests/data/devices/third-reality-inc-3rsb015bz.json
@@ -1571,7 +1571,7 @@
           "installed_version": "0x00000048",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000048",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/third-reality-inc-3rsm0147z.json
+++ b/tests/data/devices/third-reality-inc-3rsm0147z.json
@@ -1160,7 +1160,7 @@
           "installed_version": "0x0000001f",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x0000001f",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/third-reality-inc-3rsnl02043z.json
+++ b/tests/data/devices/third-reality-inc-3rsnl02043z.json
@@ -1954,7 +1954,7 @@
           "installed_version": "0x0000003c",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x0000003c",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/third-reality-inc-3rsp019bz.json
+++ b/tests/data/devices/third-reality-inc-3rsp019bz.json
@@ -1764,7 +1764,7 @@
           "installed_version": "0x1001301e",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x1001301e",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/third-reality-inc-3rsp02028bz.json
+++ b/tests/data/devices/third-reality-inc-3rsp02028bz.json
@@ -2037,7 +2037,7 @@
           "installed_version": "0x10013058",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x10013058",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/third-reality-inc-3rss009z.json
+++ b/tests/data/devices/third-reality-inc-3rss009z.json
@@ -1127,7 +1127,7 @@
           "installed_version": "0x0000001d",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x0000001d",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/third-reality-inc-3rths24bz.json
+++ b/tests/data/devices/third-reality-inc-3rths24bz.json
@@ -1155,7 +1155,7 @@
           "installed_version": "0x00000015",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000015",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/third-reality-inc-3rvs01031z.json
+++ b/tests/data/devices/third-reality-inc-3rvs01031z.json
@@ -1113,7 +1113,7 @@
           "installed_version": "0x00000028",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000028",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/third-reality-inc-3rws18bz.json
+++ b/tests/data/devices/third-reality-inc-3rws18bz.json
@@ -1305,7 +1305,7 @@
           "installed_version": "0x00000038",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000038",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/tyst11-i5j6ifxj-5j6ifxj.json
+++ b/tests/data/devices/tyst11-i5j6ifxj-5j6ifxj.json
@@ -715,7 +715,7 @@
           "installed_version": "0x00000049",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000049",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/tyzb01-o63ssaah-ts0207.json
+++ b/tests/data/devices/tyzb01-o63ssaah-ts0207.json
@@ -1178,7 +1178,7 @@
           "installed_version": "0x00000043",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000043",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/tyzb01-qm6djpta-ts0215.json
+++ b/tests/data/devices/tyzb01-qm6djpta-ts0215.json
@@ -1561,7 +1561,7 @@
           "installed_version": "0x00000046",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000046",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/tyzb01-rifa0wlb-ts0011.json
+++ b/tests/data/devices/tyzb01-rifa0wlb-ts0011.json
@@ -699,7 +699,7 @@
           "installed_version": "0x00000041",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000041",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/tz3000-bguser20-ts0201.json
+++ b/tests/data/devices/tz3000-bguser20-ts0201.json
@@ -1355,7 +1355,7 @@
           "installed_version": "0x00000045",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000045",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/tz3000-cehuw1lw-ts011f.json
+++ b/tests/data/devices/tz3000-cehuw1lw-ts011f.json
@@ -2933,7 +2933,7 @@
           "installed_version": "0x0000004d",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x0000004d",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/tz3000-f2bw0b6k-ts0201.json
+++ b/tests/data/devices/tz3000-f2bw0b6k-ts0201.json
@@ -1355,7 +1355,7 @@
           "installed_version": "0x00000046",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000046",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/tz3000-itnrsufe-ts0201.json
+++ b/tests/data/devices/tz3000-itnrsufe-ts0201.json
@@ -1431,7 +1431,7 @@
           "installed_version": "0x00000042",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000042",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/tz3000-uwkja6z1-ts011f.json
+++ b/tests/data/devices/tz3000-uwkja6z1-ts011f.json
@@ -5260,7 +5260,7 @@
           "installed_version": "0x00000045",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000045",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/tz3000-zw7yf6yk-ts0001.json
+++ b/tests/data/devices/tz3000-zw7yf6yk-ts0001.json
@@ -2953,7 +2953,7 @@
           "installed_version": "0x00000048",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000048",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/tz3210-09hzmirw-ts0502b.json
+++ b/tests/data/devices/tz3210-09hzmirw-ts0502b.json
@@ -1486,7 +1486,7 @@
           "installed_version": "0x0000005b",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x0000005b",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/tz3210-j4pdtz9v-ts0001.json
+++ b/tests/data/devices/tz3210-j4pdtz9v-ts0001.json
@@ -1545,7 +1545,7 @@
           "installed_version": "0x00000062",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000062",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/tz3210-jaap6jeb-ts0505b.json
+++ b/tests/data/devices/tz3210-jaap6jeb-ts0505b.json
@@ -1433,7 +1433,7 @@
           "installed_version": "0x00000065",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000065",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/tz3210-tgvtvdoc-ts0207.json
+++ b/tests/data/devices/tz3210-tgvtvdoc-ts0207.json
@@ -1609,7 +1609,7 @@
           "installed_version": "0x00000043",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000043",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/tz6210-duv6fhwt-ts0601.json
+++ b/tests/data/devices/tz6210-duv6fhwt-ts0601.json
@@ -1362,7 +1362,7 @@
           "installed_version": "0x00000042",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000042",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/tze200-9caxna4s-ts0301.json
+++ b/tests/data/devices/tze200-9caxna4s-ts0301.json
@@ -1477,7 +1477,7 @@
           "installed_version": "0x00000049",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000049",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/tze200-locansqn-ts0601.json
+++ b/tests/data/devices/tze200-locansqn-ts0601.json
@@ -2029,7 +2029,7 @@
           "installed_version": "0x00000048",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000048",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/tze200-myd45weu-ts0601.json
+++ b/tests/data/devices/tze200-myd45weu-ts0601.json
@@ -1349,7 +1349,7 @@
           "installed_version": "0x00000048",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000048",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/tze204-81yrt3lo-ts0601.json
+++ b/tests/data/devices/tze204-81yrt3lo-ts0601.json
@@ -7351,7 +7351,7 @@
           "installed_version": "0x0000004a",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x0000004a",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/tze204-ai4rqhky-ts0601.json
+++ b/tests/data/devices/tze204-ai4rqhky-ts0601.json
@@ -667,7 +667,7 @@
           "installed_version": "0x00000049",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000049",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/tze204-iaeejhvf-ts0601.json
+++ b/tests/data/devices/tze204-iaeejhvf-ts0601.json
@@ -2823,7 +2823,7 @@
           "installed_version": "0x0000004a",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x0000004a",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/tze204-nklqjk62-ts0601.json
+++ b/tests/data/devices/tze204-nklqjk62-ts0601.json
@@ -682,7 +682,7 @@
           "installed_version": "0x0000004a",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x0000004a",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/tze204-nlrfgpny-ts0601.json
+++ b/tests/data/devices/tze204-nlrfgpny-ts0601.json
@@ -1767,7 +1767,7 @@
           "installed_version": "0x00000049",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000049",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/tze204-qasjif9e-ts0601.json
+++ b/tests/data/devices/tze204-qasjif9e-ts0601.json
@@ -1319,7 +1319,7 @@
           "installed_version": "0x0000004a",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x0000004a",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/tze204-qtnjuoae-ts0601.json
+++ b/tests/data/devices/tze204-qtnjuoae-ts0601.json
@@ -667,7 +667,7 @@
           "installed_version": "0x00000049",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x00000049",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/tze284-qyflbnbj-ts0601.json
+++ b/tests/data/devices/tze284-qyflbnbj-ts0601.json
@@ -1354,7 +1354,7 @@
           "installed_version": "0x0000004d",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x0000004d",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/xiaoyan-terncy-sd01.json
+++ b/tests/data/devices/xiaoyan-terncy-sd01.json
@@ -1139,7 +1139,7 @@
           "installed_version": "0x0000001a",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x0000001a",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/yale-yrd256-tsdb.json
+++ b/tests/data/devices/yale-yrd256-tsdb.json
@@ -1919,7 +1919,7 @@
           "installed_version": "0x0105002b",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x0105002b",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/data/devices/yooksmart-d10110.json
+++ b/tests/data/devices/yooksmart-d10110.json
@@ -1535,7 +1535,7 @@
           "installed_version": "0x12046780",
           "in_progress": false,
           "update_percentage": null,
-          "latest_version": "0x12046780",
+          "latest_version": null,
           "release_summary": null,
           "release_notes": null,
           "release_url": null

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -606,3 +606,28 @@ async def test_firmware_update_latest_version_even_if_downgrade(
         entity.state[ATTR_LATEST_VERSION]
         == f"0x{fw_image_downgrade.firmware.header.file_version:08x}"
     )
+
+
+@pytest.mark.parametrize(
+    "latest_version",
+    [
+        "0x1234",
+        "0x12345678",
+    ],
+)
+async def test_firmware_update_state_restoration(
+    zha_gateway: Gateway, latest_version: str
+) -> None:
+    """Test the firmware update state restoration function."""
+    zigpy_device = zigpy_device_mock(zha_gateway)
+    zha_device, ota_cluster, fw_image, installed_fw_version = await setup_test_data(
+        zha_gateway, zigpy_device
+    )
+
+    entity = get_entity(zha_device, platform=Platform.UPDATE)
+    assert not entity.state[ATTR_LATEST_VERSION]
+
+    entity.restore_external_state_attributes(
+        latest_version=latest_version,
+    )
+    assert entity.state[ATTR_LATEST_VERSION] == latest_version

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -166,11 +166,8 @@ async def test_firmware_update_notification_from_zigpy(zha_gateway: Gateway) -> 
     )
 
     entity = get_entity(zha_device, platform=Platform.UPDATE)
-    assert (
-        entity.state["latest_version"]
-        == entity.state["installed_version"]
-        == f"0x{installed_fw_version:08x}"
-    )
+    assert entity.state["installed_version"] == f"0x{installed_fw_version:08x}"
+    assert entity.state["latest_version"] is None
 
     # simulate an image available notification
     await ota_cluster._handle_query_next_image(

--- a/zha/application/platforms/update.py
+++ b/zha/application/platforms/update.py
@@ -317,7 +317,6 @@ class FirmwareUpdateEntity(BaseFirmwareUpdateEntity):
             CLUSTER_HANDLER_OTA
         ]
         self._attr_installed_version: str | None = self._get_cluster_version()
-        self._attr_latest_version = self._attr_installed_version
         self._compatible_images: OtaImagesResult = OtaImagesResult(
             upgrades=(), downgrades=()
         )
@@ -342,7 +341,6 @@ class FirmwareUpdateServerEntity(BaseFirmwareUpdateEntity):
             CLUSTER_HANDLER_OTA_SERVER
         ]
         self._attr_installed_version: str | None = self._get_cluster_version()
-        self._attr_latest_version = self._attr_installed_version
         self._compatible_images: OtaImagesResult = OtaImagesResult(
             upgrades=(), downgrades=()
         )

--- a/zha/application/platforms/update.py
+++ b/zha/application/platforms/update.py
@@ -298,6 +298,11 @@ class BaseFirmwareUpdateEntity(PlatformEntity):
         self._attr_in_progress = False
         await super().on_remove()
 
+    def restore_external_state_attributes(self, *, latest_version: str | None) -> None:
+        """Restore extra state attributes that are stored outside of the ZCL cache."""
+        if latest_version is not None:
+            self._attr_latest_version = latest_version
+
 
 @CONFIG_DIAGNOSTIC_MATCH(cluster_handler_names=CLUSTER_HANDLER_OTA)
 class FirmwareUpdateEntity(BaseFirmwareUpdateEntity):


### PR DESCRIPTION
If a version update was previously available but the user skipped it, setting the `latest_version` to be the same as the `installed_version` on startup will clear the `skipped_version` flag (see https://github.com/home-assistant/core/blob/dev/homeassistant/components/update/__init__.py#L459-L459 ).
After a while, when the new version is fetched and `latest_version` is set to the correct version, the skipped update will show up again.

Example:
- `installed_version`: 1.
- `latest_version`: 2, user skips the update.

After restart:
- `installed_version` is 1.
- `latest_version` is 1.
- `skipped_version` is gets cleared.


