### PR TITLE
Revert restoring update entity `latest_version`

### DIFF
--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -606,28 +606,3 @@ async def test_firmware_update_latest_version_even_if_downgrade(
         entity.state[ATTR_LATEST_VERSION]
         == f"0x{fw_image_downgrade.firmware.header.file_version:08x}"
     )
-
-
-@pytest.mark.parametrize(
-    "latest_version",
-    [
-        "0x1234",
-        "0x12345678",
-    ],
-)
-async def test_firmware_update_state_restoration(
-    zha_gateway: Gateway, latest_version: str
-) -> None:
-    """Test the firmware update state restoration function."""
-    zigpy_device = zigpy_device_mock(zha_gateway)
-    zha_device, ota_cluster, fw_image, installed_fw_version = await setup_test_data(
-        zha_gateway, zigpy_device
-    )
-
-    entity = get_entity(zha_device, platform=Platform.UPDATE)
-    assert not entity.state[ATTR_LATEST_VERSION]
-
-    entity.restore_external_state_attributes(
-        latest_version=latest_version,
-    )
-    assert entity.state[ATTR_LATEST_VERSION] == latest_version

--- a/zha/application/platforms/update.py
+++ b/zha/application/platforms/update.py
@@ -298,11 +298,6 @@ class BaseFirmwareUpdateEntity(PlatformEntity):
         self._attr_in_progress = False
         await super().on_remove()
 
-    def restore_external_state_attributes(self, *, latest_version: str | None) -> None:
-        """Restore extra state attributes that are stored outside of the ZCL cache."""
-        if latest_version is not None:
-            self._attr_latest_version = latest_version
-
 
 @CONFIG_DIAGNOSTIC_MATCH(cluster_handler_names=CLUSTER_HANDLER_OTA)
 class FirmwareUpdateEntity(BaseFirmwareUpdateEntity):


### PR DESCRIPTION
Follow up to https://github.com/zigpy/zha/pull/460#issuecomment-2959795803 since restoring only the version is not enough to make the update work after a restart.
