### PR TITLE
Fix CI: deprecated `event_loop` fixture 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     with:
       CODE_FOLDER: zha
       CACHE_VERSION: 2
-      PYTHON_VERSION_DEFAULT: 3.12
+      PYTHON_VERSION_DEFAULT: "3.12.10"
       PRE_COMMIT_CACHE_PATH: ~/.cache/pre-commit
       MINIMUM_COVERAGE_PERCENTAGE: 95
       PYTHON_MATRIX: '"3.12.10", "3.13.3"'

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -9,6 +9,6 @@ jobs:
   shared-build-and-publish:
     uses: zigpy/workflows/.github/workflows/publish-to-pypi.yml@main
     with:
-      PYTHON_VERSION_DEFAULT: 3.12
+      PYTHON_VERSION_DEFAULT: "3.12.10"
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,7 +6,7 @@ pre-commit
 pytest-cov
 pytest-sugar
 pytest-timeout
-pytest-asyncio
+pytest-asyncio<1.0
 pytest-xdist
 pytest
 zigpy>=0.65.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,11 +152,11 @@ def expected_lingering_timers() -> bool:
 
 @pytest.fixture(autouse=True)
 def verify_cleanup(
+    event_loop: asyncio.AbstractEventLoop,
     expected_lingering_tasks: bool,  # pylint: disable=redefined-outer-name
     expected_lingering_timers: bool,  # pylint: disable=redefined-outer-name
 ) -> Generator[None, None, None]:
     """Verify that the test has cleaned up resources correctly."""
-    event_loop = asyncio.get_event_loop()
     threads_before = frozenset(threading.enumerate())
     tasks_before = asyncio.all_tasks(event_loop)
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,11 +152,11 @@ def expected_lingering_timers() -> bool:
 
 @pytest.fixture(autouse=True)
 def verify_cleanup(
-    event_loop: asyncio.AbstractEventLoop,
     expected_lingering_tasks: bool,  # pylint: disable=redefined-outer-name
     expected_lingering_timers: bool,  # pylint: disable=redefined-outer-name
 ) -> Generator[None, None, None]:
     """Verify that the test has cleaned up resources correctly."""
+    event_loop = asyncio.get_running_loop()
     threads_before = frozenset(threading.enumerate())
     tasks_before = asyncio.all_tasks(event_loop)
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -156,7 +156,7 @@ def verify_cleanup(
     expected_lingering_timers: bool,  # pylint: disable=redefined-outer-name
 ) -> Generator[None, None, None]:
     """Verify that the test has cleaned up resources correctly."""
-    event_loop = asyncio.get_running_loop()
+    event_loop = asyncio.get_event_loop()
     threads_before = frozenset(threading.enumerate())
     tasks_before = asyncio.all_tasks(event_loop)
     yield


### PR DESCRIPTION
It looks like CI was triple broken recently:

1. pytest-asyncio has formally removed the `event_loop` fixture
2. GitHub still has huge cache disparities between workers and Python `3.12` currently matches both `3.12.10` and `3.12.11`.
3. The new version of pytest-asyncio is no longer compatible with `looptime`, which we use to magically speed up nested instances of `await asyncio.sleep()`: https://github.com/nolar/looptime/issues/5

I'm keeping back pytest-asyncio for the time being, since we have no pressing need to upgrade.