### PR TITLE
Remove routes on diagnostics import

### DIFF
--- a/tools/import_diagnostics.py
+++ b/tools/import_diagnostics.py
@@ -186,6 +186,7 @@ def zigpy_device_from_diagnostics(
 
     # Neighbors contain EUI64 addresses and EPIDs
     zha_data["neighbors"] = []
+    zha_data["routes"] = []
 
     # Use our normal testing function to load the data
     return zigpy_device_from_device_data(app, zha_data, patch_cluster)


### PR DESCRIPTION
puddly noticed this while troubleshooting the diagnostics import of https://github.com/zigpy/zha/pull/492. I'm merely committing the fix here.

This is to avoid creating a diff between diagnostics after (virtually) re-joining the device, blocking the import.
Relevant section:
https://github.com/zigpy/zha/blob/7d9ae1b1c1fbeea4818c9cfda962fb81b2f2b66e/tools/import_diagnostics.py#L256-L262