### PR TITLE
Drop `direction` attribute from button test command

### DIFF
--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -187,7 +187,7 @@ class FakeManufacturerCluster(CustomCluster, ManufacturerSpecificCluster):
         """Server command definitions."""
 
         self_test: Final = zcl_f.ZCLCommandDef(
-            id=0x00, schema={"identify_time": t.uint16_t}, direction=False
+            id=0x00, schema={"identify_time": t.uint16_t}
         )
 
 


### PR DESCRIPTION
This fixes noisy button tests by dropping the (incorrect) `direction` attribute from the command definition used in that test.