### PR TITLE
Clean up electrical measurement sensors

### DIFF
--- a/tests/data/devices/frient-a-s-emizb-151.json
+++ b/tests/data/devices/frient-a-s-emizb-151.json
@@ -1506,7 +1506,7 @@
           "unique_id": "ab:cd:ef:12:74:0f:89:c3-2-2820-active_power_ph_b",
           "migrate_unique_ids": [],
           "platform": "sensor",
-          "class_name": "ElectricalMeasurementRMSActivePowerPhB",
+          "class_name": "ElectricalMeasurementActivePowerPhB",
           "translation_key": "active_power_ph_b",
           "device_class": "power",
           "state_class": "measurement",
@@ -1547,7 +1547,7 @@
           "unit": "W"
         },
         "state": {
-          "class_name": "ElectricalMeasurementRMSActivePowerPhB",
+          "class_name": "ElectricalMeasurementActivePowerPhB",
           "available": true,
           "state": 1274.0,
           "measurement_type": "ACTIVE_MEASUREMENT, PHASE_A_MEASUREMENT, PHASE_B_MEASUREMENT, PHASE_C_MEASUREMENT"
@@ -1559,7 +1559,7 @@
           "unique_id": "ab:cd:ef:12:74:0f:89:c3-2-2820-active_power_ph_c",
           "migrate_unique_ids": [],
           "platform": "sensor",
-          "class_name": "ElectricalMeasurementRMSActivePowerPhC",
+          "class_name": "ElectricalMeasurementActivePowerPhC",
           "translation_key": "active_power_ph_c",
           "device_class": "power",
           "state_class": "measurement",
@@ -1600,7 +1600,7 @@
           "unit": "W"
         },
         "state": {
-          "class_name": "ElectricalMeasurementRMSActivePowerPhC",
+          "class_name": "ElectricalMeasurementActivePowerPhC",
           "available": true,
           "state": 29.0,
           "measurement_type": "ACTIVE_MEASUREMENT, PHASE_A_MEASUREMENT, PHASE_B_MEASUREMENT, PHASE_C_MEASUREMENT"

--- a/tests/data/devices/ikea-of-sweden-inspelning-smart-plug.json
+++ b/tests/data/devices/ikea-of-sweden-inspelning-smart-plug.json
@@ -746,7 +746,7 @@
           "unique_id": "d4:48:67:ff:fe:13:d6:f8-1-2820",
           "migrate_unique_ids": [],
           "platform": "sensor",
-          "class_name": "ElectricalMeasurement",
+          "class_name": "ReportingElectricalMeasurement",
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
@@ -787,7 +787,7 @@
           "unit": "W"
         },
         "state": {
-          "class_name": "ElectricalMeasurement",
+          "class_name": "ReportingElectricalMeasurement",
           "available": true,
           "state": 0.0,
           "measurement_type": "ACTIVE_MEASUREMENT, PHASE_A_MEASUREMENT"

--- a/tests/data/devices/innr-sp-234.json
+++ b/tests/data/devices/innr-sp-234.json
@@ -710,7 +710,7 @@
           "unique_id": "70:ac:08:ff:fe:ef:c4:b7-1-2820",
           "migrate_unique_ids": [],
           "platform": "sensor",
-          "class_name": "ElectricalMeasurement",
+          "class_name": "ReportingElectricalMeasurement",
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
@@ -751,7 +751,7 @@
           "unit": "W"
         },
         "state": {
-          "class_name": "ElectricalMeasurement",
+          "class_name": "ReportingElectricalMeasurement",
           "available": true,
           "state": 0.0,
           "measurement_type": "ACTIVE_MEASUREMENT"

--- a/tests/data/devices/inovelli-vzm31-sn.json
+++ b/tests/data/devices/inovelli-vzm31-sn.json
@@ -2631,7 +2631,7 @@
           "unique_id": "ab:cd:ef:12:dc:41:3c:40-1-2820",
           "migrate_unique_ids": [],
           "platform": "sensor",
-          "class_name": "ElectricalMeasurement",
+          "class_name": "ReportingElectricalMeasurement",
           "translation_key": null,
           "device_class": "power",
           "state_class": "measurement",
@@ -2672,7 +2672,7 @@
           "unit": "W"
         },
         "state": {
-          "class_name": "ElectricalMeasurement",
+          "class_name": "ReportingElectricalMeasurement",
           "available": true,
           "state": 0.0
         }

--- a/tests/data/devices/tze200-ny94onlb-ts0601.json
+++ b/tests/data/devices/tze200-ny94onlb-ts0601.json
@@ -1015,7 +1015,7 @@
           "unique_id": "ab:cd:ef:12:58:8c:89:ff-1-2820-active_power_ph_b",
           "migrate_unique_ids": [],
           "platform": "sensor",
-          "class_name": "ElectricalMeasurementRMSActivePowerPhB",
+          "class_name": "ElectricalMeasurementActivePowerPhB",
           "translation_key": "active_power_ph_b",
           "device_class": "power",
           "state_class": "measurement",
@@ -1056,7 +1056,7 @@
           "unit": "W"
         },
         "state": {
-          "class_name": "ElectricalMeasurementRMSActivePowerPhB",
+          "class_name": "ElectricalMeasurementActivePowerPhB",
           "available": true,
           "state": 266.0
         }
@@ -1067,7 +1067,7 @@
           "unique_id": "ab:cd:ef:12:58:8c:89:ff-1-2820-active_power_ph_c",
           "migrate_unique_ids": [],
           "platform": "sensor",
-          "class_name": "ElectricalMeasurementRMSActivePowerPhC",
+          "class_name": "ElectricalMeasurementActivePowerPhC",
           "translation_key": "active_power_ph_c",
           "device_class": "power",
           "state_class": "measurement",
@@ -1108,7 +1108,7 @@
           "unit": "W"
         },
         "state": {
-          "class_name": "ElectricalMeasurementRMSActivePowerPhC",
+          "class_name": "ElectricalMeasurementActivePowerPhC",
           "available": true,
           "state": 70.0
         }

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -665,15 +665,12 @@ class Battery(Sensor):
 class BaseElectricalMeasurement(PollableSensor):
     """Base class for electrical measurement."""
 
+    _attr_max_attribute_name: str | None = None
     _use_custom_polling: bool = False
-    _attribute_name = "active_power"
     _attr_suggested_display_precision = 1
-    _attr_device_class: SensorDeviceClass = SensorDeviceClass.POWER
+    _divisor_attribute_name: str | None = None
+    _multiplier_attribute_name: str | None = None
     _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
-    _attr_native_unit_of_measurement: str = UnitOfPower.WATT
-    _divisor_attribute_name: str | None = "ac_power_divisor"
-    _multiplier_attribute_name: str | None = "ac_power_multiplier"
-    _attr_max_attribute_name: str = None
 
     def __init__(
         self,
@@ -686,13 +683,8 @@ class BaseElectricalMeasurement(PollableSensor):
         super().__init__(cluster_handlers, endpoint, device, **kwargs)
         self._attr_extra_state_attribute_names: set[str] = {
             "measurement_type",
-            self._max_attribute_name,
+            self._attr_max_attribute_name,  # None values are ignored in HA
         }
-
-    @property
-    def _max_attribute_name(self) -> str:
-        """Return the max attribute name."""
-        return self._attr_max_attribute_name or f"{self._attribute_name}_max"
 
     @property
     def state(self) -> dict[str, Any]:
@@ -701,8 +693,7 @@ class BaseElectricalMeasurement(PollableSensor):
         if self._cluster_handler.measurement_type is not None:
             response["measurement_type"] = self._cluster_handler.measurement_type
 
-        max_attr_name = self._max_attribute_name
-        if not hasattr(self._cluster_handler.cluster.AttributeDefs, max_attr_name):
+        if (max_attr_name := self._attr_max_attribute_name) is None:
             return response
 
         if (max_v := self._cluster_handler.cluster.get(max_attr_name)) is not None:
@@ -733,13 +724,27 @@ class BaseElectricalMeasurement(PollableSensor):
         raise AttributeError("Cannot set divisor directly")
 
 
+# this entity will be created by ReportingEM or PolledEM class below
+class ElectricalMeasurementActivePower(BaseElectricalMeasurement):
+    """Active power phase measurement."""
+
+    _attribute_name = "active_power"
+    # no unique id suffix for backwards compatibility
+    # no translation key due to device class
+    _attr_max_attribute_name = "active_power_max"
+    _divisor_attribute_name = "ac_power_divisor"
+    _multiplier_attribute_name = "ac_power_multiplier"
+    _attr_device_class: SensorDeviceClass = SensorDeviceClass.POWER
+    _attr_native_unit_of_measurement: str = UnitOfPower.WATT
+
+
 @MULTI_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_ELECTRICAL_MEASUREMENT,
     stop_on_match_group=CLUSTER_HANDLER_ELECTRICAL_MEASUREMENT,
     models={"VZM31-SN", "SP 234", "outletv4", "INSPELNING Smart plug"},
 )
-class ElectricalMeasurement(BaseElectricalMeasurement):
-    """Active power measurement."""
+class ReportingElectricalMeasurement(ElectricalMeasurementActivePower):
+    """Unpolled active power measurement."""
 
     pass
 
@@ -748,71 +753,67 @@ class ElectricalMeasurement(BaseElectricalMeasurement):
     cluster_handler_names=CLUSTER_HANDLER_ELECTRICAL_MEASUREMENT,
     stop_on_match_group=CLUSTER_HANDLER_ELECTRICAL_MEASUREMENT,
 )
-class PolledElectricalMeasurement(BaseElectricalMeasurement):
-    """Polled active power measurement."""
+class PolledElectricalMeasurement(ElectricalMeasurementActivePower):
+    """Polled active power measurement that polls all relevant EM attributes."""
 
     _use_custom_polling: bool = True
 
 
 @MULTI_MATCH(cluster_handler_names=CLUSTER_HANDLER_ELECTRICAL_MEASUREMENT)
-class ElectricalMeasurementRMSActivePowerPhB(PolledElectricalMeasurement):
-    """RMS active power phase B measurement."""
+class ElectricalMeasurementActivePowerPhB(ElectricalMeasurementActivePower):
+    """Active power phase B measurement."""
 
     _attribute_name = "active_power_ph_b"
     _unique_id_suffix = "active_power_ph_b"
     _attr_translation_key: str = "active_power_ph_b"
-    _use_custom_polling = False  # Poll indirectly by ElectricalMeasurementSensor
-    _skip_creation_if_no_attr_cache = True
     _attr_max_attribute_name = "active_power_max_ph_b"
+    _skip_creation_if_no_attr_cache = True
 
 
 @MULTI_MATCH(cluster_handler_names=CLUSTER_HANDLER_ELECTRICAL_MEASUREMENT)
-class ElectricalMeasurementRMSActivePowerPhC(PolledElectricalMeasurement):
-    """RMS active power phase C measurement."""
+class ElectricalMeasurementActivePowerPhC(ElectricalMeasurementActivePower):
+    """Active power phase C measurement."""
 
     _attribute_name = "active_power_ph_c"
     _unique_id_suffix = "active_power_ph_c"
     _attr_translation_key: str = "active_power_ph_c"
-    _use_custom_polling = False  # Poll indirectly by ElectricalMeasurementSensor
-    _skip_creation_if_no_attr_cache = True
     _attr_max_attribute_name = "active_power_max_ph_c"
+    _skip_creation_if_no_attr_cache = True
 
 
 @MULTI_MATCH(cluster_handler_names=CLUSTER_HANDLER_ELECTRICAL_MEASUREMENT)
-class ElectricalMeasurementTotalActivePower(PolledElectricalMeasurement):
+class ElectricalMeasurementTotalActivePower(ElectricalMeasurementActivePower):
     """Total active power measurement."""
 
     _attribute_name = "total_active_power"
     _unique_id_suffix = "total_active_power"
     _attr_translation_key: str = "total_active_power"
-    _use_custom_polling = False  # Poll indirectly by ElectricalMeasurementSensor
     _skip_creation_if_no_attr_cache = True
 
 
 @MULTI_MATCH(cluster_handler_names=CLUSTER_HANDLER_ELECTRICAL_MEASUREMENT)
-class ElectricalMeasurementApparentPower(PolledElectricalMeasurement):
+class ElectricalMeasurementApparentPower(BaseElectricalMeasurement):
     """Apparent power measurement."""
 
     _attribute_name = "apparent_power"
     _unique_id_suffix = "apparent_power"
-    _use_custom_polling = False  # Poll indirectly by ElectricalMeasurementSensor
-    _attr_device_class: SensorDeviceClass = SensorDeviceClass.APPARENT_POWER
-    _attr_native_unit_of_measurement = UnitOfApparentPower.VOLT_AMPERE
     _divisor_attribute_name = "ac_power_divisor"
     _multiplier_attribute_name = "ac_power_multiplier"
+    _attr_device_class: SensorDeviceClass = SensorDeviceClass.APPARENT_POWER
+    _attr_native_unit_of_measurement = UnitOfApparentPower.VOLT_AMPERE
 
 
 @MULTI_MATCH(cluster_handler_names=CLUSTER_HANDLER_ELECTRICAL_MEASUREMENT)
-class ElectricalMeasurementRMSCurrent(PolledElectricalMeasurement):
+class ElectricalMeasurementRMSCurrent(BaseElectricalMeasurement):
     """RMS current measurement."""
 
     _attribute_name = "rms_current"
     _unique_id_suffix = "rms_current"
-    _use_custom_polling = False  # Poll indirectly by ElectricalMeasurementSensor
-    _attr_device_class: SensorDeviceClass = SensorDeviceClass.CURRENT
-    _attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+    _attr_max_attribute_name = "rms_current_max"
     _divisor_attribute_name = "ac_current_divisor"
     _multiplier_attribute_name = "ac_current_multiplier"
+    _attr_device_class: SensorDeviceClass = SensorDeviceClass.CURRENT
+    _attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
 
 
 @MULTI_MATCH(cluster_handler_names=CLUSTER_HANDLER_ELECTRICAL_MEASUREMENT)
@@ -822,8 +823,8 @@ class ElectricalMeasurementRMSCurrentPhB(ElectricalMeasurementRMSCurrent):
     _attribute_name = "rms_current_ph_b"
     _unique_id_suffix = "rms_current_ph_b"
     _attr_translation_key: str = "rms_current_ph_b"
-    _skip_creation_if_no_attr_cache = True
     _attr_max_attribute_name: str = "rms_current_max_ph_b"
+    _skip_creation_if_no_attr_cache = True
 
 
 @MULTI_MATCH(cluster_handler_names=CLUSTER_HANDLER_ELECTRICAL_MEASUREMENT)
@@ -833,21 +834,21 @@ class ElectricalMeasurementRMSCurrentPhC(ElectricalMeasurementRMSCurrent):
     _attribute_name: str = "rms_current_ph_c"
     _unique_id_suffix: str = "rms_current_ph_c"
     _attr_translation_key: str = "rms_current_ph_c"
-    _skip_creation_if_no_attr_cache = True
     _attr_max_attribute_name: str = "rms_current_max_ph_c"
+    _skip_creation_if_no_attr_cache = True
 
 
 @MULTI_MATCH(cluster_handler_names=CLUSTER_HANDLER_ELECTRICAL_MEASUREMENT)
-class ElectricalMeasurementRMSVoltage(PolledElectricalMeasurement):
+class ElectricalMeasurementRMSVoltage(BaseElectricalMeasurement):
     """RMS Voltage measurement."""
 
     _attribute_name = "rms_voltage"
     _unique_id_suffix = "rms_voltage"
-    _use_custom_polling = False  # Poll indirectly by ElectricalMeasurementSensor
-    _attr_device_class: SensorDeviceClass = SensorDeviceClass.VOLTAGE
-    _attr_native_unit_of_measurement = UnitOfElectricPotential.VOLT
+    _attr_max_attribute_name = "rms_voltage_max"
     _divisor_attribute_name = "ac_voltage_divisor"
     _multiplier_attribute_name = "ac_voltage_multiplier"
+    _attr_device_class: SensorDeviceClass = SensorDeviceClass.VOLTAGE
+    _attr_native_unit_of_measurement = UnitOfElectricPotential.VOLT
 
 
 @MULTI_MATCH(cluster_handler_names=CLUSTER_HANDLER_ELECTRICAL_MEASUREMENT)
@@ -857,8 +858,8 @@ class ElectricalMeasurementRMSVoltagePhB(ElectricalMeasurementRMSVoltage):
     _attribute_name = "rms_voltage_ph_b"
     _unique_id_suffix = "rms_voltage_ph_b"
     _attr_translation_key: str = "rms_voltage_ph_b"
-    _skip_creation_if_no_attr_cache = True
     _attr_max_attribute_name = "rms_voltage_max_ph_b"
+    _skip_creation_if_no_attr_cache = True
 
 
 @MULTI_MATCH(cluster_handler_names=CLUSTER_HANDLER_ELECTRICAL_MEASUREMENT)
@@ -868,35 +869,32 @@ class ElectricalMeasurementRMSVoltagePhC(ElectricalMeasurementRMSVoltage):
     _attribute_name = "rms_voltage_ph_c"
     _unique_id_suffix = "rms_voltage_ph_c"
     _attr_translation_key: str = "rms_voltage_ph_c"
-    _skip_creation_if_no_attr_cache = True
     _attr_max_attribute_name = "rms_voltage_max_ph_c"
+    _skip_creation_if_no_attr_cache = True
 
 
 @MULTI_MATCH(cluster_handler_names=CLUSTER_HANDLER_ELECTRICAL_MEASUREMENT)
-class ElectricalMeasurementFrequency(PolledElectricalMeasurement):
+class ElectricalMeasurementFrequency(BaseElectricalMeasurement):
     """Frequency measurement."""
 
     _attribute_name = "ac_frequency"
     _unique_id_suffix = "ac_frequency"
-    _use_custom_polling = False  # Poll indirectly by ElectricalMeasurementSensor
-    _attr_device_class: SensorDeviceClass = SensorDeviceClass.FREQUENCY
     _attr_translation_key: str = "ac_frequency"
-    _attr_native_unit_of_measurement = UnitOfFrequency.HERTZ
+    _attr_max_attribute_name = "ac_frequency_max"
     _divisor_attribute_name = "ac_frequency_divisor"
     _multiplier_attribute_name = "ac_frequency_multiplier"
+    _attr_device_class: SensorDeviceClass = SensorDeviceClass.FREQUENCY
+    _attr_native_unit_of_measurement = UnitOfFrequency.HERTZ
 
 
 @MULTI_MATCH(cluster_handler_names=CLUSTER_HANDLER_ELECTRICAL_MEASUREMENT)
-class ElectricalMeasurementPowerFactor(PolledElectricalMeasurement):
+class ElectricalMeasurementPowerFactor(BaseElectricalMeasurement):
     """Power Factor measurement."""
 
     _attribute_name = "power_factor"
     _unique_id_suffix = "power_factor"
-    _use_custom_polling = False  # Poll indirectly by ElectricalMeasurementSensor
     _attr_device_class: SensorDeviceClass = SensorDeviceClass.POWER_FACTOR
     _attr_native_unit_of_measurement = PERCENTAGE
-    _divisor_attribute_name = None
-    _multiplier_attribute_name = None
 
 
 @MULTI_MATCH(cluster_handler_names=CLUSTER_HANDLER_ELECTRICAL_MEASUREMENT)
@@ -907,7 +905,6 @@ class ElectricalMeasurementPowerFactorPhB(ElectricalMeasurementPowerFactor):
     _unique_id_suffix = "power_factor_ph_b"
     _attr_translation_key: str = "power_factor_ph_b"
     _skip_creation_if_no_attr_cache = True
-    _attr_max_attribute_name = "power_factor_max_ph_b"
 
 
 @MULTI_MATCH(cluster_handler_names=CLUSTER_HANDLER_ELECTRICAL_MEASUREMENT)
@@ -918,7 +915,6 @@ class ElectricalMeasurementPowerFactorPhC(ElectricalMeasurementPowerFactor):
     _unique_id_suffix = "power_factor_ph_c"
     _attr_translation_key: str = "power_factor_ph_c"
     _skip_creation_if_no_attr_cache = True
-    _attr_max_attribute_name = "power_factor_max_ph_c"
 
 
 @MULTI_MATCH(

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -665,9 +665,9 @@ class Battery(Sensor):
 class BaseElectricalMeasurement(PollableSensor):
     """Base class for electrical measurement."""
 
-    _attr_max_attribute_name: str | None = None
     _use_custom_polling: bool = False
     _attr_suggested_display_precision = 1
+    _attr_max_attribute_name: str | None = None
     _divisor_attribute_name: str | None = None
     _multiplier_attribute_name: str | None = None
     _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT


### PR DESCRIPTION
### Summary of the PR

This PR cleans up the electrical measurement sensors and removes an unexpected extra state attribute for the recently added "total active power" sensor.

Fixes https://github.com/zigpy/zha/issues/501


### Background

https://github.com/zigpy/zha/pull/458 added the "total active power" entity, but due to some magic we did in the base EM class, it also included an extra state attribute that HA doesn't expect (and which we should not have added).

This causes the following error in HA:
```python
Unexpected extra state attributes found for sensor <zha.application.platforms.sensor.ElectricalMeasurementTotalActivePower object at 0x7f791aece120>: {'total_active_power_max'}
```

Now, removing the extra state attribute just for this one sensor was slightly hacky, so since we may wanna land this during the beta period, I kept everything backwards compatible, so keeping the `_max` state attributes for all existing entities, yet still cleaned up everything *a lot* to prevent a bunch of inadvertent side effects when creating a new entity.

See this comment for some explanation on the changes in this PR: https://github.com/zigpy/zha/pull/498#discussion_r2246882172


### Future

In the future, we can remove all of the `_max` extra state attributes, since they're pretty much useless anyway, as no device supports them, yet we currently all poll them across phases A, B, C for current, power, and voltage, as well as one for frequency.

We may also want to apply a similar refactoring to the `SmartEnergy` sensors.


### Testing

Tests pass, which is good. The regenerated diagnostics are just due to a class name change.
Other than removing the (unpolled) extra state attribute for the "total active power" entity, that was mistakenly added in HA 2025.8.0b1, there should not be any behavioral changes.

So, this is just a bugfix, although it required a bit of refactoring first.