### PR TITLE
Add extra state attributes to diagnostics JSON

### DIFF
--- a/tests/data/devices/adurosmart-eria-ad-rgbw3001.json
+++ b/tests/data/devices/adurosmart-eria-ad-rgbw3001.json
@@ -429,7 +429,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/adurosmart-eria-vms-adurolight.json
+++ b/tests/data/devices/adurosmart-eria-vms-adurolight.json
@@ -405,7 +405,12 @@
           "available": true,
           "state": 90.0,
           "battery_voltage": 2.9
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ]
   },

--- a/tests/data/devices/aug-winkhaus-gmbh-co-kg-fm-v-zb.json
+++ b/tests/data/devices/aug-winkhaus-gmbh-co-kg-fm-v-zb.json
@@ -392,7 +392,12 @@
           "class_name": "Battery",
           "available": true,
           "state": null
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/bosch-rbsh-mms-zb-eu.json
+++ b/tests/data/devices/bosch-rbsh-mms-zb-eu.json
@@ -763,7 +763,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       },
       {
         "info_object": {
@@ -833,7 +837,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "select": [
@@ -1110,7 +1118,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -1165,7 +1178,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -1270,7 +1288,11 @@
           "available": true,
           "state": 0.0,
           "measurement_type": "ACTIVE_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       }
     ],
     "switch": [

--- a/tests/data/devices/centralite-3320-l.json
+++ b/tests/data/devices/centralite-3320-l.json
@@ -528,7 +528,12 @@
           "battery_size": "Other",
           "battery_quantity": 1,
           "battery_voltage": 2.8
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/centralite-3326-l.json
+++ b/tests/data/devices/centralite-3326-l.json
@@ -515,7 +515,12 @@
           "battery_size": "Other",
           "battery_quantity": 1,
           "battery_voltage": 2.6
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/centralite-3405-l.json
+++ b/tests/data/devices/centralite-3405-l.json
@@ -555,7 +555,12 @@
           "battery_size": "Other",
           "battery_quantity": 2,
           "battery_voltage": 3.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/centralite-systems-3156105.json
+++ b/tests/data/devices/centralite-systems-3156105.json
@@ -503,7 +503,17 @@
           "pi_cooling_demand": null,
           "unoccupied_cooling_setpoint": 2600,
           "unoccupied_heating_setpoint": 2000
-        }
+        },
+        "extra_state_attributes": [
+          "occupancy",
+          "occupied_cooling_setpoint",
+          "occupied_heating_setpoint",
+          "pi_cooling_demand",
+          "pi_heating_demand",
+          "system_mode",
+          "unoccupied_cooling_setpoint",
+          "unoccupied_heating_setpoint"
+        ]
       }
     ],
     "number": [
@@ -889,7 +899,12 @@
           "available": true,
           "state": null,
           "battery_voltage": 2.9
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/ecolink-4655bc0-r.json
+++ b/tests/data/devices/ecolink-4655bc0-r.json
@@ -494,7 +494,12 @@
           "battery_size": "Unknown",
           "battery_quantity": 1,
           "battery_voltage": 2.8
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/enktro-acmidea.json
+++ b/tests/data/devices/enktro-acmidea.json
@@ -380,7 +380,17 @@
           "pi_cooling_demand": null,
           "unoccupied_cooling_setpoint": null,
           "unoccupied_heating_setpoint": null
-        }
+        },
+        "extra_state_attributes": [
+          "occupancy",
+          "occupied_cooling_setpoint",
+          "occupied_heating_setpoint",
+          "pi_cooling_demand",
+          "pi_heating_demand",
+          "system_mode",
+          "unoccupied_cooling_setpoint",
+          "unoccupied_heating_setpoint"
+        ]
       }
     ],
     "sensor": [

--- a/tests/data/devices/ericsity-gl-c-008p.json
+++ b/tests/data/devices/ericsity-gl-c-008p.json
@@ -408,7 +408,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/ericsity-gl-c-009p.json
+++ b/tests/data/devices/ericsity-gl-c-009p.json
@@ -438,7 +438,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/ewelink-ck-bl702-al-01-7009-z102lg03-1.json
+++ b/tests/data/devices/ewelink-ck-bl702-al-01-7009-z102lg03-1.json
@@ -423,7 +423,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/ewelink-snzb-01p.json
+++ b/tests/data/devices/ewelink-snzb-01p.json
@@ -352,7 +352,12 @@
           "available": true,
           "state": 100.0,
           "battery_voltage": 2.9
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/ewelink-snzb-02p.json
+++ b/tests/data/devices/ewelink-snzb-02p.json
@@ -369,7 +369,12 @@
           "class_name": "Battery",
           "available": true,
           "state": 100.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/ewelink-wb01.json
+++ b/tests/data/devices/ewelink-wb01.json
@@ -323,7 +323,12 @@
           "available": true,
           "state": 100.0,
           "battery_voltage": 3.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ]
   },

--- a/tests/data/devices/ewelink-zb-sw02.json
+++ b/tests/data/devices/ewelink-zb-sw02.json
@@ -282,7 +282,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       },
       {
         "info_object": {
@@ -352,7 +356,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "sensor": [

--- a/tests/data/devices/feibit-inc-co-fzb56-zcw27lx1-0.json
+++ b/tests/data/devices/feibit-inc-co-fzb56-zcw27lx1-0.json
@@ -417,7 +417,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "sensor": [

--- a/tests/data/devices/frient-a-s-aqszb-110.json
+++ b/tests/data/devices/frient-a-s-aqszb-110.json
@@ -426,7 +426,12 @@
           "battery_size": "AA",
           "battery_quantity": 2,
           "battery_voltage": 2.9
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/frient-a-s-emizb-141.json
+++ b/tests/data/devices/frient-a-s-emizb-141.json
@@ -486,7 +486,12 @@
           "battery_size": "AA",
           "battery_quantity": 2,
           "battery_voltage": 3.1
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {
@@ -541,7 +546,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -596,7 +606,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/frient-a-s-emizb-151.json
+++ b/tests/data/devices/frient-a-s-emizb-151.json
@@ -1280,7 +1280,12 @@
           "class_name": "Battery",
           "available": true,
           "state": null
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {
@@ -1335,7 +1340,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -1390,7 +1400,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -1445,7 +1460,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -1498,7 +1518,11 @@
           "available": true,
           "state": 517.0,
           "measurement_type": "ACTIVE_MEASUREMENT, PHASE_A_MEASUREMENT, PHASE_B_MEASUREMENT, PHASE_C_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -1551,7 +1575,11 @@
           "available": true,
           "state": 1274.0,
           "measurement_type": "ACTIVE_MEASUREMENT, PHASE_A_MEASUREMENT, PHASE_B_MEASUREMENT, PHASE_C_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max_ph_b",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -1604,7 +1632,11 @@
           "available": true,
           "state": 29.0,
           "measurement_type": "ACTIVE_MEASUREMENT, PHASE_A_MEASUREMENT, PHASE_B_MEASUREMENT, PHASE_C_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max_ph_c",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -1657,7 +1689,11 @@
           "available": true,
           "state": 5.0,
           "measurement_type": "ACTIVE_MEASUREMENT, PHASE_A_MEASUREMENT, PHASE_B_MEASUREMENT, PHASE_C_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -1710,7 +1746,11 @@
           "available": true,
           "state": 5.0,
           "measurement_type": "ACTIVE_MEASUREMENT, PHASE_A_MEASUREMENT, PHASE_B_MEASUREMENT, PHASE_C_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max_ph_b"
+        ]
       },
       {
         "info_object": {
@@ -1763,7 +1803,11 @@
           "available": true,
           "state": 0.0,
           "measurement_type": "ACTIVE_MEASUREMENT, PHASE_A_MEASUREMENT, PHASE_B_MEASUREMENT, PHASE_C_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max_ph_c"
+        ]
       },
       {
         "info_object": {
@@ -1816,7 +1860,11 @@
           "available": true,
           "state": 228.0,
           "measurement_type": "ACTIVE_MEASUREMENT, PHASE_A_MEASUREMENT, PHASE_B_MEASUREMENT, PHASE_C_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -1869,7 +1917,11 @@
           "available": true,
           "state": 228.0,
           "measurement_type": "ACTIVE_MEASUREMENT, PHASE_A_MEASUREMENT, PHASE_B_MEASUREMENT, PHASE_C_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max_ph_b"
+        ]
       },
       {
         "info_object": {
@@ -1922,7 +1974,11 @@
           "available": true,
           "state": 227.0,
           "measurement_type": "ACTIVE_MEASUREMENT, PHASE_A_MEASUREMENT, PHASE_B_MEASUREMENT, PHASE_C_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max_ph_c"
+        ]
       },
       {
         "info_object": {
@@ -1975,7 +2031,11 @@
           "available": true,
           "state": 1821.0,
           "measurement_type": "ACTIVE_MEASUREMENT, PHASE_A_MEASUREMENT, PHASE_B_MEASUREMENT, PHASE_C_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/frient-a-s-flszb-110.json
+++ b/tests/data/devices/frient-a-s-flszb-110.json
@@ -731,7 +731,12 @@
           "available": true,
           "state": null,
           "battery_voltage": 3.2
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/frient-a-s-hmszb-120.json
+++ b/tests/data/devices/frient-a-s-hmszb-120.json
@@ -416,7 +416,12 @@
           "battery_size": "AA",
           "battery_quantity": 2,
           "battery_voltage": 3.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/frient-a-s-kepzb-110.json
+++ b/tests/data/devices/frient-a-s-kepzb-110.json
@@ -523,7 +523,12 @@
           "battery_size": "AA",
           "battery_quantity": 4,
           "battery_voltage": 5.3
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/frient-a-s-moszb-153.json
+++ b/tests/data/devices/frient-a-s-moszb-153.json
@@ -683,7 +683,12 @@
           "battery_size": "AA",
           "battery_quantity": 2,
           "battery_voltage": 2.9
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/frient-a-s-sbtzb-110.json
+++ b/tests/data/devices/frient-a-s-sbtzb-110.json
@@ -469,7 +469,12 @@
           "battery_size": "Other",
           "battery_quantity": 1,
           "battery_voltage": 2.8
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/frient-a-s-smszb-120.json
+++ b/tests/data/devices/frient-a-s-smszb-120.json
@@ -750,7 +750,12 @@
           "battery_size": "CR123A",
           "battery_quantity": 1,
           "battery_voltage": 2.9
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/frient-a-s-splzb-141.json
+++ b/tests/data/devices/frient-a-s-splzb-141.json
@@ -715,7 +715,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -770,7 +775,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -875,7 +885,11 @@
           "available": true,
           "state": 2.0,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -928,7 +942,11 @@
           "available": true,
           "state": 59.986,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -982,7 +1000,11 @@
           "state": 0.037,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, PHASE_A_MEASUREMENT",
           "rms_current_max": 0.27
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -1036,7 +1058,11 @@
           "state": 123.08,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, PHASE_A_MEASUREMENT",
           "rms_voltage_max": 125.01
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       }
     ],
     "switch": [

--- a/tests/data/devices/frient-a-s-wiszb-131.json
+++ b/tests/data/devices/frient-a-s-wiszb-131.json
@@ -520,7 +520,12 @@
           "battery_size": "AAA",
           "battery_quantity": 2,
           "battery_voltage": 2.9
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/gledopto-gl-b-008p.json
+++ b/tests/data/devices/gledopto-gl-b-008p.json
@@ -453,7 +453,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/homr-hrmsn01.json
+++ b/tests/data/devices/homr-hrmsn01.json
@@ -559,7 +559,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/ikea-of-sweden-fyrtur-block-out-roller-blind.json
+++ b/tests/data/devices/ikea-of-sweden-fyrtur-block-out-roller-blind.json
@@ -531,7 +531,12 @@
           "available": true,
           "state": 77.0,
           "battery_voltage": 7.6
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/ikea-of-sweden-inspelning-smart-plug.json
+++ b/tests/data/devices/ikea-of-sweden-inspelning-smart-plug.json
@@ -738,7 +738,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -791,7 +796,11 @@
           "available": true,
           "state": 0.0,
           "measurement_type": "ACTIVE_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -844,7 +853,11 @@
           "available": true,
           "state": 0.007,
           "measurement_type": "ACTIVE_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -897,7 +910,11 @@
           "available": true,
           "state": 0.0,
           "measurement_type": "ACTIVE_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       }
     ],
     "switch": [

--- a/tests/data/devices/ikea-of-sweden-parasoll-door-window-sensor.json
+++ b/tests/data/devices/ikea-of-sweden-parasoll-door-window-sensor.json
@@ -487,7 +487,12 @@
           "battery_size": "AAA",
           "battery_quantity": 1,
           "battery_voltage": 1.6
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/ikea-of-sweden-praktlysing-cellular-blind.json
+++ b/tests/data/devices/ikea-of-sweden-praktlysing-cellular-blind.json
@@ -538,7 +538,12 @@
           "available": true,
           "state": 95.0,
           "battery_voltage": 8.1
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/ikea-of-sweden-rodret-dimmer.json
+++ b/tests/data/devices/ikea-of-sweden-rodret-dimmer.json
@@ -409,7 +409,12 @@
           "battery_size": "AAA",
           "battery_quantity": 1,
           "battery_voltage": 1.2
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-w-op-ch-400lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-w-op-ch-400lm.json
@@ -354,7 +354,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-ws-opal-400lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-ws-opal-400lm.json
@@ -463,7 +463,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-opal-1000lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-opal-1000lm.json
@@ -344,7 +344,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-w-opal-1000lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-w-opal-1000lm.json
@@ -348,7 +348,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-ws-opal-980lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-ws-opal-980lm.json
@@ -444,7 +444,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-gu10-ws-400lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-gu10-ws-400lm.json
@@ -468,7 +468,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/ikea-of-sweden-tradfri-motion-sensor.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-motion-sensor.json
@@ -461,7 +461,12 @@
           "battery_size": "CR2032",
           "battery_quantity": 2,
           "battery_voltage": 2.9
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/ikea-of-sweden-tradfri-on-off-switch.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-on-off-switch.json
@@ -407,7 +407,12 @@
           "battery_size": "CR2032",
           "battery_quantity": 1,
           "battery_voltage": 0.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/ikea-of-sweden-tradfri-open-close-remote.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-open-close-remote.json
@@ -426,7 +426,12 @@
           "battery_size": "CR2032",
           "battery_quantity": 1,
           "battery_voltage": 3.1
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/ikea-of-sweden-tradfri-remote-control.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-remote-control.json
@@ -407,7 +407,12 @@
           "battery_size": "CR2032",
           "battery_quantity": 1,
           "battery_voltage": 2.6
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/ikea-of-sweden-tradfri-wireless-dimmer.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-wireless-dimmer.json
@@ -414,7 +414,12 @@
           "battery_size": "CR2032",
           "battery_quantity": 1,
           "battery_voltage": 0.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/ikea-of-sweden-vallhorn-wireless-motion-sensor.json
+++ b/tests/data/devices/ikea-of-sweden-vallhorn-wireless-motion-sensor.json
@@ -678,7 +678,12 @@
           "battery_size": "AAA",
           "battery_quantity": 2,
           "battery_voltage": 2.5
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/innr-ae-280-c.json
+++ b/tests/data/devices/innr-ae-280-c.json
@@ -409,7 +409,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/innr-rb-285-c.json
+++ b/tests/data/devices/innr-rb-285-c.json
@@ -435,7 +435,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/innr-sp-120.json
+++ b/tests/data/devices/innr-sp-120.json
@@ -827,7 +827,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -880,7 +885,11 @@
           "available": true,
           "state": 0.0,
           "measurement_type": ""
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -933,7 +942,11 @@
           "available": true,
           "state": 0.0,
           "measurement_type": ""
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -986,7 +999,11 @@
           "available": true,
           "state": 238.0,
           "measurement_type": ""
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       }
     ],
     "switch": [

--- a/tests/data/devices/innr-sp-234.json
+++ b/tests/data/devices/innr-sp-234.json
@@ -702,7 +702,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -755,7 +760,11 @@
           "available": true,
           "state": 0.0,
           "measurement_type": "ACTIVE_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -808,7 +817,11 @@
           "available": true,
           "state": 0.007,
           "measurement_type": "ACTIVE_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -861,7 +874,11 @@
           "available": true,
           "state": 123.0,
           "measurement_type": "ACTIVE_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       }
     ],
     "switch": [

--- a/tests/data/devices/inovelli-vzm30-sn.json
+++ b/tests/data/devices/inovelli-vzm30-sn.json
@@ -812,7 +812,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [
@@ -1254,7 +1258,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -1306,7 +1315,11 @@
           "class_name": "PolledElectricalMeasurement",
           "available": true,
           "state": 0.0
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -1358,7 +1371,11 @@
           "class_name": "ElectricalMeasurementRMSCurrent",
           "available": true,
           "state": 0.0
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -1410,7 +1427,11 @@
           "class_name": "ElectricalMeasurementRMSVoltage",
           "available": true,
           "state": 124.4
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/inovelli-vzm31-sn.json
+++ b/tests/data/devices/inovelli-vzm31-sn.json
@@ -969,7 +969,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [
@@ -2623,7 +2627,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -2675,7 +2684,11 @@
           "class_name": "ReportingElectricalMeasurement",
           "available": true,
           "state": 0.0
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/isilentllc-home-energy-monitor.json
+++ b/tests/data/devices/isilentllc-home-energy-monitor.json
@@ -3920,7 +3920,11 @@
           "available": true,
           "state": 16.11,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -3973,7 +3977,11 @@
           "available": true,
           "state": 60.04,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -4026,7 +4034,11 @@
           "available": true,
           "state": 25.01,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -4079,7 +4091,11 @@
           "available": true,
           "state": 55,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -4132,7 +4148,11 @@
           "available": true,
           "state": 11.04,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -4185,7 +4205,11 @@
           "available": true,
           "state": 118.42,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -4238,7 +4262,11 @@
           "available": true,
           "state": 61.25,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -4291,7 +4319,11 @@
           "available": true,
           "state": 60.57,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -4344,7 +4376,11 @@
           "available": true,
           "state": 83.22,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -4397,7 +4433,11 @@
           "available": true,
           "state": 30,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -4450,7 +4490,11 @@
           "available": true,
           "state": 10.5,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -4503,7 +4547,11 @@
           "available": true,
           "state": 121.93,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -4556,7 +4604,11 @@
           "available": true,
           "state": 0.37,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -4609,7 +4661,11 @@
           "available": true,
           "state": 60.04,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -4662,7 +4718,11 @@
           "available": true,
           "state": 29.04,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -4715,7 +4775,11 @@
           "available": true,
           "state": 56,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -4768,7 +4832,11 @@
           "available": true,
           "state": 4.35,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -4821,7 +4889,11 @@
           "available": true,
           "state": 123.32,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -4874,7 +4946,11 @@
           "available": true,
           "state": 73.87,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -4927,7 +5003,11 @@
           "available": true,
           "state": 60.65,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -4980,7 +5060,11 @@
           "available": true,
           "state": 71.56,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -5033,7 +5117,11 @@
           "available": true,
           "state": 63,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -5086,7 +5174,11 @@
           "available": true,
           "state": 4.36,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -5139,7 +5231,11 @@
           "available": true,
           "state": 117.29,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -5192,7 +5288,11 @@
           "available": true,
           "state": 80.66,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -5245,7 +5345,11 @@
           "available": true,
           "state": 60.94,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -5298,7 +5402,11 @@
           "available": true,
           "state": 58.59,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -5351,7 +5459,11 @@
           "available": true,
           "state": 18,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -5404,7 +5516,11 @@
           "available": true,
           "state": 8.26,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -5457,7 +5573,11 @@
           "available": true,
           "state": 117.36,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -5510,7 +5630,11 @@
           "available": true,
           "state": 5.34,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -5563,7 +5687,11 @@
           "available": true,
           "state": 60.74,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -5616,7 +5744,11 @@
           "available": true,
           "state": 77.12,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -5669,7 +5801,11 @@
           "available": true,
           "state": 99,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -5722,7 +5858,11 @@
           "available": true,
           "state": 12.19,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -5775,7 +5915,11 @@
           "available": true,
           "state": 120.67,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -5828,7 +5972,11 @@
           "available": true,
           "state": 82.07,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -5881,7 +6029,11 @@
           "available": true,
           "state": 60.32,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -5934,7 +6086,11 @@
           "available": true,
           "state": 8.98,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -5987,7 +6143,11 @@
           "available": true,
           "state": 44,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -6040,7 +6200,11 @@
           "available": true,
           "state": 11.93,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -6093,7 +6257,11 @@
           "available": true,
           "state": 116.78,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -6146,7 +6314,11 @@
           "available": true,
           "state": 53.88,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -6199,7 +6371,11 @@
           "available": true,
           "state": 60.88,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -6252,7 +6428,11 @@
           "available": true,
           "state": 65.55,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -6305,7 +6485,11 @@
           "available": true,
           "state": 95,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -6358,7 +6542,11 @@
           "available": true,
           "state": 10.07,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -6411,7 +6599,11 @@
           "available": true,
           "state": 120.71,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -6464,7 +6656,11 @@
           "available": true,
           "state": 15.29,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -6517,7 +6713,11 @@
           "available": true,
           "state": 60.85,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -6570,7 +6770,11 @@
           "available": true,
           "state": 55.31,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -6623,7 +6827,11 @@
           "available": true,
           "state": 24,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -6676,7 +6884,11 @@
           "available": true,
           "state": 14.46,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -6729,7 +6941,11 @@
           "available": true,
           "state": 116.15,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -6782,7 +6998,11 @@
           "available": true,
           "state": 2.92,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -6835,7 +7055,11 @@
           "available": true,
           "state": 59.93,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -6888,7 +7112,11 @@
           "available": true,
           "state": 50.75,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -6941,7 +7169,11 @@
           "available": true,
           "state": 34,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -6994,7 +7226,11 @@
           "available": true,
           "state": 5.23,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -7047,7 +7283,11 @@
           "available": true,
           "state": 121.3,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -7100,7 +7340,11 @@
           "available": true,
           "state": 10.61,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -7153,7 +7397,11 @@
           "available": true,
           "state": 60.17,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -7206,7 +7454,11 @@
           "available": true,
           "state": 53.61,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -7259,7 +7511,11 @@
           "available": true,
           "state": 85,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -7312,7 +7568,11 @@
           "available": true,
           "state": 6.28,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -7365,7 +7625,11 @@
           "available": true,
           "state": 118.51,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -7418,7 +7682,11 @@
           "available": true,
           "state": 59.51,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -7471,7 +7739,11 @@
           "available": true,
           "state": 60.21,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -7524,7 +7796,11 @@
           "available": true,
           "state": 92.69,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -7577,7 +7853,11 @@
           "available": true,
           "state": 91,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -7630,7 +7910,11 @@
           "available": true,
           "state": 6.7,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -7683,7 +7967,11 @@
           "available": true,
           "state": 119.91,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -7736,7 +8024,11 @@
           "available": true,
           "state": 4.17,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -7789,7 +8081,11 @@
           "available": true,
           "state": 59.17,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -7842,7 +8138,11 @@
           "available": true,
           "state": 79.9,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -7895,7 +8195,11 @@
           "available": true,
           "state": 51,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -7948,7 +8252,11 @@
           "available": true,
           "state": 3.94,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -8001,7 +8309,11 @@
           "available": true,
           "state": 116.88,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -8054,7 +8366,11 @@
           "available": true,
           "state": 61.28,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -8107,7 +8423,11 @@
           "available": true,
           "state": 59.33,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -8160,7 +8480,11 @@
           "available": true,
           "state": 5.13,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -8213,7 +8537,11 @@
           "available": true,
           "state": 97,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -8266,7 +8594,11 @@
           "available": true,
           "state": 5.64,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -8319,7 +8651,11 @@
           "available": true,
           "state": 122.72,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -8372,7 +8708,11 @@
           "available": true,
           "state": 11.9,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -8425,7 +8765,11 @@
           "available": true,
           "state": 59.34,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -8478,7 +8822,11 @@
           "available": true,
           "state": 39.19,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -8531,7 +8879,11 @@
           "available": true,
           "state": 21,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -8584,7 +8936,11 @@
           "available": true,
           "state": 3.91,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -8637,7 +8993,11 @@
           "available": true,
           "state": 116.66,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -8690,7 +9050,11 @@
           "available": true,
           "state": 4.11,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -8743,7 +9107,11 @@
           "available": true,
           "state": 59.99,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -8796,7 +9164,11 @@
           "available": true,
           "state": 94.32,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -8849,7 +9221,11 @@
           "available": true,
           "state": 55,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -8902,7 +9278,11 @@
           "available": true,
           "state": 1.84,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -8955,7 +9335,11 @@
           "available": true,
           "state": 121.41,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -9008,7 +9392,11 @@
           "available": true,
           "state": 13.49,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -9061,7 +9449,11 @@
           "available": true,
           "state": 59.46,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -9114,7 +9506,11 @@
           "available": true,
           "state": 28.08,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -9167,7 +9563,11 @@
           "available": true,
           "state": 0,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -9220,7 +9620,11 @@
           "available": true,
           "state": 1.68,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -9273,7 +9677,11 @@
           "available": true,
           "state": 118.04,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -9326,7 +9734,11 @@
           "available": true,
           "state": 84.08,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -9379,7 +9791,11 @@
           "available": true,
           "state": 59.58,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -9432,7 +9848,11 @@
           "available": true,
           "state": 9.18,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -9485,7 +9905,11 @@
           "available": true,
           "state": 41,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -9538,7 +9962,11 @@
           "available": true,
           "state": 3.52,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -9591,7 +10019,11 @@
           "available": true,
           "state": 124.04,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -9644,7 +10076,11 @@
           "available": true,
           "state": 39.33,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -9697,7 +10133,11 @@
           "available": true,
           "state": 59.36,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -9750,7 +10190,11 @@
           "available": true,
           "state": 6.4,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -9803,7 +10247,11 @@
           "available": true,
           "state": 27,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -9856,7 +10304,11 @@
           "available": true,
           "state": 5.29,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -9909,7 +10361,11 @@
           "available": true,
           "state": 115.19,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -9962,7 +10418,11 @@
           "available": true,
           "state": 63.77,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -10015,7 +10475,11 @@
           "available": true,
           "state": 59.99,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -10068,7 +10532,11 @@
           "available": true,
           "state": 61.39,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -10121,7 +10589,11 @@
           "available": true,
           "state": 93,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -10174,7 +10646,11 @@
           "available": true,
           "state": 8.33,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -10227,7 +10703,11 @@
           "available": true,
           "state": 117.45,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -10280,7 +10760,11 @@
           "available": true,
           "state": 4.37,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -10333,7 +10817,11 @@
           "available": true,
           "state": 60.57,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -10386,7 +10874,11 @@
           "available": true,
           "state": 22.23,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -10439,7 +10931,11 @@
           "available": true,
           "state": 93,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -10492,7 +10988,11 @@
           "available": true,
           "state": 14.64,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -10545,7 +11045,11 @@
           "available": true,
           "state": 124.16,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -10598,7 +11102,11 @@
           "available": true,
           "state": 31.48,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -10651,7 +11159,11 @@
           "available": true,
           "state": 59.0,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -10704,7 +11216,11 @@
           "available": true,
           "state": 81.49,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -10757,7 +11273,11 @@
           "available": true,
           "state": 23,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -10810,7 +11330,11 @@
           "available": true,
           "state": 10.24,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -10863,7 +11387,11 @@
           "available": true,
           "state": 123.42,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -10916,7 +11444,11 @@
           "available": true,
           "state": 7.6,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -10969,7 +11501,11 @@
           "available": true,
           "state": 60.92,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -11022,7 +11558,11 @@
           "available": true,
           "state": 36.56,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -11075,7 +11615,11 @@
           "available": true,
           "state": 52,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -11128,7 +11672,11 @@
           "available": true,
           "state": 3.39,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -11181,7 +11729,11 @@
           "available": true,
           "state": 118.6,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -11234,7 +11786,11 @@
           "available": true,
           "state": 2.47,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -11287,7 +11843,11 @@
           "available": true,
           "state": 60.04,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -11340,7 +11900,11 @@
           "available": true,
           "state": 43.42,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -11393,7 +11957,11 @@
           "available": true,
           "state": 77,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -11446,7 +12014,11 @@
           "available": true,
           "state": 4.09,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -11499,7 +12071,11 @@
           "available": true,
           "state": 124.38,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -11552,7 +12128,11 @@
           "available": true,
           "state": 63.6,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -11605,7 +12185,11 @@
           "available": true,
           "state": 60.71,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -11658,7 +12242,11 @@
           "available": true,
           "state": 25.72,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -11711,7 +12299,11 @@
           "available": true,
           "state": 37,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -11764,7 +12356,11 @@
           "available": true,
           "state": 3.48,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -11817,7 +12413,11 @@
           "available": true,
           "state": 124.69,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       }
     ]
   },

--- a/tests/data/devices/isilentllc-masterbed-light-controller.json
+++ b/tests/data/devices/isilentllc-masterbed-light-controller.json
@@ -654,7 +654,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/isilentllc-safe.json
+++ b/tests/data/devices/isilentllc-safe.json
@@ -495,7 +495,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "sensor": [

--- a/tests/data/devices/isilentllc-water-heater.json
+++ b/tests/data/devices/isilentllc-water-heater.json
@@ -425,7 +425,11 @@
           "state": 0.0,
           "measurement_type": "PHASE_B_MEASUREMENT, PHASE_C_MEASUREMENT, DC_MEASUREMENT",
           "ac_frequency_max": 0.0
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -478,7 +482,11 @@
           "available": true,
           "state": 0.0,
           "measurement_type": "PHASE_B_MEASUREMENT, PHASE_C_MEASUREMENT, DC_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -532,7 +540,11 @@
           "state": 0.0,
           "measurement_type": "PHASE_B_MEASUREMENT, PHASE_C_MEASUREMENT, DC_MEASUREMENT",
           "rms_voltage_max": 0.0
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/jasco-products-45856.json
+++ b/tests/data/devices/jasco-products-45856.json
@@ -396,7 +396,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "sensor": [
@@ -557,7 +561,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -612,7 +621,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/jasco-products-45857.json
+++ b/tests/data/devices/jasco-products-45857.json
@@ -464,7 +464,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [
@@ -682,7 +686,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -737,7 +746,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/ke-tradfri-open-close-remote.json
+++ b/tests/data/devices/ke-tradfri-open-close-remote.json
@@ -426,7 +426,12 @@
           "battery_size": "CR2032",
           "battery_quantity": 1,
           "battery_voltage": 2.9
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/keen-home-inc-sv01-410-mp-1-1.json
+++ b/tests/data/devices/keen-home-inc-sv01-410-mp-1-1.json
@@ -580,7 +580,12 @@
           "battery_size": "AA",
           "battery_quantity": 4,
           "battery_voltage": 3.1
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/keen-home-inc-sv02-610-mp-1-3.json
+++ b/tests/data/devices/keen-home-inc-sv02-610-mp-1-3.json
@@ -537,7 +537,12 @@
           "battery_size": "AA",
           "battery_quantity": 4,
           "battery_voltage": 2.3
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/keen-home-inc-sv02-612-mp-1-3.json
+++ b/tests/data/devices/keen-home-inc-sv02-612-mp-1-3.json
@@ -586,7 +586,12 @@
           "battery_size": "AA",
           "battery_quantity": 4,
           "battery_voltage": 1.3
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/king-of-fans-inc-hbuniversalcfremote.json
+++ b/tests/data/devices/king-of-fans-inc-hbuniversalcfremote.json
@@ -410,7 +410,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/king-of-fans-inc-hdc52eastwindfan.json
+++ b/tests/data/devices/king-of-fans-inc-hdc52eastwindfan.json
@@ -416,7 +416,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/konke-3afe140103020000.json
+++ b/tests/data/devices/konke-3afe140103020000.json
@@ -376,7 +376,12 @@
           "state": null,
           "battery_size": "Unknown",
           "battery_voltage": 4.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/konke-3afe220103020000.json
+++ b/tests/data/devices/konke-3afe220103020000.json
@@ -376,7 +376,12 @@
           "state": null,
           "battery_size": "Unknown",
           "battery_voltage": 3.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/konke-3afe270104020015.json
+++ b/tests/data/devices/konke-3afe270104020015.json
@@ -446,7 +446,12 @@
           "state": null,
           "battery_size": "Unknown",
           "battery_voltage": 3.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ]
   },

--- a/tests/data/devices/konke-3afe280100510001.json
+++ b/tests/data/devices/konke-3afe280100510001.json
@@ -371,7 +371,12 @@
           "state": null,
           "battery_size": "Unknown",
           "battery_voltage": 3.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ]
   },

--- a/tests/data/devices/konke-3afe28010402000d.json
+++ b/tests/data/devices/konke-3afe28010402000d.json
@@ -513,7 +513,12 @@
           "state": null,
           "battery_size": "Unknown",
           "battery_voltage": 3.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ]
   },

--- a/tests/data/devices/kwikset-smartcode-convert-gen1.json
+++ b/tests/data/devices/kwikset-smartcode-convert-gen1.json
@@ -480,7 +480,12 @@
           "battery_size": "AA",
           "battery_quantity": 4,
           "battery_voltage": 6.2
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/lds-zb-onoffplug-d0005.json
+++ b/tests/data/devices/lds-zb-onoffplug-d0005.json
@@ -610,7 +610,12 @@
           "state": 3.0,
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": null
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -663,7 +668,11 @@
           "available": true,
           "state": 67.0,
           "measurement_type": "ACTIVE_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -716,7 +725,11 @@
           "available": true,
           "state": 0.0,
           "measurement_type": "ACTIVE_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -769,7 +782,11 @@
           "available": true,
           "state": 0.0,
           "measurement_type": "ACTIVE_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       }
     ],
     "switch": [

--- a/tests/data/devices/lds-zbt-cctswitch-d0001.json
+++ b/tests/data/devices/lds-zbt-cctswitch-d0001.json
@@ -402,7 +402,12 @@
           "battery_size": "Other",
           "battery_quantity": 1,
           "battery_voltage": 3.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/ledvance-flex-rgbw.json
+++ b/tests/data/devices/ledvance-flex-rgbw.json
@@ -469,7 +469,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/ledvance-outdoor-accent-light-rgb.json
+++ b/tests/data/devices/ledvance-outdoor-accent-light-rgb.json
@@ -417,7 +417,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/level-home-b2.json
+++ b/tests/data/devices/level-home-b2.json
@@ -470,7 +470,12 @@
           "battery_size": "CR2",
           "battery_quantity": 1,
           "battery_voltage": 3.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/level-home-bolt.json
+++ b/tests/data/devices/level-home-bolt.json
@@ -313,7 +313,12 @@
           "battery_size": "CR2",
           "battery_quantity": 1,
           "battery_voltage": 2.8
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/lk-zb-doorsensor-d0003.json
+++ b/tests/data/devices/lk-zb-doorsensor-d0003.json
@@ -418,7 +418,12 @@
           "battery_size": "Other",
           "battery_quantity": 1,
           "battery_voltage": 2.4
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/lk-zbt-dimswitch-d0001.json
+++ b/tests/data/devices/lk-zbt-dimswitch-d0001.json
@@ -372,7 +372,12 @@
           "battery_size": "Other",
           "battery_quantity": 1,
           "battery_voltage": 2.5
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/lumi-lumi-airmonitor-acn01.json
+++ b/tests/data/devices/lumi-lumi-airmonitor-acn01.json
@@ -403,7 +403,12 @@
           "battery_size": "CR2",
           "battery_quantity": 1,
           "battery_voltage": 3.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/lumi-lumi-curtain-agl001.json
+++ b/tests/data/devices/lumi-lumi-curtain-agl001.json
@@ -675,7 +675,12 @@
           "battery_size": "CR2032",
           "battery_quantity": 1,
           "battery_voltage": 3.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/lumi-lumi-flood-acn001.json
+++ b/tests/data/devices/lumi-lumi-flood-acn001.json
@@ -444,7 +444,12 @@
           "battery_size": "CR2032",
           "battery_quantity": 1,
           "battery_voltage": 2.96
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/lumi-lumi-flood-agl02.json
+++ b/tests/data/devices/lumi-lumi-flood-agl02.json
@@ -437,7 +437,12 @@
           "battery_size": "CR2032",
           "battery_quantity": 1,
           "battery_voltage": 3.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/lumi-lumi-light-aqcn02.json
+++ b/tests/data/devices/lumi-lumi-light-aqcn02.json
@@ -443,7 +443,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/lumi-lumi-magnet-ac01.json
+++ b/tests/data/devices/lumi-lumi-magnet-ac01.json
@@ -476,7 +476,12 @@
           "battery_size": "CR123A",
           "battery_quantity": 1,
           "battery_voltage": 1.9
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/lumi-lumi-magnet-acn001.json
+++ b/tests/data/devices/lumi-lumi-magnet-acn001.json
@@ -450,7 +450,12 @@
           "battery_size": "CR1632",
           "battery_quantity": 1,
           "battery_voltage": 2.9
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/lumi-lumi-motion-ac02.json
+++ b/tests/data/devices/lumi-lumi-motion-ac02.json
@@ -651,7 +651,12 @@
           "battery_size": "CR1632",
           "battery_quantity": 1,
           "battery_voltage": 3.03
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/lumi-lumi-motion-agl02.json
+++ b/tests/data/devices/lumi-lumi-motion-agl02.json
@@ -517,7 +517,12 @@
           "battery_size": "CR1632",
           "battery_quantity": 1,
           "battery_voltage": 2.9
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/lumi-lumi-motion-agl04.json
+++ b/tests/data/devices/lumi-lumi-motion-agl04.json
@@ -634,7 +634,12 @@
           "battery_size": "CR1632",
           "battery_quantity": 1,
           "battery_voltage": 3.13
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/lumi-lumi-plug-maus01.json
+++ b/tests/data/devices/lumi-lumi-plug-maus01.json
@@ -748,7 +748,12 @@
           "state": null,
           "device_type": "Electric Metering",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -802,7 +807,12 @@
           "state": 5.027,
           "device_type": "Electric Metering",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -906,7 +916,11 @@
           "class_name": "PolledElectricalMeasurement",
           "available": true,
           "state": 0.9
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -958,7 +972,11 @@
           "class_name": "ElectricalMeasurementFrequency",
           "available": true,
           "state": null
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -1010,7 +1028,11 @@
           "class_name": "ElectricalMeasurementApparentPower",
           "available": true,
           "state": null
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -1062,7 +1084,11 @@
           "class_name": "ElectricalMeasurementRMSCurrent",
           "available": true,
           "state": null
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -1114,7 +1140,11 @@
           "class_name": "ElectricalMeasurementRMSVoltage",
           "available": true,
           "state": 0.0
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -1166,7 +1196,11 @@
           "class_name": "ElectricalMeasurementTotalActivePower",
           "available": true,
           "state": 502.7
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       }
     ],
     "switch": [

--- a/tests/data/devices/lumi-lumi-relay-c2acn01.json
+++ b/tests/data/devices/lumi-lumi-relay-c2acn01.json
@@ -515,7 +515,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       },
       {
         "info_object": {
@@ -585,7 +589,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "sensor": [
@@ -745,7 +753,12 @@
           "state": null,
           "device_type": "Electric Metering",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -799,7 +812,12 @@
           "state": 0.096,
           "device_type": "Electric Metering",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -903,7 +921,11 @@
           "class_name": "PolledElectricalMeasurement",
           "available": true,
           "state": 0.0
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -955,7 +977,11 @@
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
           "state": null
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -1007,7 +1033,11 @@
           "class_name": "ElectricalMeasurementRMSVoltage",
           "available": true,
           "state": 0.0
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -1059,7 +1089,11 @@
           "class_name": "ElectricalMeasurementTotalActivePower",
           "available": true,
           "state": 9.6
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/lumi-lumi-remote-b286opcn01.json
+++ b/tests/data/devices/lumi-lumi-remote-b286opcn01.json
@@ -592,7 +592,12 @@
           "battery_size": "CR2",
           "battery_quantity": 1,
           "battery_voltage": 2.8
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ]
   },

--- a/tests/data/devices/lumi-lumi-remote-b486opcn01.json
+++ b/tests/data/devices/lumi-lumi-remote-b486opcn01.json
@@ -458,7 +458,12 @@
           "battery_size": "CR2",
           "battery_quantity": 1,
           "battery_voltage": 2.9
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ]
   },

--- a/tests/data/devices/lumi-lumi-remote-b686opcn01.json
+++ b/tests/data/devices/lumi-lumi-remote-b686opcn01.json
@@ -566,7 +566,12 @@
           "battery_size": "CR2",
           "battery_quantity": 1,
           "battery_voltage": 3.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ]
   },

--- a/tests/data/devices/lumi-lumi-remote-cagl02.json
+++ b/tests/data/devices/lumi-lumi-remote-cagl02.json
@@ -447,7 +447,12 @@
           "battery_size": "CR2450",
           "battery_quantity": 1,
           "battery_voltage": 2.8
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/lumi-lumi-sen-ill-mgl01.json
+++ b/tests/data/devices/lumi-lumi-sen-ill-mgl01.json
@@ -358,7 +358,12 @@
           "battery_size": "CR2",
           "battery_quantity": 1,
           "battery_voltage": 3.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/lumi-lumi-sensor-86sw2.json
+++ b/tests/data/devices/lumi-lumi-sensor-86sw2.json
@@ -550,7 +550,12 @@
           "battery_size": "CR2032",
           "battery_quantity": 1,
           "battery_voltage": 2.99
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/lumi-lumi-sensor-ht-agl02.json
+++ b/tests/data/devices/lumi-lumi-sensor-ht-agl02.json
@@ -397,7 +397,12 @@
           "battery_size": "CR2032",
           "battery_quantity": 1,
           "battery_voltage": 3.01
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/lumi-lumi-sensor-magnet-aq2.json
+++ b/tests/data/devices/lumi-lumi-sensor-magnet-aq2.json
@@ -451,7 +451,12 @@
           "battery_size": "CR1632",
           "battery_quantity": 1,
           "battery_voltage": 3.04
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/lumi-lumi-sensor-motion-aq2.json
+++ b/tests/data/devices/lumi-lumi-sensor-motion-aq2.json
@@ -541,7 +541,12 @@
           "battery_size": "CR2450",
           "battery_quantity": 1,
           "battery_voltage": 3.04
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/lumi-lumi-sensor-smoke-acn03.json
+++ b/tests/data/devices/lumi-lumi-sensor-smoke-acn03.json
@@ -570,7 +570,12 @@
           "battery_size": "Unknown",
           "battery_quantity": 1,
           "battery_voltage": 3.04
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/lumi-lumi-sensor-smoke.json
+++ b/tests/data/devices/lumi-lumi-sensor-smoke.json
@@ -526,7 +526,12 @@
           "battery_size": "CR123A",
           "battery_quantity": 1,
           "battery_voltage": 3.18
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/lumi-lumi-sensor-switch-aq2.json
+++ b/tests/data/devices/lumi-lumi-sensor-switch-aq2.json
@@ -342,7 +342,12 @@
           "battery_size": "CR2032",
           "battery_quantity": 1,
           "battery_voltage": 3.04
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/lumi-lumi-sensor-switch-aq3.json
+++ b/tests/data/devices/lumi-lumi-sensor-switch-aq3.json
@@ -314,7 +314,12 @@
           "battery_size": "CR2032",
           "battery_quantity": 1,
           "battery_voltage": 2.99
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/lumi-lumi-sensor-switch.json
+++ b/tests/data/devices/lumi-lumi-sensor-switch.json
@@ -388,7 +388,12 @@
           "battery_size": "CR2032",
           "battery_quantity": 1,
           "battery_voltage": 3.07
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/lumi-lumi-switch-b1laus01.json
+++ b/tests/data/devices/lumi-lumi-switch-b1laus01.json
@@ -278,7 +278,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "sensor": [

--- a/tests/data/devices/lumi-lumi-switch-b1naus01.json
+++ b/tests/data/devices/lumi-lumi-switch-b1naus01.json
@@ -518,7 +518,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "sensor": [
@@ -679,7 +683,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -784,7 +793,11 @@
           "available": true,
           "state": 0.0,
           "measurement_type": "PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/lumi-lumi-vibration-aq1.json
+++ b/tests/data/devices/lumi-lumi-vibration-aq1.json
@@ -544,7 +544,12 @@
           "battery_size": "CR2032",
           "battery_quantity": 1,
           "battery_voltage": 2.96
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/lumi-lumi-weather.json
+++ b/tests/data/devices/lumi-lumi-weather.json
@@ -418,7 +418,12 @@
           "battery_size": "CR2032",
           "battery_quantity": 1,
           "battery_voltage": 2.99
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/lutron-z3-1brl.json
+++ b/tests/data/devices/lutron-z3-1brl.json
@@ -359,7 +359,12 @@
           "available": true,
           "state": 100.0,
           "battery_voltage": 3.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/osram-switch-4x-lightify.json
+++ b/tests/data/devices/osram-switch-4x-lightify.json
@@ -913,7 +913,12 @@
           "available": true,
           "state": null,
           "battery_voltage": 2.9
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/philips-7602031u7.json
+++ b/tests/data/devices/philips-7602031u7.json
@@ -482,7 +482,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/philips-lct014.json
+++ b/tests/data/devices/philips-lct014.json
@@ -446,7 +446,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/philips-llc020.json
+++ b/tests/data/devices/philips-llc020.json
@@ -434,7 +434,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/philips-lst002.json
+++ b/tests/data/devices/philips-lst002.json
@@ -460,7 +460,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "sensor": [

--- a/tests/data/devices/philips-rom001.json
+++ b/tests/data/devices/philips-rom001.json
@@ -426,7 +426,12 @@
           "available": true,
           "state": 100.0,
           "battery_voltage": 2.8
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/philips-rwl020.json
+++ b/tests/data/devices/philips-rwl020.json
@@ -497,7 +497,12 @@
           "available": true,
           "state": 100.0,
           "battery_voltage": 3.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/philips-sml001.json
+++ b/tests/data/devices/philips-sml001.json
@@ -630,7 +630,12 @@
           "available": true,
           "state": 38.5,
           "battery_voltage": 2.5
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/plaid-systems-ps-sprzms-slp3.json
+++ b/tests/data/devices/plaid-systems-ps-sprzms-slp3.json
@@ -368,7 +368,12 @@
           "battery_size": "CR123A",
           "battery_quantity": 1,
           "battery_voltage": 3.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/samjin-button.json
+++ b/tests/data/devices/samjin-button.json
@@ -461,7 +461,12 @@
           "available": true,
           "state": 100.0,
           "battery_voltage": 3.5
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/samjin-multi.json
+++ b/tests/data/devices/samjin-multi.json
@@ -538,7 +538,12 @@
           "available": true,
           "state": 100.0,
           "battery_voltage": 3.1
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/securifi-ltd-unk-model.json
+++ b/tests/data/devices/securifi-ltd-unk-model.json
@@ -522,7 +522,11 @@
           "available": true,
           "state": 0.0,
           "measurement_type": "PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -575,7 +579,11 @@
           "available": true,
           "state": 0.0,
           "measurement_type": "PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -628,7 +636,11 @@
           "available": true,
           "state": 0,
           "measurement_type": "PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -681,7 +693,11 @@
           "available": true,
           "state": 0.0,
           "measurement_type": "PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -734,7 +750,11 @@
           "available": true,
           "state": 122.98466468299382,
           "measurement_type": "PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       }
     ],
     "switch": [

--- a/tests/data/devices/sengled-e11-g13.json
+++ b/tests/data/devices/sengled-e11-g13.json
@@ -411,7 +411,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [
@@ -629,7 +633,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -684,7 +693,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/sengled-e12-n14.json
+++ b/tests/data/devices/sengled-e12-n14.json
@@ -405,7 +405,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [
@@ -623,7 +627,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -678,7 +687,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/sengled-e12-n1e.json
+++ b/tests/data/devices/sengled-e12-n1e.json
@@ -523,7 +523,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "sensor": [
@@ -684,7 +688,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -739,7 +748,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/sengled-e1c-nb7.json
+++ b/tests/data/devices/sengled-e1c-nb7.json
@@ -505,7 +505,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -560,7 +565,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       }
     ],
     "switch": [

--- a/tests/data/devices/sengled-e1f-n9g.json
+++ b/tests/data/devices/sengled-e1f-n9g.json
@@ -420,7 +420,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [
@@ -638,7 +642,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -693,7 +702,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/sengled-e1g-g8e.json
+++ b/tests/data/devices/sengled-e1g-g8e.json
@@ -528,7 +528,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "sensor": [
@@ -689,7 +693,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -744,7 +753,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/sengled-e21-n1ea.json
+++ b/tests/data/devices/sengled-e21-n1ea.json
@@ -528,7 +528,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [
@@ -856,7 +860,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -911,7 +920,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/sengled-z01-a19nae26.json
+++ b/tests/data/devices/sengled-z01-a19nae26.json
@@ -504,7 +504,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [
@@ -722,7 +726,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -777,7 +786,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/signify-netherlands-b-v-lca001.json
+++ b/tests/data/devices/signify-netherlands-b-v-lca001.json
@@ -463,7 +463,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/signify-netherlands-b-v-lca005.json
+++ b/tests/data/devices/signify-netherlands-b-v-lca005.json
@@ -445,7 +445,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/signify-netherlands-b-v-lca007.json
+++ b/tests/data/devices/signify-netherlands-b-v-lca007.json
@@ -433,7 +433,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/signify-netherlands-b-v-lcb001.json
+++ b/tests/data/devices/signify-netherlands-b-v-lcb001.json
@@ -470,7 +470,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/signify-netherlands-b-v-lcb002.json
+++ b/tests/data/devices/signify-netherlands-b-v-lcb002.json
@@ -433,7 +433,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/signify-netherlands-b-v-lce001.json
+++ b/tests/data/devices/signify-netherlands-b-v-lce001.json
@@ -432,7 +432,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/signify-netherlands-b-v-lcx004.json
+++ b/tests/data/devices/signify-netherlands-b-v-lcx004.json
@@ -427,7 +427,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/signify-netherlands-b-v-lta010.json
+++ b/tests/data/devices/signify-netherlands-b-v-lta010.json
@@ -422,7 +422,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/signify-netherlands-b-v-ltb003.json
+++ b/tests/data/devices/signify-netherlands-b-v-ltb003.json
@@ -429,7 +429,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/signify-netherlands-b-v-lwa003.json
+++ b/tests/data/devices/signify-netherlands-b-v-lwa003.json
@@ -323,7 +323,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/signify-netherlands-b-v-rdm001.json
+++ b/tests/data/devices/signify-netherlands-b-v-rdm001.json
@@ -388,7 +388,12 @@
           "available": true,
           "state": 100.0,
           "battery_voltage": 2.8
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/signify-netherlands-b-v-rdm002.json
+++ b/tests/data/devices/signify-netherlands-b-v-rdm002.json
@@ -404,7 +404,12 @@
           "available": true,
           "state": 100.0,
           "battery_voltage": 2.7
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/signify-netherlands-b-v-rwl022.json
+++ b/tests/data/devices/signify-netherlands-b-v-rwl022.json
@@ -400,7 +400,12 @@
           "available": true,
           "state": 95.5,
           "battery_voltage": 2.8
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/signify-netherlands-b-v-sml004.json
+++ b/tests/data/devices/signify-netherlands-b-v-sml004.json
@@ -596,7 +596,12 @@
           "available": true,
           "state": 100.0,
           "battery_voltage": 3.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/sinope-technologies-va4220zb.json
+++ b/tests/data/devices/sinope-technologies-va4220zb.json
@@ -873,7 +873,12 @@
           "device_type": "Water Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 7
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -928,7 +933,12 @@
           "device_type": "Water Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 7
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       }
     ],
     "switch": [

--- a/tests/data/devices/smartwings-wm25-l-z.json
+++ b/tests/data/devices/smartwings-wm25-l-z.json
@@ -556,7 +556,12 @@
           "available": true,
           "state": 100.0,
           "battery_voltage": 0.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/somfy-situo-4-zigbee.json
+++ b/tests/data/devices/somfy-situo-4-zigbee.json
@@ -755,7 +755,12 @@
           "class_name": "Battery",
           "available": true,
           "state": 77.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/somfy-sonesse-28-wf-li-ion-roller.json
+++ b/tests/data/devices/somfy-sonesse-28-wf-li-ion-roller.json
@@ -558,7 +558,12 @@
           "class_name": "Battery",
           "available": true,
           "state": 20.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "switch": [

--- a/tests/data/devices/somfy-ysia-5-hp-zigbee.json
+++ b/tests/data/devices/somfy-ysia-5-hp-zigbee.json
@@ -1018,7 +1018,12 @@
           "class_name": "Battery",
           "available": true,
           "state": 92.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/sonoff-01minizb.json
+++ b/tests/data/devices/sonoff-01minizb.json
@@ -248,7 +248,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "sensor": [

--- a/tests/data/devices/sonoff-snzb-02d.json
+++ b/tests/data/devices/sonoff-snzb-02d.json
@@ -772,7 +772,12 @@
           "class_name": "Battery",
           "available": true,
           "state": 63.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/sonoff-swv.json
+++ b/tests/data/devices/sonoff-swv.json
@@ -701,7 +701,12 @@
           "available": true,
           "state": 100.0,
           "battery_voltage": 6.3
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/sunricher-hk-ln-dim-a.json
+++ b/tests/data/devices/sunricher-hk-ln-dim-a.json
@@ -347,7 +347,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/the-home-depot-ecosmart-zbt-a19-cct-bulb.json
+++ b/tests/data/devices/the-home-depot-ecosmart-zbt-a19-cct-bulb.json
@@ -456,7 +456,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/third-reality-inc-3rds17bz.json
+++ b/tests/data/devices/third-reality-inc-3rds17bz.json
@@ -339,7 +339,12 @@
           "available": true,
           "state": 75.0,
           "battery_voltage": 2.9
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/third-reality-inc-3rms16bz.json
+++ b/tests/data/devices/third-reality-inc-3rms16bz.json
@@ -428,7 +428,12 @@
           "available": true,
           "state": 50.5,
           "battery_voltage": 2.6
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/third-reality-inc-3rsb015bz.json
+++ b/tests/data/devices/third-reality-inc-3rsb015bz.json
@@ -535,7 +535,12 @@
           "available": true,
           "state": 58.0,
           "battery_voltage": 5.3
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/third-reality-inc-3rsb22bz.json
+++ b/tests/data/devices/third-reality-inc-3rsb22bz.json
@@ -296,7 +296,12 @@
           "available": true,
           "state": 67.5,
           "battery_voltage": 2.9
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/third-reality-inc-3rsm0147z.json
+++ b/tests/data/devices/third-reality-inc-3rsm0147z.json
@@ -7,8 +7,8 @@
   "friendly_manufacturer": "Third Reality, Inc",
   "friendly_model": "3RSM0147Z",
   "name": "Third Reality, Inc 3RSM0147Z",
-  "quirk_applied": false,
-  "quirk_class": "zigpy.device.Device",
+  "quirk_applied": true,
+  "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
   "quirk_id": null,
   "manufacturer_code": 5127,
   "power_source": "Battery or Unknown",
@@ -141,6 +141,7 @@
       ]
     }
   },
+  "original_signature": {},
   "zha_lib_entities": {
     "sensor": [
       {
@@ -298,7 +299,12 @@
           "available": true,
           "state": 100.0,
           "battery_voltage": 1.5
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {
@@ -354,18 +360,18 @@
       },
       {
         "info_object": {
-          "fallback_name": null,
+          "fallback_name": "Soil moisture",
           "unique_id": "28:2c:02:bf:ff:ef:2b:82-1-1029",
           "migrate_unique_ids": [],
           "platform": "sensor",
-          "class_name": "Humidity",
-          "translation_key": null,
+          "class_name": "Sensor",
+          "translation_key": "soil_moisture",
           "device_class": "humidity",
           "state_class": "measurement",
           "entity_category": null,
           "entity_registry_enabled_default": true,
           "enabled": true,
-          "primary": false,
+          "primary": true,
           "cluster_handlers": [
             {
               "class_name": "RelativeHumidityClusterHandler",
@@ -399,7 +405,7 @@
           "unit": "%"
         },
         "state": {
-          "class_name": "Humidity",
+          "class_name": "Sensor",
           "available": true,
           "state": 31.21
         }

--- a/tests/data/devices/third-reality-inc-3rsm0147z.json
+++ b/tests/data/devices/third-reality-inc-3rsm0147z.json
@@ -7,8 +7,8 @@
   "friendly_manufacturer": "Third Reality, Inc",
   "friendly_model": "3RSM0147Z",
   "name": "Third Reality, Inc 3RSM0147Z",
-  "quirk_applied": true,
-  "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
+  "quirk_applied": false,
+  "quirk_class": "zigpy.device.Device",
   "quirk_id": null,
   "manufacturer_code": 5127,
   "power_source": "Battery or Unknown",
@@ -141,7 +141,6 @@
       ]
     }
   },
-  "original_signature": {},
   "zha_lib_entities": {
     "sensor": [
       {
@@ -360,18 +359,18 @@
       },
       {
         "info_object": {
-          "fallback_name": "Soil moisture",
+          "fallback_name": null,
           "unique_id": "28:2c:02:bf:ff:ef:2b:82-1-1029",
           "migrate_unique_ids": [],
           "platform": "sensor",
-          "class_name": "Sensor",
-          "translation_key": "soil_moisture",
+          "class_name": "Humidity",
+          "translation_key": null,
           "device_class": "humidity",
           "state_class": "measurement",
           "entity_category": null,
           "entity_registry_enabled_default": true,
           "enabled": true,
-          "primary": true,
+          "primary": false,
           "cluster_handlers": [
             {
               "class_name": "RelativeHumidityClusterHandler",
@@ -405,7 +404,7 @@
           "unit": "%"
         },
         "state": {
-          "class_name": "Sensor",
+          "class_name": "Humidity",
           "available": true,
           "state": 31.21
         }

--- a/tests/data/devices/third-reality-inc-3rsnl02043z.json
+++ b/tests/data/devices/third-reality-inc-3rsnl02043z.json
@@ -543,7 +543,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/third-reality-inc-3rsp02028bz.json
+++ b/tests/data/devices/third-reality-inc-3rsp02028bz.json
@@ -673,7 +673,11 @@
           "class_name": "PolledElectricalMeasurement",
           "available": true,
           "state": 0.0
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -725,7 +729,11 @@
           "class_name": "ElectricalMeasurementFrequency",
           "available": true,
           "state": 60.0
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -777,7 +785,11 @@
           "class_name": "ElectricalMeasurementPowerFactor",
           "available": true,
           "state": 0
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -829,7 +841,11 @@
           "class_name": "ElectricalMeasurementRMSCurrent",
           "available": true,
           "state": 0.0
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -881,7 +897,11 @@
           "class_name": "ElectricalMeasurementRMSVoltage",
           "available": true,
           "state": 124.5
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       }
     ],
     "switch": [

--- a/tests/data/devices/third-reality-inc-3rss009z.json
+++ b/tests/data/devices/third-reality-inc-3rss009z.json
@@ -302,7 +302,12 @@
           "available": true,
           "state": 56.0,
           "battery_voltage": 2.8
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "switch": [

--- a/tests/data/devices/third-reality-inc-3rths24bz.json
+++ b/tests/data/devices/third-reality-inc-3rths24bz.json
@@ -293,7 +293,12 @@
           "available": true,
           "state": 42.0,
           "battery_voltage": 2.5
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/third-reality-inc-3rvs01031z.json
+++ b/tests/data/devices/third-reality-inc-3rvs01031z.json
@@ -399,7 +399,12 @@
           "available": true,
           "state": 83.5,
           "battery_voltage": 3.1
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/third-reality-inc-3rws18bz.json
+++ b/tests/data/devices/third-reality-inc-3rws18bz.json
@@ -502,7 +502,12 @@
           "available": true,
           "state": 52.0,
           "battery_voltage": 2.6
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "switch": [

--- a/tests/data/devices/tuyatec-gqhxixyk-rh3052.json
+++ b/tests/data/devices/tuyatec-gqhxixyk-rh3052.json
@@ -357,7 +357,12 @@
           "available": true,
           "state": 100.0,
           "battery_voltage": 3.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/tuyatec-r9hgssol-rh3001.json
+++ b/tests/data/devices/tuyatec-r9hgssol-rh3001.json
@@ -412,7 +412,12 @@
           "available": true,
           "state": 100.0,
           "battery_voltage": 3.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ]
   },

--- a/tests/data/devices/tuyatec-rkqiqvcs-rh3001.json
+++ b/tests/data/devices/tuyatec-rkqiqvcs-rh3001.json
@@ -418,7 +418,12 @@
           "available": true,
           "state": 49.0,
           "battery_voltage": 2.6
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ]
   },

--- a/tests/data/devices/tuyatec-yg5dcbfu-rh3052.json
+++ b/tests/data/devices/tuyatec-yg5dcbfu-rh3052.json
@@ -369,7 +369,12 @@
           "available": true,
           "state": 76.0,
           "battery_voltage": 2.8
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/tyzb01-o63ssaah-ts0207.json
+++ b/tests/data/devices/tyzb01-o63ssaah-ts0207.json
@@ -429,7 +429,12 @@
           "available": true,
           "state": 100.0,
           "battery_voltage": 3.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/tyzb01-qm6djpta-ts0215.json
+++ b/tests/data/devices/tyzb01-qm6djpta-ts0215.json
@@ -489,7 +489,12 @@
           "available": true,
           "state": 100.0,
           "battery_voltage": 3.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/tyzb01-rifa0wlb-ts0011.json
+++ b/tests/data/devices/tyzb01-rifa0wlb-ts0011.json
@@ -234,7 +234,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "sensor": [

--- a/tests/data/devices/tyzb01-zanh6v1o-ts0121.json
+++ b/tests/data/devices/tyzb01-zanh6v1o-ts0121.json
@@ -576,7 +576,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -628,7 +633,11 @@
           "class_name": "PolledElectricalMeasurement",
           "available": true,
           "state": 1.0
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -680,7 +689,11 @@
           "class_name": "ElectricalMeasurementRMSCurrent",
           "available": true,
           "state": 8.0
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -732,7 +745,11 @@
           "class_name": "ElectricalMeasurementRMSVoltage",
           "available": true,
           "state": 123.0
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       }
     ],
     "switch": [

--- a/tests/data/devices/tz3000-8yhypbo7-ts0203.json
+++ b/tests/data/devices/tz3000-8yhypbo7-ts0203.json
@@ -486,7 +486,12 @@
           "available": true,
           "state": 67.0,
           "battery_voltage": 2.8
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/tz3000-bguser20-ts0201.json
+++ b/tests/data/devices/tz3000-bguser20-ts0201.json
@@ -358,7 +358,12 @@
           "available": true,
           "state": 1.0,
           "battery_voltage": 2.6
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/tz3000-cehuw1lw-ts011f.json
+++ b/tests/data/devices/tz3000-cehuw1lw-ts011f.json
@@ -609,7 +609,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -661,7 +666,11 @@
           "class_name": "PolledElectricalMeasurement",
           "available": true,
           "state": 0.0
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -713,7 +722,11 @@
           "class_name": "ElectricalMeasurementRMSCurrent",
           "available": true,
           "state": 0.0
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -765,7 +778,11 @@
           "class_name": "ElectricalMeasurementRMSVoltage",
           "available": true,
           "state": 231.0
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       }
     ],
     "switch": [

--- a/tests/data/devices/tz3000-f2bw0b6k-ts0201.json
+++ b/tests/data/devices/tz3000-f2bw0b6k-ts0201.json
@@ -358,7 +358,12 @@
           "available": true,
           "state": 57.0,
           "battery_voltage": 2.7
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/tz3000-itnrsufe-ts0201.json
+++ b/tests/data/devices/tz3000-itnrsufe-ts0201.json
@@ -384,7 +384,12 @@
           "available": true,
           "state": 78.0,
           "battery_voltage": 2.8
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/tz3000-kjfzuycl-ts004f.json
+++ b/tests/data/devices/tz3000-kjfzuycl-ts004f.json
@@ -410,7 +410,12 @@
           "available": true,
           "state": 100.0,
           "battery_voltage": 3.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/tz3000-uwkja6z1-ts011f.json
+++ b/tests/data/devices/tz3000-uwkja6z1-ts011f.json
@@ -875,7 +875,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -927,7 +932,11 @@
           "class_name": "PolledElectricalMeasurement",
           "available": true,
           "state": 0.0
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -979,7 +988,11 @@
           "class_name": "ElectricalMeasurementRMSCurrent",
           "available": true,
           "state": 0.0
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -1031,7 +1044,11 @@
           "class_name": "ElectricalMeasurementRMSVoltage",
           "available": true,
           "state": 241.0
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -1086,7 +1103,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -1138,7 +1160,11 @@
           "class_name": "PolledElectricalMeasurement",
           "available": true,
           "state": 0.0
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -1190,7 +1216,11 @@
           "class_name": "ElectricalMeasurementRMSCurrent",
           "available": true,
           "state": 0.0
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -1242,7 +1272,11 @@
           "class_name": "ElectricalMeasurementRMSVoltage",
           "available": true,
           "state": 241.0
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       }
     ],
     "switch": [

--- a/tests/data/devices/tz3000-w0qqde0g-ts011f.json
+++ b/tests/data/devices/tz3000-w0qqde0g-ts011f.json
@@ -724,7 +724,12 @@
           "available": true,
           "state": 0.0,
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -776,7 +781,11 @@
           "class_name": "PolledElectricalMeasurement",
           "available": true,
           "state": 0.0
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -828,7 +837,11 @@
           "class_name": "ElectricalMeasurementRMSCurrent",
           "available": true,
           "state": 0.0
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -880,7 +893,11 @@
           "class_name": "ElectricalMeasurementRMSVoltage",
           "available": true,
           "state": 208.0
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       }
     ],
     "switch": [

--- a/tests/data/devices/tz3000-zw7yf6yk-ts0001.json
+++ b/tests/data/devices/tz3000-zw7yf6yk-ts0001.json
@@ -508,7 +508,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "sensor": [
@@ -669,7 +673,12 @@
           "device_type": "Electric Metering",
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -721,7 +730,11 @@
           "class_name": "PolledElectricalMeasurement",
           "available": true,
           "state": 0.0
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -773,7 +786,11 @@
           "class_name": "ElectricalMeasurementRMSCurrent",
           "available": true,
           "state": 0.0
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -825,7 +842,11 @@
           "class_name": "ElectricalMeasurementRMSVoltage",
           "available": true,
           "state": 0.0
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/tz3210-09hzmirw-ts0502b.json
+++ b/tests/data/devices/tz3210-09hzmirw-ts0502b.json
@@ -409,7 +409,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/tz3210-j4pdtz9v-ts0001.json
+++ b/tests/data/devices/tz3210-j4pdtz9v-ts0001.json
@@ -604,7 +604,12 @@
           "state": null,
           "battery_size": "CR2",
           "battery_quantity": 1
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "switch": [

--- a/tests/data/devices/tz3210-jaap6jeb-ts0505b.json
+++ b/tests/data/devices/tz3210-jaap6jeb-ts0505b.json
@@ -467,7 +467,11 @@
           "off_with_transition": false,
           "off_brightness": null,
           "available": true
-        }
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
       }
     ],
     "sensor": [

--- a/tests/data/devices/tz3210-tgvtvdoc-ts0207.json
+++ b/tests/data/devices/tz3210-tgvtvdoc-ts0207.json
@@ -434,7 +434,12 @@
           "battery_size": "Other",
           "battery_quantity": 1,
           "battery_voltage": 0.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/tze200-9caxna4s-ts0301.json
+++ b/tests/data/devices/tze200-9caxna4s-ts0301.json
@@ -461,7 +461,12 @@
           "available": true,
           "state": 35.0,
           "battery_voltage": 0.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/tze200-ijey4q29-ts0601.json
+++ b/tests/data/devices/tze200-ijey4q29-ts0601.json
@@ -425,7 +425,12 @@
           "available": true,
           "state": 100.0,
           "battery_voltage": 3.3
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/tze200-locansqn-ts0601.json
+++ b/tests/data/devices/tze200-locansqn-ts0601.json
@@ -906,7 +906,12 @@
           "state": 1.0,
           "battery_size": "AA",
           "battery_quantity": 2
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/tze200-myd45weu-ts0601.json
+++ b/tests/data/devices/tze200-myd45weu-ts0601.json
@@ -322,7 +322,12 @@
           "state": 20.0,
           "battery_size": "AA",
           "battery_quantity": 2
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/tze200-ny94onlb-ts0601.json
+++ b/tests/data/devices/tze200-ny94onlb-ts0601.json
@@ -955,7 +955,12 @@
           "available": true,
           "state": 0.26,
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -1007,7 +1012,11 @@
           "class_name": "PolledElectricalMeasurement",
           "available": true,
           "state": 298.0
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -1059,7 +1068,11 @@
           "class_name": "ElectricalMeasurementActivePowerPhB",
           "available": true,
           "state": 266.0
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max_ph_b",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -1111,7 +1124,11 @@
           "class_name": "ElectricalMeasurementActivePowerPhC",
           "available": true,
           "state": 70.0
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max_ph_c",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -1163,7 +1180,11 @@
           "class_name": "ElectricalMeasurementRMSCurrent",
           "available": true,
           "state": 1.38
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -1215,7 +1236,11 @@
           "class_name": "ElectricalMeasurementRMSCurrentPhB",
           "available": true,
           "state": 1.576
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max_ph_b"
+        ]
       },
       {
         "info_object": {
@@ -1267,7 +1292,11 @@
           "class_name": "ElectricalMeasurementRMSCurrentPhC",
           "available": true,
           "state": 0.413
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max_ph_c"
+        ]
       },
       {
         "info_object": {
@@ -1319,7 +1348,11 @@
           "class_name": "ElectricalMeasurementRMSVoltage",
           "available": true,
           "state": 223.8
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -1371,7 +1404,11 @@
           "class_name": "ElectricalMeasurementRMSVoltagePhB",
           "available": true,
           "state": 215.9
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max_ph_b"
+        ]
       },
       {
         "info_object": {
@@ -1423,7 +1460,11 @@
           "class_name": "ElectricalMeasurementRMSVoltagePhC",
           "available": true,
           "state": 227.2
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max_ph_c"
+        ]
       },
       {
         "info_object": {
@@ -1475,7 +1516,11 @@
           "class_name": "PolledElectricalMeasurement",
           "available": true,
           "state": 298.0
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -1527,7 +1572,11 @@
           "class_name": "ElectricalMeasurementRMSCurrent",
           "available": true,
           "state": 1.38
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -1579,7 +1628,11 @@
           "class_name": "ElectricalMeasurementRMSVoltage",
           "available": true,
           "state": 223.8
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -1631,7 +1684,11 @@
           "class_name": "PolledElectricalMeasurement",
           "available": true,
           "state": 266.0
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -1683,7 +1740,11 @@
           "class_name": "ElectricalMeasurementRMSCurrent",
           "available": true,
           "state": 1.576
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -1735,7 +1796,11 @@
           "class_name": "ElectricalMeasurementRMSVoltage",
           "available": true,
           "state": 215.9
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -1787,7 +1852,11 @@
           "class_name": "PolledElectricalMeasurement",
           "available": true,
           "state": 70.0
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -1839,7 +1908,11 @@
           "class_name": "ElectricalMeasurementRMSCurrent",
           "available": true,
           "state": 0.413
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -1891,7 +1964,11 @@
           "class_name": "ElectricalMeasurementRMSVoltage",
           "available": true,
           "state": 227.2
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/tze200-pay2byax-ts0601.json
+++ b/tests/data/devices/tze200-pay2byax-ts0601.json
@@ -414,7 +414,12 @@
           "battery_size": "CR2032",
           "battery_quantity": 1,
           "battery_voltage": 2.7
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/tze200-yjjdcqsq-ts0601.json
+++ b/tests/data/devices/tze200-yjjdcqsq-ts0601.json
@@ -352,7 +352,12 @@
           "state": null,
           "battery_size": "AAA",
           "battery_quantity": 2
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/tze204-81yrt3lo-ts0601.json
+++ b/tests/data/devices/tze204-81yrt3lo-ts0601.json
@@ -1003,7 +1003,12 @@
           "state": 0.0,
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -1057,7 +1062,12 @@
           "state": 0.0,
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -1111,7 +1121,12 @@
           "state": 0.0,
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -1164,7 +1179,11 @@
           "available": true,
           "state": 0.0,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -1217,7 +1236,11 @@
           "available": true,
           "state": 49.13,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "ac_frequency_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -1270,7 +1293,11 @@
           "available": true,
           "state": 0.0,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -1323,7 +1350,11 @@
           "available": true,
           "state": 100,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -1376,7 +1407,11 @@
           "available": true,
           "state": 0.0,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -1429,7 +1464,11 @@
           "available": true,
           "state": 240.3,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
       },
       {
         "info_object": {
@@ -1483,7 +1522,12 @@
           "state": 55.0,
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -1537,7 +1581,12 @@
           "state": 0.33,
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -1591,7 +1640,12 @@
           "state": 0.0,
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -1644,7 +1698,11 @@
           "available": true,
           "state": 52.5,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -1697,7 +1755,11 @@
           "available": true,
           "state": 95.4,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -1750,7 +1812,11 @@
           "available": true,
           "state": 57,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -1803,7 +1869,11 @@
           "available": true,
           "state": 0.397,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       },
       {
         "info_object": {
@@ -1857,7 +1927,12 @@
           "state": 55.0,
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -1911,7 +1986,12 @@
           "state": 0.33,
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -1965,7 +2045,12 @@
           "state": 0.0,
           "status": "NO_ALARMS",
           "zcl_unit_of_measurement": 0
-        }
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
       },
       {
         "info_object": {
@@ -2018,7 +2103,11 @@
           "available": true,
           "state": 52.5,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
       },
       {
         "info_object": {
@@ -2071,7 +2160,11 @@
           "available": true,
           "state": 95.4,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          null
+        ]
       },
       {
         "info_object": {
@@ -2124,7 +2217,11 @@
           "available": true,
           "state": 0.397,
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
-        }
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/tze204-nlrfgpny-ts0601.json
+++ b/tests/data/devices/tze204-nlrfgpny-ts0601.json
@@ -622,7 +622,12 @@
           "state": null,
           "battery_size": "Other",
           "battery_quantity": 1
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/tze284-ne4pikwm-ts0601.json
+++ b/tests/data/devices/tze284-ne4pikwm-ts0601.json
@@ -368,7 +368,17 @@
           "pi_cooling_demand": null,
           "unoccupied_cooling_setpoint": null,
           "unoccupied_heating_setpoint": null
-        }
+        },
+        "extra_state_attributes": [
+          "occupancy",
+          "occupied_cooling_setpoint",
+          "occupied_heating_setpoint",
+          "pi_cooling_demand",
+          "pi_heating_demand",
+          "system_mode",
+          "unoccupied_cooling_setpoint",
+          "unoccupied_heating_setpoint"
+        ]
       }
     ],
     "number": [

--- a/tests/data/devices/tze284-qyflbnbj-ts0601.json
+++ b/tests/data/devices/tze284-qyflbnbj-ts0601.json
@@ -356,7 +356,12 @@
           "state": null,
           "battery_size": "AA",
           "battery_quantity": 2
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/xiaomi-lywsd03mmc.json
+++ b/tests/data/devices/xiaomi-lywsd03mmc.json
@@ -691,7 +691,12 @@
           "available": true,
           "state": 1.5,
           "battery_voltage": 2.2
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/xiaoyan-terncy-sd01.json
+++ b/tests/data/devices/xiaoyan-terncy-sd01.json
@@ -361,7 +361,12 @@
           "class_name": "Battery",
           "available": true,
           "state": 79.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/yale-yrd256-tsdb.json
+++ b/tests/data/devices/yale-yrd256-tsdb.json
@@ -464,7 +464,12 @@
           "battery_size": "AA",
           "battery_quantity": 4,
           "battery_voltage": 5.2
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/tests/data/devices/yooksmart-d10110.json
+++ b/tests/data/devices/yooksmart-d10110.json
@@ -467,7 +467,12 @@
           "class_name": "Battery",
           "available": true,
           "state": 65.0
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       },
       {
         "info_object": {

--- a/tests/data/devices/yunding-ford.json
+++ b/tests/data/devices/yunding-ford.json
@@ -407,7 +407,12 @@
           "state": 100.0,
           "battery_size": "AA",
           "battery_quantity": 4
-        }
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
       }
     ],
     "update": [

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -1507,12 +1507,17 @@ class Device(LogMixin, EventBase):
                 if cluster_info is not None:
                     cluster_info.pop("commands", None)
 
-            info["zha_lib_entities"][platform].append(
-                {
-                    "info_object": info_object,
-                    "state": platform_entity.state,
-                }
-            )
+            obj = {
+                "info_object": info_object,
+                "state": platform_entity.state,
+            }
+
+            if platform_entity.extra_state_attribute_names is not None:
+                obj["extra_state_attributes"] = (
+                    platform_entity.extra_state_attribute_names
+                )
+
+            info["zha_lib_entities"][platform].append(obj)
 
         topology = self.gateway.application_controller.topology
         info["neighbors"] = [


### PR DESCRIPTION
We currently have a small bug where a `None` state attribute name has made it into `extra_state_attributes`, causing downstream warnings. We should include the list of extra state attributes in the JSON to make sure changes like this are caught.