### PR TITLE
Fix `device_ieee` in diagnostics

### DIFF
--- a/tests/data/devices/adurosmart-eria-ad-rgbw3001.json
+++ b/tests/data/devices/adurosmart-eria-ad-rgbw3001.json
@@ -299,16 +299,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            218,
-            158,
-            66,
-            3,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:03:42:9e:da",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -383,16 +374,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            218,
-            158,
-            66,
-            3,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:03:42:9e:da",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -467,16 +449,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            218,
-            158,
-            66,
-            3,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:03:42:9e:da",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -522,16 +495,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            218,
-            158,
-            66,
-            3,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:03:42:9e:da",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -577,16 +541,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            218,
-            158,
-            66,
-            3,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:03:42:9e:da",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -632,16 +587,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            218,
-            158,
-            66,
-            3,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:03:42:9e:da",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -687,16 +633,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            218,
-            158,
-            66,
-            3,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:03:42:9e:da",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -742,16 +679,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            218,
-            158,
-            66,
-            3,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:03:42:9e:da",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -799,16 +727,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            218,
-            158,
-            66,
-            3,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:03:42:9e:da",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -858,16 +777,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            218,
-            158,
-            66,
-            3,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:03:42:9e:da",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -910,16 +820,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            218,
-            158,
-            66,
-            3,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:03:42:9e:da",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -964,16 +865,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            218,
-            158,
-            66,
-            3,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:03:42:9e:da",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/adurosmart-eria-vms-adurolight.json
+++ b/tests/data/devices/adurosmart-eria-vms-adurolight.json
@@ -171,16 +171,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            144,
-            64,
-            91,
-            7,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:07:5b:40:90",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -224,16 +215,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            144,
-            64,
-            91,
-            7,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:07:5b:40:90",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -280,16 +262,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            144,
-            64,
-            91,
-            7,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:07:5b:40:90",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -332,16 +305,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            144,
-            64,
-            91,
-            7,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:07:5b:40:90",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -384,16 +348,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            144,
-            64,
-            91,
-            7,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:07:5b:40:90",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/aqara-lumi-lunar-acn01.json
+++ b/tests/data/devices/aqara-lumi-lunar-acn01.json
@@ -122,16 +122,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            140,
-            95,
-            33,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:21:5f:8c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -178,16 +169,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            140,
-            95,
-            33,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:21:5f:8c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -230,16 +212,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            140,
-            95,
-            33,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:21:5f:8c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -284,16 +257,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            140,
-            95,
-            33,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:21:5f:8c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/aqara-lumi-motion-ac01.json
+++ b/tests/data/devices/aqara-lumi-motion-ac01.json
@@ -213,16 +213,7 @@
               "value_attribute": "occupancy"
             }
           ],
-          "device_ieee": [
-            91,
-            45,
-            77,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:4d:2d:5b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -266,16 +257,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            91,
-            45,
-            77,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:4d:2d:5b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -320,16 +302,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            91,
-            45,
-            77,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:4d:2d:5b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -373,16 +346,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            91,
-            45,
-            77,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:4d:2d:5b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -429,16 +393,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            91,
-            45,
-            77,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:4d:2d:5b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -484,16 +439,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            91,
-            45,
-            77,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:4d:2d:5b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -542,16 +488,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            91,
-            45,
-            77,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:4d:2d:5b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -594,16 +531,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            91,
-            45,
-            77,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:4d:2d:5b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -646,16 +574,7 @@
               "value_attribute": "current_temperature"
             }
           ],
-          "device_ieee": [
-            91,
-            45,
-            77,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:4d:2d:5b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -700,16 +619,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            91,
-            45,
-            77,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:4d:2d:5b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/aug-winkhaus-gmbh-co-kg-fm-v-zb.json
+++ b/tests/data/devices/aug-winkhaus-gmbh-co-kg-fm-v-zb.json
@@ -159,16 +159,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            182,
-            69,
-            43,
-            208,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:d0:2b:45:b6",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -212,16 +203,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            182,
-            69,
-            43,
-            208,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:d0:2b:45:b6",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -268,16 +250,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            182,
-            69,
-            43,
-            208,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:d0:2b:45:b6",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -320,16 +293,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            182,
-            69,
-            43,
-            208,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:d0:2b:45:b6",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -372,16 +336,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            182,
-            69,
-            43,
-            208,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:d0:2b:45:b6",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -431,16 +386,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            182,
-            69,
-            43,
-            208,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:d0:2b:45:b6",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/awox-tlsr82xx.json
+++ b/tests/data/devices/awox-tlsr82xx.json
@@ -182,16 +182,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            209,
-            223,
-            214,
-            156,
-            1,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:01:9c:d6:df:d1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -238,16 +229,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            209,
-            223,
-            214,
-            156,
-            1,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:01:9c:d6:df:d1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -290,16 +272,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            209,
-            223,
-            214,
-            156,
-            1,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:01:9c:d6:df:d1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/bosch-rbsh-mms-zb-eu.json
+++ b/tests/data/devices/bosch-rbsh-mms-zb-eu.json
@@ -612,16 +612,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            165,
-            150,
-            228,
-            117,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:75:e4:96:a5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -668,16 +659,7 @@
               "value_attribute": "current_position_lift_percentage"
             }
           ],
-          "device_ieee": [
-            165,
-            150,
-            228,
-            117,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:75:e4:96:a5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -725,16 +707,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            165,
-            150,
-            228,
-            117,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:75:e4:96:a5",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -799,16 +772,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            165,
-            150,
-            228,
-            117,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:75:e4:96:a5",
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
@@ -875,16 +839,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            165,
-            150,
-            228,
-            117,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:75:e4:96:a5",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -932,16 +887,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            165,
-            150,
-            228,
-            117,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:75:e4:96:a5",
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
@@ -991,16 +937,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            165,
-            150,
-            228,
-            117,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:75:e4:96:a5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1043,16 +980,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            165,
-            150,
-            228,
-            117,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:75:e4:96:a5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1095,16 +1023,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            165,
-            150,
-            228,
-            117,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:75:e4:96:a5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1155,16 +1074,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            165,
-            150,
-            228,
-            117,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:75:e4:96:a5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1215,16 +1125,7 @@
               "value_attribute": "current_position_lift_percentage"
             }
           ],
-          "device_ieee": [
-            165,
-            150,
-            228,
-            117,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:75:e4:96:a5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1267,16 +1168,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            165,
-            150,
-            228,
-            117,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:75:e4:96:a5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1326,16 +1218,7 @@
               "value_attribute": "current_position_lift_percentage"
             }
           ],
-          "device_ieee": [
-            165,
-            150,
-            228,
-            117,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:75:e4:96:a5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1384,16 +1267,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            165,
-            150,
-            228,
-            117,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:75:e4:96:a5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/centralite-3320-l.json
+++ b/tests/data/devices/centralite-3320-l.json
@@ -292,16 +292,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            105,
-            227,
-            58,
-            15,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:0f:3a:e3:69",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -345,16 +336,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            105,
-            227,
-            58,
-            15,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:0f:3a:e3:69",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -401,16 +383,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            105,
-            227,
-            58,
-            15,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:0f:3a:e3:69",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -453,16 +426,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            105,
-            227,
-            58,
-            15,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:0f:3a:e3:69",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -505,16 +469,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            105,
-            227,
-            58,
-            15,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:0f:3a:e3:69",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -565,16 +520,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            105,
-            227,
-            58,
-            15,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:0f:3a:e3:69",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -619,16 +565,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            105,
-            227,
-            58,
-            15,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:0f:3a:e3:69",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/centralite-3326-l.json
+++ b/tests/data/devices/centralite-3326-l.json
@@ -279,16 +279,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            101,
-            20,
-            154,
-            16,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:10:9a:14:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -332,16 +323,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            101,
-            20,
-            154,
-            16,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:10:9a:14:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -388,16 +370,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            101,
-            20,
-            154,
-            16,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:10:9a:14:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -440,16 +413,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            101,
-            20,
-            154,
-            16,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:10:9a:14:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -492,16 +456,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            101,
-            20,
-            154,
-            16,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:10:9a:14:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -552,16 +507,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            101,
-            20,
-            154,
-            16,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:10:9a:14:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -606,16 +552,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            101,
-            20,
-            154,
-            16,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:10:9a:14:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/centralite-3405-l.json
+++ b/tests/data/devices/centralite-3405-l.json
@@ -211,16 +211,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            242,
-            131,
-            101,
-            5,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:05:65:83:f2",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -264,16 +255,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            242,
-            131,
-            101,
-            5,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:05:65:83:f2",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -319,16 +301,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            242,
-            131,
-            101,
-            5,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:05:65:83:f2",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -372,16 +345,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            242,
-            131,
-            101,
-            5,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:05:65:83:f2",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -428,16 +392,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            242,
-            131,
-            101,
-            5,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:05:65:83:f2",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -480,16 +435,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            242,
-            131,
-            101,
-            5,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:05:65:83:f2",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -532,16 +478,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            242,
-            131,
-            101,
-            5,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:05:65:83:f2",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -592,16 +529,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            242,
-            131,
-            101,
-            5,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:05:65:83:f2",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -646,16 +574,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            242,
-            131,
-            101,
-            5,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:05:65:83:f2",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/centralite-systems-3156105.json
+++ b/tests/data/devices/centralite-systems-3156105.json
@@ -386,16 +386,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            190,
-            241,
-            87,
-            3,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:03:57:f1:be",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -456,16 +447,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            190,
-            241,
-            87,
-            3,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:03:57:f1:be",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -547,16 +529,7 @@
               "value_attribute": "local_temperature"
             }
           ],
-          "device_ieee": [
-            190,
-            241,
-            87,
-            3,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:03:57:f1:be",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -602,16 +575,7 @@
               "value_attribute": "local_temperature"
             }
           ],
-          "device_ieee": [
-            190,
-            241,
-            87,
-            3,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:03:57:f1:be",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -657,16 +621,7 @@
               "value_attribute": "local_temperature"
             }
           ],
-          "device_ieee": [
-            190,
-            241,
-            87,
-            3,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:03:57:f1:be",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -714,16 +669,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            190,
-            241,
-            87,
-            3,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:03:57:f1:be",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -774,16 +720,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            190,
-            241,
-            87,
-            3,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:03:57:f1:be",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -826,16 +763,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            190,
-            241,
-            87,
-            3,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:03:57:f1:be",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -878,16 +806,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            190,
-            241,
-            87,
-            3,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:03:57:f1:be",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -936,16 +855,7 @@
               "value_attribute": "local_temperature"
             }
           ],
-          "device_ieee": [
-            190,
-            241,
-            87,
-            3,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:03:57:f1:be",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -988,16 +898,7 @@
               "value_attribute": "local_temperature"
             }
           ],
-          "device_ieee": [
-            190,
-            241,
-            87,
-            3,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:03:57:f1:be",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1042,16 +943,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            190,
-            241,
-            87,
-            3,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:03:57:f1:be",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/climaxtechnology-sd8sc-00-00-03-12tc.json
+++ b/tests/data/devices/climaxtechnology-sd8sc-00-00-03-12tc.json
@@ -141,16 +141,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            207,
-            90,
-            110,
-            9,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:09:6e:5a:cf",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -194,16 +185,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            207,
-            90,
-            110,
-            9,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:09:6e:5a:cf",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -250,16 +232,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            207,
-            90,
-            110,
-            9,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:09:6e:5a:cf",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -307,16 +280,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            207,
-            90,
-            110,
-            9,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:09:6e:5a:cf",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -362,16 +326,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            207,
-            90,
-            110,
-            9,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:09:6e:5a:cf",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -419,16 +374,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            207,
-            90,
-            110,
-            9,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:09:6e:5a:cf",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -481,16 +427,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            207,
-            90,
-            110,
-            9,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:09:6e:5a:cf",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -533,16 +470,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            207,
-            90,
-            110,
-            9,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:09:6e:5a:cf",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -587,16 +515,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            207,
-            90,
-            110,
-            9,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:09:6e:5a:cf",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ecolink-4655bc0-r.json
+++ b/tests/data/devices/ecolink-4655bc0-r.json
@@ -258,16 +258,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            170,
-            148,
-            21,
-            17,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:11:15:94:aa",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -311,16 +302,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            170,
-            148,
-            21,
-            17,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:11:15:94:aa",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -367,16 +349,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            170,
-            148,
-            21,
-            17,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:11:15:94:aa",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -419,16 +392,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            170,
-            148,
-            21,
-            17,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:11:15:94:aa",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -471,16 +435,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            170,
-            148,
-            21,
-            17,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:11:15:94:aa",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -531,16 +486,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            170,
-            148,
-            21,
-            17,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:11:15:94:aa",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -585,16 +531,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            170,
-            148,
-            21,
-            17,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:11:15:94:aa",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/enktro-acmidea.json
+++ b/tests/data/devices/enktro-acmidea.json
@@ -262,16 +262,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            129,
-            45,
-            16,
-            249,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:f9:10:2d:81",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -332,16 +323,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            129,
-            45,
-            16,
-            249,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:f9:10:2d:81",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -424,16 +406,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            129,
-            45,
-            16,
-            249,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:f9:10:2d:81",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -476,16 +449,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            129,
-            45,
-            16,
-            249,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:f9:10:2d:81",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -528,16 +492,7 @@
               "value_attribute": "local_temperature"
             }
           ],
-          "device_ieee": [
-            129,
-            45,
-            16,
-            249,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:f9:10:2d:81",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -580,16 +535,7 @@
               "value_attribute": "local_temperature"
             }
           ],
-          "device_ieee": [
-            129,
-            45,
-            16,
-            249,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:f9:10:2d:81",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ericsity-gl-c-008p.json
+++ b/tests/data/devices/ericsity-gl-c-008p.json
@@ -278,16 +278,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            184,
-            96,
-            224,
-            254,
-            222,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:de:fe:e0:60:b8",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -362,16 +353,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            184,
-            96,
-            224,
-            254,
-            222,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:de:fe:e0:60:b8",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -446,16 +428,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            184,
-            96,
-            224,
-            254,
-            222,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:de:fe:e0:60:b8",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -501,16 +474,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            184,
-            96,
-            224,
-            254,
-            222,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:de:fe:e0:60:b8",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -558,16 +522,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            184,
-            96,
-            224,
-            254,
-            222,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:de:fe:e0:60:b8",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -617,16 +572,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            184,
-            96,
-            224,
-            254,
-            222,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:de:fe:e0:60:b8",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -669,16 +615,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            184,
-            96,
-            224,
-            254,
-            222,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:de:fe:e0:60:b8",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -723,16 +660,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            184,
-            96,
-            224,
-            254,
-            222,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:de:fe:e0:60:b8",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ericsity-gl-c-009p.json
+++ b/tests/data/devices/ericsity-gl-c-009p.json
@@ -314,16 +314,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            194,
-            117,
-            77,
-            198,
-            68,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:44:c6:4d:75:c2",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -398,16 +389,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            194,
-            117,
-            77,
-            198,
-            68,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:44:c6:4d:75:c2",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -476,16 +458,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            194,
-            117,
-            77,
-            198,
-            68,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:44:c6:4d:75:c2",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -531,16 +504,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            194,
-            117,
-            77,
-            198,
-            68,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:44:c6:4d:75:c2",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -588,16 +552,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            194,
-            117,
-            77,
-            198,
-            68,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:44:c6:4d:75:c2",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -647,16 +602,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            194,
-            117,
-            77,
-            198,
-            68,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:44:c6:4d:75:c2",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -699,16 +645,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            194,
-            117,
-            77,
-            198,
-            68,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:44:c6:4d:75:c2",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -753,16 +690,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            194,
-            117,
-            77,
-            198,
-            68,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:44:c6:4d:75:c2",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/espressif-zigbeeanalogdevice.json
+++ b/tests/data/devices/espressif-zigbeeanalogdevice.json
@@ -220,16 +220,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            85,
-            115,
-            162,
-            57,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:39:a2:73:55",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -276,16 +267,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            85,
-            115,
-            162,
-            57,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:39:a2:73:55",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -333,16 +315,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            85,
-            115,
-            162,
-            57,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:39:a2:73:55",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -385,16 +358,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            85,
-            115,
-            162,
-            57,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:39:a2:73:55",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -437,16 +401,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            85,
-            115,
-            162,
-            57,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:39:a2:73:55",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/espressif-zigbeebinaryoutputdevice.json
+++ b/tests/data/devices/espressif-zigbeebinaryoutputdevice.json
@@ -118,16 +118,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            86,
-            115,
-            162,
-            57,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:39:a2:73:56",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -174,16 +165,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            86,
-            115,
-            162,
-            57,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:39:a2:73:56",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -226,16 +208,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            86,
-            115,
-            162,
-            57,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:39:a2:73:56",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -280,16 +253,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            86,
-            115,
-            162,
-            57,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:39:a2:73:56",
           "endpoint_id": 1,
           "available": true,
           "group_id": null

--- a/tests/data/devices/espressif-zigbeecarbondioxidesensor.json
+++ b/tests/data/devices/espressif-zigbeecarbondioxidesensor.json
@@ -112,16 +112,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            100,
-            134,
-            1,
-            254,
-            255,
-            189,
-            245,
-            240
-          ],
+          "device_ieee": "f0:f5:bd:ff:fe:01:86:64",
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
@@ -168,16 +159,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            100,
-            134,
-            1,
-            254,
-            255,
-            189,
-            245,
-            240
-          ],
+          "device_ieee": "f0:f5:bd:ff:fe:01:86:64",
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
@@ -220,16 +202,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            100,
-            134,
-            1,
-            254,
-            255,
-            189,
-            245,
-            240
-          ],
+          "device_ieee": "f0:f5:bd:ff:fe:01:86:64",
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
@@ -272,16 +245,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            100,
-            134,
-            1,
-            254,
-            255,
-            189,
-            245,
-            240
-          ],
+          "device_ieee": "f0:f5:bd:ff:fe:01:86:64",
           "endpoint_id": 10,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ewelink-ck-bl702-al-01-7009-z102lg03-1.json
+++ b/tests/data/devices/ewelink-ck-bl702-al-01-7009-z102lg03-1.json
@@ -293,16 +293,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            0,
-            0,
-            208,
-            51,
-            119,
-            76,
-            185,
-            124
-          ],
+          "device_ieee": "7c:b9:4c:77:33:d0:00:00",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -377,16 +368,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            0,
-            0,
-            208,
-            51,
-            119,
-            76,
-            185,
-            124
-          ],
+          "device_ieee": "7c:b9:4c:77:33:d0:00:00",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -461,16 +443,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            0,
-            0,
-            208,
-            51,
-            119,
-            76,
-            185,
-            124
-          ],
+          "device_ieee": "7c:b9:4c:77:33:d0:00:00",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -516,16 +489,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            0,
-            0,
-            208,
-            51,
-            119,
-            76,
-            185,
-            124
-          ],
+          "device_ieee": "7c:b9:4c:77:33:d0:00:00",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -571,16 +535,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            0,
-            0,
-            208,
-            51,
-            119,
-            76,
-            185,
-            124
-          ],
+          "device_ieee": "7c:b9:4c:77:33:d0:00:00",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -626,16 +581,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            0,
-            0,
-            208,
-            51,
-            119,
-            76,
-            185,
-            124
-          ],
+          "device_ieee": "7c:b9:4c:77:33:d0:00:00",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -683,16 +629,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            0,
-            0,
-            208,
-            51,
-            119,
-            76,
-            185,
-            124
-          ],
+          "device_ieee": "7c:b9:4c:77:33:d0:00:00",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -742,16 +679,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            0,
-            0,
-            208,
-            51,
-            119,
-            76,
-            185,
-            124
-          ],
+          "device_ieee": "7c:b9:4c:77:33:d0:00:00",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -794,16 +722,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            0,
-            0,
-            208,
-            51,
-            119,
-            76,
-            185,
-            124
-          ],
+          "device_ieee": "7c:b9:4c:77:33:d0:00:00",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -848,16 +767,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            0,
-            0,
-            208,
-            51,
-            119,
-            76,
-            185,
-            124
-          ],
+          "device_ieee": "7c:b9:4c:77:33:d0:00:00",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ewelink-sa-003-zigbee.json
+++ b/tests/data/devices/ewelink-sa-003-zigbee.json
@@ -134,16 +134,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            28,
-            101,
-            139,
-            29,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:1d:8b:65:1c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -190,16 +181,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            28,
-            101,
-            139,
-            29,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:1d:8b:65:1c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -242,16 +224,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            28,
-            101,
-            139,
-            29,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:1d:8b:65:1c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -296,16 +269,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            28,
-            101,
-            139,
-            29,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:1d:8b:65:1c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null

--- a/tests/data/devices/ewelink-snzb-01p.json
+++ b/tests/data/devices/ewelink-snzb-01p.json
@@ -171,16 +171,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            254,
-            65,
-            210,
-            254,
-            255,
-            32,
-            186,
-            132
-          ],
+          "device_ieee": "84:ba:20:ff:fe:d2:41:fe",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -227,16 +218,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            254,
-            65,
-            210,
-            254,
-            255,
-            32,
-            186,
-            132
-          ],
+          "device_ieee": "84:ba:20:ff:fe:d2:41:fe",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -279,16 +261,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            254,
-            65,
-            210,
-            254,
-            255,
-            32,
-            186,
-            132
-          ],
+          "device_ieee": "84:ba:20:ff:fe:d2:41:fe",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -331,16 +304,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            254,
-            65,
-            210,
-            254,
-            255,
-            32,
-            186,
-            132
-          ],
+          "device_ieee": "84:ba:20:ff:fe:d2:41:fe",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -391,16 +355,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            254,
-            65,
-            210,
-            254,
-            255,
-            32,
-            186,
-            132
-          ],
+          "device_ieee": "84:ba:20:ff:fe:d2:41:fe",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ewelink-snzb-02p.json
+++ b/tests/data/devices/ewelink-snzb-02p.json
@@ -189,16 +189,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            94,
-            138,
-            13,
-            254,
-            255,
-            234,
-            53,
-            144
-          ],
+          "device_ieee": "90:35:ea:ff:fe:0d:8a:5e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -245,16 +236,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            94,
-            138,
-            13,
-            254,
-            255,
-            234,
-            53,
-            144
-          ],
+          "device_ieee": "90:35:ea:ff:fe:0d:8a:5e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -297,16 +279,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            94,
-            138,
-            13,
-            254,
-            255,
-            234,
-            53,
-            144
-          ],
+          "device_ieee": "90:35:ea:ff:fe:0d:8a:5e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -349,16 +322,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            94,
-            138,
-            13,
-            254,
-            255,
-            234,
-            53,
-            144
-          ],
+          "device_ieee": "90:35:ea:ff:fe:0d:8a:5e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -406,16 +370,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            94,
-            138,
-            13,
-            254,
-            255,
-            234,
-            53,
-            144
-          ],
+          "device_ieee": "90:35:ea:ff:fe:0d:8a:5e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -458,16 +413,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            94,
-            138,
-            13,
-            254,
-            255,
-            234,
-            53,
-            144
-          ],
+          "device_ieee": "90:35:ea:ff:fe:0d:8a:5e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -512,16 +458,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            94,
-            138,
-            13,
-            254,
-            255,
-            234,
-            53,
-            144
-          ],
+          "device_ieee": "90:35:ea:ff:fe:0d:8a:5e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ewelink-wb01.json
+++ b/tests/data/devices/ewelink-wb01.json
@@ -142,16 +142,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            249,
-            224,
-            18,
-            37,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:25:12:e0:f9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -198,16 +189,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            249,
-            224,
-            18,
-            37,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:25:12:e0:f9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -250,16 +232,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            249,
-            224,
-            18,
-            37,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:25:12:e0:f9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -302,16 +275,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            249,
-            224,
-            18,
-            37,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:25:12:e0:f9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ewelink-zb-sw02.json
+++ b/tests/data/devices/ewelink-zb-sw02.json
@@ -188,16 +188,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            206,
-            208,
-            183,
-            35,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:23:b7:d0:ce",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -244,16 +235,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            206,
-            208,
-            183,
-            35,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:23:b7:d0:ce",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -318,16 +300,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            206,
-            208,
-            183,
-            35,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:23:b7:d0:ce",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -394,16 +367,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            206,
-            208,
-            183,
-            35,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:23:b7:d0:ce",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -446,16 +410,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            206,
-            208,
-            183,
-            35,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:23:b7:d0:ce",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/feibit-inc-co-fzb56-zcw27lx1-0.json
+++ b/tests/data/devices/feibit-inc-co-fzb56-zcw27lx1-0.json
@@ -287,16 +287,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            177,
-            95,
-            70,
-            28,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:1c:46:5f:b1",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -371,16 +362,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            177,
-            95,
-            70,
-            28,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:1c:46:5f:b1",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -455,16 +437,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            177,
-            95,
-            70,
-            28,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:1c:46:5f:b1",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -507,16 +480,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            177,
-            95,
-            70,
-            28,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:1c:46:5f:b1",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/frient-a-s-aqszb-110.json
+++ b/tests/data/devices/frient-a-s-aqszb-110.json
@@ -243,16 +243,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            238,
-            31,
-            0,
-            54,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:36:00:1f:ee",
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
@@ -299,16 +290,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            238,
-            31,
-            0,
-            54,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:36:00:1f:ee",
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
@@ -351,16 +333,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            238,
-            31,
-            0,
-            54,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:36:00:1f:ee",
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
@@ -403,16 +376,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            238,
-            31,
-            0,
-            54,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:36:00:1f:ee",
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
@@ -463,16 +427,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            238,
-            31,
-            0,
-            54,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:36:00:1f:ee",
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
@@ -515,16 +470,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            238,
-            31,
-            0,
-            54,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:36:00:1f:ee",
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
@@ -567,16 +513,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            238,
-            31,
-            0,
-            54,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:36:00:1f:ee",
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
@@ -621,16 +558,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            238,
-            31,
-            0,
-            54,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:36:00:1f:ee",
           "endpoint_id": 38,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/frient-a-s-emizb-141.json
+++ b/tests/data/devices/frient-a-s-emizb-141.json
@@ -303,16 +303,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            92,
-            1,
-            16,
-            27,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:1b:10:01:5c",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -359,16 +350,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            92,
-            1,
-            16,
-            27,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:1b:10:01:5c",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -411,16 +393,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            92,
-            1,
-            16,
-            27,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:1b:10:01:5c",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -463,16 +436,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            92,
-            1,
-            16,
-            27,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:1b:10:01:5c",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -523,16 +487,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            92,
-            1,
-            16,
-            27,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:1b:10:01:5c",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -583,16 +538,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            92,
-            1,
-            16,
-            27,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:1b:10:01:5c",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -645,16 +591,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            92,
-            1,
-            16,
-            27,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:1b:10:01:5c",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/frient-a-s-emizb-151.json
+++ b/tests/data/devices/frient-a-s-emizb-151.json
@@ -1100,16 +1100,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            195,
-            137,
-            15,
-            116,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:74:0f:89:c3",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1156,16 +1147,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            195,
-            137,
-            15,
-            116,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:74:0f:89:c3",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1208,16 +1190,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            195,
-            137,
-            15,
-            116,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:74:0f:89:c3",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1260,16 +1233,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            195,
-            137,
-            15,
-            116,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:74:0f:89:c3",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1317,16 +1281,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            195,
-            137,
-            15,
-            116,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:74:0f:89:c3",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1377,16 +1332,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            195,
-            137,
-            15,
-            116,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:74:0f:89:c3",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1437,16 +1383,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            195,
-            137,
-            15,
-            116,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:74:0f:89:c3",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1497,16 +1434,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            195,
-            137,
-            15,
-            116,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:74:0f:89:c3",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1554,16 +1482,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            195,
-            137,
-            15,
-            116,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:74:0f:89:c3",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1611,16 +1530,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            195,
-            137,
-            15,
-            116,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:74:0f:89:c3",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1668,16 +1578,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            195,
-            137,
-            15,
-            116,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:74:0f:89:c3",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1725,16 +1626,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            195,
-            137,
-            15,
-            116,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:74:0f:89:c3",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1782,16 +1674,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            195,
-            137,
-            15,
-            116,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:74:0f:89:c3",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1839,16 +1722,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            195,
-            137,
-            15,
-            116,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:74:0f:89:c3",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1896,16 +1770,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            195,
-            137,
-            15,
-            116,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:74:0f:89:c3",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1953,16 +1818,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            195,
-            137,
-            15,
-            116,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:74:0f:89:c3",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -2010,16 +1866,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            195,
-            137,
-            15,
-            116,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:74:0f:89:c3",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -2069,16 +1916,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            195,
-            137,
-            15,
-            116,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:74:0f:89:c3",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/frient-a-s-flszb-110.json
+++ b/tests/data/devices/frient-a-s-flszb-110.json
@@ -266,16 +266,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            154,
-            118,
-            0,
-            51,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:33:00:76:9a",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -319,16 +310,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            154,
-            118,
-            0,
-            51,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:33:00:76:9a",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -375,16 +357,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            154,
-            118,
-            0,
-            51,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:33:00:76:9a",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -432,16 +405,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            154,
-            118,
-            0,
-            51,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:33:00:76:9a",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -487,16 +451,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            154,
-            118,
-            0,
-            51,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:33:00:76:9a",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -544,16 +499,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            154,
-            118,
-            0,
-            51,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:33:00:76:9a",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -606,16 +552,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            154,
-            118,
-            0,
-            51,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:33:00:76:9a",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -658,16 +595,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            154,
-            118,
-            0,
-            51,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:33:00:76:9a",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -710,16 +638,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            154,
-            118,
-            0,
-            51,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:33:00:76:9a",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -768,16 +687,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            154,
-            118,
-            0,
-            51,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:33:00:76:9a",
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
@@ -822,16 +732,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            154,
-            118,
-            0,
-            51,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:33:00:76:9a",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -883,16 +784,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            154,
-            118,
-            0,
-            51,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:33:00:76:9a",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/frient-a-s-hmszb-120.json
+++ b/tests/data/devices/frient-a-s-hmszb-120.json
@@ -233,16 +233,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            170,
-            38,
-            0,
-            53,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:35:00:26:aa",
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
@@ -289,16 +280,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            170,
-            38,
-            0,
-            53,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:35:00:26:aa",
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
@@ -341,16 +323,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            170,
-            38,
-            0,
-            53,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:35:00:26:aa",
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
@@ -393,16 +366,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            170,
-            38,
-            0,
-            53,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:35:00:26:aa",
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
@@ -453,16 +417,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            170,
-            38,
-            0,
-            53,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:35:00:26:aa",
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
@@ -505,16 +460,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            170,
-            38,
-            0,
-            53,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:35:00:26:aa",
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
@@ -559,16 +505,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            170,
-            38,
-            0,
-            53,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:35:00:26:aa",
           "endpoint_id": 38,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/frient-a-s-iomzb-110.json
+++ b/tests/data/devices/frient-a-s-iomzb-110.json
@@ -432,16 +432,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            28,
-            9,
-            0,
-            66,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:42:00:09:1c",
           "endpoint_id": 112,
           "available": true,
           "group_id": null,
@@ -483,16 +474,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            28,
-            9,
-            0,
-            66,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:42:00:09:1c",
           "endpoint_id": 113,
           "available": true,
           "group_id": null,
@@ -534,16 +516,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            28,
-            9,
-            0,
-            66,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:42:00:09:1c",
           "endpoint_id": 114,
           "available": true,
           "group_id": null,
@@ -585,16 +558,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            28,
-            9,
-            0,
-            66,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:42:00:09:1c",
           "endpoint_id": 115,
           "available": true,
           "group_id": null,
@@ -638,16 +602,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            28,
-            9,
-            0,
-            66,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:42:00:09:1c",
           "endpoint_id": 112,
           "available": true,
           "group_id": null,
@@ -694,16 +649,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            28,
-            9,
-            0,
-            66,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:42:00:09:1c",
           "endpoint_id": 112,
           "available": true,
           "group_id": null,
@@ -746,16 +692,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            28,
-            9,
-            0,
-            66,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:42:00:09:1c",
           "endpoint_id": 112,
           "available": true,
           "group_id": null,
@@ -800,16 +737,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            28,
-            9,
-            0,
-            66,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:42:00:09:1c",
           "endpoint_id": 116,
           "available": true,
           "group_id": null
@@ -850,16 +778,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            28,
-            9,
-            0,
-            66,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:42:00:09:1c",
           "endpoint_id": 117,
           "available": true,
           "group_id": null
@@ -902,16 +821,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            28,
-            9,
-            0,
-            66,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:42:00:09:1c",
           "endpoint_id": 112,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/frient-a-s-kepzb-110.json
+++ b/tests/data/devices/frient-a-s-kepzb-110.json
@@ -232,16 +232,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            57,
-            74,
-            0,
-            67,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:43:00:4a:39",
           "endpoint_id": 44,
           "available": true,
           "group_id": null,
@@ -287,16 +278,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            57,
-            74,
-            0,
-            67,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:43:00:4a:39",
           "endpoint_id": 44,
           "available": true,
           "group_id": null,
@@ -340,16 +322,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            57,
-            74,
-            0,
-            67,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:43:00:4a:39",
           "endpoint_id": 44,
           "available": true,
           "group_id": null,
@@ -396,16 +369,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            57,
-            74,
-            0,
-            67,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:43:00:4a:39",
           "endpoint_id": 44,
           "available": true,
           "group_id": null,
@@ -448,16 +412,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            57,
-            74,
-            0,
-            67,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:43:00:4a:39",
           "endpoint_id": 44,
           "available": true,
           "group_id": null,
@@ -500,16 +455,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            57,
-            74,
-            0,
-            67,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:43:00:4a:39",
           "endpoint_id": 44,
           "available": true,
           "group_id": null,
@@ -562,16 +508,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            57,
-            74,
-            0,
-            67,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:43:00:4a:39",
           "endpoint_id": 44,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/frient-a-s-moszb-153.json
+++ b/tests/data/devices/frient-a-s-moszb-153.json
@@ -447,16 +447,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            229,
-            138,
-            16,
-            26,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:1a:10:8a:e5",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -500,16 +491,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            229,
-            138,
-            16,
-            26,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:1a:10:8a:e5",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -556,16 +538,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            229,
-            138,
-            16,
-            26,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:1a:10:8a:e5",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -608,16 +581,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            229,
-            138,
-            16,
-            26,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:1a:10:8a:e5",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -660,16 +624,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            229,
-            138,
-            16,
-            26,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:1a:10:8a:e5",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -720,16 +675,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            229,
-            138,
-            16,
-            26,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:1a:10:8a:e5",
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
@@ -772,16 +718,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            229,
-            138,
-            16,
-            26,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:1a:10:8a:e5",
           "endpoint_id": 39,
           "available": true,
           "group_id": null,
@@ -826,16 +763,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            229,
-            138,
-            16,
-            26,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:1a:10:8a:e5",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/frient-a-s-sbtzb-110.json
+++ b/tests/data/devices/frient-a-s-sbtzb-110.json
@@ -233,16 +233,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            205,
-            82,
-            0,
-            57,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:39:00:52:cd",
           "endpoint_id": 32,
           "available": true,
           "group_id": null,
@@ -286,16 +277,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            205,
-            82,
-            0,
-            57,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:39:00:52:cd",
           "endpoint_id": 32,
           "available": true,
           "group_id": null,
@@ -342,16 +324,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            205,
-            82,
-            0,
-            57,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:39:00:52:cd",
           "endpoint_id": 32,
           "available": true,
           "group_id": null,
@@ -394,16 +367,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            205,
-            82,
-            0,
-            57,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:39:00:52:cd",
           "endpoint_id": 32,
           "available": true,
           "group_id": null,
@@ -446,16 +410,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            205,
-            82,
-            0,
-            57,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:39:00:52:cd",
           "endpoint_id": 32,
           "available": true,
           "group_id": null,
@@ -508,16 +463,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            205,
-            82,
-            0,
-            57,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:39:00:52:cd",
           "endpoint_id": 32,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/frient-a-s-sirzb-111.json
+++ b/tests/data/devices/frient-a-s-sirzb-111.json
@@ -241,16 +241,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            142,
-            111,
-            0,
-            65,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:41:00:6f:8e",
           "endpoint_id": 43,
           "available": true,
           "group_id": null,
@@ -297,16 +288,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            142,
-            111,
-            0,
-            65,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:41:00:6f:8e",
           "endpoint_id": 43,
           "available": true,
           "group_id": null,
@@ -354,16 +336,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            142,
-            111,
-            0,
-            65,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:41:00:6f:8e",
           "endpoint_id": 43,
           "available": true,
           "group_id": null,
@@ -409,16 +382,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            142,
-            111,
-            0,
-            65,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:41:00:6f:8e",
           "endpoint_id": 43,
           "available": true,
           "group_id": null,
@@ -466,16 +430,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            142,
-            111,
-            0,
-            65,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:41:00:6f:8e",
           "endpoint_id": 43,
           "available": true,
           "group_id": null,
@@ -528,16 +483,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            142,
-            111,
-            0,
-            65,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:41:00:6f:8e",
           "endpoint_id": 43,
           "available": true,
           "group_id": null,
@@ -580,16 +526,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            142,
-            111,
-            0,
-            65,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:41:00:6f:8e",
           "endpoint_id": 43,
           "available": true,
           "group_id": null,
@@ -632,16 +569,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            142,
-            111,
-            0,
-            65,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:41:00:6f:8e",
           "endpoint_id": 43,
           "available": true,
           "group_id": null,
@@ -686,16 +614,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            142,
-            111,
-            0,
-            65,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:41:00:6f:8e",
           "endpoint_id": 43,
           "available": true,
           "group_id": null,
@@ -747,16 +666,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            142,
-            111,
-            0,
-            65,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:41:00:6f:8e",
           "endpoint_id": 43,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/frient-a-s-smszb-120.json
+++ b/tests/data/devices/frient-a-s-smszb-120.json
@@ -283,16 +283,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            146,
-            248,
-            1,
-            49,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:31:01:f8:92",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -336,16 +327,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            146,
-            248,
-            1,
-            49,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:31:01:f8:92",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -392,16 +374,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            146,
-            248,
-            1,
-            49,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:31:01:f8:92",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -449,16 +422,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            146,
-            248,
-            1,
-            49,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:31:01:f8:92",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -504,16 +468,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            146,
-            248,
-            1,
-            49,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:31:01:f8:92",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -561,16 +516,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            146,
-            248,
-            1,
-            49,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:31:01:f8:92",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -623,16 +569,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            146,
-            248,
-            1,
-            49,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:31:01:f8:92",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -675,16 +612,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            146,
-            248,
-            1,
-            49,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:31:01:f8:92",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -727,16 +655,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            146,
-            248,
-            1,
-            49,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:31:01:f8:92",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -787,16 +706,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            146,
-            248,
-            1,
-            49,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:31:01:f8:92",
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
@@ -841,16 +751,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            146,
-            248,
-            1,
-            49,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:31:01:f8:92",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -902,16 +803,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            146,
-            248,
-            1,
-            49,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:31:01:f8:92",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/frient-a-s-splzb-141.json
+++ b/tests/data/devices/frient-a-s-splzb-141.json
@@ -532,16 +532,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            121,
-            25,
-            2,
-            47,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:2f:02:19:79",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -588,16 +579,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            121,
-            25,
-            2,
-            47,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:2f:02:19:79",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -640,16 +622,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            121,
-            25,
-            2,
-            47,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:2f:02:19:79",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -692,16 +665,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            121,
-            25,
-            2,
-            47,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:2f:02:19:79",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -752,16 +716,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            121,
-            25,
-            2,
-            47,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:2f:02:19:79",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -812,16 +767,7 @@
               "value_attribute": "current_temperature"
             }
           ],
-          "device_ieee": [
-            121,
-            25,
-            2,
-            47,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:2f:02:19:79",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -864,16 +810,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            121,
-            25,
-            2,
-            47,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:2f:02:19:79",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -921,16 +858,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            121,
-            25,
-            2,
-            47,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:2f:02:19:79",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -978,16 +906,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            121,
-            25,
-            2,
-            47,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:2f:02:19:79",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1036,16 +955,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            121,
-            25,
-            2,
-            47,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:2f:02:19:79",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1096,16 +1006,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            121,
-            25,
-            2,
-            47,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:2f:02:19:79",
           "endpoint_id": 2,
           "available": true,
           "group_id": null
@@ -1148,16 +1049,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            121,
-            25,
-            2,
-            47,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:2f:02:19:79",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/frient-a-s-wiszb-131.json
+++ b/tests/data/devices/frient-a-s-wiszb-131.json
@@ -284,16 +284,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            249,
-            17,
-            1,
-            68,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:44:01:11:f9",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -337,16 +328,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            249,
-            17,
-            1,
-            68,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:44:01:11:f9",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -393,16 +375,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            249,
-            17,
-            1,
-            68,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:44:01:11:f9",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -445,16 +418,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            249,
-            17,
-            1,
-            68,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:44:01:11:f9",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -497,16 +461,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            249,
-            17,
-            1,
-            68,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:44:01:11:f9",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,
@@ -557,16 +512,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            249,
-            17,
-            1,
-            68,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:44:01:11:f9",
           "endpoint_id": 38,
           "available": true,
           "group_id": null,
@@ -611,16 +557,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            249,
-            17,
-            1,
-            68,
-            0,
-            188,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:bc:00:44:01:11:f9",
           "endpoint_id": 35,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/gledopto-gl-b-008p.json
+++ b/tests/data/devices/gledopto-gl-b-008p.json
@@ -323,16 +323,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            171,
-            30,
-            214,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:d6:1e:ab",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -407,16 +398,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            171,
-            30,
-            214,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:d6:1e:ab",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -491,16 +473,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            171,
-            30,
-            214,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:d6:1e:ab",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -546,16 +519,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            171,
-            30,
-            214,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:d6:1e:ab",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -603,16 +567,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            171,
-            30,
-            214,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:d6:1e:ab",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -662,16 +617,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            171,
-            30,
-            214,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:d6:1e:ab",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -714,16 +660,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            171,
-            30,
-            214,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:d6:1e:ab",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -768,16 +705,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            171,
-            30,
-            214,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:d6:1e:ab",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/homr-hrmsn01.json
+++ b/tests/data/devices/homr-hrmsn01.json
@@ -378,16 +378,7 @@
               "value_attribute": "occupancy"
             }
           ],
-          "device_ieee": [
-            93,
-            195,
-            228,
-            236,
-            248,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:f8:ec:e4:c3:5d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -431,16 +422,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            93,
-            195,
-            228,
-            236,
-            248,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:f8:ec:e4:c3:5d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -515,16 +497,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            93,
-            195,
-            228,
-            236,
-            248,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:f8:ec:e4:c3:5d",
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
@@ -597,16 +570,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            93,
-            195,
-            228,
-            236,
-            248,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:f8:ec:e4:c3:5d",
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
@@ -654,16 +618,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            93,
-            195,
-            228,
-            236,
-            248,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:f8:ec:e4:c3:5d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -711,16 +666,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            93,
-            195,
-            228,
-            236,
-            248,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:f8:ec:e4:c3:5d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -766,16 +712,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            93,
-            195,
-            228,
-            236,
-            248,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:f8:ec:e4:c3:5d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -823,16 +760,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            93,
-            195,
-            228,
-            236,
-            248,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:f8:ec:e4:c3:5d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -885,16 +813,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            93,
-            195,
-            228,
-            236,
-            248,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:f8:ec:e4:c3:5d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -937,16 +856,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            93,
-            195,
-            228,
-            236,
-            248,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:f8:ec:e4:c3:5d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -989,16 +899,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            93,
-            195,
-            228,
-            236,
-            248,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:f8:ec:e4:c3:5d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1041,16 +942,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            93,
-            195,
-            228,
-            236,
-            248,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:f8:ec:e4:c3:5d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1093,16 +985,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            93,
-            195,
-            228,
-            236,
-            248,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:f8:ec:e4:c3:5d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1145,16 +1028,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            93,
-            195,
-            228,
-            236,
-            248,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:f8:ec:e4:c3:5d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1199,16 +1073,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            93,
-            195,
-            228,
-            236,
-            248,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:f8:ec:e4:c3:5d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1260,16 +1125,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            93,
-            195,
-            228,
-            236,
-            248,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:f8:ec:e4:c3:5d",
           "endpoint_id": 5,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ikea-of-sweden-fyrtur-block-out-roller-blind.json
+++ b/tests/data/devices/ikea-of-sweden-fyrtur-block-out-roller-blind.json
@@ -293,16 +293,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            95,
-            90,
-            140,
-            254,
-            255,
-            177,
-            179,
-            244
-          ],
+          "device_ieee": "f4:b3:b1:ff:fe:8c:5a:5f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -349,16 +340,7 @@
               "value_attribute": "current_position_lift_percentage"
             }
           ],
-          "device_ieee": [
-            95,
-            90,
-            140,
-            254,
-            255,
-            177,
-            179,
-            244
-          ],
+          "device_ieee": "f4:b3:b1:ff:fe:8c:5a:5f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -406,16 +388,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            95,
-            90,
-            140,
-            254,
-            255,
-            177,
-            179,
-            244
-          ],
+          "device_ieee": "f4:b3:b1:ff:fe:8c:5a:5f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -458,16 +431,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            95,
-            90,
-            140,
-            254,
-            255,
-            177,
-            179,
-            244
-          ],
+          "device_ieee": "f4:b3:b1:ff:fe:8c:5a:5f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -510,16 +474,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            95,
-            90,
-            140,
-            254,
-            255,
-            177,
-            179,
-            244
-          ],
+          "device_ieee": "f4:b3:b1:ff:fe:8c:5a:5f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -568,16 +523,7 @@
               "value_attribute": "current_position_lift_percentage"
             }
           ],
-          "device_ieee": [
-            95,
-            90,
-            140,
-            254,
-            255,
-            177,
-            179,
-            244
-          ],
+          "device_ieee": "f4:b3:b1:ff:fe:8c:5a:5f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -622,16 +568,7 @@
               "value_attribute": "current_position_lift_percentage"
             }
           ],
-          "device_ieee": [
-            95,
-            90,
-            140,
-            254,
-            255,
-            177,
-            179,
-            244
-          ],
+          "device_ieee": "f4:b3:b1:ff:fe:8c:5a:5f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -680,16 +617,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            95,
-            90,
-            140,
-            254,
-            255,
-            177,
-            179,
-            244
-          ],
+          "device_ieee": "f4:b3:b1:ff:fe:8c:5a:5f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ikea-of-sweden-inspelning-smart-plug.json
+++ b/tests/data/devices/ikea-of-sweden-inspelning-smart-plug.json
@@ -496,16 +496,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            248,
-            214,
-            19,
-            254,
-            255,
-            103,
-            72,
-            212
-          ],
+          "device_ieee": "d4:48:67:ff:fe:13:d6:f8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -552,16 +543,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            248,
-            214,
-            19,
-            254,
-            255,
-            103,
-            72,
-            212
-          ],
+          "device_ieee": "d4:48:67:ff:fe:13:d6:f8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -611,16 +593,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            248,
-            214,
-            19,
-            254,
-            255,
-            103,
-            72,
-            212
-          ],
+          "device_ieee": "d4:48:67:ff:fe:13:d6:f8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -663,16 +636,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            248,
-            214,
-            19,
-            254,
-            255,
-            103,
-            72,
-            212
-          ],
+          "device_ieee": "d4:48:67:ff:fe:13:d6:f8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -715,16 +679,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            248,
-            214,
-            19,
-            254,
-            255,
-            103,
-            72,
-            212
-          ],
+          "device_ieee": "d4:48:67:ff:fe:13:d6:f8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -775,16 +730,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            248,
-            214,
-            19,
-            254,
-            255,
-            103,
-            72,
-            212
-          ],
+          "device_ieee": "d4:48:67:ff:fe:13:d6:f8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -832,16 +778,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            248,
-            214,
-            19,
-            254,
-            255,
-            103,
-            72,
-            212
-          ],
+          "device_ieee": "d4:48:67:ff:fe:13:d6:f8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -889,16 +826,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            248,
-            214,
-            19,
-            254,
-            255,
-            103,
-            72,
-            212
-          ],
+          "device_ieee": "d4:48:67:ff:fe:13:d6:f8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -948,16 +876,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            248,
-            214,
-            19,
-            254,
-            255,
-            103,
-            72,
-            212
-          ],
+          "device_ieee": "d4:48:67:ff:fe:13:d6:f8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -1000,16 +919,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            248,
-            214,
-            19,
-            254,
-            255,
-            103,
-            72,
-            212
-          ],
+          "device_ieee": "d4:48:67:ff:fe:13:d6:f8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ikea-of-sweden-parasoll-door-window-sensor.json
+++ b/tests/data/devices/ikea-of-sweden-parasoll-door-window-sensor.json
@@ -251,16 +251,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            37,
-            179,
-            74,
-            254,
-            255,
-            39,
-            135,
-            4
-          ],
+          "device_ieee": "04:87:27:ff:fe:4a:b3:25",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -304,16 +295,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            37,
-            179,
-            74,
-            254,
-            255,
-            39,
-            135,
-            4
-          ],
+          "device_ieee": "04:87:27:ff:fe:4a:b3:25",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -360,16 +342,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            37,
-            179,
-            74,
-            254,
-            255,
-            39,
-            135,
-            4
-          ],
+          "device_ieee": "04:87:27:ff:fe:4a:b3:25",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -412,16 +385,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            37,
-            179,
-            74,
-            254,
-            255,
-            39,
-            135,
-            4
-          ],
+          "device_ieee": "04:87:27:ff:fe:4a:b3:25",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -464,16 +428,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            37,
-            179,
-            74,
-            254,
-            255,
-            39,
-            135,
-            4
-          ],
+          "device_ieee": "04:87:27:ff:fe:4a:b3:25",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -526,16 +481,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            37,
-            179,
-            74,
-            254,
-            255,
-            39,
-            135,
-            4
-          ],
+          "device_ieee": "04:87:27:ff:fe:4a:b3:25",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ikea-of-sweden-praktlysing-cellular-blind.json
+++ b/tests/data/devices/ikea-of-sweden-praktlysing-cellular-blind.json
@@ -300,16 +300,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            253,
-            175,
-            94,
-            254,
-            255,
-            110,
-            2,
-            188
-          ],
+          "device_ieee": "bc:02:6e:ff:fe:5e:af:fd",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -356,16 +347,7 @@
               "value_attribute": "current_position_lift_percentage"
             }
           ],
-          "device_ieee": [
-            253,
-            175,
-            94,
-            254,
-            255,
-            110,
-            2,
-            188
-          ],
+          "device_ieee": "bc:02:6e:ff:fe:5e:af:fd",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -413,16 +395,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            253,
-            175,
-            94,
-            254,
-            255,
-            110,
-            2,
-            188
-          ],
+          "device_ieee": "bc:02:6e:ff:fe:5e:af:fd",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -465,16 +438,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            253,
-            175,
-            94,
-            254,
-            255,
-            110,
-            2,
-            188
-          ],
+          "device_ieee": "bc:02:6e:ff:fe:5e:af:fd",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -517,16 +481,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            253,
-            175,
-            94,
-            254,
-            255,
-            110,
-            2,
-            188
-          ],
+          "device_ieee": "bc:02:6e:ff:fe:5e:af:fd",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -575,16 +530,7 @@
               "value_attribute": "current_position_lift_percentage"
             }
           ],
-          "device_ieee": [
-            253,
-            175,
-            94,
-            254,
-            255,
-            110,
-            2,
-            188
-          ],
+          "device_ieee": "bc:02:6e:ff:fe:5e:af:fd",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -629,16 +575,7 @@
               "value_attribute": "current_position_lift_percentage"
             }
           ],
-          "device_ieee": [
-            253,
-            175,
-            94,
-            254,
-            255,
-            110,
-            2,
-            188
-          ],
+          "device_ieee": "bc:02:6e:ff:fe:5e:af:fd",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -687,16 +624,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            253,
-            175,
-            94,
-            254,
-            255,
-            110,
-            2,
-            188
-          ],
+          "device_ieee": "bc:02:6e:ff:fe:5e:af:fd",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ikea-of-sweden-rodret-dimmer.json
+++ b/tests/data/devices/ikea-of-sweden-rodret-dimmer.json
@@ -226,16 +226,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            217,
-            25,
-            204,
-            254,
-            255,
-            193,
-            199,
-            92
-          ],
+          "device_ieee": "5c:c7:c1:ff:fe:cc:19:d9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -282,16 +273,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            217,
-            25,
-            204,
-            254,
-            255,
-            193,
-            199,
-            92
-          ],
+          "device_ieee": "5c:c7:c1:ff:fe:cc:19:d9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -334,16 +316,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            217,
-            25,
-            204,
-            254,
-            255,
-            193,
-            199,
-            92
-          ],
+          "device_ieee": "5c:c7:c1:ff:fe:cc:19:d9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -386,16 +359,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            217,
-            25,
-            204,
-            254,
-            255,
-            193,
-            199,
-            92
-          ],
+          "device_ieee": "5c:c7:c1:ff:fe:cc:19:d9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -448,16 +412,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            217,
-            25,
-            204,
-            254,
-            255,
-            193,
-            199,
-            92
-          ],
+          "device_ieee": "5c:c7:c1:ff:fe:cc:19:d9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ikea-of-sweden-starkvind-air-purifier.json
+++ b/tests/data/devices/ikea-of-sweden-starkvind-air-purifier.json
@@ -260,16 +260,7 @@
               "value_attribute": "filter_run_time"
             }
           ],
-          "device_ieee": [
-            226,
-            7,
-            115,
-            254,
-            255,
-            20,
-            67,
-            12
-          ],
+          "device_ieee": "0c:43:14:ff:fe:73:07:e2",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -313,16 +304,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            226,
-            7,
-            115,
-            254,
-            255,
-            20,
-            67,
-            12
-          ],
+          "device_ieee": "0c:43:14:ff:fe:73:07:e2",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -369,16 +351,7 @@
               "value_attribute": "filter_run_time"
             }
           ],
-          "device_ieee": [
-            226,
-            7,
-            115,
-            254,
-            255,
-            20,
-            67,
-            12
-          ],
+          "device_ieee": "0c:43:14:ff:fe:73:07:e2",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -436,16 +409,7 @@
               "value_attribute": "filter_run_time"
             }
           ],
-          "device_ieee": [
-            226,
-            7,
-            115,
-            254,
-            255,
-            20,
-            67,
-            12
-          ],
+          "device_ieee": "0c:43:14:ff:fe:73:07:e2",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -493,16 +457,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            226,
-            7,
-            115,
-            254,
-            255,
-            20,
-            67,
-            12
-          ],
+          "device_ieee": "0c:43:14:ff:fe:73:07:e2",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -545,16 +500,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            226,
-            7,
-            115,
-            254,
-            255,
-            20,
-            67,
-            12
-          ],
+          "device_ieee": "0c:43:14:ff:fe:73:07:e2",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -597,16 +543,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            226,
-            7,
-            115,
-            254,
-            255,
-            20,
-            67,
-            12
-          ],
+          "device_ieee": "0c:43:14:ff:fe:73:07:e2",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -649,16 +586,7 @@
               "value_attribute": "filter_run_time"
             }
           ],
-          "device_ieee": [
-            226,
-            7,
-            115,
-            254,
-            255,
-            20,
-            67,
-            12
-          ],
+          "device_ieee": "0c:43:14:ff:fe:73:07:e2",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -701,16 +629,7 @@
               "value_attribute": "filter_run_time"
             }
           ],
-          "device_ieee": [
-            226,
-            7,
-            115,
-            254,
-            255,
-            20,
-            67,
-            12
-          ],
+          "device_ieee": "0c:43:14:ff:fe:73:07:e2",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -755,16 +674,7 @@
               "value_attribute": "filter_run_time"
             }
           ],
-          "device_ieee": [
-            226,
-            7,
-            115,
-            254,
-            255,
-            20,
-            67,
-            12
-          ],
+          "device_ieee": "0c:43:14:ff:fe:73:07:e2",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -811,16 +721,7 @@
               "value_attribute": "filter_run_time"
             }
           ],
-          "device_ieee": [
-            226,
-            7,
-            115,
-            254,
-            255,
-            20,
-            67,
-            12
-          ],
+          "device_ieee": "0c:43:14:ff:fe:73:07:e2",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -869,16 +770,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            226,
-            7,
-            115,
-            254,
-            255,
-            20,
-            67,
-            12
-          ],
+          "device_ieee": "0c:43:14:ff:fe:73:07:e2",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-w-op-ch-400lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-w-op-ch-400lm.json
@@ -245,16 +245,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            101,
-            55,
-            213,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:d5:37:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -315,16 +306,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            101,
-            55,
-            213,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:d5:37:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -392,16 +374,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            101,
-            55,
-            213,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:d5:37:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -447,16 +420,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            101,
-            55,
-            213,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:d5:37:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -502,16 +466,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            101,
-            55,
-            213,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:d5:37:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -559,16 +514,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            101,
-            55,
-            213,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:d5:37:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -618,16 +564,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            101,
-            55,
-            213,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:d5:37:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -670,16 +607,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            101,
-            55,
-            213,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:d5:37:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -724,16 +652,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            101,
-            55,
-            213,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:d5:37:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-ws-opal-400lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-ws-opal-400lm.json
@@ -339,16 +339,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            44,
-            117,
-            116,
-            254,
-            255,
-            159,
-            253,
-            144
-          ],
+          "device_ieee": "90:fd:9f:ff:fe:74:75:2c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -423,16 +414,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            44,
-            117,
-            116,
-            254,
-            255,
-            159,
-            253,
-            144
-          ],
+          "device_ieee": "90:fd:9f:ff:fe:74:75:2c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -501,16 +483,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            44,
-            117,
-            116,
-            254,
-            255,
-            159,
-            253,
-            144
-          ],
+          "device_ieee": "90:fd:9f:ff:fe:74:75:2c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -556,16 +529,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            44,
-            117,
-            116,
-            254,
-            255,
-            159,
-            253,
-            144
-          ],
+          "device_ieee": "90:fd:9f:ff:fe:74:75:2c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -611,16 +575,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            44,
-            117,
-            116,
-            254,
-            255,
-            159,
-            253,
-            144
-          ],
+          "device_ieee": "90:fd:9f:ff:fe:74:75:2c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -666,16 +621,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            44,
-            117,
-            116,
-            254,
-            255,
-            159,
-            253,
-            144
-          ],
+          "device_ieee": "90:fd:9f:ff:fe:74:75:2c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -723,16 +669,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            44,
-            117,
-            116,
-            254,
-            255,
-            159,
-            253,
-            144
-          ],
+          "device_ieee": "90:fd:9f:ff:fe:74:75:2c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -782,16 +719,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            44,
-            117,
-            116,
-            254,
-            255,
-            159,
-            253,
-            144
-          ],
+          "device_ieee": "90:fd:9f:ff:fe:74:75:2c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -834,16 +762,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            44,
-            117,
-            116,
-            254,
-            255,
-            159,
-            253,
-            144
-          ],
+          "device_ieee": "90:fd:9f:ff:fe:74:75:2c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -888,16 +807,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            44,
-            117,
-            116,
-            254,
-            255,
-            159,
-            253,
-            144
-          ],
+          "device_ieee": "90:fd:9f:ff:fe:74:75:2c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-opal-1000lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-opal-1000lm.json
@@ -235,16 +235,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            60,
-            61,
-            57,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:39:3d:3c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -305,16 +296,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            60,
-            61,
-            57,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:39:3d:3c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -382,16 +364,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            60,
-            61,
-            57,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:39:3d:3c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -437,16 +410,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            60,
-            61,
-            57,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:39:3d:3c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -492,16 +456,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            60,
-            61,
-            57,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:39:3d:3c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -549,16 +504,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            60,
-            61,
-            57,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:39:3d:3c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -608,16 +554,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            60,
-            61,
-            57,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:39:3d:3c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -660,16 +597,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            60,
-            61,
-            57,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:39:3d:3c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -714,16 +642,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            60,
-            61,
-            57,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:39:3d:3c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-w-opal-1000lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-w-opal-1000lm.json
@@ -239,16 +239,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            68,
-            140,
-            142,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:8e:8c:44",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -309,16 +300,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            68,
-            140,
-            142,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:8e:8c:44",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -386,16 +368,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            68,
-            140,
-            142,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:8e:8c:44",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -441,16 +414,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            68,
-            140,
-            142,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:8e:8c:44",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -496,16 +460,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            68,
-            140,
-            142,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:8e:8c:44",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -553,16 +508,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            68,
-            140,
-            142,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:8e:8c:44",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -612,16 +558,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            68,
-            140,
-            142,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:8e:8c:44",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -664,16 +601,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            68,
-            140,
-            142,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:8e:8c:44",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -718,16 +646,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            68,
-            140,
-            142,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:8e:8c:44",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-ws-opal-980lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-ws-opal-980lm.json
@@ -320,16 +320,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            84,
-            73,
-            221,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:dd:49:54",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -404,16 +395,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            84,
-            73,
-            221,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:dd:49:54",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -482,16 +464,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            84,
-            73,
-            221,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:dd:49:54",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -537,16 +510,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            84,
-            73,
-            221,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:dd:49:54",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -592,16 +556,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            84,
-            73,
-            221,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:dd:49:54",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -647,16 +602,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            84,
-            73,
-            221,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:dd:49:54",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -704,16 +650,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            84,
-            73,
-            221,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:dd:49:54",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -763,16 +700,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            84,
-            73,
-            221,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:dd:49:54",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -815,16 +743,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            84,
-            73,
-            221,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:dd:49:54",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -869,16 +788,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            84,
-            73,
-            221,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:dd:49:54",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-gu10-ws-400lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-gu10-ws-400lm.json
@@ -344,16 +344,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            51,
-            250,
-            143,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:8f:fa:33",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -428,16 +419,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            51,
-            250,
-            143,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:8f:fa:33",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -506,16 +488,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            51,
-            250,
-            143,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:8f:fa:33",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -561,16 +534,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            51,
-            250,
-            143,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:8f:fa:33",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -616,16 +580,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            51,
-            250,
-            143,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:8f:fa:33",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -671,16 +626,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            51,
-            250,
-            143,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:8f:fa:33",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -728,16 +674,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            51,
-            250,
-            143,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:8f:fa:33",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -787,16 +724,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            51,
-            250,
-            143,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:8f:fa:33",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -839,16 +767,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            51,
-            250,
-            143,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:8f:fa:33",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -893,16 +812,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            51,
-            250,
-            143,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:8f:fa:33",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ikea-of-sweden-tradfri-control-outlet.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-control-outlet.json
@@ -213,16 +213,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            147,
-            183,
-            165,
-            254,
-            255,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:ff:fe:a5:b7:93",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -269,16 +260,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            147,
-            183,
-            165,
-            254,
-            255,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:ff:fe:a5:b7:93",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -328,16 +310,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            147,
-            183,
-            165,
-            254,
-            255,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:ff:fe:a5:b7:93",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -380,16 +353,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            147,
-            183,
-            165,
-            254,
-            255,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:ff:fe:a5:b7:93",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -434,16 +398,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            147,
-            183,
-            165,
-            254,
-            255,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:ff:fe:a5:b7:93",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -486,16 +441,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            147,
-            183,
-            165,
-            254,
-            255,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:ff:fe:a5:b7:93",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ikea-of-sweden-tradfri-motion-sensor.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-motion-sensor.json
@@ -225,16 +225,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            63,
-            118,
-            148,
-            153,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:99:94:76:3f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -278,16 +269,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            63,
-            118,
-            148,
-            153,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:99:94:76:3f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -334,16 +316,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            63,
-            118,
-            148,
-            153,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:99:94:76:3f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -386,16 +359,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            63,
-            118,
-            148,
-            153,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:99:94:76:3f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -438,16 +402,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            63,
-            118,
-            148,
-            153,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:99:94:76:3f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -500,16 +455,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            63,
-            118,
-            148,
-            153,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:99:94:76:3f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ikea-of-sweden-tradfri-on-off-switch.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-on-off-switch.json
@@ -224,16 +224,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            215,
-            101,
-            83,
-            254,
-            255,
-            87,
-            180,
-            20
-          ],
+          "device_ieee": "14:b4:57:ff:fe:53:65:d7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -280,16 +271,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            215,
-            101,
-            83,
-            254,
-            255,
-            87,
-            180,
-            20
-          ],
+          "device_ieee": "14:b4:57:ff:fe:53:65:d7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -332,16 +314,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            215,
-            101,
-            83,
-            254,
-            255,
-            87,
-            180,
-            20
-          ],
+          "device_ieee": "14:b4:57:ff:fe:53:65:d7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -384,16 +357,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            215,
-            101,
-            83,
-            254,
-            255,
-            87,
-            180,
-            20
-          ],
+          "device_ieee": "14:b4:57:ff:fe:53:65:d7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -446,16 +410,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            215,
-            101,
-            83,
-            254,
-            255,
-            87,
-            180,
-            20
-          ],
+          "device_ieee": "14:b4:57:ff:fe:53:65:d7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ikea-of-sweden-tradfri-open-close-remote.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-open-close-remote.json
@@ -243,16 +243,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            133,
-            138,
-            230,
-            254,
-            255,
-            68,
-            91,
-            56
-          ],
+          "device_ieee": "38:5b:44:ff:fe:e6:8a:85",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -299,16 +290,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            133,
-            138,
-            230,
-            254,
-            255,
-            68,
-            91,
-            56
-          ],
+          "device_ieee": "38:5b:44:ff:fe:e6:8a:85",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -351,16 +333,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            133,
-            138,
-            230,
-            254,
-            255,
-            68,
-            91,
-            56
-          ],
+          "device_ieee": "38:5b:44:ff:fe:e6:8a:85",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -403,16 +376,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            133,
-            138,
-            230,
-            254,
-            255,
-            68,
-            91,
-            56
-          ],
+          "device_ieee": "38:5b:44:ff:fe:e6:8a:85",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -465,16 +429,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            133,
-            138,
-            230,
-            254,
-            255,
-            68,
-            91,
-            56
-          ],
+          "device_ieee": "38:5b:44:ff:fe:e6:8a:85",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ikea-of-sweden-tradfri-remote-control.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-remote-control.json
@@ -224,16 +224,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            161,
-            216,
-            254,
-            254,
-            255,
-            159,
-            253,
-            144
-          ],
+          "device_ieee": "90:fd:9f:ff:fe:fe:d8:a1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -280,16 +271,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            161,
-            216,
-            254,
-            254,
-            255,
-            159,
-            253,
-            144
-          ],
+          "device_ieee": "90:fd:9f:ff:fe:fe:d8:a1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -332,16 +314,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            161,
-            216,
-            254,
-            254,
-            255,
-            159,
-            253,
-            144
-          ],
+          "device_ieee": "90:fd:9f:ff:fe:fe:d8:a1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -384,16 +357,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            161,
-            216,
-            254,
-            254,
-            255,
-            159,
-            253,
-            144
-          ],
+          "device_ieee": "90:fd:9f:ff:fe:fe:d8:a1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -446,16 +410,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            161,
-            216,
-            254,
-            254,
-            255,
-            159,
-            253,
-            144
-          ],
+          "device_ieee": "90:fd:9f:ff:fe:fe:d8:a1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ikea-of-sweden-tradfri-wireless-dimmer.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-wireless-dimmer.json
@@ -231,16 +231,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            31,
-            207,
-            43,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:2b:cf:1f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -287,16 +278,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            31,
-            207,
-            43,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:2b:cf:1f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -339,16 +321,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            31,
-            207,
-            43,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:2b:cf:1f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -391,16 +364,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            31,
-            207,
-            43,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:2b:cf:1f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -453,16 +417,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            31,
-            207,
-            43,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:2b:cf:1f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ikea-of-sweden-vallhorn-wireless-motion-sensor.json
+++ b/tests/data/devices/ikea-of-sweden-vallhorn-wireless-motion-sensor.json
@@ -334,16 +334,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            74,
-            59,
-            38,
-            254,
-            255,
-            185,
-            111,
-            140
-          ],
+          "device_ieee": "8c:6f:b9:ff:fe:26:3b:4a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -385,16 +376,7 @@
               "value_attribute": "occupancy"
             }
           ],
-          "device_ieee": [
-            74,
-            59,
-            38,
-            254,
-            255,
-            185,
-            111,
-            140
-          ],
+          "device_ieee": "8c:6f:b9:ff:fe:26:3b:4a",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -438,16 +420,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            74,
-            59,
-            38,
-            254,
-            255,
-            185,
-            111,
-            140
-          ],
+          "device_ieee": "8c:6f:b9:ff:fe:26:3b:4a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -494,16 +467,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            74,
-            59,
-            38,
-            254,
-            255,
-            185,
-            111,
-            140
-          ],
+          "device_ieee": "8c:6f:b9:ff:fe:26:3b:4a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -551,16 +515,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            74,
-            59,
-            38,
-            254,
-            255,
-            185,
-            111,
-            140
-          ],
+          "device_ieee": "8c:6f:b9:ff:fe:26:3b:4a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -603,16 +558,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            74,
-            59,
-            38,
-            254,
-            255,
-            185,
-            111,
-            140
-          ],
+          "device_ieee": "8c:6f:b9:ff:fe:26:3b:4a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -655,16 +601,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            74,
-            59,
-            38,
-            254,
-            255,
-            185,
-            111,
-            140
-          ],
+          "device_ieee": "8c:6f:b9:ff:fe:26:3b:4a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -715,16 +652,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            74,
-            59,
-            38,
-            254,
-            255,
-            185,
-            111,
-            140
-          ],
+          "device_ieee": "8c:6f:b9:ff:fe:26:3b:4a",
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
@@ -769,16 +697,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            74,
-            59,
-            38,
-            254,
-            255,
-            185,
-            111,
-            140
-          ],
+          "device_ieee": "8c:6f:b9:ff:fe:26:3b:4a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -827,16 +746,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            74,
-            59,
-            38,
-            254,
-            255,
-            185,
-            111,
-            140
-          ],
+          "device_ieee": "8c:6f:b9:ff:fe:26:3b:4a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/innr-ae-280-c.json
+++ b/tests/data/devices/innr-ae-280-c.json
@@ -279,16 +279,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            39,
-            170,
-            88,
-            254,
-            255,
-            65,
-            45,
-            20
-          ],
+          "device_ieee": "14:2d:41:ff:fe:58:aa:27",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -363,16 +354,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            39,
-            170,
-            88,
-            254,
-            255,
-            65,
-            45,
-            20
-          ],
+          "device_ieee": "14:2d:41:ff:fe:58:aa:27",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -447,16 +429,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            39,
-            170,
-            88,
-            254,
-            255,
-            65,
-            45,
-            20
-          ],
+          "device_ieee": "14:2d:41:ff:fe:58:aa:27",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -502,16 +475,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            39,
-            170,
-            88,
-            254,
-            255,
-            65,
-            45,
-            20
-          ],
+          "device_ieee": "14:2d:41:ff:fe:58:aa:27",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -557,16 +521,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            39,
-            170,
-            88,
-            254,
-            255,
-            65,
-            45,
-            20
-          ],
+          "device_ieee": "14:2d:41:ff:fe:58:aa:27",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -612,16 +567,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            39,
-            170,
-            88,
-            254,
-            255,
-            65,
-            45,
-            20
-          ],
+          "device_ieee": "14:2d:41:ff:fe:58:aa:27",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -669,16 +615,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            39,
-            170,
-            88,
-            254,
-            255,
-            65,
-            45,
-            20
-          ],
+          "device_ieee": "14:2d:41:ff:fe:58:aa:27",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -728,16 +665,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            39,
-            170,
-            88,
-            254,
-            255,
-            65,
-            45,
-            20
-          ],
+          "device_ieee": "14:2d:41:ff:fe:58:aa:27",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -780,16 +708,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            39,
-            170,
-            88,
-            254,
-            255,
-            65,
-            45,
-            20
-          ],
+          "device_ieee": "14:2d:41:ff:fe:58:aa:27",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -834,16 +753,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            39,
-            170,
-            88,
-            254,
-            255,
-            65,
-            45,
-            20
-          ],
+          "device_ieee": "14:2d:41:ff:fe:58:aa:27",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/innr-rb-285-c.json
+++ b/tests/data/devices/innr-rb-285-c.json
@@ -305,16 +305,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            98,
-            1,
-            0,
-            3,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:03:00:01:62",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -389,16 +380,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            98,
-            1,
-            0,
-            3,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:03:00:01:62",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -473,16 +455,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            98,
-            1,
-            0,
-            3,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:03:00:01:62",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -528,16 +501,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            98,
-            1,
-            0,
-            3,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:03:00:01:62",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -585,16 +549,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            98,
-            1,
-            0,
-            3,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:03:00:01:62",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -644,16 +599,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            98,
-            1,
-            0,
-            3,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:03:00:01:62",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -696,16 +642,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            98,
-            1,
-            0,
-            3,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:03:00:01:62",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -750,16 +687,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            98,
-            1,
-            0,
-            3,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:03:00:01:62",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/innr-sp-120.json
+++ b/tests/data/devices/innr-sp-120.json
@@ -587,16 +587,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            75,
-            251,
-            211,
-            118,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:76:d3:fb:4b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -643,16 +634,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            75,
-            251,
-            211,
-            118,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:76:d3:fb:4b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -700,16 +682,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            75,
-            251,
-            211,
-            118,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:76:d3:fb:4b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -752,16 +725,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            75,
-            251,
-            211,
-            118,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:76:d3:fb:4b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -804,16 +768,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            75,
-            251,
-            211,
-            118,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:76:d3:fb:4b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -864,16 +819,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            75,
-            251,
-            211,
-            118,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:76:d3:fb:4b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -921,16 +867,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            75,
-            251,
-            211,
-            118,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:76:d3:fb:4b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -978,16 +915,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            75,
-            251,
-            211,
-            118,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:76:d3:fb:4b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1037,16 +965,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            75,
-            251,
-            211,
-            118,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:76:d3:fb:4b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -1089,16 +1008,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            75,
-            251,
-            211,
-            118,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:76:d3:fb:4b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/innr-sp-234.json
+++ b/tests/data/devices/innr-sp-234.json
@@ -460,16 +460,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            183,
-            196,
-            239,
-            254,
-            255,
-            8,
-            172,
-            112
-          ],
+          "device_ieee": "70:ac:08:ff:fe:ef:c4:b7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -516,16 +507,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            183,
-            196,
-            239,
-            254,
-            255,
-            8,
-            172,
-            112
-          ],
+          "device_ieee": "70:ac:08:ff:fe:ef:c4:b7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -575,16 +557,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            183,
-            196,
-            239,
-            254,
-            255,
-            8,
-            172,
-            112
-          ],
+          "device_ieee": "70:ac:08:ff:fe:ef:c4:b7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -627,16 +600,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            183,
-            196,
-            239,
-            254,
-            255,
-            8,
-            172,
-            112
-          ],
+          "device_ieee": "70:ac:08:ff:fe:ef:c4:b7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -679,16 +643,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            183,
-            196,
-            239,
-            254,
-            255,
-            8,
-            172,
-            112
-          ],
+          "device_ieee": "70:ac:08:ff:fe:ef:c4:b7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -739,16 +694,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            183,
-            196,
-            239,
-            254,
-            255,
-            8,
-            172,
-            112
-          ],
+          "device_ieee": "70:ac:08:ff:fe:ef:c4:b7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -796,16 +742,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            183,
-            196,
-            239,
-            254,
-            255,
-            8,
-            172,
-            112
-          ],
+          "device_ieee": "70:ac:08:ff:fe:ef:c4:b7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -853,16 +790,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            183,
-            196,
-            239,
-            254,
-            255,
-            8,
-            172,
-            112
-          ],
+          "device_ieee": "70:ac:08:ff:fe:ef:c4:b7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -912,16 +840,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            183,
-            196,
-            239,
-            254,
-            255,
-            8,
-            172,
-            112
-          ],
+          "device_ieee": "70:ac:08:ff:fe:ef:c4:b7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -964,16 +883,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            183,
-            196,
-            239,
-            254,
-            255,
-            8,
-            172,
-            112
-          ],
+          "device_ieee": "70:ac:08:ff:fe:ef:c4:b7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/inovelli-vzm30-sn.json
+++ b/tests/data/devices/inovelli-vzm30-sn.json
@@ -703,16 +703,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            231,
-            203,
-            214,
-            154,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9a:d6:cb:e7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -773,16 +764,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            231,
-            203,
-            214,
-            154,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9a:d6:cb:e7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -850,16 +832,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            231,
-            203,
-            214,
-            154,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9a:d6:cb:e7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -905,16 +878,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            231,
-            203,
-            214,
-            154,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9a:d6:cb:e7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -960,16 +924,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            231,
-            203,
-            214,
-            154,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9a:d6:cb:e7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1015,16 +970,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            231,
-            203,
-            214,
-            154,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9a:d6:cb:e7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1072,16 +1018,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            231,
-            203,
-            214,
-            154,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9a:d6:cb:e7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1131,16 +1068,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            231,
-            203,
-            214,
-            154,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9a:d6:cb:e7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1183,16 +1111,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            231,
-            203,
-            214,
-            154,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9a:d6:cb:e7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1235,16 +1154,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            231,
-            203,
-            214,
-            154,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9a:d6:cb:e7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1295,16 +1205,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            231,
-            203,
-            214,
-            154,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9a:d6:cb:e7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1351,16 +1252,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            231,
-            203,
-            214,
-            154,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9a:d6:cb:e7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1407,16 +1299,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            231,
-            203,
-            214,
-            154,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9a:d6:cb:e7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1463,16 +1346,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            231,
-            203,
-            214,
-            154,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9a:d6:cb:e7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1515,16 +1389,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            231,
-            203,
-            214,
-            154,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9a:d6:cb:e7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1567,16 +1432,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            231,
-            203,
-            214,
-            154,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9a:d6:cb:e7",
           "endpoint_id": 4,
           "available": true,
           "group_id": null,
@@ -1619,16 +1475,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            231,
-            203,
-            214,
-            154,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9a:d6:cb:e7",
           "endpoint_id": 4,
           "available": true,
           "group_id": null,
@@ -1673,16 +1520,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            231,
-            203,
-            214,
-            154,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9a:d6:cb:e7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/inovelli-vzm31-sn.json
+++ b/tests/data/devices/inovelli-vzm31-sn.json
@@ -860,16 +860,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -930,16 +921,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1007,16 +989,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1062,16 +1035,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1117,16 +1081,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1172,16 +1127,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1227,16 +1173,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1282,16 +1219,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1337,16 +1265,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1392,16 +1311,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1447,16 +1357,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1502,16 +1403,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1557,16 +1449,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1612,16 +1495,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1667,16 +1541,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1722,16 +1587,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1777,16 +1633,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1832,16 +1679,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1887,16 +1725,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1942,16 +1771,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1997,16 +1817,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -2052,16 +1863,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -2107,16 +1909,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -2162,16 +1955,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -2217,16 +2001,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -2274,16 +2049,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -2331,16 +2097,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -2386,16 +2143,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -2441,16 +2189,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -2500,16 +2239,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -2552,16 +2282,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -2604,16 +2325,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -2664,16 +2376,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -2720,16 +2423,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -2772,16 +2466,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -2826,16 +2511,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -2882,16 +2558,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -2938,16 +2605,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -2994,16 +2652,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -3050,16 +2699,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -3106,16 +2746,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -3162,16 +2793,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -3218,16 +2840,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -3276,16 +2889,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            64,
-            60,
-            65,
-            220,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:dc:41:3c:40",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/isilentllc-dog-feeder.json
+++ b/tests/data/devices/isilentllc-dog-feeder.json
@@ -280,16 +280,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            215,
-            31,
-            103,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:67:1f:d7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -331,16 +322,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            215,
-            31,
-            103,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:67:1f:d7",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -382,16 +364,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            215,
-            31,
-            103,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:67:1f:d7",
           "endpoint_id": 4,
           "available": true,
           "group_id": null,
@@ -435,16 +408,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            215,
-            31,
-            103,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:67:1f:d7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -492,16 +456,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            215,
-            31,
-            103,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:67:1f:d7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -544,16 +499,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            215,
-            31,
-            103,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:67:1f:d7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -598,16 +544,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            215,
-            31,
-            103,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:67:1f:d7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null

--- a/tests/data/devices/isilentllc-doorbell.json
+++ b/tests/data/devices/isilentllc-doorbell.json
@@ -158,16 +158,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            84,
-            78,
-            192,
-            64,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:40:c0:4e:54",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -211,16 +202,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            84,
-            78,
-            192,
-            64,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:40:c0:4e:54",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -263,16 +245,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            84,
-            78,
-            192,
-            64,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:40:c0:4e:54",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -315,16 +288,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            84,
-            78,
-            192,
-            64,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:40:c0:4e:54",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -367,16 +331,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            84,
-            78,
-            192,
-            64,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:40:c0:4e:54",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/isilentllc-freezer-monitor.json
+++ b/tests/data/devices/isilentllc-freezer-monitor.json
@@ -161,16 +161,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            144,
-            224,
-            44,
-            254,
-            255,
-            189,
-            245,
-            240
-          ],
+          "device_ieee": "f0:f5:bd:ff:fe:2c:e0:90",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -214,16 +205,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            144,
-            224,
-            44,
-            254,
-            255,
-            189,
-            245,
-            240
-          ],
+          "device_ieee": "f0:f5:bd:ff:fe:2c:e0:90",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -270,16 +252,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            144,
-            224,
-            44,
-            254,
-            255,
-            189,
-            245,
-            240
-          ],
+          "device_ieee": "f0:f5:bd:ff:fe:2c:e0:90",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -322,16 +295,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            144,
-            224,
-            44,
-            254,
-            255,
-            189,
-            245,
-            240
-          ],
+          "device_ieee": "f0:f5:bd:ff:fe:2c:e0:90",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -374,16 +338,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            144,
-            224,
-            44,
-            254,
-            255,
-            189,
-            245,
-            240
-          ],
+          "device_ieee": "f0:f5:bd:ff:fe:2c:e0:90",
           "endpoint_id": 3,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/isilentllc-home-energy-monitor.json
+++ b/tests/data/devices/isilentllc-home-energy-monitor.json
@@ -3795,16 +3795,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -3847,16 +3838,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -3899,16 +3881,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
@@ -3956,16 +3929,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
@@ -4013,16 +3977,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
@@ -4070,16 +4025,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
@@ -4127,16 +4073,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
@@ -4184,16 +4121,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
@@ -4241,16 +4169,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -4298,16 +4217,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -4355,16 +4265,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -4412,16 +4313,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -4469,16 +4361,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -4526,16 +4409,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -4583,16 +4457,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 12,
           "available": true,
           "group_id": null,
@@ -4640,16 +4505,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 12,
           "available": true,
           "group_id": null,
@@ -4697,16 +4553,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 12,
           "available": true,
           "group_id": null,
@@ -4754,16 +4601,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 12,
           "available": true,
           "group_id": null,
@@ -4811,16 +4649,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 12,
           "available": true,
           "group_id": null,
@@ -4868,16 +4697,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 12,
           "available": true,
           "group_id": null,
@@ -4925,16 +4745,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 13,
           "available": true,
           "group_id": null,
@@ -4982,16 +4793,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 13,
           "available": true,
           "group_id": null,
@@ -5039,16 +4841,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 13,
           "available": true,
           "group_id": null,
@@ -5096,16 +4889,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 13,
           "available": true,
           "group_id": null,
@@ -5153,16 +4937,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 13,
           "available": true,
           "group_id": null,
@@ -5210,16 +4985,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 13,
           "available": true,
           "group_id": null,
@@ -5267,16 +5033,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 14,
           "available": true,
           "group_id": null,
@@ -5324,16 +5081,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 14,
           "available": true,
           "group_id": null,
@@ -5381,16 +5129,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 14,
           "available": true,
           "group_id": null,
@@ -5438,16 +5177,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 14,
           "available": true,
           "group_id": null,
@@ -5495,16 +5225,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 14,
           "available": true,
           "group_id": null,
@@ -5552,16 +5273,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 14,
           "available": true,
           "group_id": null,
@@ -5609,16 +5321,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 15,
           "available": true,
           "group_id": null,
@@ -5666,16 +5369,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 15,
           "available": true,
           "group_id": null,
@@ -5723,16 +5417,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 15,
           "available": true,
           "group_id": null,
@@ -5780,16 +5465,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 15,
           "available": true,
           "group_id": null,
@@ -5837,16 +5513,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 15,
           "available": true,
           "group_id": null,
@@ -5894,16 +5561,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 15,
           "available": true,
           "group_id": null,
@@ -5951,16 +5609,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 16,
           "available": true,
           "group_id": null,
@@ -6008,16 +5657,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 16,
           "available": true,
           "group_id": null,
@@ -6065,16 +5705,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 16,
           "available": true,
           "group_id": null,
@@ -6122,16 +5753,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 16,
           "available": true,
           "group_id": null,
@@ -6179,16 +5801,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 16,
           "available": true,
           "group_id": null,
@@ -6236,16 +5849,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 16,
           "available": true,
           "group_id": null,
@@ -6293,16 +5897,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 17,
           "available": true,
           "group_id": null,
@@ -6350,16 +5945,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 17,
           "available": true,
           "group_id": null,
@@ -6407,16 +5993,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 17,
           "available": true,
           "group_id": null,
@@ -6464,16 +6041,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 17,
           "available": true,
           "group_id": null,
@@ -6521,16 +6089,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 17,
           "available": true,
           "group_id": null,
@@ -6578,16 +6137,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 17,
           "available": true,
           "group_id": null,
@@ -6635,16 +6185,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 18,
           "available": true,
           "group_id": null,
@@ -6692,16 +6233,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 18,
           "available": true,
           "group_id": null,
@@ -6749,16 +6281,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 18,
           "available": true,
           "group_id": null,
@@ -6806,16 +6329,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 18,
           "available": true,
           "group_id": null,
@@ -6863,16 +6377,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 18,
           "available": true,
           "group_id": null,
@@ -6920,16 +6425,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 18,
           "available": true,
           "group_id": null,
@@ -6977,16 +6473,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 19,
           "available": true,
           "group_id": null,
@@ -7034,16 +6521,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 19,
           "available": true,
           "group_id": null,
@@ -7091,16 +6569,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 19,
           "available": true,
           "group_id": null,
@@ -7148,16 +6617,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 19,
           "available": true,
           "group_id": null,
@@ -7205,16 +6665,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 19,
           "available": true,
           "group_id": null,
@@ -7262,16 +6713,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 19,
           "available": true,
           "group_id": null,
@@ -7319,16 +6761,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -7376,16 +6809,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -7433,16 +6857,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -7490,16 +6905,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -7547,16 +6953,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -7604,16 +7001,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -7661,16 +7049,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 20,
           "available": true,
           "group_id": null,
@@ -7718,16 +7097,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 20,
           "available": true,
           "group_id": null,
@@ -7775,16 +7145,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 20,
           "available": true,
           "group_id": null,
@@ -7832,16 +7193,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 20,
           "available": true,
           "group_id": null,
@@ -7889,16 +7241,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 20,
           "available": true,
           "group_id": null,
@@ -7946,16 +7289,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 20,
           "available": true,
           "group_id": null,
@@ -8003,16 +7337,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 21,
           "available": true,
           "group_id": null,
@@ -8060,16 +7385,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 21,
           "available": true,
           "group_id": null,
@@ -8117,16 +7433,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 21,
           "available": true,
           "group_id": null,
@@ -8174,16 +7481,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 21,
           "available": true,
           "group_id": null,
@@ -8231,16 +7529,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 21,
           "available": true,
           "group_id": null,
@@ -8288,16 +7577,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 21,
           "available": true,
           "group_id": null,
@@ -8345,16 +7625,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 22,
           "available": true,
           "group_id": null,
@@ -8402,16 +7673,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 22,
           "available": true,
           "group_id": null,
@@ -8459,16 +7721,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 22,
           "available": true,
           "group_id": null,
@@ -8516,16 +7769,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 22,
           "available": true,
           "group_id": null,
@@ -8573,16 +7817,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 22,
           "available": true,
           "group_id": null,
@@ -8630,16 +7865,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 22,
           "available": true,
           "group_id": null,
@@ -8687,16 +7913,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 23,
           "available": true,
           "group_id": null,
@@ -8744,16 +7961,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 23,
           "available": true,
           "group_id": null,
@@ -8801,16 +8009,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 23,
           "available": true,
           "group_id": null,
@@ -8858,16 +8057,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 23,
           "available": true,
           "group_id": null,
@@ -8915,16 +8105,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 23,
           "available": true,
           "group_id": null,
@@ -8972,16 +8153,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 23,
           "available": true,
           "group_id": null,
@@ -9029,16 +8201,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 24,
           "available": true,
           "group_id": null,
@@ -9086,16 +8249,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 24,
           "available": true,
           "group_id": null,
@@ -9143,16 +8297,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 24,
           "available": true,
           "group_id": null,
@@ -9200,16 +8345,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 24,
           "available": true,
           "group_id": null,
@@ -9257,16 +8393,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 24,
           "available": true,
           "group_id": null,
@@ -9314,16 +8441,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 24,
           "available": true,
           "group_id": null,
@@ -9371,16 +8489,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 25,
           "available": true,
           "group_id": null,
@@ -9428,16 +8537,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 25,
           "available": true,
           "group_id": null,
@@ -9485,16 +8585,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 25,
           "available": true,
           "group_id": null,
@@ -9542,16 +8633,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 25,
           "available": true,
           "group_id": null,
@@ -9599,16 +8681,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 25,
           "available": true,
           "group_id": null,
@@ -9656,16 +8729,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 25,
           "available": true,
           "group_id": null,
@@ -9713,16 +8777,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 26,
           "available": true,
           "group_id": null,
@@ -9770,16 +8825,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 26,
           "available": true,
           "group_id": null,
@@ -9827,16 +8873,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 26,
           "available": true,
           "group_id": null,
@@ -9884,16 +8921,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 26,
           "available": true,
           "group_id": null,
@@ -9941,16 +8969,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 26,
           "available": true,
           "group_id": null,
@@ -9998,16 +9017,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 26,
           "available": true,
           "group_id": null,
@@ -10055,16 +9065,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
@@ -10112,16 +9113,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
@@ -10169,16 +9161,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
@@ -10226,16 +9209,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
@@ -10283,16 +9257,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
@@ -10340,16 +9305,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
@@ -10397,16 +9353,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 4,
           "available": true,
           "group_id": null,
@@ -10454,16 +9401,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 4,
           "available": true,
           "group_id": null,
@@ -10511,16 +9449,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 4,
           "available": true,
           "group_id": null,
@@ -10568,16 +9497,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 4,
           "available": true,
           "group_id": null,
@@ -10625,16 +9545,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 4,
           "available": true,
           "group_id": null,
@@ -10682,16 +9593,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 4,
           "available": true,
           "group_id": null,
@@ -10739,16 +9641,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
@@ -10796,16 +9689,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
@@ -10853,16 +9737,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
@@ -10910,16 +9785,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
@@ -10967,16 +9833,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
@@ -11024,16 +9881,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
@@ -11081,16 +9929,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 6,
           "available": true,
           "group_id": null,
@@ -11138,16 +9977,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 6,
           "available": true,
           "group_id": null,
@@ -11195,16 +10025,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 6,
           "available": true,
           "group_id": null,
@@ -11252,16 +10073,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 6,
           "available": true,
           "group_id": null,
@@ -11309,16 +10121,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 6,
           "available": true,
           "group_id": null,
@@ -11366,16 +10169,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 6,
           "available": true,
           "group_id": null,
@@ -11423,16 +10217,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 7,
           "available": true,
           "group_id": null,
@@ -11480,16 +10265,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 7,
           "available": true,
           "group_id": null,
@@ -11537,16 +10313,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 7,
           "available": true,
           "group_id": null,
@@ -11594,16 +10361,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 7,
           "available": true,
           "group_id": null,
@@ -11651,16 +10409,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 7,
           "available": true,
           "group_id": null,
@@ -11708,16 +10457,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 7,
           "available": true,
           "group_id": null,
@@ -11765,16 +10505,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 8,
           "available": true,
           "group_id": null,
@@ -11822,16 +10553,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 8,
           "available": true,
           "group_id": null,
@@ -11879,16 +10601,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 8,
           "available": true,
           "group_id": null,
@@ -11936,16 +10649,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 8,
           "available": true,
           "group_id": null,
@@ -11993,16 +10697,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 8,
           "available": true,
           "group_id": null,
@@ -12050,16 +10745,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 8,
           "available": true,
           "group_id": null,
@@ -12107,16 +10793,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 9,
           "available": true,
           "group_id": null,
@@ -12164,16 +10841,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 9,
           "available": true,
           "group_id": null,
@@ -12221,16 +10889,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 9,
           "available": true,
           "group_id": null,
@@ -12278,16 +10937,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 9,
           "available": true,
           "group_id": null,
@@ -12335,16 +10985,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 9,
           "available": true,
           "group_id": null,
@@ -12392,16 +11033,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            223,
-            254,
-            147,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:93:fe:df",
           "endpoint_id": 9,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/isilentllc-masterbed-light-controller.json
+++ b/tests/data/devices/isilentllc-masterbed-light-controller.json
@@ -479,16 +479,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            6,
-            144,
-            177,
-            64,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:40:b1:90:06",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -530,16 +521,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            6,
-            144,
-            177,
-            64,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:40:b1:90:06",
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
@@ -611,16 +593,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            6,
-            144,
-            177,
-            64,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:40:b1:90:06",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -692,16 +665,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            6,
-            144,
-            177,
-            64,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:40:b1:90:06",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -747,16 +711,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            6,
-            144,
-            177,
-            64,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:40:b1:90:06",
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
@@ -804,16 +759,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            6,
-            144,
-            177,
-            64,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:40:b1:90:06",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -856,16 +802,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            6,
-            144,
-            177,
-            64,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:40:b1:90:06",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -908,16 +845,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            6,
-            144,
-            177,
-            64,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:40:b1:90:06",
           "endpoint_id": 4,
           "available": true,
           "group_id": null,
@@ -960,16 +888,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            6,
-            144,
-            177,
-            64,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:40:b1:90:06",
           "endpoint_id": 4,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/isilentllc-safe.json
+++ b/tests/data/devices/isilentllc-safe.json
@@ -320,16 +320,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            166,
-            195,
-            149,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:95:c3:a6",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -371,16 +362,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            166,
-            195,
-            149,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:95:c3:a6",
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
@@ -452,16 +434,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            166,
-            195,
-            149,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:95:c3:a6",
           "endpoint_id": 4,
           "available": true,
           "group_id": null,
@@ -533,16 +506,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            166,
-            195,
-            149,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:95:c3:a6",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -585,16 +549,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            166,
-            195,
-            149,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:95:c3:a6",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -637,16 +592,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            166,
-            195,
-            149,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:95:c3:a6",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -689,16 +635,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            166,
-            195,
-            149,
-            65,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:41:95:c3:a6",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/isilentllc-test-device.json
+++ b/tests/data/devices/isilentllc-test-device.json
@@ -163,16 +163,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            194,
-            124,
-            96,
-            254,
-            255,
-            189,
-            77,
-            116
-          ],
+          "device_ieee": "74:4d:bd:ff:fe:60:7c:c2",
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
@@ -219,16 +210,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            194,
-            124,
-            96,
-            254,
-            255,
-            189,
-            77,
-            116
-          ],
+          "device_ieee": "74:4d:bd:ff:fe:60:7c:c2",
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
@@ -271,16 +253,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            194,
-            124,
-            96,
-            254,
-            255,
-            189,
-            77,
-            116
-          ],
+          "device_ieee": "74:4d:bd:ff:fe:60:7c:c2",
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
@@ -325,16 +298,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            194,
-            124,
-            96,
-            254,
-            255,
-            189,
-            77,
-            116
-          ],
+          "device_ieee": "74:4d:bd:ff:fe:60:7c:c2",
           "endpoint_id": 10,
           "available": true,
           "group_id": null
@@ -375,16 +339,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            194,
-            124,
-            96,
-            254,
-            255,
-            189,
-            77,
-            116
-          ],
+          "device_ieee": "74:4d:bd:ff:fe:60:7c:c2",
           "endpoint_id": 11,
           "available": true,
           "group_id": null

--- a/tests/data/devices/isilentllc-test-mule.json
+++ b/tests/data/devices/isilentllc-test-mule.json
@@ -139,16 +139,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            128,
-            124,
-            96,
-            254,
-            255,
-            189,
-            77,
-            116
-          ],
+          "device_ieee": "74:4d:bd:ff:fe:60:7c:80",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -192,16 +183,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            128,
-            124,
-            96,
-            254,
-            255,
-            189,
-            77,
-            116
-          ],
+          "device_ieee": "74:4d:bd:ff:fe:60:7c:80",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -248,16 +230,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            128,
-            124,
-            96,
-            254,
-            255,
-            189,
-            77,
-            116
-          ],
+          "device_ieee": "74:4d:bd:ff:fe:60:7c:80",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -300,16 +273,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            128,
-            124,
-            96,
-            254,
-            255,
-            189,
-            77,
-            116
-          ],
+          "device_ieee": "74:4d:bd:ff:fe:60:7c:80",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/isilentllc-water-heater.json
+++ b/tests/data/devices/isilentllc-water-heater.json
@@ -299,16 +299,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            203,
-            77,
-            192,
-            64,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:40:c0:4d:cb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -351,16 +342,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            203,
-            77,
-            192,
-            64,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:40:c0:4d:cb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -403,16 +385,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            203,
-            77,
-            192,
-            64,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:40:c0:4d:cb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -461,16 +434,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            203,
-            77,
-            192,
-            64,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:40:c0:4d:cb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -518,16 +482,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            203,
-            77,
-            192,
-            64,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:40:c0:4d:cb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -576,16 +531,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            203,
-            77,
-            192,
-            64,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:40:c0:4d:cb",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -628,16 +574,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            203,
-            77,
-            192,
-            64,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:40:c0:4d:cb",
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
@@ -682,16 +619,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            203,
-            77,
-            192,
-            64,
-            0,
-            162,
-            19,
-            0
-          ],
+          "device_ieee": "00:13:a2:00:40:c0:4d:cb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null

--- a/tests/data/devices/jasco-products-45856.json
+++ b/tests/data/devices/jasco-products-45856.json
@@ -302,16 +302,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            97,
-            211,
-            38,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:26:d3:61",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -358,16 +349,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            97,
-            211,
-            38,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:26:d3:61",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -434,16 +416,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            97,
-            211,
-            38,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:26:d3:61",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -486,16 +459,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            97,
-            211,
-            38,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:26:d3:61",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -538,16 +502,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            97,
-            211,
-            38,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:26:d3:61",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -598,16 +553,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            97,
-            211,
-            38,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:26:d3:61",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -660,16 +606,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            97,
-            211,
-            38,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:26:d3:61",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/jasco-products-45857.json
+++ b/tests/data/devices/jasco-products-45857.json
@@ -355,16 +355,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            36,
-            44,
-            37,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:25:2c:24",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -425,16 +416,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            36,
-            44,
-            37,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:25:2c:24",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -502,16 +484,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            36,
-            44,
-            37,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:25:2c:24",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -559,16 +532,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            36,
-            44,
-            37,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:25:2c:24",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -611,16 +575,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            36,
-            44,
-            37,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:25:2c:24",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -663,16 +618,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            36,
-            44,
-            37,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:25:2c:24",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -723,16 +669,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            36,
-            44,
-            37,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:25:2c:24",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -785,16 +722,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            36,
-            44,
-            37,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:25:2c:24",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ke-tradfri-open-close-remote.json
+++ b/tests/data/devices/ke-tradfri-open-close-remote.json
@@ -243,16 +243,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            4,
-            72,
-            150,
-            254,
-            255,
-            114,
-            2,
-            92
-          ],
+          "device_ieee": "5c:02:72:ff:fe:96:48:04",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -299,16 +290,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            4,
-            72,
-            150,
-            254,
-            255,
-            114,
-            2,
-            92
-          ],
+          "device_ieee": "5c:02:72:ff:fe:96:48:04",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -351,16 +333,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            4,
-            72,
-            150,
-            254,
-            255,
-            114,
-            2,
-            92
-          ],
+          "device_ieee": "5c:02:72:ff:fe:96:48:04",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -403,16 +376,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            4,
-            72,
-            150,
-            254,
-            255,
-            114,
-            2,
-            92
-          ],
+          "device_ieee": "5c:02:72:ff:fe:96:48:04",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -465,16 +429,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            4,
-            72,
-            150,
-            254,
-            255,
-            114,
-            2,
-            92
-          ],
+          "device_ieee": "5c:02:72:ff:fe:96:48:04",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/keen-home-inc-sv01-410-mp-1-1.json
+++ b/tests/data/devices/keen-home-inc-sv01-410-mp-1-1.json
@@ -329,16 +329,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            201,
-            91,
-            107,
-            254,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:fe:6b:5b:c9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -399,16 +390,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            201,
-            91,
-            107,
-            254,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:fe:6b:5b:c9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -453,16 +435,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            201,
-            91,
-            107,
-            254,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:fe:6b:5b:c9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -505,16 +478,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            201,
-            91,
-            107,
-            254,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:fe:6b:5b:c9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -557,16 +521,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            201,
-            91,
-            107,
-            254,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:fe:6b:5b:c9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -617,16 +572,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            201,
-            91,
-            107,
-            254,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:fe:6b:5b:c9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -669,16 +615,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            201,
-            91,
-            107,
-            254,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:fe:6b:5b:c9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -723,16 +660,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            201,
-            91,
-            107,
-            254,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:fe:6b:5b:c9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/keen-home-inc-sv02-610-mp-1-3.json
+++ b/tests/data/devices/keen-home-inc-sv02-610-mp-1-3.json
@@ -286,16 +286,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            41,
-            72,
-            129,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:81:48:29",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -356,16 +347,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            41,
-            72,
-            129,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:81:48:29",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -410,16 +392,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            41,
-            72,
-            129,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:81:48:29",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -462,16 +435,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            41,
-            72,
-            129,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:81:48:29",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -514,16 +478,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            41,
-            72,
-            129,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:81:48:29",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -574,16 +529,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            41,
-            72,
-            129,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:81:48:29",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -626,16 +572,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            41,
-            72,
-            129,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:81:48:29",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -680,16 +617,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            41,
-            72,
-            129,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:81:48:29",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/keen-home-inc-sv02-612-mp-1-3.json
+++ b/tests/data/devices/keen-home-inc-sv02-612-mp-1-3.json
@@ -335,16 +335,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            228,
-            230,
-            146,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:92:e6:e4",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -405,16 +396,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            228,
-            230,
-            146,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:92:e6:e4",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -459,16 +441,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            228,
-            230,
-            146,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:92:e6:e4",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -511,16 +484,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            228,
-            230,
-            146,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:92:e6:e4",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -563,16 +527,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            228,
-            230,
-            146,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:92:e6:e4",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -623,16 +578,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            228,
-            230,
-            146,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:92:e6:e4",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -675,16 +621,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            228,
-            230,
-            146,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:92:e6:e4",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -729,16 +666,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            228,
-            230,
-            146,
-            254,
-            255,
-            87,
-            11,
-            0
-          ],
+          "device_ieee": "00:0b:57:ff:fe:92:e6:e4",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/king-of-fans-inc-hbuniversalcfremote.json
+++ b/tests/data/devices/king-of-fans-inc-hbuniversalcfremote.json
@@ -234,16 +234,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            65,
-            173,
-            9,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:09:ad:41",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -290,16 +281,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            65,
-            173,
-            9,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:09:ad:41",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -371,16 +353,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            65,
-            173,
-            9,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:09:ad:41",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -448,16 +421,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            65,
-            173,
-            9,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:09:ad:41",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -505,16 +469,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            65,
-            173,
-            9,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:09:ad:41",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -557,16 +512,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            65,
-            173,
-            9,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:09:ad:41",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -611,16 +557,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            65,
-            173,
-            9,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:09:ad:41",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/king-of-fans-inc-hdc52eastwindfan.json
+++ b/tests/data/devices/king-of-fans-inc-hdc52eastwindfan.json
@@ -240,16 +240,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            132,
-            72,
-            39,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:27:48:84",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -296,16 +287,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            132,
-            72,
-            39,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:27:48:84",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -377,16 +359,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            132,
-            72,
-            39,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:27:48:84",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -454,16 +427,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            132,
-            72,
-            39,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:27:48:84",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -511,16 +475,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            132,
-            72,
-            39,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:27:48:84",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -563,16 +518,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            132,
-            72,
-            39,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:27:48:84",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -617,16 +563,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            132,
-            72,
-            39,
-            0,
-            0,
-            163,
-            34,
-            0
-          ],
+          "device_ieee": "00:22:a3:00:00:27:48:84",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/konke-3afe140103020000.json
+++ b/tests/data/devices/konke-3afe140103020000.json
@@ -194,16 +194,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            122,
-            95,
-            145,
-            254,
-            255,
-            215,
-            107,
-            8
-          ],
+          "device_ieee": "08:6b:d7:ff:fe:91:5f:7a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -250,16 +241,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            122,
-            95,
-            145,
-            254,
-            255,
-            215,
-            107,
-            8
-          ],
+          "device_ieee": "08:6b:d7:ff:fe:91:5f:7a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -302,16 +284,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            122,
-            95,
-            145,
-            254,
-            255,
-            215,
-            107,
-            8
-          ],
+          "device_ieee": "08:6b:d7:ff:fe:91:5f:7a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -354,16 +327,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            122,
-            95,
-            145,
-            254,
-            255,
-            215,
-            107,
-            8
-          ],
+          "device_ieee": "08:6b:d7:ff:fe:91:5f:7a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -413,16 +377,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            122,
-            95,
-            145,
-            254,
-            255,
-            215,
-            107,
-            8
-          ],
+          "device_ieee": "08:6b:d7:ff:fe:91:5f:7a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -465,16 +420,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            122,
-            95,
-            145,
-            254,
-            255,
-            215,
-            107,
-            8
-          ],
+          "device_ieee": "08:6b:d7:ff:fe:91:5f:7a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/konke-3afe220103020000.json
+++ b/tests/data/devices/konke-3afe220103020000.json
@@ -194,16 +194,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            209,
-            95,
-            145,
-            254,
-            255,
-            215,
-            107,
-            8
-          ],
+          "device_ieee": "08:6b:d7:ff:fe:91:5f:d1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -250,16 +241,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            209,
-            95,
-            145,
-            254,
-            255,
-            215,
-            107,
-            8
-          ],
+          "device_ieee": "08:6b:d7:ff:fe:91:5f:d1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -302,16 +284,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            209,
-            95,
-            145,
-            254,
-            255,
-            215,
-            107,
-            8
-          ],
+          "device_ieee": "08:6b:d7:ff:fe:91:5f:d1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -354,16 +327,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            209,
-            95,
-            145,
-            254,
-            255,
-            215,
-            107,
-            8
-          ],
+          "device_ieee": "08:6b:d7:ff:fe:91:5f:d1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -413,16 +377,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            209,
-            95,
-            145,
-            254,
-            255,
-            215,
-            107,
-            8
-          ],
+          "device_ieee": "08:6b:d7:ff:fe:91:5f:d1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -465,16 +420,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            209,
-            95,
-            145,
-            254,
-            255,
-            215,
-            107,
-            8
-          ],
+          "device_ieee": "08:6b:d7:ff:fe:91:5f:d1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/konke-3afe270104020015.json
+++ b/tests/data/devices/konke-3afe270104020015.json
@@ -211,16 +211,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            150,
-            115,
-            233,
-            254,
-            255,
-            215,
-            107,
-            8
-          ],
+          "device_ieee": "08:6b:d7:ff:fe:e9:73:96",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -264,16 +255,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            150,
-            115,
-            233,
-            254,
-            255,
-            215,
-            107,
-            8
-          ],
+          "device_ieee": "08:6b:d7:ff:fe:e9:73:96",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -320,16 +302,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            150,
-            115,
-            233,
-            254,
-            255,
-            215,
-            107,
-            8
-          ],
+          "device_ieee": "08:6b:d7:ff:fe:e9:73:96",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -372,16 +345,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            150,
-            115,
-            233,
-            254,
-            255,
-            215,
-            107,
-            8
-          ],
+          "device_ieee": "08:6b:d7:ff:fe:e9:73:96",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -424,16 +388,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            150,
-            115,
-            233,
-            254,
-            255,
-            215,
-            107,
-            8
-          ],
+          "device_ieee": "08:6b:d7:ff:fe:e9:73:96",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/konke-3afe280100510001.json
+++ b/tests/data/devices/konke-3afe280100510001.json
@@ -189,16 +189,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            10,
-            89,
-            7,
-            254,
-            255,
-            87,
-            180,
-            20
-          ],
+          "device_ieee": "14:b4:57:ff:fe:07:59:0a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -245,16 +236,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            10,
-            89,
-            7,
-            254,
-            255,
-            87,
-            180,
-            20
-          ],
+          "device_ieee": "14:b4:57:ff:fe:07:59:0a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -297,16 +279,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            10,
-            89,
-            7,
-            254,
-            255,
-            87,
-            180,
-            20
-          ],
+          "device_ieee": "14:b4:57:ff:fe:07:59:0a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -349,16 +322,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            10,
-            89,
-            7,
-            254,
-            255,
-            87,
-            180,
-            20
-          ],
+          "device_ieee": "14:b4:57:ff:fe:07:59:0a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/konke-3afe28010402000d.json
+++ b/tests/data/devices/konke-3afe28010402000d.json
@@ -227,16 +227,7 @@
               "value_attribute": "occupancy"
             }
           ],
-          "device_ieee": [
-            251,
-            112,
-            7,
-            254,
-            255,
-            87,
-            180,
-            20
-          ],
+          "device_ieee": "14:b4:57:ff:fe:07:70:fb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -278,16 +269,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            251,
-            112,
-            7,
-            254,
-            255,
-            87,
-            180,
-            20
-          ],
+          "device_ieee": "14:b4:57:ff:fe:07:70:fb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -331,16 +313,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            251,
-            112,
-            7,
-            254,
-            255,
-            87,
-            180,
-            20
-          ],
+          "device_ieee": "14:b4:57:ff:fe:07:70:fb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -387,16 +360,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            251,
-            112,
-            7,
-            254,
-            255,
-            87,
-            180,
-            20
-          ],
+          "device_ieee": "14:b4:57:ff:fe:07:70:fb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -439,16 +403,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            251,
-            112,
-            7,
-            254,
-            255,
-            87,
-            180,
-            20
-          ],
+          "device_ieee": "14:b4:57:ff:fe:07:70:fb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -491,16 +446,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            251,
-            112,
-            7,
-            254,
-            255,
-            87,
-            180,
-            20
-          ],
+          "device_ieee": "14:b4:57:ff:fe:07:70:fb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/kwikset-smartcode-convert-gen1.json
+++ b/tests/data/devices/kwikset-smartcode-convert-gen1.json
@@ -245,16 +245,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            217,
-            131,
-            3,
-            253,
-            255,
-            70,
-            36,
-            0
-          ],
+          "device_ieee": "00:24:46:ff:fd:03:83:d9",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -301,16 +292,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            217,
-            131,
-            3,
-            253,
-            255,
-            70,
-            36,
-            0
-          ],
+          "device_ieee": "00:24:46:ff:fd:03:83:d9",
           "endpoint_id": 2,
           "available": true,
           "group_id": null
@@ -353,16 +335,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            217,
-            131,
-            3,
-            253,
-            255,
-            70,
-            36,
-            0
-          ],
+          "device_ieee": "00:24:46:ff:fd:03:83:d9",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -405,16 +378,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            217,
-            131,
-            3,
-            253,
-            255,
-            70,
-            36,
-            0
-          ],
+          "device_ieee": "00:24:46:ff:fd:03:83:d9",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -457,16 +421,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            217,
-            131,
-            3,
-            253,
-            255,
-            70,
-            36,
-            0
-          ],
+          "device_ieee": "00:24:46:ff:fd:03:83:d9",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -517,16 +472,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            217,
-            131,
-            3,
-            253,
-            255,
-            70,
-            36,
-            0
-          ],
+          "device_ieee": "00:24:46:ff:fd:03:83:d9",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -571,16 +517,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            217,
-            131,
-            3,
-            253,
-            255,
-            70,
-            36,
-            0
-          ],
+          "device_ieee": "00:24:46:ff:fd:03:83:d9",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lds-zb-onoffplug-d0005.json
+++ b/tests/data/devices/lds-zb-onoffplug-d0005.json
@@ -369,16 +369,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            44,
-            90,
-            72,
-            171,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:ab:48:5a:2c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -425,16 +416,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            44,
-            90,
-            72,
-            171,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:ab:48:5a:2c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -484,16 +466,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            44,
-            90,
-            72,
-            171,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:ab:48:5a:2c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -536,16 +509,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            44,
-            90,
-            72,
-            171,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:ab:48:5a:2c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -588,16 +552,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            44,
-            90,
-            72,
-            171,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:ab:48:5a:2c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -647,16 +602,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            44,
-            90,
-            72,
-            171,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:ab:48:5a:2c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -704,16 +650,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            44,
-            90,
-            72,
-            171,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:ab:48:5a:2c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -761,16 +698,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            44,
-            90,
-            72,
-            171,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:ab:48:5a:2c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -820,16 +748,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            44,
-            90,
-            72,
-            171,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:ab:48:5a:2c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -872,16 +791,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            44,
-            90,
-            72,
-            171,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:ab:48:5a:2c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lds-zbt-cctswitch-d0001.json
+++ b/tests/data/devices/lds-zbt-cctswitch-d0001.json
@@ -219,16 +219,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            51,
-            86,
-            129,
-            254,
-            255,
-            87,
-            180,
-            20
-          ],
+          "device_ieee": "14:b4:57:ff:fe:81:56:33",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -275,16 +266,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            51,
-            86,
-            129,
-            254,
-            255,
-            87,
-            180,
-            20
-          ],
+          "device_ieee": "14:b4:57:ff:fe:81:56:33",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -327,16 +309,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            51,
-            86,
-            129,
-            254,
-            255,
-            87,
-            180,
-            20
-          ],
+          "device_ieee": "14:b4:57:ff:fe:81:56:33",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -379,16 +352,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            51,
-            86,
-            129,
-            254,
-            255,
-            87,
-            180,
-            20
-          ],
+          "device_ieee": "14:b4:57:ff:fe:81:56:33",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -441,16 +405,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            51,
-            86,
-            129,
-            254,
-            255,
-            87,
-            180,
-            20
-          ],
+          "device_ieee": "14:b4:57:ff:fe:81:56:33",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ledvance-flex-rgbw.json
+++ b/tests/data/devices/ledvance-flex-rgbw.json
@@ -341,16 +341,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            245,
-            107,
-            0,
-            0,
-            0,
-            184,
-            209,
-            240
-          ],
+          "device_ieee": "f0:d1:b8:00:00:00:6b:f5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -425,16 +416,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            245,
-            107,
-            0,
-            0,
-            0,
-            184,
-            209,
-            240
-          ],
+          "device_ieee": "f0:d1:b8:00:00:00:6b:f5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -507,16 +489,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            245,
-            107,
-            0,
-            0,
-            0,
-            184,
-            209,
-            240
-          ],
+          "device_ieee": "f0:d1:b8:00:00:00:6b:f5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -562,16 +535,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            245,
-            107,
-            0,
-            0,
-            0,
-            184,
-            209,
-            240
-          ],
+          "device_ieee": "f0:d1:b8:00:00:00:6b:f5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -617,16 +581,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            245,
-            107,
-            0,
-            0,
-            0,
-            184,
-            209,
-            240
-          ],
+          "device_ieee": "f0:d1:b8:00:00:00:6b:f5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -672,16 +627,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            245,
-            107,
-            0,
-            0,
-            0,
-            184,
-            209,
-            240
-          ],
+          "device_ieee": "f0:d1:b8:00:00:00:6b:f5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -727,16 +673,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            245,
-            107,
-            0,
-            0,
-            0,
-            184,
-            209,
-            240
-          ],
+          "device_ieee": "f0:d1:b8:00:00:00:6b:f5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -784,16 +721,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            245,
-            107,
-            0,
-            0,
-            0,
-            184,
-            209,
-            240
-          ],
+          "device_ieee": "f0:d1:b8:00:00:00:6b:f5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -836,16 +764,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            245,
-            107,
-            0,
-            0,
-            0,
-            184,
-            209,
-            240
-          ],
+          "device_ieee": "f0:d1:b8:00:00:00:6b:f5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -890,16 +809,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            245,
-            107,
-            0,
-            0,
-            0,
-            184,
-            209,
-            240
-          ],
+          "device_ieee": "f0:d1:b8:00:00:00:6b:f5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ledvance-outdoor-accent-light-rgb.json
+++ b/tests/data/devices/ledvance-outdoor-accent-light-rgb.json
@@ -289,16 +289,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            142,
-            131,
-            7,
-            0,
-            0,
-            184,
-            209,
-            240
-          ],
+          "device_ieee": "f0:d1:b8:00:00:07:83:8e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -373,16 +364,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            142,
-            131,
-            7,
-            0,
-            0,
-            184,
-            209,
-            240
-          ],
+          "device_ieee": "f0:d1:b8:00:00:07:83:8e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -455,16 +437,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            142,
-            131,
-            7,
-            0,
-            0,
-            184,
-            209,
-            240
-          ],
+          "device_ieee": "f0:d1:b8:00:00:07:83:8e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -510,16 +483,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            142,
-            131,
-            7,
-            0,
-            0,
-            184,
-            209,
-            240
-          ],
+          "device_ieee": "f0:d1:b8:00:00:07:83:8e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -565,16 +529,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            142,
-            131,
-            7,
-            0,
-            0,
-            184,
-            209,
-            240
-          ],
+          "device_ieee": "f0:d1:b8:00:00:07:83:8e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -620,16 +575,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            142,
-            131,
-            7,
-            0,
-            0,
-            184,
-            209,
-            240
-          ],
+          "device_ieee": "f0:d1:b8:00:00:07:83:8e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -675,16 +621,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            142,
-            131,
-            7,
-            0,
-            0,
-            184,
-            209,
-            240
-          ],
+          "device_ieee": "f0:d1:b8:00:00:07:83:8e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -732,16 +669,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            142,
-            131,
-            7,
-            0,
-            0,
-            184,
-            209,
-            240
-          ],
+          "device_ieee": "f0:d1:b8:00:00:07:83:8e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -784,16 +712,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            142,
-            131,
-            7,
-            0,
-            0,
-            184,
-            209,
-            240
-          ],
+          "device_ieee": "f0:d1:b8:00:00:07:83:8e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -838,16 +757,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            142,
-            131,
-            7,
-            0,
-            0,
-            184,
-            209,
-            240
-          ],
+          "device_ieee": "f0:d1:b8:00:00:07:83:8e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/ledvance-plug.json
+++ b/tests/data/devices/ledvance-plug.json
@@ -173,16 +173,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            34,
-            73,
-            5,
-            0,
-            0,
-            184,
-            209,
-            240
-          ],
+          "device_ieee": "f0:d1:b8:00:00:05:49:22",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -229,16 +220,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            34,
-            73,
-            5,
-            0,
-            0,
-            184,
-            209,
-            240
-          ],
+          "device_ieee": "f0:d1:b8:00:00:05:49:22",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -281,16 +263,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            34,
-            73,
-            5,
-            0,
-            0,
-            184,
-            209,
-            240
-          ],
+          "device_ieee": "f0:d1:b8:00:00:05:49:22",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -335,16 +308,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            34,
-            73,
-            5,
-            0,
-            0,
-            184,
-            209,
-            240
-          ],
+          "device_ieee": "f0:d1:b8:00:00:05:49:22",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -387,16 +351,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            34,
-            73,
-            5,
-            0,
-            0,
-            184,
-            209,
-            240
-          ],
+          "device_ieee": "f0:d1:b8:00:00:05:49:22",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/level-home-b2.json
+++ b/tests/data/devices/level-home-b2.json
@@ -339,16 +339,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            89,
-            25,
-            103,
-            130,
-            19,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:13:82:67:19:59",
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
@@ -395,16 +386,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            89,
-            25,
-            103,
-            130,
-            19,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:13:82:67:19:59",
           "endpoint_id": 10,
           "available": true,
           "group_id": null
@@ -447,16 +429,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            89,
-            25,
-            103,
-            130,
-            19,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:13:82:67:19:59",
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
@@ -507,16 +480,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            89,
-            25,
-            103,
-            130,
-            19,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:13:82:67:19:59",
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
@@ -559,16 +523,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            89,
-            25,
-            103,
-            130,
-            19,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:13:82:67:19:59",
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
@@ -613,16 +568,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            89,
-            25,
-            103,
-            130,
-            19,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:13:82:67:19:59",
           "endpoint_id": 5,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/level-home-bolt.json
+++ b/tests/data/devices/level-home-bolt.json
@@ -182,16 +182,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            214,
-            134,
-            122,
-            80,
-            185,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:b9:50:7a:86:d6",
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
@@ -238,16 +229,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            214,
-            134,
-            122,
-            80,
-            185,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:b9:50:7a:86:d6",
           "endpoint_id": 10,
           "available": true,
           "group_id": null
@@ -290,16 +272,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            214,
-            134,
-            122,
-            80,
-            185,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:b9:50:7a:86:d6",
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
@@ -350,16 +323,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            214,
-            134,
-            122,
-            80,
-            185,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:b9:50:7a:86:d6",
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
@@ -402,16 +366,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            214,
-            134,
-            122,
-            80,
-            185,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:b9:50:7a:86:d6",
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
@@ -456,16 +411,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            214,
-            134,
-            122,
-            80,
-            185,
-            54,
-            206,
-            244
-          ],
+          "device_ieee": "f4:ce:36:b9:50:7a:86:d6",
           "endpoint_id": 5,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lk-zb-doorsensor-d0003.json
+++ b/tests/data/devices/lk-zb-doorsensor-d0003.json
@@ -182,16 +182,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            113,
-            158,
-            68,
-            254,
-            255,
-            20,
-            46,
-            132
-          ],
+          "device_ieee": "84:2e:14:ff:fe:44:9e:71",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -235,16 +226,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            113,
-            158,
-            68,
-            254,
-            255,
-            20,
-            46,
-            132
-          ],
+          "device_ieee": "84:2e:14:ff:fe:44:9e:71",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -291,16 +273,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            113,
-            158,
-            68,
-            254,
-            255,
-            20,
-            46,
-            132
-          ],
+          "device_ieee": "84:2e:14:ff:fe:44:9e:71",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -343,16 +316,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            113,
-            158,
-            68,
-            254,
-            255,
-            20,
-            46,
-            132
-          ],
+          "device_ieee": "84:2e:14:ff:fe:44:9e:71",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -395,16 +359,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            113,
-            158,
-            68,
-            254,
-            255,
-            20,
-            46,
-            132
-          ],
+          "device_ieee": "84:2e:14:ff:fe:44:9e:71",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -457,16 +412,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            113,
-            158,
-            68,
-            254,
-            255,
-            20,
-            46,
-            132
-          ],
+          "device_ieee": "84:2e:14:ff:fe:44:9e:71",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lk-zbt-dimswitch-d0001.json
+++ b/tests/data/devices/lk-zbt-dimswitch-d0001.json
@@ -189,16 +189,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            164,
-            140,
-            63,
-            254,
-            255,
-            114,
-            2,
-            92
-          ],
+          "device_ieee": "5c:02:72:ff:fe:3f:8c:a4",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -245,16 +236,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            164,
-            140,
-            63,
-            254,
-            255,
-            114,
-            2,
-            92
-          ],
+          "device_ieee": "5c:02:72:ff:fe:3f:8c:a4",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -297,16 +279,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            164,
-            140,
-            63,
-            254,
-            255,
-            114,
-            2,
-            92
-          ],
+          "device_ieee": "5c:02:72:ff:fe:3f:8c:a4",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -349,16 +322,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            164,
-            140,
-            63,
-            254,
-            255,
-            114,
-            2,
-            92
-          ],
+          "device_ieee": "5c:02:72:ff:fe:3f:8c:a4",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -411,16 +375,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            164,
-            140,
-            63,
-            254,
-            255,
-            114,
-            2,
-            92
-          ],
+          "device_ieee": "5c:02:72:ff:fe:3f:8c:a4",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lk-zbt-onoffplug-d0001.json
+++ b/tests/data/devices/lk-zbt-onoffplug-d0001.json
@@ -230,16 +230,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            115,
-            188,
-            211,
-            254,
-            255,
-            114,
-            2,
-            92
-          ],
+          "device_ieee": "5c:02:72:ff:fe:d3:bc:73",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -286,16 +277,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            115,
-            188,
-            211,
-            254,
-            255,
-            114,
-            2,
-            92
-          ],
+          "device_ieee": "5c:02:72:ff:fe:d3:bc:73",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -341,16 +323,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            115,
-            188,
-            211,
-            254,
-            255,
-            114,
-            2,
-            92
-          ],
+          "device_ieee": "5c:02:72:ff:fe:d3:bc:73",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -396,16 +369,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            115,
-            188,
-            211,
-            254,
-            255,
-            114,
-            2,
-            92
-          ],
+          "device_ieee": "5c:02:72:ff:fe:d3:bc:73",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -453,16 +417,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            115,
-            188,
-            211,
-            254,
-            255,
-            114,
-            2,
-            92
-          ],
+          "device_ieee": "5c:02:72:ff:fe:d3:bc:73",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -512,16 +467,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            115,
-            188,
-            211,
-            254,
-            255,
-            114,
-            2,
-            92
-          ],
+          "device_ieee": "5c:02:72:ff:fe:d3:bc:73",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -564,16 +510,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            115,
-            188,
-            211,
-            254,
-            255,
-            114,
-            2,
-            92
-          ],
+          "device_ieee": "5c:02:72:ff:fe:d3:bc:73",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -618,16 +555,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            115,
-            188,
-            211,
-            254,
-            255,
-            114,
-            2,
-            92
-          ],
+          "device_ieee": "5c:02:72:ff:fe:d3:bc:73",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -670,16 +598,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            115,
-            188,
-            211,
-            254,
-            255,
-            114,
-            2,
-            92
-          ],
+          "device_ieee": "5c:02:72:ff:fe:d3:bc:73",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-airmonitor-acn01.json
+++ b/tests/data/devices/lumi-lumi-airmonitor-acn01.json
@@ -220,16 +220,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            161,
-            97,
-            16,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:10:61:a1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -276,16 +267,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            161,
-            97,
-            16,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:10:61:a1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -328,16 +310,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            161,
-            97,
-            16,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:10:61:a1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -380,16 +353,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            161,
-            97,
-            16,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:10:61:a1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -440,16 +404,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            161,
-            97,
-            16,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:10:61:a1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -492,16 +447,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            161,
-            97,
-            16,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:10:61:a1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -544,16 +490,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            161,
-            97,
-            16,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:10:61:a1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -598,16 +535,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            161,
-            97,
-            16,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:10:61:a1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-curtain-agl001.json
+++ b/tests/data/devices/lumi-lumi-curtain-agl001.json
@@ -330,16 +330,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            167,
-            251,
-            79,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:4f:fb:a7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -383,16 +374,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            167,
-            251,
-            79,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:4f:fb:a7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -439,16 +421,7 @@
               "value_attribute": "current_position_lift_percentage"
             }
           ],
-          "device_ieee": [
-            167,
-            251,
-            79,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:4f:fb:a7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -496,16 +469,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            167,
-            251,
-            79,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:4f:fb:a7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -548,16 +512,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            167,
-            251,
-            79,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:4f:fb:a7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -600,16 +555,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            167,
-            251,
-            79,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:4f:fb:a7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -652,16 +598,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            167,
-            251,
-            79,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:4f:fb:a7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -712,16 +649,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            167,
-            251,
-            79,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:4f:fb:a7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -764,16 +692,7 @@
               "value_attribute": "current_position_lift_percentage"
             }
           ],
-          "device_ieee": [
-            167,
-            251,
-            79,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:4f:fb:a7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -816,16 +735,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            167,
-            251,
-            79,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:4f:fb:a7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -870,16 +780,7 @@
               "value_attribute": "current_position_lift_percentage"
             }
           ],
-          "device_ieee": [
-            167,
-            251,
-            79,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:4f:fb:a7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -926,16 +827,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            167,
-            251,
-            79,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:4f:fb:a7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -984,16 +876,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            167,
-            251,
-            79,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:4f:fb:a7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-flood-acn001.json
+++ b/tests/data/devices/lumi-lumi-flood-acn001.json
@@ -208,16 +208,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            223,
-            20,
-            34,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:22:14:df",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -261,16 +252,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            223,
-            20,
-            34,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:22:14:df",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -317,16 +299,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            223,
-            20,
-            34,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:22:14:df",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -369,16 +342,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            223,
-            20,
-            34,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:22:14:df",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -421,16 +385,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            223,
-            20,
-            34,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:22:14:df",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -483,16 +438,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            223,
-            20,
-            34,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:22:14:df",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-flood-agl02.json
+++ b/tests/data/devices/lumi-lumi-flood-agl02.json
@@ -201,16 +201,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            37,
-            200,
-            170,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:aa:c8:25",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -254,16 +245,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            37,
-            200,
-            170,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:aa:c8:25",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -310,16 +292,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            37,
-            200,
-            170,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:aa:c8:25",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -362,16 +335,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            37,
-            200,
-            170,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:aa:c8:25",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -414,16 +378,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            37,
-            200,
-            170,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:aa:c8:25",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -476,16 +431,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            37,
-            200,
-            170,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:aa:c8:25",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-light-aqcn02.json
+++ b/tests/data/devices/lumi-lumi-light-aqcn02.json
@@ -319,16 +319,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            144,
-            187,
-            22,
-            210,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:d2:16:bb:90",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -403,16 +394,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            144,
-            187,
-            22,
-            210,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:d2:16:bb:90",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -481,16 +463,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            144,
-            187,
-            22,
-            210,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:d2:16:bb:90",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -538,16 +511,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            144,
-            187,
-            22,
-            210,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:d2:16:bb:90",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -590,16 +554,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            144,
-            187,
-            22,
-            210,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:d2:16:bb:90",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -644,16 +599,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            144,
-            187,
-            22,
-            210,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:d2:16:bb:90",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-magnet-ac01.json
+++ b/tests/data/devices/lumi-lumi-magnet-ac01.json
@@ -182,16 +182,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            127,
-            133,
-            30,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:1e:85:7f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -235,16 +226,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            127,
-            133,
-            30,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:1e:85:7f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -291,16 +273,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            127,
-            133,
-            30,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:1e:85:7f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -349,16 +322,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            127,
-            133,
-            30,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:1e:85:7f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -401,16 +365,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            127,
-            133,
-            30,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:1e:85:7f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -453,16 +408,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            127,
-            133,
-            30,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:1e:85:7f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -515,16 +461,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            127,
-            133,
-            30,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:1e:85:7f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-magnet-acn001.json
+++ b/tests/data/devices/lumi-lumi-magnet-acn001.json
@@ -214,16 +214,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            126,
-            135,
-            37,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:25:87:7e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -267,16 +258,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            126,
-            135,
-            37,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:25:87:7e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -323,16 +305,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            126,
-            135,
-            37,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:25:87:7e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -375,16 +348,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            126,
-            135,
-            37,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:25:87:7e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -427,16 +391,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            126,
-            135,
-            37,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:25:87:7e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -489,16 +444,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            126,
-            135,
-            37,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:25:87:7e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-motion-ac02.json
+++ b/tests/data/devices/lumi-lumi-motion-ac02.json
@@ -249,16 +249,7 @@
               "value_attribute": "occupancy"
             }
           ],
-          "device_ieee": [
-            199,
-            116,
-            73,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:49:74:c7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -300,16 +291,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            199,
-            116,
-            73,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:49:74:c7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -353,16 +335,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            199,
-            116,
-            73,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:49:74:c7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -409,16 +382,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            199,
-            116,
-            73,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:49:74:c7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -466,16 +430,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            199,
-            116,
-            73,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:49:74:c7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -524,16 +479,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            199,
-            116,
-            73,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:49:74:c7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -576,16 +522,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            199,
-            116,
-            73,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:49:74:c7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -628,16 +565,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            199,
-            116,
-            73,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:49:74:c7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -688,16 +616,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            199,
-            116,
-            73,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:49:74:c7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -742,16 +661,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            199,
-            116,
-            73,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:49:74:c7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -800,16 +710,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            199,
-            116,
-            73,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:49:74:c7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-motion-agl02.json
+++ b/tests/data/devices/lumi-lumi-motion-agl02.json
@@ -230,16 +230,7 @@
               "value_attribute": "occupancy"
             }
           ],
-          "device_ieee": [
-            157,
-            224,
-            25,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:19:e0:9d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -281,16 +272,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            157,
-            224,
-            25,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:19:e0:9d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -334,16 +316,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            157,
-            224,
-            25,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:19:e0:9d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -390,16 +363,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            157,
-            224,
-            25,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:19:e0:9d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -442,16 +406,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            157,
-            224,
-            25,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:19:e0:9d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -494,16 +449,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            157,
-            224,
-            25,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:19:e0:9d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -554,16 +500,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            157,
-            224,
-            25,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:19:e0:9d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -608,16 +545,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            157,
-            224,
-            25,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:19:e0:9d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-motion-agl04.json
+++ b/tests/data/devices/lumi-lumi-motion-agl04.json
@@ -232,16 +232,7 @@
               "value_attribute": "occupancy"
             }
           ],
-          "device_ieee": [
-            187,
-            162,
-            64,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:40:a2:bb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -283,16 +274,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            187,
-            162,
-            64,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:40:a2:bb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -336,16 +318,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            187,
-            162,
-            64,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:40:a2:bb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -392,16 +365,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            187,
-            162,
-            64,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:40:a2:bb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -449,16 +413,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            187,
-            162,
-            64,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:40:a2:bb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -507,16 +462,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            187,
-            162,
-            64,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:40:a2:bb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -559,16 +505,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            187,
-            162,
-            64,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:40:a2:bb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -611,16 +548,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            187,
-            162,
-            64,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:40:a2:bb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -671,16 +599,7 @@
               "value_attribute": "current_temperature"
             }
           ],
-          "device_ieee": [
-            187,
-            162,
-            64,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:40:a2:bb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -725,16 +644,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            187,
-            162,
-            64,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:40:a2:bb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-plug-maus01.json
+++ b/tests/data/devices/lumi-lumi-plug-maus01.json
@@ -513,16 +513,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            120,
-            208,
-            130,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:82:d0:78",
           "endpoint_id": 100,
           "available": true,
           "group_id": null,
@@ -566,16 +557,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            120,
-            208,
-            130,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:82:d0:78",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -622,16 +604,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            120,
-            208,
-            130,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:82:d0:78",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -674,16 +647,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            120,
-            208,
-            130,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:82:d0:78",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -726,16 +690,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            120,
-            208,
-            130,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:82:d0:78",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -785,16 +740,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            120,
-            208,
-            130,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:82:d0:78",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -844,16 +790,7 @@
               "value_attribute": "current_temperature"
             }
           ],
-          "device_ieee": [
-            120,
-            208,
-            130,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:82:d0:78",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -896,16 +833,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            120,
-            208,
-            130,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:82:d0:78",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -952,16 +880,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            120,
-            208,
-            130,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:82:d0:78",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1008,16 +927,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            120,
-            208,
-            130,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:82:d0:78",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1064,16 +974,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            120,
-            208,
-            130,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:82:d0:78",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1120,16 +1021,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            120,
-            208,
-            130,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:82:d0:78",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1176,16 +1068,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            120,
-            208,
-            130,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:82:d0:78",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1234,16 +1117,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            120,
-            208,
-            130,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:82:d0:78",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -1286,16 +1160,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            120,
-            208,
-            130,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:82:d0:78",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-relay-c2acn01.json
+++ b/tests/data/devices/lumi-lumi-relay-c2acn01.json
@@ -421,16 +421,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            8,
-            236,
-            68,
-            4,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:04:44:ec:08",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -477,16 +468,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            8,
-            236,
-            68,
-            4,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:04:44:ec:08",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -551,16 +533,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            8,
-            236,
-            68,
-            4,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:04:44:ec:08",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -627,16 +600,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            8,
-            236,
-            68,
-            4,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:04:44:ec:08",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -679,16 +643,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            8,
-            236,
-            68,
-            4,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:04:44:ec:08",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -731,16 +686,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            8,
-            236,
-            68,
-            4,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:04:44:ec:08",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -790,16 +736,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            8,
-            236,
-            68,
-            4,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:04:44:ec:08",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -849,16 +786,7 @@
               "value_attribute": "current_temperature"
             }
           ],
-          "device_ieee": [
-            8,
-            236,
-            68,
-            4,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:04:44:ec:08",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -901,16 +829,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            8,
-            236,
-            68,
-            4,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:04:44:ec:08",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -957,16 +876,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            8,
-            236,
-            68,
-            4,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:04:44:ec:08",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1013,16 +923,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            8,
-            236,
-            68,
-            4,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:04:44:ec:08",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1069,16 +970,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            8,
-            236,
-            68,
-            4,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:04:44:ec:08",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1127,16 +1019,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            8,
-            236,
-            68,
-            4,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:04:44:ec:08",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-remote-b286opcn01.json
+++ b/tests/data/devices/lumi-lumi-remote-b286opcn01.json
@@ -409,16 +409,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            103,
-            193,
-            117,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:75:c1:67",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -465,16 +456,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            103,
-            193,
-            117,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:75:c1:67",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -517,16 +499,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            103,
-            193,
-            117,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:75:c1:67",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -569,16 +542,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            103,
-            193,
-            117,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:75:c1:67",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-remote-b486opcn01.json
+++ b/tests/data/devices/lumi-lumi-remote-b486opcn01.json
@@ -275,16 +275,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            123,
-            193,
-            117,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:75:c1:7b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -331,16 +322,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            123,
-            193,
-            117,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:75:c1:7b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -383,16 +365,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            123,
-            193,
-            117,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:75:c1:7b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -435,16 +408,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            123,
-            193,
-            117,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:75:c1:7b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-remote-b686opcn01.json
+++ b/tests/data/devices/lumi-lumi-remote-b686opcn01.json
@@ -383,16 +383,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            118,
-            71,
-            121,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:79:47:76",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -439,16 +430,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            118,
-            71,
-            121,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:79:47:76",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -491,16 +473,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            118,
-            71,
-            121,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:79:47:76",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -543,16 +516,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            118,
-            71,
-            121,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:79:47:76",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-remote-cagl02.json
+++ b/tests/data/devices/lumi-lumi-remote-cagl02.json
@@ -264,16 +264,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            231,
-            243,
-            20,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:14:f3:e7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -320,16 +311,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            231,
-            243,
-            20,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:14:f3:e7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -372,16 +354,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            231,
-            243,
-            20,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:14:f3:e7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -424,16 +397,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            231,
-            243,
-            20,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:14:f3:e7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -500,16 +464,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            231,
-            243,
-            20,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:14:f3:e7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-sen-ill-mgl01.json
+++ b/tests/data/devices/lumi-lumi-sen-ill-mgl01.json
@@ -175,16 +175,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            117,
-            25,
-            119,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:77:19:75",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -231,16 +222,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            117,
-            25,
-            119,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:77:19:75",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -283,16 +265,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            117,
-            25,
-            119,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:77:19:75",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -335,16 +308,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            117,
-            25,
-            119,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:77:19:75",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -395,16 +359,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            117,
-            25,
-            119,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:77:19:75",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-sensor-86sw2.json
+++ b/tests/data/devices/lumi-lumi-sensor-86sw2.json
@@ -367,16 +367,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            250,
-            203,
-            84,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:54:cb:fa",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -423,16 +414,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            250,
-            203,
-            84,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:54:cb:fa",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -475,16 +457,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            250,
-            203,
-            84,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:54:cb:fa",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -527,16 +500,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            250,
-            203,
-            84,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:54:cb:fa",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -587,16 +551,7 @@
               "value_attribute": "current_temperature"
             }
           ],
-          "device_ieee": [
-            250,
-            203,
-            84,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:54:cb:fa",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -655,16 +610,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            250,
-            203,
-            84,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:54:cb:fa",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-sensor-ht-agl02.json
+++ b/tests/data/devices/lumi-lumi-sensor-ht-agl02.json
@@ -214,16 +214,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            167,
-            197,
-            127,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:7f:c5:a7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -270,16 +261,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            167,
-            197,
-            127,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:7f:c5:a7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -322,16 +304,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            167,
-            197,
-            127,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:7f:c5:a7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -374,16 +347,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            167,
-            197,
-            127,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:7f:c5:a7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -434,16 +398,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            167,
-            197,
-            127,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:7f:c5:a7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -486,16 +441,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            167,
-            197,
-            127,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:7f:c5:a7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -538,16 +484,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            167,
-            197,
-            127,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:7f:c5:a7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -592,16 +529,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            167,
-            197,
-            127,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:7f:c5:a7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-sensor-magnet-aq2.json
+++ b/tests/data/devices/lumi-lumi-sensor-magnet-aq2.json
@@ -215,16 +215,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            82,
-            64,
-            171,
-            1,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:01:ab:40:52",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -268,16 +259,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            82,
-            64,
-            171,
-            1,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:01:ab:40:52",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -324,16 +306,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            82,
-            64,
-            171,
-            1,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:01:ab:40:52",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -376,16 +349,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            82,
-            64,
-            171,
-            1,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:01:ab:40:52",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -428,16 +392,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            82,
-            64,
-            171,
-            1,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:01:ab:40:52",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -488,16 +443,7 @@
               "value_attribute": "current_temperature"
             }
           ],
-          "device_ieee": [
-            82,
-            64,
-            171,
-            1,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:01:ab:40:52",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-sensor-motion-aq2.json
+++ b/tests/data/devices/lumi-lumi-sensor-motion-aq2.json
@@ -254,16 +254,7 @@
               "value_attribute": "occupancy"
             }
           ],
-          "device_ieee": [
-            235,
-            202,
-            177,
-            1,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:01:b1:ca:eb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -305,16 +296,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            235,
-            202,
-            177,
-            1,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:01:b1:ca:eb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -358,16 +340,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            235,
-            202,
-            177,
-            1,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:01:b1:ca:eb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -414,16 +387,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            235,
-            202,
-            177,
-            1,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:01:b1:ca:eb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -466,16 +430,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            235,
-            202,
-            177,
-            1,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:01:b1:ca:eb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -518,16 +473,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            235,
-            202,
-            177,
-            1,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:01:b1:ca:eb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -578,16 +524,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            235,
-            202,
-            177,
-            1,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:01:b1:ca:eb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -630,16 +567,7 @@
               "value_attribute": "current_temperature"
             }
           ],
-          "device_ieee": [
-            235,
-            202,
-            177,
-            1,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:01:b1:ca:eb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -684,16 +612,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            235,
-            202,
-            177,
-            1,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:01:b1:ca:eb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-sensor-smoke-acn03.json
+++ b/tests/data/devices/lumi-lumi-sensor-smoke-acn03.json
@@ -232,16 +232,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            147,
-            110,
-            90,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:5a:6e:93",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -283,16 +274,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            147,
-            110,
-            90,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:5a:6e:93",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -336,16 +318,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            147,
-            110,
-            90,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:5a:6e:93",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -390,16 +363,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            147,
-            110,
-            90,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:5a:6e:93",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -443,16 +407,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            147,
-            110,
-            90,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:5a:6e:93",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -495,16 +450,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            147,
-            110,
-            90,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:5a:6e:93",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -547,16 +493,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            147,
-            110,
-            90,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:5a:6e:93",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -607,16 +544,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            147,
-            110,
-            90,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:5a:6e:93",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -661,16 +589,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            147,
-            110,
-            90,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:5a:6e:93",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -717,16 +636,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            147,
-            110,
-            90,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:5a:6e:93",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -773,16 +683,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            147,
-            110,
-            90,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:5a:6e:93",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -829,16 +730,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            147,
-            110,
-            90,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:5a:6e:93",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -887,16 +779,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            147,
-            110,
-            90,
-            0,
-            16,
-            68,
-            239,
-            84
-          ],
+          "device_ieee": "54:ef:44:10:00:5a:6e:93",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-sensor-smoke.json
+++ b/tests/data/devices/lumi-lumi-sensor-smoke.json
@@ -290,16 +290,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            169,
-            46,
-            203,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:cb:2e:a9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -343,16 +334,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            169,
-            46,
-            203,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:cb:2e:a9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -399,16 +381,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            169,
-            46,
-            203,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:cb:2e:a9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -451,16 +424,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            169,
-            46,
-            203,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:cb:2e:a9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -503,16 +467,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            169,
-            46,
-            203,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:cb:2e:a9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -563,16 +518,7 @@
               "value_attribute": "current_temperature"
             }
           ],
-          "device_ieee": [
-            169,
-            46,
-            203,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:cb:2e:a9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -617,16 +563,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            169,
-            46,
-            203,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:cb:2e:a9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-sensor-switch-aq2.json
+++ b/tests/data/devices/lumi-lumi-sensor-switch-aq2.json
@@ -215,16 +215,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            56,
-            145,
-            19,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:13:91:38",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -267,16 +258,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            56,
-            145,
-            19,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:13:91:38",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -319,16 +301,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            56,
-            145,
-            19,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:13:91:38",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -379,16 +352,7 @@
               "value_attribute": "current_temperature"
             }
           ],
-          "device_ieee": [
-            56,
-            145,
-            19,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:13:91:38",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-sensor-switch-aq3.json
+++ b/tests/data/devices/lumi-lumi-sensor-switch-aq3.json
@@ -187,16 +187,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            145,
-            229,
-            176,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:b0:e5:91",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -239,16 +230,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            145,
-            229,
-            176,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:b0:e5:91",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -291,16 +273,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            145,
-            229,
-            176,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:b0:e5:91",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -351,16 +324,7 @@
               "value_attribute": "current_temperature"
             }
           ],
-          "device_ieee": [
-            145,
-            229,
-            176,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:b0:e5:91",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-sensor-switch.json
+++ b/tests/data/devices/lumi-lumi-sensor-switch.json
@@ -205,16 +205,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            114,
-            186,
-            16,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:10:ba:72",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -261,16 +252,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            114,
-            186,
-            16,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:10:ba:72",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -313,16 +295,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            114,
-            186,
-            16,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:10:ba:72",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -365,16 +338,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            114,
-            186,
-            16,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:10:ba:72",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -427,16 +391,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            114,
-            186,
-            16,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:10:ba:72",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-switch-b1laus01.json
+++ b/tests/data/devices/lumi-lumi-switch-b1laus01.json
@@ -184,16 +184,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            207,
-            218,
-            117,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:75:da:cf",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -240,16 +231,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            207,
-            218,
-            117,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:75:da:cf",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -316,16 +298,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            207,
-            218,
-            117,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:75:da:cf",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -368,16 +341,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            207,
-            218,
-            117,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:75:da:cf",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -420,16 +384,7 @@
               "value_attribute": "current_temperature"
             }
           ],
-          "device_ieee": [
-            207,
-            218,
-            117,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:75:da:cf",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -474,16 +429,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            207,
-            218,
-            117,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:75:da:cf",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-switch-b1naus01.json
+++ b/tests/data/devices/lumi-lumi-switch-b1naus01.json
@@ -424,16 +424,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            130,
-            28,
-            118,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:76:1c:82",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -480,16 +471,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            130,
-            28,
-            118,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:76:1c:82",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -556,16 +538,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            130,
-            28,
-            118,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:76:1c:82",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -608,16 +581,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            130,
-            28,
-            118,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:76:1c:82",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -660,16 +624,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            130,
-            28,
-            118,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:76:1c:82",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -720,16 +675,7 @@
               "value_attribute": "current_temperature"
             }
           ],
-          "device_ieee": [
-            130,
-            28,
-            118,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:76:1c:82",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -772,16 +718,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            130,
-            28,
-            118,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:76:1c:82",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -831,16 +768,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            130,
-            28,
-            118,
-            60,
-            223,
-            140,
-            207,
-            4
-          ],
+          "device_ieee": "04:cf:8c:df:3c:76:1c:82",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-vibration-aq1.json
+++ b/tests/data/devices/lumi-lumi-vibration-aq1.json
@@ -308,16 +308,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            39,
-            151,
-            175,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:af:97:27",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -361,16 +352,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            39,
-            151,
-            175,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:af:97:27",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -417,16 +399,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            39,
-            151,
-            175,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:af:97:27",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -469,16 +442,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            39,
-            151,
-            175,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:af:97:27",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -521,16 +485,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            39,
-            151,
-            175,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:af:97:27",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -581,16 +536,7 @@
               "value_attribute": "current_temperature"
             }
           ],
-          "device_ieee": [
-            39,
-            151,
-            175,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:af:97:27",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -649,16 +595,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            39,
-            151,
-            175,
-            2,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:02:af:97:27",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lumi-lumi-weather.json
+++ b/tests/data/devices/lumi-lumi-weather.json
@@ -235,16 +235,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            31,
-            157,
-            75,
-            5,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:05:4b:9d:1f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -291,16 +282,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            31,
-            157,
-            75,
-            5,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:05:4b:9d:1f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -343,16 +325,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            31,
-            157,
-            75,
-            5,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:05:4b:9d:1f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -395,16 +368,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            31,
-            157,
-            75,
-            5,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:05:4b:9d:1f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -455,16 +419,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            31,
-            157,
-            75,
-            5,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:05:4b:9d:1f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -507,16 +462,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            31,
-            157,
-            75,
-            5,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:05:4b:9d:1f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -559,16 +505,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            31,
-            157,
-            75,
-            5,
-            0,
-            141,
-            21,
-            0
-          ],
+          "device_ieee": "00:15:8d:00:05:4b:9d:1f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lutron-lzl4bwhl01-remote.json
+++ b/tests/data/devices/lutron-lzl4bwhl01-remote.json
@@ -191,16 +191,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            179,
-            60,
-            255,
-            231,
-            15,
-            0,
-            255,
-            255
-          ],
+          "device_ieee": "ff:ff:00:0f:e7:ff:3c:b3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -243,16 +234,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            179,
-            60,
-            255,
-            231,
-            15,
-            0,
-            255,
-            255
-          ],
+          "device_ieee": "ff:ff:00:0f:e7:ff:3c:b3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/lutron-z3-1brl.json
+++ b/tests/data/devices/lutron-z3-1brl.json
@@ -178,16 +178,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            7,
-            240,
-            251,
-            231,
-            15,
-            0,
-            255,
-            255
-          ],
+          "device_ieee": "ff:ff:00:0f:e7:fb:f0:07",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -234,16 +225,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            7,
-            240,
-            251,
-            231,
-            15,
-            0,
-            255,
-            255
-          ],
+          "device_ieee": "ff:ff:00:0f:e7:fb:f0:07",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -286,16 +268,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            7,
-            240,
-            251,
-            231,
-            15,
-            0,
-            255,
-            255
-          ],
+          "device_ieee": "ff:ff:00:0f:e7:fb:f0:07",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -338,16 +311,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            7,
-            240,
-            251,
-            231,
-            15,
-            0,
-            255,
-            255
-          ],
+          "device_ieee": "ff:ff:00:0f:e7:fb:f0:07",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -398,16 +362,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            7,
-            240,
-            251,
-            231,
-            15,
-            0,
-            255,
-            255
-          ],
+          "device_ieee": "ff:ff:00:0f:e7:fb:f0:07",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/osram-switch-4x-lightify.json
+++ b/tests/data/devices/osram-switch-4x-lightify.json
@@ -788,16 +788,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            231,
-            212,
-            200,
-            14,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:0e:c8:d4:e7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -840,16 +831,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            231,
-            212,
-            200,
-            14,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:0e:c8:d4:e7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -892,16 +874,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            231,
-            212,
-            200,
-            14,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:0e:c8:d4:e7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -952,16 +925,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            231,
-            212,
-            200,
-            14,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:0e:c8:d4:e7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/philips-7602031u7.json
+++ b/tests/data/devices/philips-7602031u7.json
@@ -352,16 +352,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            252,
-            81,
-            75,
-            11,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0b:4b:51:fc",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -436,16 +427,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            252,
-            81,
-            75,
-            11,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0b:4b:51:fc",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -520,16 +502,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            252,
-            81,
-            75,
-            11,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0b:4b:51:fc",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -575,16 +548,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            252,
-            81,
-            75,
-            11,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0b:4b:51:fc",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -632,16 +596,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            252,
-            81,
-            75,
-            11,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0b:4b:51:fc",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -691,16 +646,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            252,
-            81,
-            75,
-            11,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0b:4b:51:fc",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -743,16 +689,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            252,
-            81,
-            75,
-            11,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0b:4b:51:fc",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -797,16 +734,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            252,
-            81,
-            75,
-            11,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0b:4b:51:fc",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/philips-lct014.json
+++ b/tests/data/devices/philips-lct014.json
@@ -316,16 +316,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            92,
-            234,
-            79,
-            2,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:02:4f:ea:5c",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -400,16 +391,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            92,
-            234,
-            79,
-            2,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:02:4f:ea:5c",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -484,16 +466,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            92,
-            234,
-            79,
-            2,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:02:4f:ea:5c",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -539,16 +512,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            92,
-            234,
-            79,
-            2,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:02:4f:ea:5c",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -596,16 +560,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            92,
-            234,
-            79,
-            2,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:02:4f:ea:5c",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -655,16 +610,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            92,
-            234,
-            79,
-            2,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:02:4f:ea:5c",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -707,16 +653,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            92,
-            234,
-            79,
-            2,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:02:4f:ea:5c",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -761,16 +698,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            92,
-            234,
-            79,
-            2,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:02:4f:ea:5c",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/philips-llc020.json
+++ b/tests/data/devices/philips-llc020.json
@@ -304,16 +304,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            51,
-            227,
-            22,
-            1,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:01:16:e3:33",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -388,16 +379,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            51,
-            227,
-            22,
-            1,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:01:16:e3:33",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -472,16 +454,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            51,
-            227,
-            22,
-            1,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:01:16:e3:33",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -527,16 +500,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            51,
-            227,
-            22,
-            1,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:01:16:e3:33",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -584,16 +548,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            51,
-            227,
-            22,
-            1,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:01:16:e3:33",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -643,16 +598,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            51,
-            227,
-            22,
-            1,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:01:16:e3:33",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -695,16 +641,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            51,
-            227,
-            22,
-            1,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:01:16:e3:33",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -749,16 +686,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            51,
-            227,
-            22,
-            1,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:01:16:e3:33",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/philips-lst002.json
+++ b/tests/data/devices/philips-lst002.json
@@ -330,16 +330,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            145,
-            137,
-            138,
-            173,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:ad:8a:89:91",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -414,16 +405,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            145,
-            137,
-            138,
-            173,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:ad:8a:89:91",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -498,16 +480,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            145,
-            137,
-            138,
-            173,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:ad:8a:89:91",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -550,16 +523,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            145,
-            137,
-            138,
-            173,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:ad:8a:89:91",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -604,16 +568,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            145,
-            137,
-            138,
-            173,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:ad:8a:89:91",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/philips-rom001.json
+++ b/tests/data/devices/philips-rom001.json
@@ -245,16 +245,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            195,
-            167,
-            84,
-            6,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:06:54:a7:c3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -301,16 +292,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            195,
-            167,
-            84,
-            6,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:06:54:a7:c3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -353,16 +335,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            195,
-            167,
-            84,
-            6,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:06:54:a7:c3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -405,16 +378,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            195,
-            167,
-            84,
-            6,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:06:54:a7:c3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -465,16 +429,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            195,
-            167,
-            84,
-            6,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:06:54:a7:c3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/philips-rwl020.json
+++ b/tests/data/devices/philips-rwl020.json
@@ -263,16 +263,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            91,
-            195,
-            7,
-            8,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:08:07:c3:5b",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -316,16 +307,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            91,
-            195,
-            7,
-            8,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:08:07:c3:5b",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -372,16 +354,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            91,
-            195,
-            7,
-            8,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:08:07:c3:5b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -424,16 +397,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            91,
-            195,
-            7,
-            8,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:08:07:c3:5b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -476,16 +440,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            91,
-            195,
-            7,
-            8,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:08:07:c3:5b",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -536,16 +491,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            91,
-            195,
-            7,
-            8,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:08:07:c3:5b",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/philips-sml001.json
+++ b/tests/data/devices/philips-sml001.json
@@ -287,16 +287,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            113,
-            172,
-            245,
-            6,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:06:f5:ac:71",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -338,16 +329,7 @@
               "value_attribute": "occupancy"
             }
           ],
-          "device_ieee": [
-            113,
-            172,
-            245,
-            6,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:06:f5:ac:71",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -391,16 +373,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            113,
-            172,
-            245,
-            6,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:06:f5:ac:71",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -447,16 +420,7 @@
               "value_attribute": "occupancy"
             }
           ],
-          "device_ieee": [
-            113,
-            172,
-            245,
-            6,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:06:f5:ac:71",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -505,16 +469,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            113,
-            172,
-            245,
-            6,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:06:f5:ac:71",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -557,16 +512,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            113,
-            172,
-            245,
-            6,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:06:f5:ac:71",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -609,16 +555,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            113,
-            172,
-            245,
-            6,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:06:f5:ac:71",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -667,16 +604,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            113,
-            172,
-            245,
-            6,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:06:f5:ac:71",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -719,16 +647,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            113,
-            172,
-            245,
-            6,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:06:f5:ac:71",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -773,16 +692,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            113,
-            172,
-            245,
-            6,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:06:f5:ac:71",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -831,16 +741,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            113,
-            172,
-            245,
-            6,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:06:f5:ac:71",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/plaid-systems-ps-sprzms-slp3.json
+++ b/tests/data/devices/plaid-systems-ps-sprzms-slp3.json
@@ -185,16 +185,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            135,
-            130,
-            110,
-            14,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:0e:6e:82:87",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -241,16 +232,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            135,
-            130,
-            110,
-            14,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:0e:6e:82:87",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -293,16 +275,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            135,
-            130,
-            110,
-            14,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:0e:6e:82:87",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -345,16 +318,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            135,
-            130,
-            110,
-            14,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:0e:6e:82:87",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -405,16 +369,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            135,
-            130,
-            110,
-            14,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:0e:6e:82:87",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -457,16 +412,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            135,
-            130,
-            110,
-            14,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:0e:6e:82:87",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -511,16 +457,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            135,
-            130,
-            110,
-            14,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:0e:6e:82:87",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/samjin-button.json
+++ b/tests/data/devices/samjin-button.json
@@ -227,16 +227,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            189,
-            53,
-            4,
-            1,
-            0,
-            151,
-            109,
-            40
-          ],
+          "device_ieee": "28:6d:97:00:01:04:35:bd",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -280,16 +271,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            189,
-            53,
-            4,
-            1,
-            0,
-            151,
-            109,
-            40
-          ],
+          "device_ieee": "28:6d:97:00:01:04:35:bd",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -336,16 +318,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            189,
-            53,
-            4,
-            1,
-            0,
-            151,
-            109,
-            40
-          ],
+          "device_ieee": "28:6d:97:00:01:04:35:bd",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -388,16 +361,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            189,
-            53,
-            4,
-            1,
-            0,
-            151,
-            109,
-            40
-          ],
+          "device_ieee": "28:6d:97:00:01:04:35:bd",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -440,16 +404,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            189,
-            53,
-            4,
-            1,
-            0,
-            151,
-            109,
-            40
-          ],
+          "device_ieee": "28:6d:97:00:01:04:35:bd",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -498,16 +453,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            189,
-            53,
-            4,
-            1,
-            0,
-            151,
-            109,
-            40
-          ],
+          "device_ieee": "28:6d:97:00:01:04:35:bd",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -552,16 +498,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            189,
-            53,
-            4,
-            1,
-            0,
-            151,
-            109,
-            40
-          ],
+          "device_ieee": "28:6d:97:00:01:04:35:bd",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/samjin-multi.json
+++ b/tests/data/devices/samjin-multi.json
@@ -253,16 +253,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            61,
-            21,
-            3,
-            1,
-            0,
-            151,
-            109,
-            40
-          ],
+          "device_ieee": "28:6d:97:00:01:03:15:3d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -304,16 +295,7 @@
               "value_attribute": "acceleration"
             }
           ],
-          "device_ieee": [
-            61,
-            21,
-            3,
-            1,
-            0,
-            151,
-            109,
-            40
-          ],
+          "device_ieee": "28:6d:97:00:01:03:15:3d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -357,16 +339,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            61,
-            21,
-            3,
-            1,
-            0,
-            151,
-            109,
-            40
-          ],
+          "device_ieee": "28:6d:97:00:01:03:15:3d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -413,16 +386,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            61,
-            21,
-            3,
-            1,
-            0,
-            151,
-            109,
-            40
-          ],
+          "device_ieee": "28:6d:97:00:01:03:15:3d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -465,16 +429,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            61,
-            21,
-            3,
-            1,
-            0,
-            151,
-            109,
-            40
-          ],
+          "device_ieee": "28:6d:97:00:01:03:15:3d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -517,16 +472,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            61,
-            21,
-            3,
-            1,
-            0,
-            151,
-            109,
-            40
-          ],
+          "device_ieee": "28:6d:97:00:01:03:15:3d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -575,16 +521,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            61,
-            21,
-            3,
-            1,
-            0,
-            151,
-            109,
-            40
-          ],
+          "device_ieee": "28:6d:97:00:01:03:15:3d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -629,16 +566,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            61,
-            21,
-            3,
-            1,
-            0,
-            151,
-            109,
-            40
-          ],
+          "device_ieee": "28:6d:97:00:01:03:15:3d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/securifi-ltd-unk-model.json
+++ b/tests/data/devices/securifi-ltd-unk-model.json
@@ -341,16 +341,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            104,
-            172,
-            73,
-            5,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:05:49:ac:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -397,16 +388,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            104,
-            172,
-            73,
-            5,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:05:49:ac:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -449,16 +431,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            104,
-            172,
-            73,
-            5,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:05:49:ac:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -501,16 +474,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            104,
-            172,
-            73,
-            5,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:05:49:ac:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -558,16 +522,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            104,
-            172,
-            73,
-            5,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:05:49:ac:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -615,16 +570,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            104,
-            172,
-            73,
-            5,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:05:49:ac:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -672,16 +618,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            104,
-            172,
-            73,
-            5,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:05:49:ac:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -729,16 +666,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            104,
-            172,
-            73,
-            5,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:05:49:ac:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -788,16 +716,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            104,
-            172,
-            73,
-            5,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:05:49:ac:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -840,16 +759,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            104,
-            172,
-            73,
-            5,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:05:49:ac:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/sengled-e11-g13.json
+++ b/tests/data/devices/sengled-e11-g13.json
@@ -302,16 +302,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            72,
-            155,
-            58,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:3a:9b:48",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -372,16 +363,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            72,
-            155,
-            58,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:3a:9b:48",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -449,16 +431,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            72,
-            155,
-            58,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:3a:9b:48",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -506,16 +479,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            72,
-            155,
-            58,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:3a:9b:48",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -558,16 +522,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            72,
-            155,
-            58,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:3a:9b:48",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -610,16 +565,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            72,
-            155,
-            58,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:3a:9b:48",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -670,16 +616,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            72,
-            155,
-            58,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:3a:9b:48",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -732,16 +669,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            72,
-            155,
-            58,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:3a:9b:48",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/sengled-e12-n14.json
+++ b/tests/data/devices/sengled-e12-n14.json
@@ -296,16 +296,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            21,
-            198,
-            9,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:09:c6:15",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -366,16 +357,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            21,
-            198,
-            9,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:09:c6:15",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -443,16 +425,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            21,
-            198,
-            9,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:09:c6:15",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -500,16 +473,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            21,
-            198,
-            9,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:09:c6:15",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -552,16 +516,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            21,
-            198,
-            9,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:09:c6:15",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -604,16 +559,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            21,
-            198,
-            9,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:09:c6:15",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -664,16 +610,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            21,
-            198,
-            9,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:09:c6:15",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -726,16 +663,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            21,
-            198,
-            9,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:09:c6:15",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/sengled-e12-n1e.json
+++ b/tests/data/devices/sengled-e12-n1e.json
@@ -395,16 +395,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            105,
-            52,
-            83,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:53:34:69",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -479,16 +470,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            105,
-            52,
-            83,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:53:34:69",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -561,16 +543,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            105,
-            52,
-            83,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:53:34:69",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -613,16 +586,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            105,
-            52,
-            83,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:53:34:69",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -665,16 +629,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            105,
-            52,
-            83,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:53:34:69",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -725,16 +680,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            105,
-            52,
-            83,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:53:34:69",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -787,16 +733,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            105,
-            52,
-            83,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:53:34:69",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/sengled-e1c-nb6.json
+++ b/tests/data/devices/sengled-e1c-nb6.json
@@ -145,16 +145,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            243,
-            45,
-            4,
-            0,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:00:04:2d:f3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -201,16 +192,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            243,
-            45,
-            4,
-            0,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:00:04:2d:f3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -253,16 +235,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            243,
-            45,
-            4,
-            0,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:00:04:2d:f3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -307,16 +280,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            243,
-            45,
-            4,
-            0,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:00:04:2d:f3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -359,16 +323,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            243,
-            45,
-            4,
-            0,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:00:04:2d:f3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/sengled-e1c-nb7.json
+++ b/tests/data/devices/sengled-e1c-nb7.json
@@ -263,16 +263,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            238,
-            154,
-            107,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:6b:9a:ee",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -319,16 +310,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            238,
-            154,
-            107,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:6b:9a:ee",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -378,16 +360,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            238,
-            154,
-            107,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:6b:9a:ee",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -430,16 +403,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            238,
-            154,
-            107,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:6b:9a:ee",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -482,16 +446,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            238,
-            154,
-            107,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:6b:9a:ee",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -542,16 +497,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            238,
-            154,
-            107,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:6b:9a:ee",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -604,16 +550,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            238,
-            154,
-            107,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:6b:9a:ee",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -656,16 +593,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            238,
-            154,
-            107,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:6b:9a:ee",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/sengled-e1f-n9g.json
+++ b/tests/data/devices/sengled-e1f-n9g.json
@@ -311,16 +311,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            72,
-            134,
-            28,
-            0,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:00:1c:86:48",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -381,16 +372,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            72,
-            134,
-            28,
-            0,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:00:1c:86:48",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -458,16 +440,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            72,
-            134,
-            28,
-            0,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:00:1c:86:48",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -515,16 +488,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            72,
-            134,
-            28,
-            0,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:00:1c:86:48",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -567,16 +531,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            72,
-            134,
-            28,
-            0,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:00:1c:86:48",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -619,16 +574,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            72,
-            134,
-            28,
-            0,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:00:1c:86:48",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -679,16 +625,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            72,
-            134,
-            28,
-            0,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:00:1c:86:48",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -741,16 +678,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            72,
-            134,
-            28,
-            0,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:00:1c:86:48",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/sengled-e1g-g8e.json
+++ b/tests/data/devices/sengled-e1g-g8e.json
@@ -400,16 +400,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            106,
-            242,
-            99,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:63:f2:6a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -484,16 +475,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            106,
-            242,
-            99,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:63:f2:6a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -566,16 +548,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            106,
-            242,
-            99,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:63:f2:6a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -618,16 +591,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            106,
-            242,
-            99,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:63:f2:6a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -670,16 +634,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            106,
-            242,
-            99,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:63:f2:6a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -730,16 +685,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            106,
-            242,
-            99,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:63:f2:6a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -792,16 +738,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            106,
-            242,
-            99,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:63:f2:6a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/sengled-e21-n1ea.json
+++ b/tests/data/devices/sengled-e21-n1ea.json
@@ -400,16 +400,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            104,
-            87,
-            24,
-            0,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:00:18:57:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -484,16 +475,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            104,
-            87,
-            24,
-            0,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:00:18:57:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -566,16 +548,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            104,
-            87,
-            24,
-            0,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:00:18:57:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -621,16 +594,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            104,
-            87,
-            24,
-            0,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:00:18:57:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -676,16 +640,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            104,
-            87,
-            24,
-            0,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:00:18:57:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -733,16 +688,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            104,
-            87,
-            24,
-            0,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:00:18:57:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -785,16 +731,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            104,
-            87,
-            24,
-            0,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:00:18:57:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -837,16 +774,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            104,
-            87,
-            24,
-            0,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:00:18:57:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -897,16 +825,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            104,
-            87,
-            24,
-            0,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:00:18:57:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -959,16 +878,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            104,
-            87,
-            24,
-            0,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:00:18:57:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/sengled-z01-a19nae26.json
+++ b/tests/data/devices/sengled-z01-a19nae26.json
@@ -380,16 +380,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            40,
-            29,
-            1,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:01:1d:28",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -464,16 +455,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            40,
-            29,
-            1,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:01:1d:28",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -542,16 +524,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            40,
-            29,
-            1,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:01:1d:28",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -599,16 +572,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            40,
-            29,
-            1,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:01:1d:28",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -651,16 +615,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            40,
-            29,
-            1,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:01:1d:28",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -703,16 +658,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            40,
-            29,
-            1,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:01:1d:28",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -763,16 +709,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            40,
-            29,
-            1,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:01:1d:28",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -825,16 +762,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            40,
-            29,
-            1,
-            3,
-            20,
-            24,
-            206,
-            176
-          ],
+          "device_ieee": "b0:ce:18:14:03:01:1d:28",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/signify-netherlands-b-v-lca001.json
+++ b/tests/data/devices/signify-netherlands-b-v-lca001.json
@@ -333,16 +333,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            205,
-            113,
-            15,
-            125,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:7d:0f:71:cd",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -417,16 +408,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            205,
-            113,
-            15,
-            125,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:7d:0f:71:cd",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -501,16 +483,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            205,
-            113,
-            15,
-            125,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:7d:0f:71:cd",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -556,16 +529,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            205,
-            113,
-            15,
-            125,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:7d:0f:71:cd",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -613,16 +577,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            205,
-            113,
-            15,
-            125,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:7d:0f:71:cd",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -672,16 +627,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            205,
-            113,
-            15,
-            125,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:7d:0f:71:cd",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -724,16 +670,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            205,
-            113,
-            15,
-            125,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:7d:0f:71:cd",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -778,16 +715,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            205,
-            113,
-            15,
-            125,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:7d:0f:71:cd",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/signify-netherlands-b-v-lca005.json
+++ b/tests/data/devices/signify-netherlands-b-v-lca005.json
@@ -315,16 +315,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            92,
-            188,
-            109,
-            11,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0b:6d:bc:5c",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -399,16 +390,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            92,
-            188,
-            109,
-            11,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0b:6d:bc:5c",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -483,16 +465,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            92,
-            188,
-            109,
-            11,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0b:6d:bc:5c",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -538,16 +511,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            92,
-            188,
-            109,
-            11,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0b:6d:bc:5c",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -595,16 +559,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            92,
-            188,
-            109,
-            11,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0b:6d:bc:5c",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -654,16 +609,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            92,
-            188,
-            109,
-            11,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0b:6d:bc:5c",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -706,16 +652,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            92,
-            188,
-            109,
-            11,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0b:6d:bc:5c",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -760,16 +697,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            92,
-            188,
-            109,
-            11,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0b:6d:bc:5c",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/signify-netherlands-b-v-lca007.json
+++ b/tests/data/devices/signify-netherlands-b-v-lca007.json
@@ -303,16 +303,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            24,
-            190,
-            110,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:6e:be:18",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -387,16 +378,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            24,
-            190,
-            110,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:6e:be:18",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -471,16 +453,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            24,
-            190,
-            110,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:6e:be:18",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -526,16 +499,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            24,
-            190,
-            110,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:6e:be:18",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -583,16 +547,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            24,
-            190,
-            110,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:6e:be:18",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -642,16 +597,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            24,
-            190,
-            110,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:6e:be:18",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -694,16 +640,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            24,
-            190,
-            110,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:6e:be:18",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -748,16 +685,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            24,
-            190,
-            110,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:6e:be:18",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/signify-netherlands-b-v-lcb001.json
+++ b/tests/data/devices/signify-netherlands-b-v-lcb001.json
@@ -340,16 +340,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            86,
-            135,
-            11,
-            6,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:06:0b:87:56",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -424,16 +415,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            86,
-            135,
-            11,
-            6,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:06:0b:87:56",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -508,16 +490,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            86,
-            135,
-            11,
-            6,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:06:0b:87:56",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -563,16 +536,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            86,
-            135,
-            11,
-            6,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:06:0b:87:56",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -620,16 +584,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            86,
-            135,
-            11,
-            6,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:06:0b:87:56",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -679,16 +634,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            86,
-            135,
-            11,
-            6,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:06:0b:87:56",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -731,16 +677,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            86,
-            135,
-            11,
-            6,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:06:0b:87:56",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -785,16 +722,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            86,
-            135,
-            11,
-            6,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:06:0b:87:56",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/signify-netherlands-b-v-lcb002.json
+++ b/tests/data/devices/signify-netherlands-b-v-lcb002.json
@@ -303,16 +303,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            163,
-            156,
-            1,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:01:9c:a3",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -387,16 +378,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            163,
-            156,
-            1,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:01:9c:a3",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -471,16 +453,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            163,
-            156,
-            1,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:01:9c:a3",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -526,16 +499,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            163,
-            156,
-            1,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:01:9c:a3",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -583,16 +547,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            163,
-            156,
-            1,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:01:9c:a3",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -642,16 +597,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            163,
-            156,
-            1,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:01:9c:a3",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -694,16 +640,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            163,
-            156,
-            1,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:01:9c:a3",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -748,16 +685,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            163,
-            156,
-            1,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:01:9c:a3",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/signify-netherlands-b-v-lce001.json
+++ b/tests/data/devices/signify-netherlands-b-v-lce001.json
@@ -302,16 +302,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            26,
-            147,
-            91,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:5b:93:1a",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -386,16 +377,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            26,
-            147,
-            91,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:5b:93:1a",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -470,16 +452,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            26,
-            147,
-            91,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:5b:93:1a",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -525,16 +498,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            26,
-            147,
-            91,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:5b:93:1a",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -582,16 +546,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            26,
-            147,
-            91,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:5b:93:1a",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -641,16 +596,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            26,
-            147,
-            91,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:5b:93:1a",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -693,16 +639,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            26,
-            147,
-            91,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:5b:93:1a",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -747,16 +684,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            26,
-            147,
-            91,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:5b:93:1a",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/signify-netherlands-b-v-lcx004.json
+++ b/tests/data/devices/signify-netherlands-b-v-lcx004.json
@@ -297,16 +297,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            252,
-            4,
-            51,
-            22,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:16:33:04:fc",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -381,16 +372,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            252,
-            4,
-            51,
-            22,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:16:33:04:fc",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -465,16 +447,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            252,
-            4,
-            51,
-            22,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:16:33:04:fc",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -520,16 +493,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            252,
-            4,
-            51,
-            22,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:16:33:04:fc",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -577,16 +541,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            252,
-            4,
-            51,
-            22,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:16:33:04:fc",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -636,16 +591,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            252,
-            4,
-            51,
-            22,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:16:33:04:fc",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -688,16 +634,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            252,
-            4,
-            51,
-            22,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:16:33:04:fc",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -742,16 +679,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            252,
-            4,
-            51,
-            22,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:16:33:04:fc",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/signify-netherlands-b-v-lta010.json
+++ b/tests/data/devices/signify-netherlands-b-v-lta010.json
@@ -298,16 +298,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            114,
-            120,
-            226,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:e2:78:72",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -382,16 +373,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            114,
-            120,
-            226,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:e2:78:72",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -460,16 +442,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            114,
-            120,
-            226,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:e2:78:72",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -515,16 +488,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            114,
-            120,
-            226,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:e2:78:72",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -572,16 +536,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            114,
-            120,
-            226,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:e2:78:72",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -631,16 +586,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            114,
-            120,
-            226,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:e2:78:72",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -683,16 +629,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            114,
-            120,
-            226,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:e2:78:72",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -737,16 +674,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            114,
-            120,
-            226,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:e2:78:72",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/signify-netherlands-b-v-ltb003.json
+++ b/tests/data/devices/signify-netherlands-b-v-ltb003.json
@@ -305,16 +305,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            251,
-            50,
-            0,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:00:32:fb",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -389,16 +380,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            251,
-            50,
-            0,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:00:32:fb",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -467,16 +449,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            251,
-            50,
-            0,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:00:32:fb",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -522,16 +495,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            251,
-            50,
-            0,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:00:32:fb",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -579,16 +543,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            251,
-            50,
-            0,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:00:32:fb",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -638,16 +593,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            251,
-            50,
-            0,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:00:32:fb",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -690,16 +636,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            251,
-            50,
-            0,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:00:32:fb",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -744,16 +681,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            251,
-            50,
-            0,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:00:32:fb",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/signify-netherlands-b-v-lwa003.json
+++ b/tests/data/devices/signify-netherlands-b-v-lwa003.json
@@ -214,16 +214,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            213,
-            108,
-            118,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:76:6c:d5",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -284,16 +275,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            213,
-            108,
-            118,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:76:6c:d5",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -361,16 +343,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            213,
-            108,
-            118,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:76:6c:d5",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -418,16 +391,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            213,
-            108,
-            118,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:76:6c:d5",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -477,16 +441,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            213,
-            108,
-            118,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:76:6c:d5",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -529,16 +484,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            213,
-            108,
-            118,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:76:6c:d5",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
@@ -583,16 +529,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            213,
-            108,
-            118,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:76:6c:d5",
           "endpoint_id": 11,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/signify-netherlands-b-v-rdm001.json
+++ b/tests/data/devices/signify-netherlands-b-v-rdm001.json
@@ -207,16 +207,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            121,
-            182,
-            2,
-            11,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0b:02:b6:79",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -263,16 +254,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            121,
-            182,
-            2,
-            11,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0b:02:b6:79",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -315,16 +297,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            121,
-            182,
-            2,
-            11,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0b:02:b6:79",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -367,16 +340,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            121,
-            182,
-            2,
-            11,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0b:02:b6:79",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -427,16 +391,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            121,
-            182,
-            2,
-            11,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0b:02:b6:79",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/signify-netherlands-b-v-rdm002.json
+++ b/tests/data/devices/signify-netherlands-b-v-rdm002.json
@@ -223,16 +223,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            51,
-            72,
-            19,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:13:48:33",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -279,16 +270,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            51,
-            72,
-            19,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:13:48:33",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -331,16 +313,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            51,
-            72,
-            19,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:13:48:33",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -383,16 +356,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            51,
-            72,
-            19,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:13:48:33",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -443,16 +407,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            51,
-            72,
-            19,
-            13,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0d:13:48:33",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/signify-netherlands-b-v-rwl022.json
+++ b/tests/data/devices/signify-netherlands-b-v-rwl022.json
@@ -219,16 +219,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            236,
-            66,
-            38,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:26:42:ec",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -275,16 +266,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            236,
-            66,
-            38,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:26:42:ec",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -327,16 +309,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            236,
-            66,
-            38,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:26:42:ec",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -379,16 +352,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            236,
-            66,
-            38,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:26:42:ec",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -439,16 +403,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            236,
-            66,
-            38,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:26:42:ec",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/signify-netherlands-b-v-sml004.json
+++ b/tests/data/devices/signify-netherlands-b-v-sml004.json
@@ -251,16 +251,7 @@
               "value_attribute": "occupancy"
             }
           ],
-          "device_ieee": [
-            97,
-            157,
-            220,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:dc:9d:61",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -302,16 +293,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            97,
-            157,
-            220,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:dc:9d:61",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -355,16 +337,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            97,
-            157,
-            220,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:dc:9d:61",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -411,16 +384,7 @@
               "value_attribute": "occupancy"
             }
           ],
-          "device_ieee": [
-            97,
-            157,
-            220,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:dc:9d:61",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -471,16 +435,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            97,
-            157,
-            220,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:dc:9d:61",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -523,16 +478,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            97,
-            157,
-            220,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:dc:9d:61",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -575,16 +521,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            97,
-            157,
-            220,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:dc:9d:61",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -633,16 +570,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            97,
-            157,
-            220,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:dc:9d:61",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -685,16 +613,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            97,
-            157,
-            220,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:dc:9d:61",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -739,16 +658,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            97,
-            157,
-            220,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:dc:9d:61",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -797,16 +707,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            97,
-            157,
-            220,
-            12,
-            1,
-            136,
-            23,
-            0
-          ],
+          "device_ieee": "00:17:88:01:0c:dc:9d:61",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/sinope-technologies-va4220zb.json
+++ b/tests/data/devices/sinope-technologies-va4220zb.json
@@ -425,16 +425,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            7,
-            77,
-            241,
-            235,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:eb:f1:4d:07",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -476,16 +467,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            7,
-            77,
-            241,
-            235,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:eb:f1:4d:07",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -529,16 +511,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            7,
-            77,
-            241,
-            235,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:eb:f1:4d:07",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -585,16 +558,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            7,
-            77,
-            241,
-            235,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:eb:f1:4d:07",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -642,16 +606,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            7,
-            77,
-            241,
-            235,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:eb:f1:4d:07",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -694,16 +649,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            7,
-            77,
-            241,
-            235,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:eb:f1:4d:07",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -746,16 +692,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            7,
-            77,
-            241,
-            235,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:eb:f1:4d:07",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -798,16 +735,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            7,
-            77,
-            241,
-            235,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:eb:f1:4d:07",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -850,16 +778,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            7,
-            77,
-            241,
-            235,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:eb:f1:4d:07",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -910,16 +829,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            7,
-            77,
-            241,
-            235,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:eb:f1:4d:07",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -972,16 +882,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            7,
-            77,
-            241,
-            235,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:eb:f1:4d:07",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -1024,16 +925,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            7,
-            77,
-            241,
-            235,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:eb:f1:4d:07",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/smartthings-tagv4.json
+++ b/tests/data/devices/smartthings-tagv4.json
@@ -191,16 +191,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            93,
-            79,
-            1,
-            1,
-            0,
-            91,
-            253,
-            36
-          ],
+          "device_ieee": "24:fd:5b:00:01:01:4f:5d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -244,16 +235,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            93,
-            79,
-            1,
-            1,
-            0,
-            91,
-            253,
-            36
-          ],
+          "device_ieee": "24:fd:5b:00:01:01:4f:5d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -300,16 +282,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            93,
-            79,
-            1,
-            1,
-            0,
-            91,
-            253,
-            36
-          ],
+          "device_ieee": "24:fd:5b:00:01:01:4f:5d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -353,16 +326,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            93,
-            79,
-            1,
-            1,
-            0,
-            91,
-            253,
-            36
-          ],
+          "device_ieee": "24:fd:5b:00:01:01:4f:5d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -405,16 +369,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            93,
-            79,
-            1,
-            1,
-            0,
-            91,
-            253,
-            36
-          ],
+          "device_ieee": "24:fd:5b:00:01:01:4f:5d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -459,16 +414,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            93,
-            79,
-            1,
-            1,
-            0,
-            91,
-            253,
-            36
-          ],
+          "device_ieee": "24:fd:5b:00:01:01:4f:5d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/smartwings-wm25-l-z.json
+++ b/tests/data/devices/smartwings-wm25-l-z.json
@@ -318,16 +318,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            185,
-            253,
-            190,
-            254,
-            255,
-            141,
-            121,
-            224
-          ],
+          "device_ieee": "e0:79:8d:ff:fe:be:fd:b9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -374,16 +365,7 @@
               "value_attribute": "current_position_lift_percentage"
             }
           ],
-          "device_ieee": [
-            185,
-            253,
-            190,
-            254,
-            255,
-            141,
-            121,
-            224
-          ],
+          "device_ieee": "e0:79:8d:ff:fe:be:fd:b9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -431,16 +413,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            185,
-            253,
-            190,
-            254,
-            255,
-            141,
-            121,
-            224
-          ],
+          "device_ieee": "e0:79:8d:ff:fe:be:fd:b9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -483,16 +456,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            185,
-            253,
-            190,
-            254,
-            255,
-            141,
-            121,
-            224
-          ],
+          "device_ieee": "e0:79:8d:ff:fe:be:fd:b9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -535,16 +499,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            185,
-            253,
-            190,
-            254,
-            255,
-            141,
-            121,
-            224
-          ],
+          "device_ieee": "e0:79:8d:ff:fe:be:fd:b9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -593,16 +548,7 @@
               "value_attribute": "current_position_lift_percentage"
             }
           ],
-          "device_ieee": [
-            185,
-            253,
-            190,
-            254,
-            255,
-            141,
-            121,
-            224
-          ],
+          "device_ieee": "e0:79:8d:ff:fe:be:fd:b9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -647,16 +593,7 @@
               "value_attribute": "current_position_lift_percentage"
             }
           ],
-          "device_ieee": [
-            185,
-            253,
-            190,
-            254,
-            255,
-            141,
-            121,
-            224
-          ],
+          "device_ieee": "e0:79:8d:ff:fe:be:fd:b9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -705,16 +642,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            185,
-            253,
-            190,
-            254,
-            255,
-            141,
-            121,
-            224
-          ],
+          "device_ieee": "e0:79:8d:ff:fe:be:fd:b9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/somfy-situo-4-zigbee.json
+++ b/tests/data/devices/somfy-situo-4-zigbee.json
@@ -369,16 +369,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            90,
-            152,
-            59,
-            133,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:85:3b:98:5a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -420,16 +411,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            90,
-            152,
-            59,
-            133,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:85:3b:98:5a",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -471,16 +453,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            90,
-            152,
-            59,
-            133,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:85:3b:98:5a",
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
@@ -522,16 +495,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            90,
-            152,
-            59,
-            133,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:85:3b:98:5a",
           "endpoint_id": 4,
           "available": true,
           "group_id": null,
@@ -575,16 +539,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            90,
-            152,
-            59,
-            133,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:85:3b:98:5a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -631,16 +586,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            90,
-            152,
-            59,
-            133,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:85:3b:98:5a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -683,16 +629,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            90,
-            152,
-            59,
-            133,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:85:3b:98:5a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -735,16 +672,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            90,
-            152,
-            59,
-            133,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:85:3b:98:5a",
           "endpoint_id": 232,
           "available": true,
           "group_id": null,
@@ -794,16 +722,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            90,
-            152,
-            59,
-            133,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:85:3b:98:5a",
           "endpoint_id": 232,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/somfy-sonesse-28-wf-li-ion-roller.json
+++ b/tests/data/devices/somfy-sonesse-28-wf-li-ion-roller.json
@@ -269,16 +269,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            167,
-            63,
-            124,
-            123,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:7b:7c:3f:a7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -325,16 +316,7 @@
               "value_attribute": "current_position_lift_percentage"
             }
           ],
-          "device_ieee": [
-            167,
-            63,
-            124,
-            123,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:7b:7c:3f:a7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -382,16 +364,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            167,
-            63,
-            124,
-            123,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:7b:7c:3f:a7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -434,16 +407,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            167,
-            63,
-            124,
-            123,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:7b:7c:3f:a7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -486,16 +450,7 @@
               "value_attribute": "current_position_lift_percentage"
             }
           ],
-          "device_ieee": [
-            167,
-            63,
-            124,
-            123,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:7b:7c:3f:a7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -538,16 +493,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            167,
-            63,
-            124,
-            123,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:7b:7c:3f:a7",
           "endpoint_id": 232,
           "available": true,
           "group_id": null,
@@ -597,16 +543,7 @@
               "value_attribute": "current_position_lift_percentage"
             }
           ],
-          "device_ieee": [
-            167,
-            63,
-            124,
-            123,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:7b:7c:3f:a7",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -669,16 +606,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            167,
-            63,
-            124,
-            123,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:7b:7c:3f:a7",
           "endpoint_id": 232,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/somfy-ysia-5-hp-zigbee.json
+++ b/tests/data/devices/somfy-ysia-5-hp-zigbee.json
@@ -581,16 +581,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            201,
-            46,
-            38,
-            5,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:05:26:2e:c9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -632,16 +623,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            201,
-            46,
-            38,
-            5,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:05:26:2e:c9",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -683,16 +665,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            201,
-            46,
-            38,
-            5,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:05:26:2e:c9",
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
@@ -734,16 +707,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            201,
-            46,
-            38,
-            5,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:05:26:2e:c9",
           "endpoint_id": 4,
           "available": true,
           "group_id": null,
@@ -785,16 +749,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            201,
-            46,
-            38,
-            5,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:05:26:2e:c9",
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
@@ -838,16 +793,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            201,
-            46,
-            38,
-            5,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:05:26:2e:c9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -894,16 +840,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            201,
-            46,
-            38,
-            5,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:05:26:2e:c9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -946,16 +883,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            201,
-            46,
-            38,
-            5,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:05:26:2e:c9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -998,16 +926,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            201,
-            46,
-            38,
-            5,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:05:26:2e:c9",
           "endpoint_id": 232,
           "available": true,
           "group_id": null,
@@ -1057,16 +976,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            201,
-            46,
-            38,
-            5,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:05:26:2e:c9",
           "endpoint_id": 232,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/sonoff-01minizb.json
+++ b/tests/data/devices/sonoff-01minizb.json
@@ -154,16 +154,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            79,
-            222,
-            183,
-            38,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:26:b7:de:4f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -210,16 +201,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            79,
-            222,
-            183,
-            38,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:26:b7:de:4f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -286,16 +268,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            79,
-            222,
-            183,
-            38,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:26:b7:de:4f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -338,16 +311,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            79,
-            222,
-            183,
-            38,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:26:b7:de:4f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -392,16 +356,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            79,
-            222,
-            183,
-            38,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:26:b7:de:4f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/sonoff-s31-lite-zb.json
+++ b/tests/data/devices/sonoff-s31-lite-zb.json
@@ -134,16 +134,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            220,
-            203,
-            86,
-            36,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:24:56:cb:dc",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -190,16 +181,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            220,
-            203,
-            86,
-            36,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:24:56:cb:dc",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -242,16 +224,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            220,
-            203,
-            86,
-            36,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:24:56:cb:dc",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -296,16 +269,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            220,
-            203,
-            86,
-            36,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:24:56:cb:dc",
           "endpoint_id": 1,
           "available": true,
           "group_id": null

--- a/tests/data/devices/sonoff-snzb-02d.json
+++ b/tests/data/devices/sonoff-snzb-02d.json
@@ -203,16 +203,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            245,
-            82,
-            112,
-            227,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:e3:70:52:f5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -259,16 +250,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            245,
-            82,
-            112,
-            227,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:e3:70:52:f5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -314,16 +296,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            245,
-            82,
-            112,
-            227,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:e3:70:52:f5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -369,16 +342,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            245,
-            82,
-            112,
-            227,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:e3:70:52:f5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -424,16 +388,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            245,
-            82,
-            112,
-            227,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:e3:70:52:f5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -479,16 +434,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            245,
-            82,
-            112,
-            227,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:e3:70:52:f5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -534,16 +480,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            245,
-            82,
-            112,
-            227,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:e3:70:52:f5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -591,16 +528,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            245,
-            82,
-            112,
-            227,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:e3:70:52:f5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -648,16 +576,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            245,
-            82,
-            112,
-            227,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:e3:70:52:f5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -700,16 +619,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            245,
-            82,
-            112,
-            227,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:e3:70:52:f5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -752,16 +662,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            245,
-            82,
-            112,
-            227,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:e3:70:52:f5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -809,16 +710,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            245,
-            82,
-            112,
-            227,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:e3:70:52:f5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -861,16 +753,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            245,
-            82,
-            112,
-            227,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:e3:70:52:f5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -915,16 +798,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            245,
-            82,
-            112,
-            227,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:e3:70:52:f5",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/sonoff-swv.json
+++ b/tests/data/devices/sonoff-swv.json
@@ -416,16 +416,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            124,
-            164,
-            37,
-            140,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:8c:25:a4:7c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -467,16 +458,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            124,
-            164,
-            37,
-            140,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:8c:25:a4:7c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -520,16 +502,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            124,
-            164,
-            37,
-            140,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:8c:25:a4:7c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -576,16 +549,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            124,
-            164,
-            37,
-            140,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:8c:25:a4:7c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -628,16 +592,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            124,
-            164,
-            37,
-            140,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:8c:25:a4:7c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -680,16 +635,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            124,
-            164,
-            37,
-            140,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:8c:25:a4:7c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -738,16 +684,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            124,
-            164,
-            37,
-            140,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:8c:25:a4:7c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -792,16 +729,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            124,
-            164,
-            37,
-            140,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:8c:25:a4:7c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -842,16 +770,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            124,
-            164,
-            37,
-            140,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:8c:25:a4:7c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -900,16 +819,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            124,
-            164,
-            37,
-            140,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:8c:25:a4:7c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/sonoff-zbmicro.json
+++ b/tests/data/devices/sonoff-zbmicro.json
@@ -161,16 +161,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            160,
-            135,
-            84,
-            254,
-            255,
-            163,
-            101,
-            140
-          ],
+          "device_ieee": "8c:65:a3:ff:fe:54:87:a0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -217,16 +208,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            160,
-            135,
-            84,
-            254,
-            255,
-            163,
-            101,
-            140
-          ],
+          "device_ieee": "8c:65:a3:ff:fe:54:87:a0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -276,16 +258,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            160,
-            135,
-            84,
-            254,
-            255,
-            163,
-            101,
-            140
-          ],
+          "device_ieee": "8c:65:a3:ff:fe:54:87:a0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -328,16 +301,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            160,
-            135,
-            84,
-            254,
-            255,
-            163,
-            101,
-            140
-          ],
+          "device_ieee": "8c:65:a3:ff:fe:54:87:a0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -382,16 +346,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            160,
-            135,
-            84,
-            254,
-            255,
-            163,
-            101,
-            140
-          ],
+          "device_ieee": "8c:65:a3:ff:fe:54:87:a0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -434,16 +389,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            160,
-            135,
-            84,
-            254,
-            255,
-            163,
-            101,
-            140
-          ],
+          "device_ieee": "8c:65:a3:ff:fe:54:87:a0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/sunricher-hk-ln-dim-a.json
+++ b/tests/data/devices/sunricher-hk-ln-dim-a.json
@@ -238,16 +238,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            106,
-            94,
-            106,
-            254,
-            255,
-            34,
-            53,
-            180
-          ],
+          "device_ieee": "b4:35:22:ff:fe:6a:5e:6a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -308,16 +299,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            106,
-            94,
-            106,
-            254,
-            255,
-            34,
-            53,
-            180
-          ],
+          "device_ieee": "b4:35:22:ff:fe:6a:5e:6a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -385,16 +367,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            106,
-            94,
-            106,
-            254,
-            255,
-            34,
-            53,
-            180
-          ],
+          "device_ieee": "b4:35:22:ff:fe:6a:5e:6a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -440,16 +413,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            106,
-            94,
-            106,
-            254,
-            255,
-            34,
-            53,
-            180
-          ],
+          "device_ieee": "b4:35:22:ff:fe:6a:5e:6a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -495,16 +459,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            106,
-            94,
-            106,
-            254,
-            255,
-            34,
-            53,
-            180
-          ],
+          "device_ieee": "b4:35:22:ff:fe:6a:5e:6a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -552,16 +507,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            106,
-            94,
-            106,
-            254,
-            255,
-            34,
-            53,
-            180
-          ],
+          "device_ieee": "b4:35:22:ff:fe:6a:5e:6a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -611,16 +557,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            106,
-            94,
-            106,
-            254,
-            255,
-            34,
-            53,
-            180
-          ],
+          "device_ieee": "b4:35:22:ff:fe:6a:5e:6a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -663,16 +600,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            106,
-            94,
-            106,
-            254,
-            255,
-            34,
-            53,
-            180
-          ],
+          "device_ieee": "b4:35:22:ff:fe:6a:5e:6a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -717,16 +645,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            106,
-            94,
-            106,
-            254,
-            255,
-            34,
-            53,
-            180
-          ],
+          "device_ieee": "b4:35:22:ff:fe:6a:5e:6a",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/texasinstruments-ti-router.json
+++ b/tests/data/devices/texasinstruments-ti-router.json
@@ -156,16 +156,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            41,
-            150,
-            180,
-            33,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:21:b4:96:29",
           "endpoint_id": 8,
           "available": true,
           "group_id": null,
@@ -212,16 +203,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            41,
-            150,
-            180,
-            33,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:21:b4:96:29",
           "endpoint_id": 8,
           "available": true,
           "group_id": null,
@@ -269,16 +251,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            41,
-            150,
-            180,
-            33,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:21:b4:96:29",
           "endpoint_id": 8,
           "available": true,
           "group_id": null,
@@ -321,16 +294,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            41,
-            150,
-            180,
-            33,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:21:b4:96:29",
           "endpoint_id": 8,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/the-home-depot-ecosmart-zbt-a19-cct-bulb.json
+++ b/tests/data/devices/the-home-depot-ecosmart-zbt-a19-cct-bulb.json
@@ -332,16 +332,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            57,
-            70,
-            50,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:32:46:39",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -416,16 +407,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            57,
-            70,
-            50,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:32:46:39",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -494,16 +476,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            57,
-            70,
-            50,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:32:46:39",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -549,16 +522,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            57,
-            70,
-            50,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:32:46:39",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -604,16 +568,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            57,
-            70,
-            50,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:32:46:39",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -659,16 +614,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            57,
-            70,
-            50,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:32:46:39",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -716,16 +662,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            57,
-            70,
-            50,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:32:46:39",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -775,16 +712,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            57,
-            70,
-            50,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:32:46:39",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -827,16 +755,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            57,
-            70,
-            50,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:32:46:39",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -881,16 +800,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            57,
-            70,
-            50,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:32:46:39",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/third-reality-inc-3rds17bz.json
+++ b/tests/data/devices/third-reality-inc-3rds17bz.json
@@ -161,16 +161,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            235,
-            178,
-            231,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e7:b2:eb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -214,16 +205,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            235,
-            178,
-            231,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e7:b2:eb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -266,16 +248,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            235,
-            178,
-            231,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e7:b2:eb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -318,16 +291,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            235,
-            178,
-            231,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e7:b2:eb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -378,16 +342,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            235,
-            178,
-            231,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e7:b2:eb",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/third-reality-inc-3rms16bz.json
+++ b/tests/data/devices/third-reality-inc-3rms16bz.json
@@ -193,16 +193,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            140,
-            186,
-            231,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e7:ba:8c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -246,16 +237,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            140,
-            186,
-            231,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e7:ba:8c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -303,16 +285,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            140,
-            186,
-            231,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e7:ba:8c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -355,16 +328,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            140,
-            186,
-            231,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e7:ba:8c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -407,16 +371,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            140,
-            186,
-            231,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e7:ba:8c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -467,16 +422,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            140,
-            186,
-            231,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e7:ba:8c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/third-reality-inc-3rsb015bz.json
+++ b/tests/data/devices/third-reality-inc-3rsb015bz.json
@@ -300,16 +300,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            104,
-            5,
-            234,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:ea:05:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -353,16 +344,7 @@
               "value_attribute": "current_position_lift_percentage"
             }
           ],
-          "device_ieee": [
-            104,
-            5,
-            234,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:ea:05:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -410,16 +392,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            104,
-            5,
-            234,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:ea:05:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -462,16 +435,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            104,
-            5,
-            234,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:ea:05:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -514,16 +478,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            104,
-            5,
-            234,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:ea:05:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -572,16 +527,7 @@
               "value_attribute": "current_position_lift_percentage"
             }
           ],
-          "device_ieee": [
-            104,
-            5,
-            234,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:ea:05:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -626,16 +572,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            104,
-            5,
-            234,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:ea:05:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -678,16 +615,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            104,
-            5,
-            234,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:ea:05:68",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/third-reality-inc-3rsb22bz.json
+++ b/tests/data/devices/third-reality-inc-3rsb22bz.json
@@ -171,16 +171,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            248,
-            116,
-            227,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e3:74:f8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -223,16 +214,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            248,
-            116,
-            227,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e3:74:f8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -275,16 +257,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            248,
-            116,
-            227,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e3:74:f8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -335,16 +308,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            248,
-            116,
-            227,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e3:74:f8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/third-reality-inc-3rsm0147z.json
+++ b/tests/data/devices/third-reality-inc-3rsm0147z.json
@@ -173,16 +173,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            130,
-            43,
-            239,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:ef:2b:82",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -225,16 +216,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            130,
-            43,
-            239,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:ef:2b:82",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -277,16 +259,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            130,
-            43,
-            239,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:ef:2b:82",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -335,16 +308,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            130,
-            43,
-            239,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:ef:2b:82",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -387,16 +351,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            130,
-            43,
-            239,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:ef:2b:82",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -441,16 +396,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            130,
-            43,
-            239,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:ef:2b:82",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/third-reality-inc-3rsnl02043z.json
+++ b/tests/data/devices/third-reality-inc-3rsnl02043z.json
@@ -360,16 +360,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            0,
-            0,
-            107,
-            161,
-            211,
-            207,
-            14,
-            180
-          ],
+          "device_ieee": "b4:0e:cf:d3:a1:6b:00:00",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -413,16 +404,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            0,
-            0,
-            107,
-            161,
-            211,
-            207,
-            14,
-            180
-          ],
+          "device_ieee": "b4:0e:cf:d3:a1:6b:00:00",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -497,16 +479,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            0,
-            0,
-            107,
-            161,
-            211,
-            207,
-            14,
-            180
-          ],
+          "device_ieee": "b4:0e:cf:d3:a1:6b:00:00",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -581,16 +554,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            0,
-            0,
-            107,
-            161,
-            211,
-            207,
-            14,
-            180
-          ],
+          "device_ieee": "b4:0e:cf:d3:a1:6b:00:00",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -636,16 +600,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            0,
-            0,
-            107,
-            161,
-            211,
-            207,
-            14,
-            180
-          ],
+          "device_ieee": "b4:0e:cf:d3:a1:6b:00:00",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -691,16 +646,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            0,
-            0,
-            107,
-            161,
-            211,
-            207,
-            14,
-            180
-          ],
+          "device_ieee": "b4:0e:cf:d3:a1:6b:00:00",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -746,16 +692,7 @@
               "value_attribute": "current_level"
             }
           ],
-          "device_ieee": [
-            0,
-            0,
-            107,
-            161,
-            211,
-            207,
-            14,
-            180
-          ],
+          "device_ieee": "b4:0e:cf:d3:a1:6b:00:00",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -803,16 +740,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            0,
-            0,
-            107,
-            161,
-            211,
-            207,
-            14,
-            180
-          ],
+          "device_ieee": "b4:0e:cf:d3:a1:6b:00:00",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -862,16 +790,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            0,
-            0,
-            107,
-            161,
-            211,
-            207,
-            14,
-            180
-          ],
+          "device_ieee": "b4:0e:cf:d3:a1:6b:00:00",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -914,16 +833,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            0,
-            0,
-            107,
-            161,
-            211,
-            207,
-            14,
-            180
-          ],
+          "device_ieee": "b4:0e:cf:d3:a1:6b:00:00",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -966,16 +876,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            0,
-            0,
-            107,
-            161,
-            211,
-            207,
-            14,
-            180
-          ],
+          "device_ieee": "b4:0e:cf:d3:a1:6b:00:00",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1020,16 +921,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            0,
-            0,
-            107,
-            161,
-            211,
-            207,
-            14,
-            180
-          ],
+          "device_ieee": "b4:0e:cf:d3:a1:6b:00:00",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/third-reality-inc-3rsp019bz.json
+++ b/tests/data/devices/third-reality-inc-3rsp019bz.json
@@ -299,16 +299,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            13,
-            9,
-            235,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:eb:09:0d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -355,16 +346,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            13,
-            9,
-            235,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:eb:09:0d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -414,16 +396,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            13,
-            9,
-            235,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:eb:09:0d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -466,16 +439,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            13,
-            9,
-            235,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:eb:09:0d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -520,16 +484,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            13,
-            9,
-            235,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:eb:09:0d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -572,16 +527,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            13,
-            9,
-            235,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:eb:09:0d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/third-reality-inc-3rsp02028bz.json
+++ b/tests/data/devices/third-reality-inc-3rsp02028bz.json
@@ -383,16 +383,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            47,
-            79,
-            235,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:eb:4f:2f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -437,16 +428,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            47,
-            79,
-            235,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:eb:4f:2f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -490,16 +472,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            47,
-            79,
-            235,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:eb:4f:2f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -549,16 +522,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            47,
-            79,
-            235,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:eb:4f:2f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -601,16 +565,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            47,
-            79,
-            235,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:eb:4f:2f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -653,16 +608,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            47,
-            79,
-            235,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:eb:4f:2f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -709,16 +655,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            47,
-            79,
-            235,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:eb:4f:2f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -765,16 +702,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            47,
-            79,
-            235,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:eb:4f:2f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -821,16 +749,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            47,
-            79,
-            235,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:eb:4f:2f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -877,16 +796,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            47,
-            79,
-            235,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:eb:4f:2f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -935,16 +845,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            47,
-            79,
-            235,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:eb:4f:2f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -987,16 +888,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            47,
-            79,
-            235,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:eb:4f:2f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/third-reality-inc-3rss007z.json
+++ b/tests/data/devices/third-reality-inc-3rss007z.json
@@ -133,16 +133,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            1,
-            22,
-            224,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e0:16:01",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -189,16 +180,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            1,
-            22,
-            224,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e0:16:01",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -241,16 +223,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            1,
-            22,
-            224,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e0:16:01",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -295,16 +268,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            1,
-            22,
-            224,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e0:16:01",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -347,16 +311,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            1,
-            22,
-            224,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e0:16:01",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/third-reality-inc-3rss009z.json
+++ b/tests/data/devices/third-reality-inc-3rss009z.json
@@ -177,16 +177,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            149,
-            119,
-            233,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e9:77:95",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -229,16 +220,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            149,
-            119,
-            233,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e9:77:95",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -281,16 +263,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            149,
-            119,
-            233,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e9:77:95",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -341,16 +314,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            149,
-            119,
-            233,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e9:77:95",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -393,16 +357,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            149,
-            119,
-            233,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e9:77:95",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/third-reality-inc-3rths24bz.json
+++ b/tests/data/devices/third-reality-inc-3rths24bz.json
@@ -168,16 +168,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            240,
-            131,
-            34,
-            246,
-            203,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:cb:f6:22:83:f0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -220,16 +211,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            240,
-            131,
-            34,
-            246,
-            203,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:cb:f6:22:83:f0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -272,16 +254,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            240,
-            131,
-            34,
-            246,
-            203,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:cb:f6:22:83:f0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -330,16 +303,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            240,
-            131,
-            34,
-            246,
-            203,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:cb:f6:22:83:f0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -382,16 +346,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            240,
-            131,
-            34,
-            246,
-            203,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:cb:f6:22:83:f0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -436,16 +391,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            240,
-            131,
-            34,
-            246,
-            203,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:cb:f6:22:83:f0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/third-reality-inc-3rvs01031z.json
+++ b/tests/data/devices/third-reality-inc-3rvs01031z.json
@@ -221,16 +221,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            254,
-            174,
-            235,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:eb:ae:fe",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -274,16 +265,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            254,
-            174,
-            235,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:eb:ae:fe",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -326,16 +308,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            254,
-            174,
-            235,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:eb:ae:fe",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -378,16 +351,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            254,
-            174,
-            235,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:eb:ae:fe",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -438,16 +402,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            254,
-            174,
-            235,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:eb:ae:fe",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/third-reality-inc-3rws18bz.json
+++ b/tests/data/devices/third-reality-inc-3rws18bz.json
@@ -216,16 +216,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            73,
-            201,
-            231,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e7:c9:49",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -267,16 +258,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            73,
-            201,
-            231,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e7:c9:49",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -320,16 +302,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            73,
-            201,
-            231,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e7:c9:49",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -377,16 +350,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            73,
-            201,
-            231,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e7:c9:49",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -429,16 +393,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            73,
-            201,
-            231,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e7:c9:49",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -481,16 +436,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            73,
-            201,
-            231,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e7:c9:49",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -541,16 +487,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            73,
-            201,
-            231,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e7:c9:49",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -599,16 +536,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            73,
-            201,
-            231,
-            255,
-            191,
-            2,
-            44,
-            40
-          ],
+          "device_ieee": "28:2c:02:bf:ff:e7:c9:49",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tubeszb-tubeszb-router.json
+++ b/tests/data/devices/tubeszb-tubeszb-router.json
@@ -157,16 +157,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            109,
-            56,
-            152,
-            34,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:22:98:38:6d",
           "endpoint_id": 8,
           "available": true,
           "group_id": null,
@@ -213,16 +204,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            109,
-            56,
-            152,
-            34,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:22:98:38:6d",
           "endpoint_id": 8,
           "available": true,
           "group_id": null,
@@ -265,16 +247,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            109,
-            56,
-            152,
-            34,
-            0,
-            75,
-            18,
-            0
-          ],
+          "device_ieee": "00:12:4b:00:22:98:38:6d",
           "endpoint_id": 8,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tuyatec-gqhxixyk-rh3052.json
+++ b/tests/data/devices/tuyatec-gqhxixyk-rh3052.json
@@ -176,16 +176,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            51,
-            17,
-            55,
-            254,
-            255,
-            35,
-            164,
-            96
-          ],
+          "device_ieee": "60:a4:23:ff:fe:37:11:33",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -232,16 +223,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            51,
-            17,
-            55,
-            254,
-            255,
-            35,
-            164,
-            96
-          ],
+          "device_ieee": "60:a4:23:ff:fe:37:11:33",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -284,16 +266,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            51,
-            17,
-            55,
-            254,
-            255,
-            35,
-            164,
-            96
-          ],
+          "device_ieee": "60:a4:23:ff:fe:37:11:33",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -336,16 +309,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            51,
-            17,
-            55,
-            254,
-            255,
-            35,
-            164,
-            96
-          ],
+          "device_ieee": "60:a4:23:ff:fe:37:11:33",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -394,16 +358,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            51,
-            17,
-            55,
-            254,
-            255,
-            35,
-            164,
-            96
-          ],
+          "device_ieee": "60:a4:23:ff:fe:37:11:33",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -446,16 +401,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            51,
-            17,
-            55,
-            254,
-            255,
-            35,
-            164,
-            96
-          ],
+          "device_ieee": "60:a4:23:ff:fe:37:11:33",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tuyatec-r9hgssol-rh3001.json
+++ b/tests/data/devices/tuyatec-r9hgssol-rh3001.json
@@ -178,16 +178,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            24,
-            181,
-            241,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:f1:b5:18",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -231,16 +222,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            24,
-            181,
-            241,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:f1:b5:18",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -287,16 +269,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            24,
-            181,
-            241,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:f1:b5:18",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -339,16 +312,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            24,
-            181,
-            241,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:f1:b5:18",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -391,16 +355,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            24,
-            181,
-            241,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:f1:b5:18",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tuyatec-rkqiqvcs-rh3001.json
+++ b/tests/data/devices/tuyatec-rkqiqvcs-rh3001.json
@@ -184,16 +184,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            101,
-            2,
-            201,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:c9:02:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -237,16 +228,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            101,
-            2,
-            201,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:c9:02:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -293,16 +275,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            101,
-            2,
-            201,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:c9:02:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -345,16 +318,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            101,
-            2,
-            201,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:c9:02:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -397,16 +361,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            101,
-            2,
-            201,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:c9:02:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tuyatec-yg5dcbfu-rh3052.json
+++ b/tests/data/devices/tuyatec-yg5dcbfu-rh3052.json
@@ -188,16 +188,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            236,
-            4,
-            59,
-            254,
-            255,
-            87,
-            180,
-            20
-          ],
+          "device_ieee": "14:b4:57:ff:fe:3b:04:ec",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -244,16 +235,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            236,
-            4,
-            59,
-            254,
-            255,
-            87,
-            180,
-            20
-          ],
+          "device_ieee": "14:b4:57:ff:fe:3b:04:ec",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -296,16 +278,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            236,
-            4,
-            59,
-            254,
-            255,
-            87,
-            180,
-            20
-          ],
+          "device_ieee": "14:b4:57:ff:fe:3b:04:ec",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -348,16 +321,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            236,
-            4,
-            59,
-            254,
-            255,
-            87,
-            180,
-            20
-          ],
+          "device_ieee": "14:b4:57:ff:fe:3b:04:ec",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -406,16 +370,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            236,
-            4,
-            59,
-            254,
-            255,
-            87,
-            180,
-            20
-          ],
+          "device_ieee": "14:b4:57:ff:fe:3b:04:ec",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -458,16 +413,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            236,
-            4,
-            59,
-            254,
-            255,
-            87,
-            180,
-            20
-          ],
+          "device_ieee": "14:b4:57:ff:fe:3b:04:ec",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tyst11-i5j6ifxj-5j6ifxj.json
+++ b/tests/data/devices/tyst11-i5j6ifxj-5j6ifxj.json
@@ -166,16 +166,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            81,
-            46,
-            48,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:30:2e:51",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -219,16 +210,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            81,
-            46,
-            48,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:30:2e:51",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -275,16 +257,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            81,
-            46,
-            48,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:30:2e:51",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -327,16 +300,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            81,
-            46,
-            48,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:30:2e:51",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -381,16 +345,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            81,
-            46,
-            48,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:30:2e:51",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tyzb01-o63ssaah-ts0207.json
+++ b/tests/data/devices/tyzb01-o63ssaah-ts0207.json
@@ -195,16 +195,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            62,
-            213,
-            135,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:87:d5:3e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -248,16 +239,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            62,
-            213,
-            135,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:87:d5:3e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -304,16 +286,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            62,
-            213,
-            135,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:87:d5:3e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -356,16 +329,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            62,
-            213,
-            135,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:87:d5:3e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -408,16 +372,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            62,
-            213,
-            135,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:87:d5:3e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -468,16 +423,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            62,
-            213,
-            135,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:87:d5:3e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tyzb01-qm6djpta-ts0215.json
+++ b/tests/data/devices/tyzb01-qm6djpta-ts0215.json
@@ -200,16 +200,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            211,
-            255,
-            78,
-            9,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:09:4e:ff:d3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -255,16 +246,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            211,
-            255,
-            78,
-            9,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:09:4e:ff:d3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -308,16 +290,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            211,
-            255,
-            78,
-            9,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:09:4e:ff:d3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -364,16 +337,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            211,
-            255,
-            78,
-            9,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:09:4e:ff:d3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -416,16 +380,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            211,
-            255,
-            78,
-            9,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:09:4e:ff:d3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -468,16 +423,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            211,
-            255,
-            78,
-            9,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:09:4e:ff:d3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -528,16 +474,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            211,
-            255,
-            78,
-            9,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:09:4e:ff:d3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tyzb01-rifa0wlb-ts0011.json
+++ b/tests/data/devices/tyzb01-rifa0wlb-ts0011.json
@@ -196,16 +196,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            210,
-            239,
-            208,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:d0:ef:d2",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -272,16 +263,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            210,
-            239,
-            208,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:d0:ef:d2",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -324,16 +306,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            210,
-            239,
-            208,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:d0:ef:d2",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -378,16 +351,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            210,
-            239,
-            208,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:d0:ef:d2",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tyzb01-vkwryfdr-ts0115.json
+++ b/tests/data/devices/tyzb01-vkwryfdr-ts0115.json
@@ -299,16 +299,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            172,
-            175,
-            45,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:2d:af:ac",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -351,16 +342,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            172,
-            175,
-            45,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:2d:af:ac",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -405,16 +387,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            172,
-            175,
-            45,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:2d:af:ac",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -455,16 +428,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            172,
-            175,
-            45,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:2d:af:ac",
           "endpoint_id": 2,
           "available": true,
           "group_id": null
@@ -505,16 +469,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            172,
-            175,
-            45,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:2d:af:ac",
           "endpoint_id": 3,
           "available": true,
           "group_id": null
@@ -555,16 +510,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            172,
-            175,
-            45,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:2d:af:ac",
           "endpoint_id": 4,
           "available": true,
           "group_id": null
@@ -605,16 +551,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            172,
-            175,
-            45,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:2d:af:ac",
           "endpoint_id": 7,
           "available": true,
           "group_id": null
@@ -657,16 +594,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            172,
-            175,
-            45,
-            254,
-            255,
-            189,
-            27,
-            236
-          ],
+          "device_ieee": "ec:1b:bd:ff:fe:2d:af:ac",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tyzb01-zanh6v1o-ts0121.json
+++ b/tests/data/devices/tyzb01-zanh6v1o-ts0121.json
@@ -393,16 +393,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            224,
-            177,
-            218,
-            254,
-            255,
-            204,
-            204,
-            204
-          ],
+          "device_ieee": "cc:cc:cc:ff:fe:da:b1:e0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -449,16 +440,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            224,
-            177,
-            218,
-            254,
-            255,
-            204,
-            204,
-            204
-          ],
+          "device_ieee": "cc:cc:cc:ff:fe:da:b1:e0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -501,16 +483,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            224,
-            177,
-            218,
-            254,
-            255,
-            204,
-            204,
-            204
-          ],
+          "device_ieee": "cc:cc:cc:ff:fe:da:b1:e0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -553,16 +526,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            224,
-            177,
-            218,
-            254,
-            255,
-            204,
-            204,
-            204
-          ],
+          "device_ieee": "cc:cc:cc:ff:fe:da:b1:e0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -613,16 +577,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            224,
-            177,
-            218,
-            254,
-            255,
-            204,
-            204,
-            204
-          ],
+          "device_ieee": "cc:cc:cc:ff:fe:da:b1:e0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -669,16 +624,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            224,
-            177,
-            218,
-            254,
-            255,
-            204,
-            204,
-            204
-          ],
+          "device_ieee": "cc:cc:cc:ff:fe:da:b1:e0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -725,16 +671,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            224,
-            177,
-            218,
-            254,
-            255,
-            204,
-            204,
-            204
-          ],
+          "device_ieee": "cc:cc:cc:ff:fe:da:b1:e0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -783,16 +720,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            224,
-            177,
-            218,
-            254,
-            255,
-            204,
-            204,
-            204
-          ],
+          "device_ieee": "cc:cc:cc:ff:fe:da:b1:e0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -835,16 +763,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            224,
-            177,
-            218,
-            254,
-            255,
-            204,
-            204,
-            204
-          ],
+          "device_ieee": "cc:cc:cc:ff:fe:da:b1:e0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tz3000-8yhypbo7-ts0203.json
+++ b/tests/data/devices/tz3000-8yhypbo7-ts0203.json
@@ -201,16 +201,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            43,
-            89,
-            250,
-            251,
-            1,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:01:fb:fa:59:2b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -252,16 +243,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            43,
-            89,
-            250,
-            251,
-            1,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:01:fb:fa:59:2b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -305,16 +287,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            43,
-            89,
-            250,
-            251,
-            1,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:01:fb:fa:59:2b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -361,16 +334,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            43,
-            89,
-            250,
-            251,
-            1,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:01:fb:fa:59:2b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -413,16 +377,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            43,
-            89,
-            250,
-            251,
-            1,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:01:fb:fa:59:2b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -465,16 +420,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            43,
-            89,
-            250,
-            251,
-            1,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:01:fb:fa:59:2b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -525,16 +471,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            43,
-            89,
-            250,
-            251,
-            1,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:01:fb:fa:59:2b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tz3000-bguser20-ts0201.json
+++ b/tests/data/devices/tz3000-bguser20-ts0201.json
@@ -177,16 +177,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            177,
-            216,
-            165,
-            79,
-            85,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:55:4f:a5:d8:b1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -233,16 +224,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            177,
-            216,
-            165,
-            79,
-            85,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:55:4f:a5:d8:b1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -285,16 +267,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            177,
-            216,
-            165,
-            79,
-            85,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:55:4f:a5:d8:b1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -337,16 +310,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            177,
-            216,
-            165,
-            79,
-            85,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:55:4f:a5:d8:b1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -395,16 +359,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            177,
-            216,
-            165,
-            79,
-            85,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:55:4f:a5:d8:b1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -447,16 +402,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            177,
-            216,
-            165,
-            79,
-            85,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:55:4f:a5:d8:b1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -501,16 +447,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            177,
-            216,
-            165,
-            79,
-            85,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:55:4f:a5:d8:b1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tz3000-cehuw1lw-ts011f.json
+++ b/tests/data/devices/tz3000-cehuw1lw-ts011f.json
@@ -426,16 +426,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            101,
-            94,
-            248,
-            45,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:2d:f8:5e:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -482,16 +473,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            101,
-            94,
-            248,
-            45,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:2d:f8:5e:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -534,16 +516,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            101,
-            94,
-            248,
-            45,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:2d:f8:5e:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -586,16 +559,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            101,
-            94,
-            248,
-            45,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:2d:f8:5e:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -646,16 +610,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            101,
-            94,
-            248,
-            45,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:2d:f8:5e:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -702,16 +657,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            101,
-            94,
-            248,
-            45,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:2d:f8:5e:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -758,16 +704,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            101,
-            94,
-            248,
-            45,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:2d:f8:5e:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -816,16 +753,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            101,
-            94,
-            248,
-            45,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:2d:f8:5e:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -868,16 +796,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            101,
-            94,
-            248,
-            45,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:2d:f8:5e:65",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tz3000-f2bw0b6k-ts0201.json
+++ b/tests/data/devices/tz3000-f2bw0b6k-ts0201.json
@@ -177,16 +177,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            240,
-            217,
-            62,
-            60,
-            86,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:56:3c:3e:d9:f0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -233,16 +224,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            240,
-            217,
-            62,
-            60,
-            86,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:56:3c:3e:d9:f0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -285,16 +267,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            240,
-            217,
-            62,
-            60,
-            86,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:56:3c:3e:d9:f0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -337,16 +310,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            240,
-            217,
-            62,
-            60,
-            86,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:56:3c:3e:d9:f0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -395,16 +359,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            240,
-            217,
-            62,
-            60,
-            86,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:56:3c:3e:d9:f0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -447,16 +402,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            240,
-            217,
-            62,
-            60,
-            86,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:56:3c:3e:d9:f0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -501,16 +447,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            240,
-            217,
-            62,
-            60,
-            86,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:56:3c:3e:d9:f0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tz3000-itnrsufe-ts0201.json
+++ b/tests/data/devices/tz3000-itnrsufe-ts0201.json
@@ -203,16 +203,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            145,
-            68,
-            93,
-            224,
-            254,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:fe:e0:5d:44:91",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -259,16 +250,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            145,
-            68,
-            93,
-            224,
-            254,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:fe:e0:5d:44:91",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -311,16 +293,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            145,
-            68,
-            93,
-            224,
-            254,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:fe:e0:5d:44:91",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -363,16 +336,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            145,
-            68,
-            93,
-            224,
-            254,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:fe:e0:5d:44:91",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -421,16 +385,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            145,
-            68,
-            93,
-            224,
-            254,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:fe:e0:5d:44:91",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -473,16 +428,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            145,
-            68,
-            93,
-            224,
-            254,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:fe:e0:5d:44:91",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -527,16 +473,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            145,
-            68,
-            93,
-            224,
-            254,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:fe:e0:5d:44:91",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tz3000-kjfzuycl-ts004f.json
+++ b/tests/data/devices/tz3000-kjfzuycl-ts004f.json
@@ -229,16 +229,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            15,
-            175,
-            54,
-            254,
-            255,
-            68,
-            91,
-            56
-          ],
+          "device_ieee": "38:5b:44:ff:fe:36:af:0f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -285,16 +276,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            15,
-            175,
-            54,
-            254,
-            255,
-            68,
-            91,
-            56
-          ],
+          "device_ieee": "38:5b:44:ff:fe:36:af:0f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -337,16 +319,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            15,
-            175,
-            54,
-            254,
-            255,
-            68,
-            91,
-            56
-          ],
+          "device_ieee": "38:5b:44:ff:fe:36:af:0f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -389,16 +362,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            15,
-            175,
-            54,
-            254,
-            255,
-            68,
-            91,
-            56
-          ],
+          "device_ieee": "38:5b:44:ff:fe:36:af:0f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -449,16 +413,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            15,
-            175,
-            54,
-            254,
-            255,
-            68,
-            91,
-            56
-          ],
+          "device_ieee": "38:5b:44:ff:fe:36:af:0f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tz3000-uwkja6z1-ts011f.json
+++ b/tests/data/devices/tz3000-uwkja6z1-ts011f.json
@@ -692,16 +692,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            141,
-            120,
-            239,
-            41,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:29:ef:78:8d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -748,16 +739,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            141,
-            120,
-            239,
-            41,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:29:ef:78:8d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -800,16 +782,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            141,
-            120,
-            239,
-            41,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:29:ef:78:8d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -852,16 +825,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            141,
-            120,
-            239,
-            41,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:29:ef:78:8d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -912,16 +876,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            141,
-            120,
-            239,
-            41,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:29:ef:78:8d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -968,16 +923,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            141,
-            120,
-            239,
-            41,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:29:ef:78:8d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1024,16 +970,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            141,
-            120,
-            239,
-            41,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:29:ef:78:8d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1080,16 +1017,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            141,
-            120,
-            239,
-            41,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:29:ef:78:8d",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1140,16 +1068,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            141,
-            120,
-            239,
-            41,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:29:ef:78:8d",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1196,16 +1115,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            141,
-            120,
-            239,
-            41,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:29:ef:78:8d",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1252,16 +1162,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            141,
-            120,
-            239,
-            41,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:29:ef:78:8d",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1310,16 +1211,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            141,
-            120,
-            239,
-            41,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:29:ef:78:8d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -1360,16 +1252,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            141,
-            120,
-            239,
-            41,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:29:ef:78:8d",
           "endpoint_id": 2,
           "available": true,
           "group_id": null
@@ -1412,16 +1295,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            141,
-            120,
-            239,
-            41,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:29:ef:78:8d",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tz3000-w0qqde0g-ts011f.json
+++ b/tests/data/devices/tz3000-w0qqde0g-ts011f.json
@@ -429,16 +429,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            46,
-            246,
-            14,
-            182,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:b6:0e:f6:2e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -485,16 +476,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            46,
-            246,
-            14,
-            182,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:b6:0e:f6:2e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -541,16 +523,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            46,
-            246,
-            14,
-            182,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:b6:0e:f6:2e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -599,16 +572,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            46,
-            246,
-            14,
-            182,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:b6:0e:f6:2e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -651,16 +615,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            46,
-            246,
-            14,
-            182,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:b6:0e:f6:2e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -703,16 +658,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            46,
-            246,
-            14,
-            182,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:b6:0e:f6:2e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -761,16 +707,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            46,
-            246,
-            14,
-            182,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:b6:0e:f6:2e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -817,16 +754,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            46,
-            246,
-            14,
-            182,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:b6:0e:f6:2e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -873,16 +801,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            46,
-            246,
-            14,
-            182,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:b6:0e:f6:2e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -931,16 +850,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            46,
-            246,
-            14,
-            182,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:b6:0e:f6:2e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -981,16 +891,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            46,
-            246,
-            14,
-            182,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:b6:0e:f6:2e",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tz3000-zw7yf6yk-ts0001.json
+++ b/tests/data/devices/tz3000-zw7yf6yk-ts0001.json
@@ -414,16 +414,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            201,
-            1,
-            117,
-            63,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:3f:75:01:c9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -470,16 +461,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            201,
-            1,
-            117,
-            63,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:3f:75:01:c9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -546,16 +528,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            201,
-            1,
-            117,
-            63,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:3f:75:01:c9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -598,16 +571,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            201,
-            1,
-            117,
-            63,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:3f:75:01:c9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -650,16 +614,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            201,
-            1,
-            117,
-            63,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:3f:75:01:c9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -710,16 +665,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            201,
-            1,
-            117,
-            63,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:3f:75:01:c9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -766,16 +712,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            201,
-            1,
-            117,
-            63,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:3f:75:01:c9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -822,16 +759,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            201,
-            1,
-            117,
-            63,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:3f:75:01:c9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -880,16 +808,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            201,
-            1,
-            117,
-            63,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:3f:75:01:c9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tz3210-09hzmirw-ts0502b.json
+++ b/tests/data/devices/tz3210-09hzmirw-ts0502b.json
@@ -285,16 +285,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            83,
-            141,
-            211,
-            147,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:93:d3:8d:53",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -369,16 +360,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            83,
-            141,
-            211,
-            147,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:93:d3:8d:53",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -447,16 +429,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            83,
-            141,
-            211,
-            147,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:93:d3:8d:53",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -504,16 +477,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            83,
-            141,
-            211,
-            147,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:93:d3:8d:53",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -556,16 +520,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            83,
-            141,
-            211,
-            147,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:93:d3:8d:53",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -610,16 +565,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            83,
-            141,
-            211,
-            147,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:93:d3:8d:53",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tz3210-j4pdtz9v-ts0001.json
+++ b/tests/data/devices/tz3210-j4pdtz9v-ts0001.json
@@ -198,16 +198,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            11,
-            29,
-            18,
-            200,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:c8:12:1d:0b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -253,16 +244,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            11,
-            29,
-            18,
-            200,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:c8:12:1d:0b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -308,16 +290,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            11,
-            29,
-            18,
-            200,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:c8:12:1d:0b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -365,16 +338,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            11,
-            29,
-            18,
-            200,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:c8:12:1d:0b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -421,16 +385,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            11,
-            29,
-            18,
-            200,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:c8:12:1d:0b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -478,16 +433,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            11,
-            29,
-            18,
-            200,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:c8:12:1d:0b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -530,16 +476,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            11,
-            29,
-            18,
-            200,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:c8:12:1d:0b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -582,16 +519,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            11,
-            29,
-            18,
-            200,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:c8:12:1d:0b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -643,16 +571,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            11,
-            29,
-            18,
-            200,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:c8:12:1d:0b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -693,16 +612,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            11,
-            29,
-            18,
-            200,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:c8:12:1d:0b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -751,16 +661,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            11,
-            29,
-            18,
-            200,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:c8:12:1d:0b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tz3210-jaap6jeb-ts0505b.json
+++ b/tests/data/devices/tz3210-jaap6jeb-ts0505b.json
@@ -339,16 +339,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            67,
-            232,
-            128,
-            93,
-            66,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:42:5d:80:e8:43",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -423,16 +414,7 @@
               "value_attribute": "current_x"
             }
           ],
-          "device_ieee": [
-            67,
-            232,
-            128,
-            93,
-            66,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:42:5d:80:e8:43",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -505,16 +487,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            67,
-            232,
-            128,
-            93,
-            66,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:42:5d:80:e8:43",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -557,16 +530,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            67,
-            232,
-            128,
-            93,
-            66,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:42:5d:80:e8:43",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -611,16 +575,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            67,
-            232,
-            128,
-            93,
-            66,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:42:5d:80:e8:43",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tz3210-tgvtvdoc-ts0207.json
+++ b/tests/data/devices/tz3210-tgvtvdoc-ts0207.json
@@ -203,16 +203,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            107,
-            4,
-            147,
-            155,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9b:93:04:6b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -254,16 +245,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            107,
-            4,
-            147,
-            155,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9b:93:04:6b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -307,16 +289,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            107,
-            4,
-            147,
-            155,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9b:93:04:6b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -359,16 +332,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            107,
-            4,
-            147,
-            155,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9b:93:04:6b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -411,16 +375,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            107,
-            4,
-            147,
-            155,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9b:93:04:6b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -471,16 +426,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            107,
-            4,
-            147,
-            155,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9b:93:04:6b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -523,16 +469,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            107,
-            4,
-            147,
-            155,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9b:93:04:6b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -575,16 +512,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            107,
-            4,
-            147,
-            155,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9b:93:04:6b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -627,16 +555,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            107,
-            4,
-            147,
-            155,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9b:93:04:6b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -681,16 +600,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            107,
-            4,
-            147,
-            155,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:9b:93:04:6b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tz3290-7v1k4vufotpowp9z-ts1201.json
+++ b/tests/data/devices/tz3290-7v1k4vufotpowp9z-ts1201.json
@@ -218,16 +218,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            83,
-            245,
-            24,
-            62,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:3e:18:f5:53",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -274,16 +265,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            83,
-            245,
-            24,
-            62,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:3e:18:f5:53",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -326,16 +308,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            83,
-            245,
-            24,
-            62,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:3e:18:f5:53",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -380,16 +353,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            83,
-            245,
-            24,
-            62,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:3e:18:f5:53",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -432,16 +396,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            83,
-            245,
-            24,
-            62,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:3e:18:f5:53",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tz6210-duv6fhwt-ts0601.json
+++ b/tests/data/devices/tz6210-duv6fhwt-ts0601.json
@@ -151,16 +151,7 @@
               "value_attribute": "occupancy"
             }
           ],
-          "device_ieee": [
-            15,
-            196,
-            129,
-            56,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:38:81:c4:0f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -202,16 +193,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            15,
-            196,
-            129,
-            56,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:38:81:c4:0f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -255,16 +237,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            15,
-            196,
-            129,
-            56,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:38:81:c4:0f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -311,16 +284,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            15,
-            196,
-            129,
-            56,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:38:81:c4:0f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -366,16 +330,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            15,
-            196,
-            129,
-            56,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:38:81:c4:0f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -423,16 +378,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            15,
-            196,
-            129,
-            56,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:38:81:c4:0f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -475,16 +421,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            15,
-            196,
-            129,
-            56,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:38:81:c4:0f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -527,16 +464,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            15,
-            196,
-            129,
-            56,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:38:81:c4:0f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -581,16 +509,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            15,
-            196,
-            129,
-            56,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:38:81:c4:0f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -639,16 +558,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            15,
-            196,
-            129,
-            56,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:38:81:c4:0f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tze200-2aaelwxk-ts0225.json
+++ b/tests/data/devices/tze200-2aaelwxk-ts0225.json
@@ -517,16 +517,7 @@
               "value_attribute": "occupancy"
             }
           ],
-          "device_ieee": [
-            95,
-            247,
-            133,
-            148,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:94:85:f7:5f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -570,16 +561,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            95,
-            247,
-            133,
-            148,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:94:85:f7:5f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -626,16 +608,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            95,
-            247,
-            133,
-            148,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:94:85:f7:5f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -681,16 +654,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            95,
-            247,
-            133,
-            148,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:94:85:f7:5f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -736,16 +700,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            95,
-            247,
-            133,
-            148,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:94:85:f7:5f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -791,16 +746,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            95,
-            247,
-            133,
-            148,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:94:85:f7:5f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -846,16 +792,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            95,
-            247,
-            133,
-            148,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:94:85:f7:5f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -901,16 +838,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            95,
-            247,
-            133,
-            148,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:94:85:f7:5f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -956,16 +884,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            95,
-            247,
-            133,
-            148,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:94:85:f7:5f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1011,16 +930,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            95,
-            247,
-            133,
-            148,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:94:85:f7:5f",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1066,16 +976,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            95,
-            247,
-            133,
-            148,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:94:85:f7:5f",
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
@@ -1121,16 +1022,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            95,
-            247,
-            133,
-            148,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:94:85:f7:5f",
           "endpoint_id": 4,
           "available": true,
           "group_id": null,
@@ -1176,16 +1068,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            95,
-            247,
-            133,
-            148,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:94:85:f7:5f",
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
@@ -1231,16 +1114,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            95,
-            247,
-            133,
-            148,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:94:85:f7:5f",
           "endpoint_id": 6,
           "available": true,
           "group_id": null,
@@ -1286,16 +1160,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            95,
-            247,
-            133,
-            148,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:94:85:f7:5f",
           "endpoint_id": 7,
           "available": true,
           "group_id": null,
@@ -1341,16 +1206,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            95,
-            247,
-            133,
-            148,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:94:85:f7:5f",
           "endpoint_id": 8,
           "available": true,
           "group_id": null,
@@ -1398,16 +1254,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            95,
-            247,
-            133,
-            148,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:94:85:f7:5f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1459,16 +1306,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            95,
-            247,
-            133,
-            148,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:94:85:f7:5f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1511,16 +1349,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            95,
-            247,
-            133,
-            148,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:94:85:f7:5f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1563,16 +1392,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            95,
-            247,
-            133,
-            148,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:94:85:f7:5f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1617,16 +1437,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            95,
-            247,
-            133,
-            148,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:94:85:f7:5f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -1667,16 +1478,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            95,
-            247,
-            133,
-            148,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:94:85:f7:5f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tze200-9caxna4s-ts0301.json
+++ b/tests/data/devices/tze200-9caxna4s-ts0301.json
@@ -223,16 +223,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            241,
-            156,
-            74,
-            254,
-            255,
-            126,
-            224,
-            232
-          ],
+          "device_ieee": "e8:e0:7e:ff:fe:4a:9c:f1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -279,16 +270,7 @@
               "value_attribute": "current_position_lift_percentage"
             }
           ],
-          "device_ieee": [
-            241,
-            156,
-            74,
-            254,
-            255,
-            126,
-            224,
-            232
-          ],
+          "device_ieee": "e8:e0:7e:ff:fe:4a:9c:f1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -336,16 +318,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            241,
-            156,
-            74,
-            254,
-            255,
-            126,
-            224,
-            232
-          ],
+          "device_ieee": "e8:e0:7e:ff:fe:4a:9c:f1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -388,16 +361,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            241,
-            156,
-            74,
-            254,
-            255,
-            126,
-            224,
-            232
-          ],
+          "device_ieee": "e8:e0:7e:ff:fe:4a:9c:f1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -440,16 +404,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            241,
-            156,
-            74,
-            254,
-            255,
-            126,
-            224,
-            232
-          ],
+          "device_ieee": "e8:e0:7e:ff:fe:4a:9c:f1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -498,16 +453,7 @@
               "value_attribute": "current_position_lift_percentage"
             }
           ],
-          "device_ieee": [
-            241,
-            156,
-            74,
-            254,
-            255,
-            126,
-            224,
-            232
-          ],
+          "device_ieee": "e8:e0:7e:ff:fe:4a:9c:f1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -552,16 +498,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            241,
-            156,
-            74,
-            254,
-            255,
-            126,
-            224,
-            232
-          ],
+          "device_ieee": "e8:e0:7e:ff:fe:4a:9c:f1",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tze200-akjefhj5-ts0601.json
+++ b/tests/data/devices/tze200-akjefhj5-ts0601.json
@@ -127,16 +127,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            129,
-            60,
-            70,
-            144,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:90:46:3c:81",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -179,16 +170,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            129,
-            60,
-            70,
-            144,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:90:46:3c:81",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -233,16 +215,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            129,
-            60,
-            70,
-            144,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:90:46:3c:81",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tze200-ijey4q29-ts0601.json
+++ b/tests/data/devices/tze200-ijey4q29-ts0601.json
@@ -191,16 +191,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            184,
-            153,
-            84,
-            78,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:4e:54:99:b8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -244,16 +235,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            184,
-            153,
-            84,
-            78,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:4e:54:99:b8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -300,16 +282,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            184,
-            153,
-            84,
-            78,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:4e:54:99:b8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -352,16 +325,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            184,
-            153,
-            84,
-            78,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:4e:54:99:b8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -404,16 +368,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            184,
-            153,
-            84,
-            78,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:4e:54:99:b8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -462,16 +417,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            184,
-            153,
-            84,
-            78,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:4e:54:99:b8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tze200-laqjm8qd-ts0601.json
+++ b/tests/data/devices/tze200-laqjm8qd-ts0601.json
@@ -142,16 +142,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            239,
-            112,
-            123,
-            71,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:47:7b:70:ef",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -194,16 +185,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            239,
-            112,
-            123,
-            71,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:47:7b:70:ef",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -248,16 +230,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            239,
-            112,
-            123,
-            71,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:47:7b:70:ef",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tze200-locansqn-ts0601.json
+++ b/tests/data/devices/tze200-locansqn-ts0601.json
@@ -281,16 +281,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            89,
-            182,
-            178,
-            91,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:5b:b2:b6:59",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -336,16 +327,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            89,
-            182,
-            178,
-            91,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:5b:b2:b6:59",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -391,16 +373,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            89,
-            182,
-            178,
-            91,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:5b:b2:b6:59",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -446,16 +419,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            89,
-            182,
-            178,
-            91,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:5b:b2:b6:59",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -501,16 +465,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            89,
-            182,
-            178,
-            91,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:5b:b2:b6:59",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -556,16 +511,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            89,
-            182,
-            178,
-            91,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:5b:b2:b6:59",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -611,16 +557,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            89,
-            182,
-            178,
-            91,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:5b:b2:b6:59",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -666,16 +603,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            89,
-            182,
-            178,
-            91,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:5b:b2:b6:59",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -723,16 +651,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            89,
-            182,
-            178,
-            91,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:5b:b2:b6:59",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -780,16 +699,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            89,
-            182,
-            178,
-            91,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:5b:b2:b6:59",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -832,16 +742,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            89,
-            182,
-            178,
-            91,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:5b:b2:b6:59",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -884,16 +785,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            89,
-            182,
-            178,
-            91,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:5b:b2:b6:59",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -943,16 +835,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            89,
-            182,
-            178,
-            91,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:5b:b2:b6:59",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -995,16 +878,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            89,
-            182,
-            178,
-            91,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:5b:b2:b6:59",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1047,16 +921,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            89,
-            182,
-            178,
-            91,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:5b:b2:b6:59",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1099,16 +964,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            89,
-            182,
-            178,
-            91,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:5b:b2:b6:59",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1153,16 +1009,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            89,
-            182,
-            178,
-            91,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:5b:b2:b6:59",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tze200-myd45weu-ts0601.json
+++ b/tests/data/devices/tze200-myd45weu-ts0601.json
@@ -196,16 +196,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            28,
-            67,
-            63,
-            247,
-            235,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:eb:f7:3f:43:1c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -248,16 +239,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            28,
-            67,
-            63,
-            247,
-            235,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:eb:f7:3f:43:1c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -300,16 +282,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            28,
-            67,
-            63,
-            247,
-            235,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:eb:f7:3f:43:1c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -359,16 +332,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            28,
-            67,
-            63,
-            247,
-            235,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:eb:f7:3f:43:1c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -411,16 +375,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            28,
-            67,
-            63,
-            247,
-            235,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:eb:f7:3f:43:1c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -465,16 +420,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            28,
-            67,
-            63,
-            247,
-            235,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:eb:f7:3f:43:1c",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tze200-ny94onlb-ts0601.json
+++ b/tests/data/devices/tze200-ny94onlb-ts0601.json
@@ -830,16 +830,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            255,
-            137,
-            140,
-            88,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:58:8c:89:ff",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -882,16 +873,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            255,
-            137,
-            140,
-            88,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:58:8c:89:ff",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -934,16 +916,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            255,
-            137,
-            140,
-            88,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:58:8c:89:ff",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -992,16 +965,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            255,
-            137,
-            140,
-            88,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:58:8c:89:ff",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1048,16 +1012,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            255,
-            137,
-            140,
-            88,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:58:8c:89:ff",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1104,16 +1059,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            255,
-            137,
-            140,
-            88,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:58:8c:89:ff",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1160,16 +1106,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            255,
-            137,
-            140,
-            88,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:58:8c:89:ff",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1216,16 +1153,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            255,
-            137,
-            140,
-            88,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:58:8c:89:ff",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1272,16 +1200,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            255,
-            137,
-            140,
-            88,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:58:8c:89:ff",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1328,16 +1247,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            255,
-            137,
-            140,
-            88,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:58:8c:89:ff",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1384,16 +1294,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            255,
-            137,
-            140,
-            88,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:58:8c:89:ff",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1440,16 +1341,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            255,
-            137,
-            140,
-            88,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:58:8c:89:ff",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1496,16 +1388,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            255,
-            137,
-            140,
-            88,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:58:8c:89:ff",
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
@@ -1552,16 +1435,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            255,
-            137,
-            140,
-            88,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:58:8c:89:ff",
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
@@ -1608,16 +1482,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            255,
-            137,
-            140,
-            88,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:58:8c:89:ff",
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
@@ -1664,16 +1529,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            255,
-            137,
-            140,
-            88,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:58:8c:89:ff",
           "endpoint_id": 20,
           "available": true,
           "group_id": null,
@@ -1720,16 +1576,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            255,
-            137,
-            140,
-            88,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:58:8c:89:ff",
           "endpoint_id": 20,
           "available": true,
           "group_id": null,
@@ -1776,16 +1623,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            255,
-            137,
-            140,
-            88,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:58:8c:89:ff",
           "endpoint_id": 20,
           "available": true,
           "group_id": null,
@@ -1832,16 +1670,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            255,
-            137,
-            140,
-            88,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:58:8c:89:ff",
           "endpoint_id": 30,
           "available": true,
           "group_id": null,
@@ -1888,16 +1717,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            255,
-            137,
-            140,
-            88,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:58:8c:89:ff",
           "endpoint_id": 30,
           "available": true,
           "group_id": null,
@@ -1944,16 +1764,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            255,
-            137,
-            140,
-            88,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:58:8c:89:ff",
           "endpoint_id": 30,
           "available": true,
           "group_id": null,
@@ -2002,16 +1813,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            255,
-            137,
-            140,
-            88,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:58:8c:89:ff",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tze200-pay2byax-ts0601.json
+++ b/tests/data/devices/tze200-pay2byax-ts0601.json
@@ -178,16 +178,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            172,
-            234,
-            188,
-            231,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:e7:bc:ea:ac",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -231,16 +222,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            172,
-            234,
-            188,
-            231,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:e7:bc:ea:ac",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -287,16 +269,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            172,
-            234,
-            188,
-            231,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:e7:bc:ea:ac",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -339,16 +312,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            172,
-            234,
-            188,
-            231,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:e7:bc:ea:ac",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -391,16 +355,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            172,
-            234,
-            188,
-            231,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:e7:bc:ea:ac",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -451,16 +406,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            172,
-            234,
-            188,
-            231,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:e7:bc:ea:ac",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tze200-yjjdcqsq-ts0601.json
+++ b/tests/data/devices/tze200-yjjdcqsq-ts0601.json
@@ -169,16 +169,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            82,
-            243,
-            6,
-            103,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:67:06:f3:52",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -226,16 +217,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            82,
-            243,
-            6,
-            103,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:67:06:f3:52",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -278,16 +260,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            82,
-            243,
-            6,
-            103,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:67:06:f3:52",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -330,16 +303,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            82,
-            243,
-            6,
-            103,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:67:06:f3:52",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -389,16 +353,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            82,
-            243,
-            6,
-            103,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:67:06:f3:52",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -441,16 +396,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            82,
-            243,
-            6,
-            103,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:67:06:f3:52",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -495,16 +441,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            82,
-            243,
-            6,
-            103,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:67:06:f3:52",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tze204-81yrt3lo-ts0601.json
+++ b/tests/data/devices/tze204-81yrt3lo-ts0601.json
@@ -877,16 +877,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            117,
-            219,
-            9,
-            34,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:22:09:db:75",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -929,16 +920,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            117,
-            219,
-            9,
-            34,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:22:09:db:75",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -981,16 +963,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            117,
-            219,
-            9,
-            34,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:22:09:db:75",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1040,16 +1013,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            117,
-            219,
-            9,
-            34,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:22:09:db:75",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1099,16 +1063,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            117,
-            219,
-            9,
-            34,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:22:09:db:75",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1158,16 +1113,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            117,
-            219,
-            9,
-            34,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:22:09:db:75",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1215,16 +1161,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            117,
-            219,
-            9,
-            34,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:22:09:db:75",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1272,16 +1209,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            117,
-            219,
-            9,
-            34,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:22:09:db:75",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1329,16 +1257,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            117,
-            219,
-            9,
-            34,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:22:09:db:75",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1386,16 +1305,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            117,
-            219,
-            9,
-            34,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:22:09:db:75",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1443,16 +1353,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            117,
-            219,
-            9,
-            34,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:22:09:db:75",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1500,16 +1401,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            117,
-            219,
-            9,
-            34,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:22:09:db:75",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1559,16 +1451,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            117,
-            219,
-            9,
-            34,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:22:09:db:75",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1618,16 +1501,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            117,
-            219,
-            9,
-            34,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:22:09:db:75",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1677,16 +1551,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            117,
-            219,
-            9,
-            34,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:22:09:db:75",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1734,16 +1599,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            117,
-            219,
-            9,
-            34,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:22:09:db:75",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1791,16 +1647,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            117,
-            219,
-            9,
-            34,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:22:09:db:75",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1848,16 +1695,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            117,
-            219,
-            9,
-            34,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:22:09:db:75",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1905,16 +1743,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            117,
-            219,
-            9,
-            34,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:22:09:db:75",
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
@@ -1964,16 +1793,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            117,
-            219,
-            9,
-            34,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:22:09:db:75",
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
@@ -2023,16 +1843,7 @@
               "value_attribute": "instantaneous_demand"
             }
           ],
-          "device_ieee": [
-            117,
-            219,
-            9,
-            34,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:22:09:db:75",
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
@@ -2082,16 +1893,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            117,
-            219,
-            9,
-            34,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:22:09:db:75",
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
@@ -2139,16 +1941,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            117,
-            219,
-            9,
-            34,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:22:09:db:75",
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
@@ -2196,16 +1989,7 @@
               "value_attribute": "ac_voltage_multiplier"
             }
           ],
-          "device_ieee": [
-            117,
-            219,
-            9,
-            34,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:22:09:db:75",
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
@@ -2255,16 +2039,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            117,
-            219,
-            9,
-            34,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:22:09:db:75",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tze204-ai4rqhky-ts0601.json
+++ b/tests/data/devices/tze204-ai4rqhky-ts0601.json
@@ -140,16 +140,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            83,
-            204,
-            80,
-            177,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:b1:50:cc:53",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -192,16 +183,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            83,
-            204,
-            80,
-            177,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:b1:50:cc:53",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -246,16 +228,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            83,
-            204,
-            80,
-            177,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:b1:50:cc:53",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tze204-iaeejhvf-ts0601.json
+++ b/tests/data/devices/tze204-iaeejhvf-ts0601.json
@@ -455,16 +455,7 @@
               "value_attribute": "occupancy"
             }
           ],
-          "device_ieee": [
-            176,
-            28,
-            136,
-            82,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:52:88:1c:b0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -508,16 +499,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            176,
-            28,
-            136,
-            82,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:52:88:1c:b0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -563,16 +545,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            176,
-            28,
-            136,
-            82,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:52:88:1c:b0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -618,16 +591,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            176,
-            28,
-            136,
-            82,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:52:88:1c:b0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -673,16 +637,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            176,
-            28,
-            136,
-            82,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:52:88:1c:b0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -728,16 +683,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            176,
-            28,
-            136,
-            82,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:52:88:1c:b0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -783,16 +729,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            176,
-            28,
-            136,
-            82,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:52:88:1c:b0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -838,16 +775,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            176,
-            28,
-            136,
-            82,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:52:88:1c:b0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -893,16 +821,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            176,
-            28,
-            136,
-            82,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:52:88:1c:b0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -948,16 +867,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            176,
-            28,
-            136,
-            82,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:52:88:1c:b0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1003,16 +913,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            176,
-            28,
-            136,
-            82,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:52:88:1c:b0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1058,16 +959,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            176,
-            28,
-            136,
-            82,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:52:88:1c:b0",
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
@@ -1113,16 +1005,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            176,
-            28,
-            136,
-            82,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:52:88:1c:b0",
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
@@ -1168,16 +1051,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            176,
-            28,
-            136,
-            82,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:52:88:1c:b0",
           "endpoint_id": 4,
           "available": true,
           "group_id": null,
@@ -1223,16 +1097,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            176,
-            28,
-            136,
-            82,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:52:88:1c:b0",
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
@@ -1280,16 +1145,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            176,
-            28,
-            136,
-            82,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:52:88:1c:b0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1335,16 +1191,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            176,
-            28,
-            136,
-            82,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:52:88:1c:b0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1390,16 +1237,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            176,
-            28,
-            136,
-            82,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:52:88:1c:b0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1445,16 +1283,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            176,
-            28,
-            136,
-            82,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:52:88:1c:b0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1502,16 +1331,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            176,
-            28,
-            136,
-            82,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:52:88:1c:b0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1559,16 +1379,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            176,
-            28,
-            136,
-            82,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:52:88:1c:b0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1611,16 +1422,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            176,
-            28,
-            136,
-            82,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:52:88:1c:b0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1663,16 +1465,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            176,
-            28,
-            136,
-            82,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:52:88:1c:b0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1715,16 +1508,7 @@
               "value_attribute": "present_value"
             }
           ],
-          "device_ieee": [
-            176,
-            28,
-            136,
-            82,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:52:88:1c:b0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1767,16 +1551,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            176,
-            28,
-            136,
-            82,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:52:88:1c:b0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -1821,16 +1596,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            176,
-            28,
-            136,
-            82,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:52:88:1c:b0",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tze204-nklqjk62-ts0601.json
+++ b/tests/data/devices/tze204-nklqjk62-ts0601.json
@@ -137,16 +137,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            182,
-            19,
-            183,
-            73,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:49:b7:13:b6",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -189,16 +180,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            182,
-            19,
-            183,
-            73,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:49:b7:13:b6",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -243,16 +225,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            182,
-            19,
-            183,
-            73,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:49:b7:13:b6",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tze204-nlrfgpny-ts0601.json
+++ b/tests/data/devices/tze204-nlrfgpny-ts0601.json
@@ -220,16 +220,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            243,
-            183,
-            70,
-            250,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:fa:46:b7:f3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -271,16 +262,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            243,
-            183,
-            70,
-            250,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:fa:46:b7:f3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -324,16 +306,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            243,
-            183,
-            70,
-            250,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:fa:46:b7:f3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -381,16 +354,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            243,
-            183,
-            70,
-            250,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:fa:46:b7:f3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -438,16 +402,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            243,
-            183,
-            70,
-            250,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:fa:46:b7:f3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -496,16 +451,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            243,
-            183,
-            70,
-            250,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:fa:46:b7:f3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -548,16 +494,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            243,
-            183,
-            70,
-            250,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:fa:46:b7:f3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -600,16 +537,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            243,
-            183,
-            70,
-            250,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:fa:46:b7:f3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -659,16 +587,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            243,
-            183,
-            70,
-            250,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:fa:46:b7:f3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -713,16 +632,7 @@
               "value_attribute": "on_off"
             }
           ],
-          "device_ieee": [
-            243,
-            183,
-            70,
-            250,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:fa:46:b7:f3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -763,16 +673,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            243,
-            183,
-            70,
-            250,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:fa:46:b7:f3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -819,16 +720,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            243,
-            183,
-            70,
-            250,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:fa:46:b7:f3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -877,16 +769,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            243,
-            183,
-            70,
-            250,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:fa:46:b7:f3",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tze204-qasjif9e-ts0601.json
+++ b/tests/data/devices/tze204-qasjif9e-ts0601.json
@@ -187,16 +187,7 @@
               "value_attribute": "occupancy"
             }
           ],
-          "device_ieee": [
-            136,
-            242,
-            192,
-            167,
-            248,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:f8:a7:c0:f2:88",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -240,16 +231,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            136,
-            242,
-            192,
-            167,
-            248,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:f8:a7:c0:f2:88",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -295,16 +277,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            136,
-            242,
-            192,
-            167,
-            248,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:f8:a7:c0:f2:88",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -350,16 +323,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            136,
-            242,
-            192,
-            167,
-            248,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:f8:a7:c0:f2:88",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -405,16 +369,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            136,
-            242,
-            192,
-            167,
-            248,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:f8:a7:c0:f2:88",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -460,16 +415,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            136,
-            242,
-            192,
-            167,
-            248,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:f8:a7:c0:f2:88",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -517,16 +463,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            136,
-            242,
-            192,
-            167,
-            248,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:f8:a7:c0:f2:88",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -569,16 +506,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            136,
-            242,
-            192,
-            167,
-            248,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:f8:a7:c0:f2:88",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -621,16 +549,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            136,
-            242,
-            192,
-            167,
-            248,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:f8:a7:c0:f2:88",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -673,16 +592,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            136,
-            242,
-            192,
-            167,
-            248,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:f8:a7:c0:f2:88",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -727,16 +637,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            136,
-            242,
-            192,
-            167,
-            248,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:f8:a7:c0:f2:88",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tze204-qtnjuoae-ts0601.json
+++ b/tests/data/devices/tze204-qtnjuoae-ts0601.json
@@ -134,16 +134,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            70,
-            189,
-            120,
-            101,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:65:78:bd:46",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -186,16 +177,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            70,
-            189,
-            120,
-            101,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:65:78:bd:46",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -240,16 +222,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            70,
-            189,
-            120,
-            101,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:65:78:bd:46",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tze284-ne4pikwm-ts0601.json
+++ b/tests/data/devices/tze284-ne4pikwm-ts0601.json
@@ -272,16 +272,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            232,
-            161,
-            167,
-            6,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:06:a7:a1:e8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -325,16 +316,7 @@
               "value_attribute": "local_temperature"
             }
           ],
-          "device_ieee": [
-            232,
-            161,
-            167,
-            6,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:06:a7:a1:e8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -412,16 +394,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            232,
-            161,
-            167,
-            6,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:06:a7:a1:e8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -469,16 +442,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            232,
-            161,
-            167,
-            6,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:06:a7:a1:e8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -521,16 +485,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            232,
-            161,
-            167,
-            6,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:06:a7:a1:e8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -573,16 +528,7 @@
               "value_attribute": "local_temperature"
             }
           ],
-          "device_ieee": [
-            232,
-            161,
-            167,
-            6,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:06:a7:a1:e8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -627,16 +573,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            232,
-            161,
-            167,
-            6,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:06:a7:a1:e8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -683,16 +620,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            232,
-            161,
-            167,
-            6,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:06:a7:a1:e8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -739,16 +667,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            232,
-            161,
-            167,
-            6,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:06:a7:a1:e8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -795,16 +714,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            232,
-            161,
-            167,
-            6,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:06:a7:a1:e8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -851,16 +761,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            232,
-            161,
-            167,
-            6,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:06:a7:a1:e8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -907,16 +808,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            232,
-            161,
-            167,
-            6,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:06:a7:a1:e8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -965,16 +857,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            232,
-            161,
-            167,
-            6,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:06:a7:a1:e8",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/tze284-qyflbnbj-ts0601.json
+++ b/tests/data/devices/tze284-qyflbnbj-ts0601.json
@@ -230,16 +230,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            43,
-            158,
-            141,
-            190,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:be:8d:9e:2b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -282,16 +273,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            43,
-            158,
-            141,
-            190,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:be:8d:9e:2b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -334,16 +316,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            43,
-            158,
-            141,
-            190,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:be:8d:9e:2b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -393,16 +366,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            43,
-            158,
-            141,
-            190,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:be:8d:9e:2b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -445,16 +409,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            43,
-            158,
-            141,
-            190,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:be:8d:9e:2b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -499,16 +454,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            43,
-            158,
-            141,
-            190,
-            18,
-            239,
-            205,
-            171
-          ],
+          "device_ieee": "ab:cd:ef:12:be:8d:9e:2b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/xiaomi-lywsd03mmc.json
+++ b/tests/data/devices/xiaomi-lywsd03mmc.json
@@ -178,16 +178,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            149,
-            119,
-            73,
-            237,
-            221,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:dd:ed:49:77:95",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -234,16 +225,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            149,
-            119,
-            73,
-            237,
-            221,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:dd:ed:49:77:95",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -289,16 +271,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            149,
-            119,
-            73,
-            237,
-            221,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:dd:ed:49:77:95",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -344,16 +317,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            149,
-            119,
-            73,
-            237,
-            221,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:dd:ed:49:77:95",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -399,16 +363,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            149,
-            119,
-            73,
-            237,
-            221,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:dd:ed:49:77:95",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -454,16 +409,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            149,
-            119,
-            73,
-            237,
-            221,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:dd:ed:49:77:95",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -509,16 +455,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            149,
-            119,
-            73,
-            237,
-            221,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:dd:ed:49:77:95",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -566,16 +503,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            149,
-            119,
-            73,
-            237,
-            221,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:dd:ed:49:77:95",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -618,16 +546,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            149,
-            119,
-            73,
-            237,
-            221,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:dd:ed:49:77:95",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -670,16 +589,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            149,
-            119,
-            73,
-            237,
-            221,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:dd:ed:49:77:95",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -728,16 +638,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            149,
-            119,
-            73,
-            237,
-            221,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:dd:ed:49:77:95",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -780,16 +681,7 @@
               "value_attribute": "measured_value"
             }
           ],
-          "device_ieee": [
-            149,
-            119,
-            73,
-            237,
-            221,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:dd:ed:49:77:95",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -834,16 +726,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            149,
-            119,
-            73,
-            237,
-            221,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:dd:ed:49:77:95",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -890,16 +773,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            149,
-            119,
-            73,
-            237,
-            221,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:dd:ed:49:77:95",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -948,16 +822,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            149,
-            119,
-            73,
-            237,
-            221,
-            56,
-            193,
-            164
-          ],
+          "device_ieee": "a4:c1:38:dd:ed:49:77:95",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/xiaoyan-terncy-sd01.json
+++ b/tests/data/devices/xiaoyan-terncy-sd01.json
@@ -181,16 +181,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            201,
-            193,
-            115,
-            22,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:16:73:c1:c9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -237,16 +228,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            201,
-            193,
-            115,
-            22,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:16:73:c1:c9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -289,16 +271,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            201,
-            193,
-            115,
-            22,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:16:73:c1:c9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -341,16 +314,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            201,
-            193,
-            115,
-            22,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:16:73:c1:c9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -400,16 +364,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            201,
-            193,
-            115,
-            22,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:16:73:c1:c9",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/yale-yrd256-tsdb.json
+++ b/tests/data/devices/yale-yrd256-tsdb.json
@@ -229,16 +229,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            123,
-            31,
-            25,
-            17,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:11:19:1f:7b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -285,16 +276,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            123,
-            31,
-            25,
-            17,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:11:19:1f:7b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -337,16 +319,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            123,
-            31,
-            25,
-            17,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:11:19:1f:7b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -389,16 +362,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            123,
-            31,
-            25,
-            17,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:11:19:1f:7b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -441,16 +405,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            123,
-            31,
-            25,
-            17,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:11:19:1f:7b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -503,16 +458,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            123,
-            31,
-            25,
-            17,
-            0,
-            111,
-            13,
-            0
-          ],
+          "device_ieee": "00:0d:6f:00:11:19:1f:7b",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/yooksmart-d10110.json
+++ b/tests/data/devices/yooksmart-d10110.json
@@ -230,16 +230,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            111,
-            128,
-            96,
-            254,
-            255,
-            177,
-            92,
-            108
-          ],
+          "device_ieee": "6c:5c:b1:ff:fe:60:80:6f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -286,16 +277,7 @@
               "value_attribute": "current_position_lift_percentage"
             }
           ],
-          "device_ieee": [
-            111,
-            128,
-            96,
-            254,
-            255,
-            177,
-            92,
-            108
-          ],
+          "device_ieee": "6c:5c:b1:ff:fe:60:80:6f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -343,16 +325,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            111,
-            128,
-            96,
-            254,
-            255,
-            177,
-            92,
-            108
-          ],
+          "device_ieee": "6c:5c:b1:ff:fe:60:80:6f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -395,16 +368,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            111,
-            128,
-            96,
-            254,
-            255,
-            177,
-            92,
-            108
-          ],
+          "device_ieee": "6c:5c:b1:ff:fe:60:80:6f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -447,16 +411,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            111,
-            128,
-            96,
-            254,
-            255,
-            177,
-            92,
-            108
-          ],
+          "device_ieee": "6c:5c:b1:ff:fe:60:80:6f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -504,16 +459,7 @@
               "value_attribute": "current_position_lift_percentage"
             }
           ],
-          "device_ieee": [
-            111,
-            128,
-            96,
-            254,
-            255,
-            177,
-            92,
-            108
-          ],
+          "device_ieee": "6c:5c:b1:ff:fe:60:80:6f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -558,16 +504,7 @@
               "value_attribute": "current_position_lift_percentage"
             }
           ],
-          "device_ieee": [
-            111,
-            128,
-            96,
-            254,
-            255,
-            177,
-            92,
-            108
-          ],
+          "device_ieee": "6c:5c:b1:ff:fe:60:80:6f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -616,16 +553,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            111,
-            128,
-            96,
-            254,
-            255,
-            177,
-            92,
-            108
-          ],
+          "device_ieee": "6c:5c:b1:ff:fe:60:80:6f",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/tests/data/devices/yunding-ford.json
+++ b/tests/data/devices/yunding-ford.json
@@ -173,16 +173,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            175,
-            34,
-            106,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:6a:22:af",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -229,16 +220,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            175,
-            34,
-            106,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:6a:22:af",
           "endpoint_id": 1,
           "available": true,
           "group_id": null
@@ -281,16 +263,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            175,
-            34,
-            106,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:6a:22:af",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -333,16 +306,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            175,
-            34,
-            106,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:6a:22:af",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -385,16 +349,7 @@
               "value_attribute": "battery_voltage"
             }
           ],
-          "device_ieee": [
-            175,
-            34,
-            106,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:6a:22:af",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
@@ -446,16 +401,7 @@
               "value_attribute": null
             }
           ],
-          "device_ieee": [
-            175,
-            34,
-            106,
-            254,
-            255,
-            226,
-            10,
-            104
-          ],
+          "device_ieee": "68:0a:e2:ff:fe:6a:22:af",
           "endpoint_id": 1,
           "available": true,
           "group_id": null,

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -1500,6 +1500,7 @@ class Device(LogMixin, EventBase):
             info_object = dataclasses.asdict(platform_entity.info_object)
             info_object["cluster_handlers"].sort(key=lambda i: i["unique_id"])
             info_object["migrate_unique_ids"] = list(info_object["migrate_unique_ids"])
+            info_object["device_ieee"] = str(info_object["device_ieee"])
 
             for cluster_handler_info in info_object["cluster_handlers"]:
                 cluster_info = cluster_handler_info["cluster"]


### PR DESCRIPTION
It is currently a list of integers (because EUI64 subclasses `list`), it should be a string instead.