### PR TITLE
Fix `None` extra state attribute names

### DIFF
--- a/tests/data/devices/isilentllc-home-energy-monitor.json
+++ b/tests/data/devices/isilentllc-home-energy-monitor.json
@@ -4036,8 +4036,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -4093,8 +4092,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -4378,8 +4376,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -4435,8 +4432,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -4720,8 +4716,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -4777,8 +4772,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -5062,8 +5056,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -5119,8 +5112,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -5404,8 +5396,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -5461,8 +5452,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -5746,8 +5736,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -5803,8 +5792,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -6088,8 +6076,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -6145,8 +6132,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -6430,8 +6416,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -6487,8 +6472,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -6772,8 +6756,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -6829,8 +6812,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -7114,8 +7096,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -7171,8 +7152,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -7456,8 +7436,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -7513,8 +7492,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -7798,8 +7776,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -7855,8 +7832,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -8140,8 +8116,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -8197,8 +8172,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -8482,8 +8456,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -8539,8 +8512,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -8824,8 +8796,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -8881,8 +8852,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -9166,8 +9136,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -9223,8 +9192,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -9508,8 +9476,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -9565,8 +9532,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -9850,8 +9816,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -9907,8 +9872,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -10192,8 +10156,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -10249,8 +10212,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -10534,8 +10496,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -10591,8 +10552,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -10876,8 +10836,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -10933,8 +10892,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -11218,8 +11176,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -11275,8 +11232,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -11560,8 +11516,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -11617,8 +11572,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -11902,8 +11856,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -11959,8 +11912,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -12244,8 +12196,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -12301,8 +12252,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {

--- a/tests/data/devices/lumi-lumi-plug-maus01.json
+++ b/tests/data/devices/lumi-lumi-plug-maus01.json
@@ -1030,8 +1030,7 @@
           "state": null
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {

--- a/tests/data/devices/lumi-lumi-relay-c2acn01.json
+++ b/tests/data/devices/lumi-lumi-relay-c2acn01.json
@@ -979,8 +979,7 @@
           "state": null
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {

--- a/tests/data/devices/securifi-ltd-unk-model.json
+++ b/tests/data/devices/securifi-ltd-unk-model.json
@@ -638,8 +638,7 @@
           "measurement_type": "PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {

--- a/tests/data/devices/third-reality-inc-3rsp02028bz.json
+++ b/tests/data/devices/third-reality-inc-3rsp02028bz.json
@@ -787,8 +787,7 @@
           "state": 0
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {

--- a/tests/data/devices/tze204-81yrt3lo-ts0601.json
+++ b/tests/data/devices/tze204-81yrt3lo-ts0601.json
@@ -1295,8 +1295,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -1352,8 +1351,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -1757,8 +1755,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -1814,8 +1811,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {
@@ -2162,8 +2158,7 @@
           "measurement_type": "ACTIVE_MEASUREMENT, REACTIVE_MEASUREMENT, APPARENT_MEASUREMENT, PHASE_A_MEASUREMENT"
         },
         "extra_state_attributes": [
-          "measurement_type",
-          null
+          "measurement_type"
         ]
       },
       {

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -377,6 +377,7 @@ async def async_test_em_rms_voltage(
     zha_gateway: Gateway, cluster: Cluster, entity: PlatformEntity
 ) -> None:
     """Test electrical measurement RMS Voltage sensor."""
+    assert entity.extra_state_attribute_names == {"measurement_type", "rms_voltage_max"}
 
     await send_attributes_report(zha_gateway, cluster, {0: 1, 0x0505: 1234})
     assert_state(entity, 123.4, "V")

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -331,6 +331,8 @@ async def async_test_em_power_factor(
     zha_gateway: Gateway, cluster: Cluster, entity: PlatformEntity
 ):
     """Test electrical measurement Power Factor sensor."""
+    assert entity.extra_state_attribute_names == {"measurement_type"}
+
     # update divisor cached value
     await send_attributes_report(zha_gateway, cluster, {"ac_power_divisor": 1})
     await send_attributes_report(zha_gateway, cluster, {0: 1, 0x0510: 100, 10: 1000})

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -683,8 +683,9 @@ class BaseElectricalMeasurement(PollableSensor):
         super().__init__(cluster_handlers, endpoint, device, **kwargs)
         self._attr_extra_state_attribute_names: set[str] = {
             "measurement_type",
-            self._attr_max_attribute_name,  # None values are ignored in HA
         }
+        if self._attr_max_attribute_name is not None:
+            self._attr_extra_state_attribute_names.add(self._attr_max_attribute_name)
 
     @property
     def state(self) -> dict[str, Any]:


### PR DESCRIPTION
### Proposed change

This fixes an issue where we included `None` as an extra state attribute name on some EM sensors to HA, causing (only) an unexpected warning to be logged. With this PR, the `None` name is removed from the `_attr_extra_state_attribute_names`.

### Background

Before the EM sensors clean up PR (https://github.com/zigpy/zha/pull/498), we always provided HA the extra state attributes with the attribute name and a `_max` suffix, even if that attribute did not exist in ZCL at all.

For `power_factor`, where no max attribute exists, the property evaluated to `power_factor_max`. This was the code: <https://github.com/zigpy/zha/blob/51dda469ad6869146e75a2e402b65a733b17f2a4/zha/application/platforms/sensor/__init__.py#L687-L690>
In the new ZHA release, the code for that is basically the same, except that the max attribute can be `None`. 
I thought we filter stuff, so left the `None` value until we remove `_max` state attributes soon, as this matched previous behavior more closely. This is the part in HA responsible for extra state attributes: <https://github.com/home-assistant/core/blob/b76f47cd9ff3d14c84be44ac6cce74a5776f3675/homeassistant/components/zha/sensor.py#L151-L170>

But that should also have logged with `power_factor_max`, since that's set in the state attributes that are supposedly provided. Except, we apparently include `power_factor_max` in the extra state attributes in HA, even though it doesn't exist: <https://github.com/home-assistant/core/blob/b76f47cd9ff3d14c84be44ac6cce74a5776f3675/homeassistant/components/zha/sensor.py#L37-L77>


### HA Future TO-DO

We can later remove non-existent ZCL attributes like `power_factor_max` from HA: https://github.com/home-assistant/core/blob/b76f47cd9ff3d14c84be44ac6cce74a5776f3675/homeassistant/components/zha/sensor.py#L37-L77


### Previous PR

This is a follow-up PR to:
- https://github.com/zigpy/zha/pull/498