### PR TITLE
Remove mypy `assignment` ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,6 @@ disable_error_code = [
     "attr-defined",
     "no-any-return",
     "no-untyped-call",
-    "assignment",
     "arg-type",
     "union-attr",
 ]
@@ -77,6 +76,9 @@ disable_error_code = [
 [[tool.mypy.overrides]]
 module = [
   "tests.*",
+]
+disable_error_code = [
+    "assignment"
 ]
 warn_unreachable = false
 

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -178,7 +178,7 @@ class Gateway(AsyncUtilMixin, EventBase):
         self._devices: dict[EUI64, Device] = {}
         self._groups: dict[int, Group] = {}
         self.application_controller: ControllerApplication = None
-        self.coordinator_zha_device: Device = None
+        self.coordinator_zha_device: Device | None = None
 
         self.shutting_down: bool = False
         self._reload_task: asyncio.Task | None = None
@@ -436,9 +436,10 @@ class Gateway(AsyncUtilMixin, EventBase):
 
     def device_left(self, device: zigpy.device.Device) -> None:
         """Handle device leaving the network."""
-        zha_device: Device = self._devices.get(device.ieee)
+        zha_device = self._devices.get(device.ieee)
         if zha_device is not None:
             zha_device.on_network = False
+
         self.async_update_device(device, available=False)
         self.emit(
             ZHA_GW_MSG_DEVICE_LEFT, DeviceLeftEvent(ieee=device.ieee, nwk=device.nwk)

--- a/zha/application/helpers.py
+++ b/zha/application/helpers.py
@@ -403,7 +403,7 @@ class GlobalUpdater:
 
     def __init__(self, gateway: Gateway):
         """Initialize the GlobalUpdater."""
-        self._updater_task_handle: asyncio.Task = None
+        self._updater_task_handle: asyncio.Task | None = None
         self._update_listeners: list[Callable] = []
         self._gateway: Gateway = gateway
 
@@ -470,7 +470,7 @@ class DeviceAvailabilityChecker:
     def __init__(self, gateway: Gateway):
         """Initialize the DeviceAvailabilityChecker."""
         self._gateway: Gateway = gateway
-        self._device_availability_task_handle: asyncio.Task = None
+        self._device_availability_task_handle: asyncio.Task | None = None
 
     def start(self):
         """Start the device availability checker."""

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -351,8 +351,9 @@ class PlatformEntity(BaseEntity):
         cluster_handlers: list[ClusterHandler],
         endpoint: Endpoint,
         device: Device,
+        *,
         entity_metadata: EntityMetadata | None = None,
-        legacy_discovery_unique_id: str | None = None,
+        legacy_discovery_unique_id: str,
         **kwargs: Any,
     ):
         """Initialize the platform entity."""

--- a/zha/application/platforms/alarm_control_panel/__init__.py
+++ b/zha/application/platforms/alarm_control_panel/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import functools
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from zigpy.zcl.clusters.security import IasAce
 
@@ -69,7 +69,9 @@ class AlarmControlPanel(PlatformEntity):
         """Initialize the ZHA alarm control device."""
         super().__init__(cluster_handlers, endpoint, device, **kwargs)
         alarm_options = device.gateway.config.config.alarm_control_panel_options
-        self._cluster_handler: IasAceClusterHandler = cluster_handlers[0]
+        self._cluster_handler: IasAceClusterHandler = cast(
+            IasAceClusterHandler, cluster_handlers[0]
+        )
         self._cluster_handler.panel_code = alarm_options.master_code
         self._cluster_handler.code_required_arm_actions = (
             alarm_options.arm_requires_code

--- a/zha/application/platforms/climate/__init__.py
+++ b/zha/application/platforms/climate/__init__.py
@@ -106,14 +106,14 @@ class Thermostat(PlatformEntity):
     ):
         """Initialize ZHA Thermostat instance."""
         super().__init__(cluster_handlers, endpoint, device, **kwargs)
-        self._preset = Preset.NONE
+        self._preset: Preset | str = Preset.NONE
         self._presets: list[Preset | str] = []
 
         self._thermostat_cluster_handler: ThermostatClusterHandler = cast(
             ThermostatClusterHandler, self.cluster_handlers[CLUSTER_HANDLER_THERMOSTAT]
         )
-        self._fan_cluster_handler: FanClusterHandler = cast(
-            FanClusterHandler, self.cluster_handlers[CLUSTER_HANDLER_FAN]
+        self._fan_cluster_handler: FanClusterHandler | None = cast(
+            FanClusterHandler | None, self.cluster_handlers.get(CLUSTER_HANDLER_FAN)
         )
 
         self._supported_features = ClimateEntityFeature(0)
@@ -441,7 +441,7 @@ class Thermostat(PlatformEntity):
         if preset_mode != Preset.NONE:
             await self.async_preset_handler(preset_mode, enable=True)
 
-        self._preset = Preset(preset_mode)
+        self._preset = preset_mode
         self.maybe_emit_state_changed_event()
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
@@ -916,9 +916,9 @@ class ZONNSMARTThermostat(Thermostat):
             if event.attribute_value == 1:
                 self._preset = Preset.NONE
             if event.attribute_value in (2, 3):
-                self._preset = Preset(self.PRESET_HOLIDAY)
+                self._preset = self.PRESET_HOLIDAY
             if event.attribute_value == 4:
-                self._preset = Preset(self.PRESET_FROST)
+                self._preset = self.PRESET_FROST
         super().handle_cluster_handler_attribute_updated(event)
 
     async def async_preset_handler(self, preset: str, enable: bool = False) -> None:

--- a/zha/application/platforms/climate/__init__.py
+++ b/zha/application/platforms/climate/__init__.py
@@ -6,7 +6,7 @@ from asyncio import Task
 from dataclasses import dataclass
 import datetime as dt
 import functools
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from zigpy.zcl.clusters.hvac import FanMode, RunningState, SystemMode
 
@@ -46,6 +46,7 @@ from zha.zigbee.cluster_handlers.const import (
     CLUSTER_HANDLER_FAN,
     CLUSTER_HANDLER_THERMOSTAT,
 )
+from zha.zigbee.cluster_handlers.hvac import FanClusterHandler, ThermostatClusterHandler
 
 if TYPE_CHECKING:
     from zha.zigbee.cluster_handlers import ClusterHandler
@@ -108,11 +109,11 @@ class Thermostat(PlatformEntity):
         self._preset = Preset.NONE
         self._presets: list[Preset | str] = []
 
-        self._thermostat_cluster_handler: ClusterHandler = self.cluster_handlers.get(
-            CLUSTER_HANDLER_THERMOSTAT
+        self._thermostat_cluster_handler: ThermostatClusterHandler = cast(
+            ThermostatClusterHandler, self.cluster_handlers[CLUSTER_HANDLER_THERMOSTAT]
         )
-        self._fan_cluster_handler: ClusterHandler = self.cluster_handlers.get(
-            CLUSTER_HANDLER_FAN
+        self._fan_cluster_handler: FanClusterHandler = cast(
+            FanClusterHandler, self.cluster_handlers[CLUSTER_HANDLER_FAN]
         )
 
         self._supported_features = ClimateEntityFeature(0)
@@ -440,7 +441,7 @@ class Thermostat(PlatformEntity):
         if preset_mode != Preset.NONE:
             await self.async_preset_handler(preset_mode, enable=True)
 
-        self._preset = preset_mode
+        self._preset = Preset(preset_mode)
         self.maybe_emit_state_changed_event()
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
@@ -915,9 +916,9 @@ class ZONNSMARTThermostat(Thermostat):
             if event.attribute_value == 1:
                 self._preset = Preset.NONE
             if event.attribute_value in (2, 3):
-                self._preset = self.PRESET_HOLIDAY
+                self._preset = Preset(self.PRESET_HOLIDAY)
             if event.attribute_value == 4:
-                self._preset = self.PRESET_FROST
+                self._preset = Preset(self.PRESET_FROST)
         super().handle_cluster_handler_attribute_updated(event)
 
     async def async_preset_handler(self, preset: str, enable: bool = False) -> None:

--- a/zha/application/platforms/device_tracker.py
+++ b/zha/application/platforms/device_tracker.py
@@ -58,9 +58,9 @@ class DeviceScannerEntity(PlatformEntity):
     ):
         """Initialize the ZHA device tracker."""
         super().__init__(cluster_handlers, endpoint, device, **kwargs)
-        self._battery_cluster_handler: ClusterHandler = self.cluster_handlers.get(
+        self._battery_cluster_handler: ClusterHandler = self.cluster_handlers[
             CLUSTER_HANDLER_POWER_CONFIGURATION
-        )
+        ]
         self._connected: bool = False
         self._keepalive_interval: int = 60
         self._should_poll: bool = True

--- a/zha/application/platforms/device_tracker.py
+++ b/zha/application/platforms/device_tracker.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import StrEnum
 import functools
 import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from zigpy.zcl.clusters.general import PowerConfiguration
 
@@ -19,6 +19,7 @@ from zha.zigbee.cluster_handlers.const import (
     CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
     CLUSTER_HANDLER_POWER_CONFIGURATION,
 )
+from zha.zigbee.cluster_handlers.general import PowerConfigurationClusterHandler
 
 if TYPE_CHECKING:
     from zha.zigbee.cluster_handlers import ClusterHandler
@@ -58,9 +59,10 @@ class DeviceScannerEntity(PlatformEntity):
     ):
         """Initialize the ZHA device tracker."""
         super().__init__(cluster_handlers, endpoint, device, **kwargs)
-        self._battery_cluster_handler: ClusterHandler = self.cluster_handlers[
-            CLUSTER_HANDLER_POWER_CONFIGURATION
-        ]
+        self._battery_cluster_handler: PowerConfigurationClusterHandler = cast(
+            PowerConfigurationClusterHandler,
+            self.cluster_handlers[CLUSTER_HANDLER_POWER_CONFIGURATION],
+        )
         self._connected: bool = False
         self._keepalive_interval: int = 60
         self._should_poll: bool = True

--- a/zha/application/platforms/fan/__init__.py
+++ b/zha/application/platforms/fan/__init__.py
@@ -439,6 +439,11 @@ class IkeaFan(BaseFan, PlatformEntity):
         else:
             await super().async_turn_on(speed, percentage, preset_mode)
 
+    async def _async_set_fan_mode(self, fan_mode: int) -> None:
+        """Set the fan mode for the fan."""
+        await self._fan_cluster_handler.async_set_speed(fan_mode)
+        self.maybe_emit_state_changed_event()
+
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed percentage of the fan."""
         fan_mode = math.ceil(percentage_to_ranged_value(self.speed_range, percentage))

--- a/zha/application/platforms/fan/__init__.py
+++ b/zha/application/platforms/fan/__init__.py
@@ -86,6 +86,11 @@ class BaseFan(BaseEntity):
     _attr_translation_key: str = "fan"
     _attr_primary_weight = 10
 
+    @property
+    @abstractmethod
+    def preset_mode(self) -> str | None:
+        """Return the current preset mode."""
+
     @functools.cached_property
     def preset_modes(self) -> list[str]:
         """Return the available preset modes."""
@@ -138,6 +143,40 @@ class BaseFan(BaseEntity):
         if preset_modes := self.preset_modes:
             speeds.extend(preset_modes)
         return speeds
+
+    @property
+    def speed(self) -> str | None:
+        """Return the current speed."""
+        if preset_mode := self.preset_mode:
+            return preset_mode
+        if (percentage := self.percentage) is None:
+            return None
+        return self.percentage_to_speed(percentage)
+
+    @functools.cached_property
+    def info_object(self) -> FanEntityInfo:
+        """Return a representation of the binary sensor."""
+        return FanEntityInfo(
+            **super().info_object.__dict__,
+            preset_modes=self.preset_modes,
+            supported_features=self.supported_features,
+            speed_count=self.speed_count,
+            speed_list=self.speed_list,
+        )
+
+    @property
+    def state(self) -> dict[str, Any]:
+        """Return the state of the fan."""
+        response = super().state
+        response.update(
+            {
+                "preset_mode": self.preset_mode,
+                "percentage": self.percentage,
+                "is_on": self.is_on,
+                "speed": self.speed,
+            }
+        )
+        return response
 
     async def async_turn_on(  # pylint: disable=unused-argument
         self,
@@ -203,7 +242,7 @@ class BaseFan(BaseEntity):
 
 
 @STRICT_MATCH(cluster_handler_names=CLUSTER_HANDLER_FAN)
-class Fan(PlatformEntity, BaseFan):
+class Fan(BaseFan, PlatformEntity):
     """Representation of a ZHA fan."""
 
     def __init__(
@@ -230,31 +269,6 @@ class Fan(PlatformEntity, BaseFan):
             )
         )
 
-    @functools.cached_property
-    def info_object(self) -> FanEntityInfo:
-        """Return a representation of the binary sensor."""
-        return FanEntityInfo(
-            **super().info_object.__dict__,
-            preset_modes=self.preset_modes,
-            supported_features=self.supported_features,
-            speed_count=self.speed_count,
-            speed_list=self.speed_list,
-        )
-
-    @property
-    def state(self) -> dict:
-        """Return the state of the fan."""
-        response = super().state
-        response.update(
-            {
-                "preset_mode": self.preset_mode,
-                "percentage": self.percentage,
-                "is_on": self.is_on,
-                "speed": self.speed,
-            }
-        )
-        return response
-
     @property
     def percentage(self) -> int | None:
         """Return the current speed percentage."""
@@ -274,15 +288,6 @@ class Fan(PlatformEntity, BaseFan):
         """Return the current preset mode."""
         return self.preset_modes_to_name.get(self._fan_cluster_handler.fan_mode)
 
-    @property
-    def speed(self) -> str | None:
-        """Return the current speed."""
-        if preset_mode := self.preset_mode:
-            return preset_mode
-        if (percentage := self.percentage) is None:
-            return None
-        return self.percentage_to_speed(percentage)
-
     async def _async_set_fan_mode(self, fan_mode: int) -> None:
         """Set the fan mode for the fan."""
         await self._fan_cluster_handler.async_set_speed(fan_mode)
@@ -290,7 +295,7 @@ class Fan(PlatformEntity, BaseFan):
 
 
 @GROUP_MATCH()
-class FanGroup(GroupEntity, BaseFan):
+class FanGroup(BaseFan, GroupEntity):
     """Representation of a fan group."""
 
     def __init__(self, group: Group):
@@ -305,31 +310,6 @@ class FanGroup(GroupEntity, BaseFan):
             delattr(self, "info_object")
         self.update()
 
-    @functools.cached_property
-    def info_object(self) -> FanEntityInfo:
-        """Return a representation of the binary sensor."""
-        return FanEntityInfo(
-            **super().info_object.__dict__,
-            preset_modes=self.preset_modes,
-            supported_features=self.supported_features,
-            speed_count=self.speed_count,
-            speed_list=self.speed_list,
-        )
-
-    @property
-    def state(self) -> dict[str, Any]:
-        """Return the state of the fan."""
-        response = super().state
-        response.update(
-            {
-                "preset_mode": self.preset_mode,
-                "percentage": self.percentage,
-                "is_on": self.is_on,
-                "speed": self.speed,
-            }
-        )
-        return response
-
     @property
     def percentage(self) -> int | None:
         """Return the current speed percentage."""
@@ -339,15 +319,6 @@ class FanGroup(GroupEntity, BaseFan):
     def preset_mode(self) -> str | None:
         """Return the current preset mode."""
         return self._preset_mode
-
-    @property
-    def speed(self) -> str | None:
-        """Return the current speed."""
-        if preset_mode := self.preset_mode:
-            return preset_mode
-        if (percentage := self.percentage) is None:
-            return None
-        return self.percentage_to_speed(percentage)
 
     async def _async_set_fan_mode(self, fan_mode: int) -> None:
         """Set the fan mode for the group."""
@@ -390,7 +361,7 @@ class FanGroup(GroupEntity, BaseFan):
     cluster_handler_names="ikea_airpurifier",
     models={"STARKVIND Air purifier", "STARKVIND Air purifier table"},
 )
-class IkeaFan(Fan):
+class IkeaFan(BaseFan, PlatformEntity):
     """Representation of an Ikea fan."""
 
     _attr_supported_features: FanEntityFeature = (
@@ -412,10 +383,21 @@ class IkeaFan(Fan):
         self._fan_cluster_handler: IkeaAirPurifierClusterHandler = cast(
             IkeaAirPurifierClusterHandler, self.cluster_handlers["ikea_airpurifier"]
         )
-        self._fan_cluster_handler.on_event(
-            CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
-            self.handle_cluster_handler_attribute_updated,
+
+    def on_add(self) -> None:
+        """Run when entity is added."""
+        super().on_add()
+        self._on_remove_callbacks.append(
+            self._fan_cluster_handler.on_event(
+                CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
+                self.handle_cluster_handler_attribute_updated,
+            )
         )
+
+    @property
+    def preset_mode(self) -> str | None:
+        """Return the current preset mode."""
+        return self.preset_modes_to_name.get(self._fan_cluster_handler.fan_mode)
 
     @functools.cached_property
     def preset_modes_to_name(self) -> dict[int, str]:

--- a/zha/application/platforms/fan/__init__.py
+++ b/zha/application/platforms/fan/__init__.py
@@ -211,9 +211,9 @@ class Fan(PlatformEntity, BaseFan):
     ) -> None:
         """Initialize the fan."""
         super().__init__(cluster_handlers, endpoint, device, **kwargs)
-        self._fan_cluster_handler: ClusterHandler = self.cluster_handlers.get(
+        self._fan_cluster_handler: ClusterHandler = self.cluster_handlers[
             CLUSTER_HANDLER_FAN
-        )
+        ]
         self.recompute_capabilities()
 
     def on_add(self) -> None:
@@ -403,9 +403,9 @@ class IkeaFan(Fan):
     ):
         """Initialize the fan."""
         super().__init__(cluster_handlers, endpoint, device, **kwargs)
-        self._fan_cluster_handler: ClusterHandler = self.cluster_handlers.get(
+        self._fan_cluster_handler: ClusterHandler = self.cluster_handlers[
             "ikea_airpurifier"
-        )
+        ]
         self._fan_cluster_handler.on_event(
             CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
             self.handle_cluster_handler_attribute_updated,

--- a/zha/application/platforms/fan/__init__.py
+++ b/zha/application/platforms/fan/__init__.py
@@ -6,7 +6,7 @@ from abc import abstractmethod
 from dataclasses import dataclass
 import functools
 import math
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from zigpy.zcl.clusters import hvac
 
@@ -46,6 +46,10 @@ from zha.zigbee.cluster_handlers import (
 from zha.zigbee.cluster_handlers.const import (
     CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
     CLUSTER_HANDLER_FAN,
+)
+from zha.zigbee.cluster_handlers.hvac import FanClusterHandler
+from zha.zigbee.cluster_handlers.manufacturerspecific import (
+    IkeaAirPurifierClusterHandler,
 )
 from zha.zigbee.group import Group
 
@@ -211,9 +215,9 @@ class Fan(PlatformEntity, BaseFan):
     ) -> None:
         """Initialize the fan."""
         super().__init__(cluster_handlers, endpoint, device, **kwargs)
-        self._fan_cluster_handler: ClusterHandler = self.cluster_handlers[
-            CLUSTER_HANDLER_FAN
-        ]
+        self._fan_cluster_handler: FanClusterHandler = cast(
+            FanClusterHandler, self.cluster_handlers[CLUSTER_HANDLER_FAN]
+        )
         self.recompute_capabilities()
 
     def on_add(self) -> None:
@@ -291,7 +295,9 @@ class FanGroup(GroupEntity, BaseFan):
 
     def __init__(self, group: Group):
         """Initialize a fan group."""
-        self._fan_cluster_handler: ClusterHandler = group.endpoint[hvac.Fan.cluster_id]
+        self._fan_cluster_handler: FanClusterHandler = cast(
+            FanClusterHandler, group.endpoint[hvac.Fan.cluster_id]
+        )
         super().__init__(group)
         self._percentage = None
         self._preset_mode = None
@@ -403,9 +409,9 @@ class IkeaFan(Fan):
     ):
         """Initialize the fan."""
         super().__init__(cluster_handlers, endpoint, device, **kwargs)
-        self._fan_cluster_handler: ClusterHandler = self.cluster_handlers[
-            "ikea_airpurifier"
-        ]
+        self._fan_cluster_handler: IkeaAirPurifierClusterHandler = cast(
+            IkeaAirPurifierClusterHandler, self.cluster_handlers["ikea_airpurifier"]
+        )
         self._fan_cluster_handler.on_event(
             CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
             self.handle_cluster_handler_attribute_updated,

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 import functools
 import itertools
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from zigpy.zcl.clusters.general import Identify, LevelControl, OnOff
 from zigpy.zcl.clusters.lighting import Color
@@ -73,7 +73,13 @@ from zha.zigbee.cluster_handlers.const import (
     CLUSTER_HANDLER_LEVEL_CHANGED,
     CLUSTER_HANDLER_ON_OFF,
 )
-from zha.zigbee.cluster_handlers.general import LevelChangeEvent
+from zha.zigbee.cluster_handlers.general import (
+    IdentifyClusterHandler,
+    LevelChangeEvent,
+    LevelControlClusterHandler,
+    OnOffClusterHandler,
+)
+from zha.zigbee.cluster_handlers.lighting import ColorClusterHandler
 
 if TYPE_CHECKING:
     from zha.zigbee.cluster_handlers import ClusterHandler
@@ -129,10 +135,10 @@ class BaseLight(BaseEntity, ABC):
         self._zha_config_transition: float = self._DEFAULT_MIN_TRANSITION_TIME
         self._zha_config_enhanced_light_transition: bool = False
         self._zha_config_enable_light_transitioning_flag: bool = True
-        self._on_off_cluster_handler: ClusterHandler | None = None
-        self._level_cluster_handler: ClusterHandler | None = None
-        self._color_cluster_handler: ClusterHandler | None = None
-        self._identify_cluster_handler: ClusterHandler | None = None
+        self._on_off_cluster_handler: OnOffClusterHandler | None = None
+        self._level_cluster_handler: LevelControlClusterHandler | None = None
+        self._color_cluster_handler: ColorClusterHandler | None = None
+        self._identify_cluster_handler: IdentifyClusterHandler | None = None
         self._transitioning_individual: bool = False
         self._transitioning_group: bool = False
         self._transition_listener: asyncio.TimerHandle | None = None
@@ -654,17 +660,20 @@ class Light(PlatformEntity, BaseLight):
     ) -> None:
         """Initialize the light."""
         super().__init__(cluster_handlers, endpoint, device, **kwargs)
-        self._on_off_cluster_handler: ClusterHandler = self.cluster_handlers[
-            CLUSTER_HANDLER_ON_OFF
-        ]
+        self._on_off_cluster_handler: OnOffClusterHandler = cast(
+            OnOffClusterHandler, self.cluster_handlers[CLUSTER_HANDLER_ON_OFF]
+        )
         self._state: bool = bool(self._on_off_cluster_handler.on_off)
-        self._level_cluster_handler: ClusterHandler = self.cluster_handlers[
-            CLUSTER_HANDLER_LEVEL
-        ]
-        self._color_cluster_handler: ClusterHandler = self.cluster_handlers[
-            CLUSTER_HANDLER_COLOR
-        ]
-        self._identify_cluster_handler: ClusterHandler | None = device.identify_ch
+        self._level_cluster_handler: LevelControlClusterHandler | None = cast(
+            LevelControlClusterHandler | None,
+            self.cluster_handlers.get(CLUSTER_HANDLER_LEVEL),
+        )
+        self._color_cluster_handler: ColorClusterHandler | None = cast(
+            ColorClusterHandler | None, self.cluster_handlers.get(CLUSTER_HANDLER_COLOR)
+        )
+        self._identify_cluster_handler: IdentifyClusterHandler | None = cast(
+            IdentifyClusterHandler | None, device.identify_ch
+        )
         if self._color_cluster_handler:
             self._min_mireds: int = self._color_cluster_handler.min_mireds
             self._max_mireds: int = self._color_cluster_handler.max_mireds
@@ -1039,17 +1048,21 @@ class LightGroup(GroupEntity, BaseLight):
         """Initialize a light group."""
         super().__init__(group)
 
-        self._on_off_cluster_handler: ClusterHandler = group.zigpy_group.endpoint[
-            OnOff.cluster_id
-        ]
-        self._level_cluster_handler: ClusterHandler | None = group.zigpy_group.endpoint[
-            LevelControl.cluster_id
-        ]
-        self._color_cluster_handler: ClusterHandler | None = group.zigpy_group.endpoint[
-            Color.cluster_id
-        ]
-        self._identify_cluster_handler: ClusterHandler | None = (
-            group.zigpy_group.endpoint[Identify.cluster_id]
+        # TODO: these type annotations are not correct, these are not cluster handler
+        # objects but are instead cluster proxies!
+        self._on_off_cluster_handler: OnOffClusterHandler = cast(
+            OnOffClusterHandler, group.zigpy_group.endpoint[OnOff.cluster_id]
+        )
+        self._level_cluster_handler: LevelControlClusterHandler | None = cast(
+            LevelControlClusterHandler | None,
+            group.zigpy_group.endpoint[LevelControl.cluster_id],
+        )
+        self._color_cluster_handler: ColorClusterHandler | None = cast(
+            ColorClusterHandler | None, group.zigpy_group.endpoint[Color.cluster_id]
+        )
+        self._identify_cluster_handler: IdentifyClusterHandler | None = cast(
+            IdentifyClusterHandler | None,
+            group.zigpy_group.endpoint[Identify.cluster_id],
         )
 
         self._debounced_member_refresh: Debouncer | None = Debouncer(

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from abc import ABC
 import asyncio
 from collections import Counter
-from collections.abc import Callable
 import contextlib
 import dataclasses
 from dataclasses import dataclass
@@ -112,7 +111,6 @@ class BaseLight(BaseEntity, ABC):
 
     def __init__(self, *args, **kwargs):
         """Initialize the light."""
-        self._device: Device = None
         super().__init__(*args, **kwargs)
         self._min_mireds: int | None = 153
         self._max_mireds: int | None = 500
@@ -128,16 +126,16 @@ class BaseLight(BaseEntity, ABC):
         self._effect: str = EFFECT_OFF
         self._supported_color_modes: set[ColorMode] = set()
         self._external_supported_color_modes: set[ColorMode] = set()
-        self._zha_config_transition: int = self._DEFAULT_MIN_TRANSITION_TIME
+        self._zha_config_transition: float = self._DEFAULT_MIN_TRANSITION_TIME
         self._zha_config_enhanced_light_transition: bool = False
         self._zha_config_enable_light_transitioning_flag: bool = True
-        self._on_off_cluster_handler: ClusterHandler = None
-        self._level_cluster_handler: ClusterHandler = None
-        self._color_cluster_handler: ClusterHandler = None
-        self._identify_cluster_handler: ClusterHandler = None
+        self._on_off_cluster_handler: ClusterHandler | None = None
+        self._level_cluster_handler: ClusterHandler | None = None
+        self._color_cluster_handler: ClusterHandler | None = None
+        self._identify_cluster_handler: ClusterHandler | None = None
         self._transitioning_individual: bool = False
         self._transitioning_group: bool = False
-        self._transition_listener: Callable[[], None] | None = None
+        self._transition_listener: asyncio.TimerHandle | None = None
 
     @property
     def state(self) -> dict[str, Any]:
@@ -660,13 +658,13 @@ class Light(PlatformEntity, BaseLight):
             CLUSTER_HANDLER_ON_OFF
         ]
         self._state: bool = bool(self._on_off_cluster_handler.on_off)
-        self._level_cluster_handler: ClusterHandler = self.cluster_handlers.get(
+        self._level_cluster_handler: ClusterHandler = self.cluster_handlers[
             CLUSTER_HANDLER_LEVEL
-        )
-        self._color_cluster_handler: ClusterHandler = self.cluster_handlers.get(
+        ]
+        self._color_cluster_handler: ClusterHandler = self.cluster_handlers[
             CLUSTER_HANDLER_COLOR
-        )
-        self._identify_cluster_handler: ClusterHandler = device.identify_ch
+        ]
+        self._identify_cluster_handler: ClusterHandler | None = device.identify_ch
         if self._color_cluster_handler:
             self._min_mireds: int = self._color_cluster_handler.min_mireds
             self._max_mireds: int = self._color_cluster_handler.max_mireds
@@ -1044,15 +1042,15 @@ class LightGroup(GroupEntity, BaseLight):
         self._on_off_cluster_handler: ClusterHandler = group.zigpy_group.endpoint[
             OnOff.cluster_id
         ]
-        self._level_cluster_handler: None | (
-            ClusterHandler
-        ) = group.zigpy_group.endpoint[LevelControl.cluster_id]
-        self._color_cluster_handler: None | (
-            ClusterHandler
-        ) = group.zigpy_group.endpoint[Color.cluster_id]
-        self._identify_cluster_handler: None | (
-            ClusterHandler
-        ) = group.zigpy_group.endpoint[Identify.cluster_id]
+        self._level_cluster_handler: ClusterHandler | None = group.zigpy_group.endpoint[
+            LevelControl.cluster_id
+        ]
+        self._color_cluster_handler: ClusterHandler | None = group.zigpy_group.endpoint[
+            Color.cluster_id
+        ]
+        self._identify_cluster_handler: ClusterHandler | None = (
+            group.zigpy_group.endpoint[Identify.cluster_id]
+        )
 
         self._debounced_member_refresh: Debouncer | None = Debouncer(
             self.group.gateway,

--- a/zha/application/platforms/lock/__init__.py
+++ b/zha/application/platforms/lock/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import functools
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from zigpy.zcl.clusters.closures import DoorLock as DoorLockCluster
 from zigpy.zcl.foundation import Status
@@ -17,6 +17,7 @@ from zha.application.platforms.lock.const import (
 )
 from zha.application.registries import PLATFORM_ENTITIES
 from zha.zigbee.cluster_handlers import ClusterAttributeUpdatedEvent
+from zha.zigbee.cluster_handlers.closures import DoorLockClusterHandler
 from zha.zigbee.cluster_handlers.const import (
     CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
     CLUSTER_HANDLER_DOORLOCK,
@@ -47,9 +48,9 @@ class DoorLock(PlatformEntity):
     ) -> None:
         """Initialize the lock."""
         super().__init__(cluster_handlers, endpoint, device, **kwargs)
-        self._doorlock_cluster_handler: ClusterHandler = self.cluster_handlers[
-            CLUSTER_HANDLER_DOORLOCK
-        ]
+        self._doorlock_cluster_handler: DoorLockClusterHandler = cast(
+            DoorLockClusterHandler, self.cluster_handlers[CLUSTER_HANDLER_DOORLOCK]
+        )
         self._state: str | None = VALUE_TO_STATE.get(
             self._doorlock_cluster_handler.cluster.get("lock_state"), None
         )

--- a/zha/application/platforms/lock/__init__.py
+++ b/zha/application/platforms/lock/__init__.py
@@ -47,9 +47,9 @@ class DoorLock(PlatformEntity):
     ) -> None:
         """Initialize the lock."""
         super().__init__(cluster_handlers, endpoint, device, **kwargs)
-        self._doorlock_cluster_handler: ClusterHandler = self.cluster_handlers.get(
+        self._doorlock_cluster_handler: ClusterHandler = self.cluster_handlers[
             CLUSTER_HANDLER_DOORLOCK
-        )
+        ]
         self._state: str | None = VALUE_TO_STATE.get(
             self._doorlock_cluster_handler.cluster.get("lock_state"), None
         )

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -681,9 +681,7 @@ class BaseElectricalMeasurement(PollableSensor):
     ) -> None:
         """Init this sensor."""
         super().__init__(cluster_handlers, endpoint, device, **kwargs)
-        self._attr_extra_state_attribute_names: set[str] = {
-            "measurement_type",
-        }
+        self._attr_extra_state_attribute_names: set[str] = {"measurement_type"}
         if self._attr_max_attribute_name is not None:
             self._attr_extra_state_attribute_names.add(self._attr_max_attribute_name)
 

--- a/zha/application/platforms/update.py
+++ b/zha/application/platforms/update.py
@@ -232,13 +232,13 @@ class BaseFirmwareUpdateEntity(PlatformEntity):
 
             firmware = self._compatible_images.upgrades[0]
         else:
-            version = int(version, 16)
+            version_int = int(version, 16)
 
             for firmware in itertools.chain(
                 self._compatible_images.upgrades,
                 self._compatible_images.downgrades,
             ):
-                if firmware.version == version:
+                if firmware.version == version_int:
                     break
             else:
                 raise ZHAException(f"Version {version!r} is not available")

--- a/zha/zigbee/cluster_handlers/hvac.py
+++ b/zha/zigbee/cluster_handlers/hvac.py
@@ -229,12 +229,12 @@ class ThermostatClusterHandler(ClusterHandler):
         return self.cluster.get(Thermostat.AttributeDefs.occupied_heating_setpoint.name)
 
     @property
-    def pi_cooling_demand(self) -> int:
+    def pi_cooling_demand(self) -> int | None:
         """Cooling demand."""
         return self.cluster.get(Thermostat.AttributeDefs.pi_cooling_demand.name)
 
     @property
-    def pi_heating_demand(self) -> int:
+    def pi_heating_demand(self) -> int | None:
         """Heating demand."""
         return self.cluster.get(Thermostat.AttributeDefs.pi_heating_demand.name)
 

--- a/zha/zigbee/cluster_handlers/manufacturerspecific.py
+++ b/zha/zigbee/cluster_handlers/manufacturerspecific.py
@@ -51,7 +51,6 @@ from zha.zigbee.cluster_handlers.const import (
     UNKNOWN,
 )
 from zha.zigbee.cluster_handlers.general import MultistateInputClusterHandler
-from zha.zigbee.cluster_handlers.hvac import FanClusterHandler
 
 from .homeautomation import DiagnosticClusterHandler
 from .hvac import ThermostatClusterHandler, UserInterfaceClusterHandler
@@ -435,10 +434,10 @@ class InovelliConfigEntityClusterHandler(ClusterHandler):
 
 @registries.CLUSTER_HANDLER_ONLY_CLUSTERS.register(IKEA_AIR_PURIFIER_CLUSTER)
 @registries.CLUSTER_HANDLER_REGISTRY.register(IKEA_AIR_PURIFIER_CLUSTER)
-class IkeaAirPurifierClusterHandler(FanClusterHandler):
+class IkeaAirPurifierClusterHandler(ClusterHandler):
     """IKEA Air Purifier cluster handler."""
 
-    REPORT_CONFIG = (  # type: ignore[assignment]
+    REPORT_CONFIG = (
         AttrReportConfig(attr="filter_run_time", config=REPORT_CONFIG_DEFAULT),
         AttrReportConfig(attr="replace_filter", config=REPORT_CONFIG_IMMEDIATE),
         AttrReportConfig(attr="filter_life_time", config=REPORT_CONFIG_DEFAULT),
@@ -451,13 +450,27 @@ class IkeaAirPurifierClusterHandler(FanClusterHandler):
     )
 
     @property
+    def fan_mode(self) -> int | None:
+        """Return current fan mode."""
+        return self.cluster.get("fan_mode")
+
+    @property
     def fan_speed(self) -> int | None:
         """Return current fan speed."""
         return self.cluster.get("fan_speed")
 
+    @property
+    def fan_mode_sequence(self) -> int | None:
+        """Return possible fan mode speeds."""
+        return self.cluster.get("fan_mode_sequence")
+
+    async def async_set_speed(self, value) -> None:
+        """Set the speed of the fan."""
+        await self.write_attributes_safe({"fan_mode": value})
+
     async def async_update(self) -> None:
         """Retrieve latest state."""
-        await super().async_update()
+        await self.get_attribute_value("fan_mode", from_cache=False)
         await self.get_attribute_value("fan_speed", from_cache=False)
 
 

--- a/zha/zigbee/cluster_handlers/manufacturerspecific.py
+++ b/zha/zigbee/cluster_handlers/manufacturerspecific.py
@@ -51,6 +51,7 @@ from zha.zigbee.cluster_handlers.const import (
     UNKNOWN,
 )
 from zha.zigbee.cluster_handlers.general import MultistateInputClusterHandler
+from zha.zigbee.cluster_handlers.hvac import FanClusterHandler
 
 from .homeautomation import DiagnosticClusterHandler
 from .hvac import ThermostatClusterHandler, UserInterfaceClusterHandler
@@ -434,10 +435,10 @@ class InovelliConfigEntityClusterHandler(ClusterHandler):
 
 @registries.CLUSTER_HANDLER_ONLY_CLUSTERS.register(IKEA_AIR_PURIFIER_CLUSTER)
 @registries.CLUSTER_HANDLER_REGISTRY.register(IKEA_AIR_PURIFIER_CLUSTER)
-class IkeaAirPurifierClusterHandler(ClusterHandler):
+class IkeaAirPurifierClusterHandler(FanClusterHandler):
     """IKEA Air Purifier cluster handler."""
 
-    REPORT_CONFIG = (
+    REPORT_CONFIG = (  # type: ignore[assignment]
         AttrReportConfig(attr="filter_run_time", config=REPORT_CONFIG_DEFAULT),
         AttrReportConfig(attr="replace_filter", config=REPORT_CONFIG_IMMEDIATE),
         AttrReportConfig(attr="filter_life_time", config=REPORT_CONFIG_DEFAULT),
@@ -450,27 +451,13 @@ class IkeaAirPurifierClusterHandler(ClusterHandler):
     )
 
     @property
-    def fan_mode(self) -> int | None:
-        """Return current fan mode."""
-        return self.cluster.get("fan_mode")
-
-    @property
     def fan_speed(self) -> int | None:
         """Return current fan speed."""
         return self.cluster.get("fan_speed")
 
-    @property
-    def fan_mode_sequence(self) -> int | None:
-        """Return possible fan mode speeds."""
-        return self.cluster.get("fan_mode_sequence")
-
-    async def async_set_speed(self, value) -> None:
-        """Set the speed of the fan."""
-        await self.write_attributes_safe({"fan_mode": value})
-
     async def async_update(self) -> None:
         """Retrieve latest state."""
-        await self.get_attribute_value("fan_mode", from_cache=False)
+        await super().async_update()
         await self.get_attribute_value("fan_speed", from_cache=False)
 
 
@@ -507,7 +494,7 @@ class SonoffPresenceSenorClusterHandler(ClusterHandler):
 class DanfossThermostatClusterHandler(ThermostatClusterHandler):
     """Thermostat cluster handler for the Danfoss TRV and derivatives."""
 
-    REPORT_CONFIG = (
+    REPORT_CONFIG = (  # type: ignore[assignment]
         *ThermostatClusterHandler.REPORT_CONFIG,
         AttrReportConfig(attr="open_window_detection", config=REPORT_CONFIG_DEFAULT),
         AttrReportConfig(attr="heat_required", config=REPORT_CONFIG_ASAP),

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Iterator
 import copy
 import dataclasses
 from dataclasses import dataclass
@@ -66,6 +66,7 @@ from zha.application.const import (
 )
 from zha.application.helpers import convert_to_zcl_values, convert_zcl_value
 from zha.application.platforms import (
+    BaseEntity,
     BaseEntityInfo,
     EntityStateChangedEvent,
     PlatformEntity,
@@ -924,6 +925,8 @@ class Device(LogMixin, EventBase):
                 entity._attr_fallback_name = meta.new_fallback_name
 
     def _discover_new_entities(self) -> None:
+        new_entities: Iterator[BaseEntity]
+
         if self.is_active_coordinator:
             new_entities = discovery.DEVICE_PROBE.discover_coordinator_device_entities(
                 self
@@ -1507,13 +1510,13 @@ class Device(LogMixin, EventBase):
                 if cluster_info is not None:
                     cluster_info.pop("commands", None)
 
-            obj = {
+            obj: dict[str, Any] = {
                 "info_object": info_object,
                 "state": platform_entity.state,
             }
 
             if platform_entity.extra_state_attribute_names is not None:
-                obj["extra_state_attributes"] = (
+                obj["extra_state_attributes"] = list(
                     platform_entity.extra_state_attribute_names
                 )
 

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -1516,7 +1516,7 @@ class Device(LogMixin, EventBase):
             }
 
             if platform_entity.extra_state_attribute_names is not None:
-                obj["extra_state_attributes"] = list(
+                obj["extra_state_attributes"] = sorted(
                     platform_entity.extra_state_attribute_names
                 )
 


### PR DESCRIPTION
It would have flagged https://github.com/zigpy/zha/pull/505.

This PR reshuffles types in a few platforms and slightly cleans up the `fan` platform. A lot of cluster handlers are pulled from the cluster handler dict via `.get` but very, very few are ever `None`, this has been made stricter.

Some TODOs:
- Group light entities directly use clusters instead of cluster handlers, which expose an identical command interface to `ClusterHandler`. This is pretty messy but required to utilize the `Light` base class logic.