### PR TITLE
Retry binding and attribute reporting configuration during device configuration

### DIFF
--- a/tests/test_cluster_handlers.py
+++ b/tests/test_cluster_handlers.py
@@ -328,7 +328,7 @@ async def test_cluster_handler_bind_error(
 
     await cluster_handler.async_configure()
 
-    assert cluster.bind.await_count == 1
+    assert cluster.bind.await_count == 3
     assert cluster.configure_reporting.await_count == 0
     assert f"Failed to bind '{cluster.ep_attribute}' cluster:" in caplog.text
 
@@ -360,7 +360,7 @@ async def test_cluster_handler_configure_reporting_error(
     await cluster_handler.async_configure()
 
     assert cluster.bind.await_count == 1
-    assert cluster.configure_reporting_multiple.await_count == 1
+    assert cluster.configure_reporting_multiple.await_count == 3
     assert f"failed to set reporting on '{cluster.ep_attribute}' cluster" in caplog.text
 
 

--- a/zha/zigbee/cluster_handlers/__init__.py
+++ b/zha/zigbee/cluster_handlers/__init__.py
@@ -287,7 +287,7 @@ class ClusterHandler(LogMixin, EventBase):
         devices are unreachable.
         """
         try:
-            res = await self.cluster.bind()
+            res = await RETRYABLE_REQUEST_DECORATOR(self.cluster.bind)()
             self.debug("bound '%s' cluster: %s", self.cluster.ep_attribute, res[0])
             self._endpoint.device.emit(
                 ZHA_CLUSTER_HANDLER_MSG_BIND,
@@ -354,7 +354,9 @@ class ClusterHandler(LogMixin, EventBase):
         while chunk:
             reports = {rec["attr"]: rec["config"] for rec in chunk}
             try:
-                res = await self.cluster.configure_reporting_multiple(reports, **kwargs)
+                res = await RETRYABLE_REQUEST_DECORATOR(
+                    self.cluster.configure_reporting_multiple
+                )(reports, **kwargs)
                 self._configure_reporting_status(reports, res[0], event_data)
             except (zigpy.exceptions.ZigbeeException, TimeoutError) as ex:
                 self.debug(
@@ -447,9 +449,11 @@ class ClusterHandler(LogMixin, EventBase):
         if self.BIND:
             self.debug("Performing cluster binding")
             await self.bind()
+
         if self.cluster.is_server:
             self.debug("Configuring cluster attribute reporting")
             await self.configure_reporting()
+
         self.debug("finished cluster handler configuration")
         self._status = ClusterHandlerStatus.CONFIGURED
 
@@ -590,7 +594,9 @@ class ClusterHandler(LogMixin, EventBase):
         while chunk:
             try:
                 self.debug("Reading attributes in chunks: %s", chunk)
-                read, _ = await self.cluster.read_attributes(
+                read, _ = await RETRYABLE_REQUEST_DECORATOR(
+                    self.cluster.read_attributes
+                )(
                     chunk,
                     allow_cache=from_cache,
                     only_cache=only_cache,

--- a/zha/zigbee/cluster_handlers/__init__.py
+++ b/zha/zigbee/cluster_handlers/__init__.py
@@ -439,16 +439,18 @@ class ClusterHandler(LogMixin, EventBase):
 
     async def async_configure(self) -> None:
         """Set cluster binding and attribute reporting."""
-        if not self._endpoint.device.skip_configuration:
-            if self.BIND:
-                self.debug("Performing cluster binding")
-                await self.bind()
-            if self.cluster.is_server:
-                self.debug("Configuring cluster attribute reporting")
-                await self.configure_reporting()
-            self.debug("finished cluster handler configuration")
-        else:
+        if self._endpoint.device.skip_configuration:
             self.debug("skipping cluster handler configuration")
+            self._status = ClusterHandlerStatus.CONFIGURED
+            return
+
+        if self.BIND:
+            self.debug("Performing cluster binding")
+            await self.bind()
+        if self.cluster.is_server:
+            self.debug("Configuring cluster attribute reporting")
+            await self.configure_reporting()
+        self.debug("finished cluster handler configuration")
         self._status = ClusterHandlerStatus.CONFIGURED
 
     async def async_initialize(self, from_cache: bool) -> None:

--- a/zha/zigbee/cluster_handlers/__init__.py
+++ b/zha/zigbee/cluster_handlers/__init__.py
@@ -446,12 +446,6 @@ class ClusterHandler(LogMixin, EventBase):
             if self.cluster.is_server:
                 self.debug("Configuring cluster attribute reporting")
                 await self.configure_reporting()
-            ch_specific_cfg = getattr(
-                self, "async_configure_cluster_handler_specific", None
-            )
-            if ch_specific_cfg:
-                self.debug("Performing cluster handler specific configuration")
-                await ch_specific_cfg()
             self.debug("finished cluster handler configuration")
         else:
             self.debug("skipping cluster handler configuration")


### PR DESCRIPTION
Currently, ZHA will skip binding and attribute reporting configuration if the request fails. This PR adds three retries, matching all other commands.