### PR TITLE
Remove "Nabu Casa" from device name

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -399,6 +399,34 @@ async def test_coordinator_info_generic_name(
 
     assert current_coordinator.model == "Generic Zigbee Coordinator (EZSP)"
     assert current_coordinator.manufacturer == ""
+    assert current_coordinator.name == " Generic Zigbee Coordinator (EZSP)"
+
+
+async def test_name_nabu_casa_devices(
+    zha_gateway: Gateway,
+) -> None:
+    """Test that Nabu Casa devices strip the manufacturer from the name."""
+
+    current_coord_dev = zigpy_device(
+        zha_gateway, ieee="aa:bb:cc:dd:ee:ff:00:11", nwk=0x0000
+    )
+    current_coord_dev.node_desc = current_coord_dev.node_desc.replace(
+        logical_type=zdo_t.LogicalType.Coordinator
+    )
+
+    app = current_coord_dev.application
+    app.state.node_info.ieee = current_coord_dev.ieee
+    app.state.node_info.model = "Home Assistant Connect ZBT-2"
+    app.state.node_info.manufacturer = "Nabu Casa"
+
+    current_coordinator = await join_zigpy_device(zha_gateway, current_coord_dev)
+    assert current_coordinator.is_active_coordinator
+
+    assert current_coordinator.model == "Home Assistant Connect ZBT-2"
+    assert current_coordinator.manufacturer == "Nabu Casa"
+
+    # device name doesn't include manufacturer
+    assert current_coordinator.name == "Home Assistant Connect ZBT-2"
 
 
 async def test_async_get_clusters(

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -353,10 +353,44 @@ async def test_device_is_active_coordinator(
     assert not stale_coordinator.is_active_coordinator
 
 
-async def test_coordinator_info_uses_node_info(
+@pytest.mark.parametrize(
+    # node_info is populated with manf and model strings
+    ("manf", "model", "expected_manf", "expected_model", "expected_name"),
+    [
+        ("RealManf", "RealModel", "RealManf", "RealModel", "RealManf RealModel"),
+        (
+            "RealManf",
+            None,
+            "RealManf",
+            "Generic Zigbee Coordinator (EZSP)",
+            "RealManf Generic Zigbee Coordinator (EZSP)",
+        ),
+        (None, "RealModel", "", "RealModel", " RealModel"),
+        (
+            None,
+            None,
+            "",
+            "Generic Zigbee Coordinator (EZSP)",
+            " Generic Zigbee Coordinator (EZSP)",
+        ),
+        (
+            "Nabu Casa",
+            "Home Assistant Connect ZBT-2",
+            "Nabu Casa",
+            "Home Assistant Connect ZBT-2",
+            "Home Assistant Connect ZBT-2",
+        ),
+    ],
+)
+async def test_coordinator_info_names(
     zha_gateway: Gateway,
+    manf,
+    model,
+    expected_manf,
+    expected_model,
+    expected_name,
 ) -> None:
-    """Test that the current coordinator uses strings from `node_info`."""
+    """Test that the current coordinator device is named correctly."""
 
     current_coord_dev = zigpy_device(
         zha_gateway, ieee="aa:bb:cc:dd:ee:ff:00:11", nwk=0x0000
@@ -367,66 +401,15 @@ async def test_coordinator_info_uses_node_info(
 
     app = current_coord_dev.application
     app.state.node_info.ieee = current_coord_dev.ieee
-    app.state.node_info.model = "Real Coordinator Model"
-    app.state.node_info.manufacturer = "Real Coordinator Manufacturer"
+    app.state.node_info.manufacturer = manf
+    app.state.node_info.model = model
 
     current_coordinator = await join_zigpy_device(zha_gateway, current_coord_dev)
     assert current_coordinator.is_active_coordinator
 
-    assert current_coordinator.model == "Real Coordinator Model"
-    assert current_coordinator.manufacturer == "Real Coordinator Manufacturer"
-
-
-async def test_coordinator_info_generic_name(
-    zha_gateway: Gateway,
-) -> None:
-    """Test that the current coordinator uses strings from `node_info`."""
-
-    current_coord_dev = zigpy_device(
-        zha_gateway, ieee="aa:bb:cc:dd:ee:ff:00:11", nwk=0x0000
-    )
-    current_coord_dev.node_desc = current_coord_dev.node_desc.replace(
-        logical_type=zdo_t.LogicalType.Coordinator
-    )
-
-    app = current_coord_dev.application
-    app.state.node_info.ieee = current_coord_dev.ieee
-    app.state.node_info.model = None
-    app.state.node_info.manufacturer = None
-
-    current_coordinator = await join_zigpy_device(zha_gateway, current_coord_dev)
-    assert current_coordinator.is_active_coordinator
-
-    assert current_coordinator.model == "Generic Zigbee Coordinator (EZSP)"
-    assert current_coordinator.manufacturer == ""
-    assert current_coordinator.name == " Generic Zigbee Coordinator (EZSP)"
-
-
-async def test_name_nabu_casa_devices(
-    zha_gateway: Gateway,
-) -> None:
-    """Test that Nabu Casa devices strip the manufacturer from the name."""
-
-    current_coord_dev = zigpy_device(
-        zha_gateway, ieee="aa:bb:cc:dd:ee:ff:00:11", nwk=0x0000
-    )
-    current_coord_dev.node_desc = current_coord_dev.node_desc.replace(
-        logical_type=zdo_t.LogicalType.Coordinator
-    )
-
-    app = current_coord_dev.application
-    app.state.node_info.ieee = current_coord_dev.ieee
-    app.state.node_info.model = "Home Assistant Connect ZBT-2"
-    app.state.node_info.manufacturer = "Nabu Casa"
-
-    current_coordinator = await join_zigpy_device(zha_gateway, current_coord_dev)
-    assert current_coordinator.is_active_coordinator
-
-    assert current_coordinator.model == "Home Assistant Connect ZBT-2"
-    assert current_coordinator.manufacturer == "Nabu Casa"
-
-    # device name doesn't include manufacturer
-    assert current_coordinator.name == "Home Assistant Connect ZBT-2"
+    assert current_coordinator.manufacturer == expected_manf
+    assert current_coordinator.model == expected_model
+    assert current_coordinator.name == expected_name
 
 
 async def test_async_get_clusters(

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -323,6 +323,9 @@ class Device(LogMixin, EventBase):
     @cached_property
     def name(self) -> str:
         """Return device name."""
+        # Nabu Casa devices include a brand name in the model
+        if self.manufacturer == "Nabu Casa":
+            return self.model
         return f"{self.manufacturer} {self.model}"
 
     @property


### PR DESCRIPTION
## Proposed change

For any devices with the "Nabu Casa" manufacturer string, this PR removes that value from the full device name that's used to create device entries in Home Assistant.

Do note that both the independent manufacturer and model values stay untouched. This only affects the "combined name".

This PR also combines the following tests: 
- `test_coordinator_info_uses_node_info`
- `test_coordinator_info_generic_name`
- `test_name_nabu_casa_devices` (temporarily added in [`7cffa90` (#539)](https://github.com/zigpy/zha/pull/539/commits/7cffa902c5fb5aff92fe5a454e2c82e86d9f0bf3))

### Other options for tests

We can also revert the latest commit that combines these tests ([`a505b8b` (#539)](https://github.com/zigpy/zha/pull/539/commits/a505b8b208aea71a250d64e53dacdec5f6fa2684)) and do this in another PR if we prefer that.

By expanding the tests cases, I've also noticed that we currently include a leading space for the full name if the manufacturer name is not provided. We should fix this in a follow-up PR, but for now, the unchanged behavior is at least seen in tests.
This likely hasn't caused us any actual issues so far, since HA might strip leading and trailing spaces from device names.


## Additional information

This is done to avoid the ZHA coordinator device entry being called "Nabu Casa Home Assistant Connect ZBT-2" by default.
Since all devices with the "Nabu Casa" manufacturer include a "brand name" (HA Connect) in the model name, we can remove that from the "name" completely. 

I also don't necessarily think we should hard-code all the "Home Assistant Connect ZBT-X" model names for the check, since what I mentioned above should apply to all Nabu Casa devices AFAIK. We can do this if required, of course.
If we can (/want to) move this into quirks in the future (see thought below), we'll do it there.

If we want to tighten the check, but keep it in a generic way for onw, we could also check that model includes just "Home Assistant" or "Home Assistant Connect" before removing "Nabu Casa" from the "combined name".

### Backlog issue

Fixes: https://github.com/zigpy/backlog/issues/44

### Other implementation possibilities

I previously played around with implementing that in Home Assistant's ZHA integration, but had nothing that I liked really much. Since ZHA is the base for the "{manf} {model}" string, and we already have special cases for active coordinators in ZHA, it makes the most sense to implement this here IMO.

Another thought was that we may be able to move this out of ZHA into quirks at some point. Right now, `friendly_name` only supports overriding the manufacturer and model individually, and we shouldn't set the manufacturer to an empty string, as that will break the "by Nabu Casa" text in HA.
But we could consider expanding this in quirks v2 in the future, since we may be able to use this for other devices, where having both the manufacturer and model name combined is redundant, for example.

See below for a sample implementation in HA's ZHA integration within the [`device_info` method](https://github.com/home-assistant/core/blob/59ca88a7e83a4cab2cb55b5feeccc60cd876dcef/homeassistant/components/zha/helpers.py#L329-L352):
<details><summary>Possible `device_info` implementation (click to open)</summary>
<p>

```python
    @property
    def device_info(self) -> dict[str, Any]:
        """Return a device description for device."""
        # ...
        name = self.device.name or ieee
        if self.device.manufacturer == "Nabu Casa":
            name = self.device.model
        return {
           # ...
            ATTR_MANUFACTURER: self.device.manufacturer,
            ATTR_MODEL: self.device.model,
            ATTR_NAME: name,
            # ...
        }
```

</p>
</details> 