### PR TITLE
Fix `IasZone` binary sensor not implementing `recompute_capabilities`

### DIFF
--- a/zha/application/platforms/binary_sensor/__init__.py
+++ b/zha/application/platforms/binary_sensor/__init__.py
@@ -247,16 +247,10 @@ class IASZone(BinarySensor):
 
     # TODO: split this sensor off into individual sensor classes per IASZone type
 
-    def __init__(
-        self,
-        cluster_handlers: list[ClusterHandler],
-        endpoint: Endpoint,
-        device: Device,
-        **kwargs,
-    ) -> None:
-        """Initialize the ZHA binary sensor."""
-        cluster_handler = cluster_handlers[0]
-        zone_type = cluster_handler.cluster.get("zone_type")
+    def recompute_capabilities(self) -> None:
+        """Recompute capabilities."""
+        super().recompute_capabilities()
+        zone_type = self._cluster_handler.cluster.get("zone_type")
 
         if zone_type is None:
             self._attr_translation_key = "ias_zone"
@@ -267,8 +261,6 @@ class IASZone(BinarySensor):
                 None if zone_type in IAS_ZONE_CLASS_MAPPING else "ias_zone"
             )
             self._attr_device_class = IAS_ZONE_CLASS_MAPPING.get(zone_type)
-
-        super().__init__(cluster_handlers, endpoint, device, **kwargs)
 
     @staticmethod
     def parse(value: bool | int) -> bool:

--- a/zha/application/platforms/binary_sensor/__init__.py
+++ b/zha/application/platforms/binary_sensor/__init__.py
@@ -75,6 +75,7 @@ class BinarySensor(PlatformEntity):
         self._cluster_handler = cluster_handlers[0]
         super().__init__(cluster_handlers, endpoint, device, **kwargs)
         self._state: bool = self.is_on
+        self.recompute_capabilities()
 
     def on_add(self) -> None:
         """Run when entity is added."""


### PR DESCRIPTION
## Proposed change

This PR fixes an issue where the `IasZone` binary sensor did not get its device class and translation key assigned.

This is done by correctly implementing `recompute_capabilities` for the `IASZone` class. Before, it tried to directly access attribute cache during initialization, at which point it would not have been read for real devices.


## Additional information

- Related PR (which "caused" the issue): https://github.com/zigpy/zha/pull/365
- Fixes https://github.com/zigpy/backlog/issues/50
- Related code (showing order of init + read + recompute): [zha/zigbee/device.py#L956-L975](https://github.com/zigpy/zha/blob/b17254948690f740a2b795d28dfad5304ad98291/zha/zigbee/device.py#L956-L975)


### TODO:

- see if we can modify our diagnostics tests for this OR add a specific unit test for just this case?
- check if other entities were also overlooked
- fix quirks `prevent_default_entity_creation` for these devices, relying on directly accessing `entity.translation_key`:
  - [zhaquirks/develco/smart_siren.py#L20](https://github.com/zigpy/zha-device-handlers/blob/02fe2c88d886c077ee5660556c4c96c286d96c1c/zhaquirks/develco/smart_siren.py#L20)
  - [zhaquirks/develco/intelligent_keypad.py#L15](https://github.com/zigpy/zha-device-handlers/blob/02fe2c88d886c077ee5660556c4c96c286d96c1c/zhaquirks/develco/intelligent_keypad.py#L15)

-> see comment for TODOs: https://github.com/zigpy/zha/pull/545#issuecomment-3453405862