### PR TITLE
Don't await for identify effect on join

### DIFF
--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -840,9 +840,13 @@ class Device(LogMixin, EventBase):
             and self.identify_ch is not None
             and not self.skip_configuration
         ):
-            await self.identify_ch.trigger_effect(
-                effect_id=Identify.EffectIdentifier.Okay,
-                effect_variant=Identify.EffectVariant.Default,
+            self._gateway.async_create_task(
+                self.identify_ch.trigger_effect(
+                    effect_id=Identify.EffectIdentifier.Okay,
+                    effect_variant=Identify.EffectVariant.Default,
+                ),
+                name=f"({self.nwk},{self.model}) trigger_effect identify",
+                eager_start=True,
             )
 
     def _is_entity_removed_by_quirk(self, entity: PlatformEntity) -> bool:


### PR DESCRIPTION
Some devices do not reply to identify requests. For those, the message will get sent 3 times and timeout after 15 seconds.
When the request times-out, the join process will (silently) be interrupted with a asyncio.exceptions.CancelledError, keeping the join stuck at "Configuring".

Catching the exception would solve the issue, but it would make the join unecessarily long. Since identify is not critical this PR moves it to a separate fire-and-forget task.

Partly addresses https://github.com/zigpy/backlog/issues/58