### PR TITLE
Don't use magic number for gateway shut down delay

### DIFF
--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -58,7 +58,7 @@ from zha.zigbee.device import Device, DeviceInfo, DeviceStatus, ExtendedDeviceIn
 from zha.zigbee.group import Group, GroupInfo, GroupMemberReference
 
 BLOCK_LOG_TIMEOUT: Final[int] = 60
-SHUT_DOWN_DELAY_S: Final[int] = 0.1
+SHUT_DOWN_DELAY_S: Final[float] = 0.1
 _R = TypeVar("_R")
 _LOGGER = logging.getLogger(__name__)
 

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -765,7 +765,9 @@ class Gateway(AsyncUtilMixin, EventBase):
         if self.application_controller is not None:
             await self.application_controller.shutdown()
             self.application_controller = None
-            await asyncio.sleep(SHUT_DOWN_DELAY_S)  # give bellows thread callback a chance to run
+            await asyncio.sleep(
+                SHUT_DOWN_DELAY_S
+            )  # give bellows thread callback a chance to run
 
         await super().shutdown()
 

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -765,9 +765,8 @@ class Gateway(AsyncUtilMixin, EventBase):
         if self.application_controller is not None:
             await self.application_controller.shutdown()
             self.application_controller = None
-            await asyncio.sleep(
-                SHUT_DOWN_DELAY_S
-            )  # give bellows thread callback a chance to run
+            # give bellows thread callback a chance to run
+            await asyncio.sleep(SHUT_DOWN_DELAY_S)
 
         await super().shutdown()
 

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -58,6 +58,7 @@ from zha.zigbee.device import Device, DeviceInfo, DeviceStatus, ExtendedDeviceIn
 from zha.zigbee.group import Group, GroupInfo, GroupMemberReference
 
 BLOCK_LOG_TIMEOUT: Final[int] = 60
+SHUT_DOWN_DELAY_S: Final[int] = 0.1
 _R = TypeVar("_R")
 _LOGGER = logging.getLogger(__name__)
 
@@ -764,7 +765,7 @@ class Gateway(AsyncUtilMixin, EventBase):
         if self.application_controller is not None:
             await self.application_controller.shutdown()
             self.application_controller = None
-            await asyncio.sleep(0.1)  # give bellows thread callback a chance to run
+            await asyncio.sleep(SHUT_DOWN_DELAY_S)  # give bellows thread callback a chance to run
 
         await super().shutdown()
 


### PR DESCRIPTION
Don't use magic number for gateway shut down delay

Apart from a minor cleanup of the code, this also means we can patch the delay in tests, which will allow removing this workaround:
https://github.com/home-assistant/core/blob/6bed6d19fec829927267aea22f17b667eb4ccbd6/tests/components/zha/test_button.py#L48-L55