### PR TITLE
Ignore `color_temperature` attribute when computing light capabilities

### DIFF
--- a/tests/data/devices/ericsity-gl-c-009p.json
+++ b/tests/data/devices/ericsity-gl-c-009p.json
@@ -407,16 +407,15 @@
           "on": false,
           "brightness": 254,
           "xy_color": null,
-          "color_temp": 500,
+          "color_temp": null,
           "effect_list": [
             "off"
           ],
           "effect": "off",
           "supported_features": 40,
-          "color_mode": "color_temp",
+          "color_mode": "brightness",
           "supported_color_modes": [
             "brightness",
-            "color_temp",
             "onoff"
           ],
           "off_with_transition": false,

--- a/tests/data/devices/homr-hrmsn01.json
+++ b/tests/data/devices/homr-hrmsn01.json
@@ -519,7 +519,7 @@
             0.0,
             0.0
           ],
-          "color_temp": 0,
+          "color_temp": null,
           "effect_list": [
             "off"
           ],
@@ -528,7 +528,6 @@
           "color_mode": "xy",
           "supported_color_modes": [
             "brightness",
-            "color_temp",
             "onoff",
             "xy"
           ],

--- a/tests/data/devices/ledvance-outdoor-accent-light-rgb.json
+++ b/tests/data/devices/ledvance-outdoor-accent-light-rgb.json
@@ -385,16 +385,15 @@
             0.16398870832379644,
             0.13199053940642405
           ],
-          "color_temp": 1901,
+          "color_temp": null,
           "effect_list": [
             "off"
           ],
           "effect": "off",
           "supported_features": 40,
-          "color_mode": "color_temp",
+          "color_mode": "xy",
           "supported_color_modes": [
             "brightness",
-            "color_temp",
             "onoff",
             "xy"
           ],

--- a/tests/data/devices/sonoff-dongle-e-r.json
+++ b/tests/data/devices/sonoff-dongle-e-r.json
@@ -532,16 +532,15 @@
           "on": false,
           "brightness": 51,
           "xy_color": null,
-          "color_temp": 17476,
+          "color_temp": null,
           "effect_list": [
             "off"
           ],
           "effect": "off",
           "supported_features": 40,
-          "color_mode": "color_temp",
+          "color_mode": "brightness",
           "supported_color_modes": [
             "brightness",
-            "color_temp",
             "onoff"
           ],
           "off_with_transition": false,

--- a/tests/data/devices/tz3210-bfwvfyx1-ts0505b.json
+++ b/tests/data/devices/tz3210-bfwvfyx1-ts0505b.json
@@ -381,16 +381,15 @@
             0.0,
             0.0
           ],
-          "color_temp": 270,
+          "color_temp": null,
           "effect_list": [
             "off"
           ],
           "effect": "off",
           "supported_features": 40,
-          "color_mode": "color_temp",
+          "color_mode": "xy",
           "supported_color_modes": [
             "brightness",
-            "color_temp",
             "onoff",
             "xy"
           ],

--- a/zha/zigbee/cluster_handlers/lighting.py
+++ b/zha/zigbee/cluster_handlers/lighting.py
@@ -142,7 +142,7 @@ class ColorClusterHandler(ClusterHandler):
         return (
             self.color_capabilities is not None
             and Color.ColorCapabilities.Color_temperature in self.color_capabilities
-        ) or self.color_temperature is not None
+        )
 
     @property
     def color_loop_supported(self) -> bool:


### PR DESCRIPTION
See https://github.com/home-assistant/core/issues/156133.

The device switches modes. Color temperature is the only mode where we peek at attribute values to determine capabilities (all others just use the `color_capabilities` bitmap). The number of affected devices according to diagnostics is very small and all of the changes look reasonable to me.