### PR TITLE
Rename `quirk_id` to `exposes_features` + allow multiple features

### DIFF
--- a/tests/data/devices/adeo-zb-watersensor-d0001.json
+++ b/tests/data/devices/adeo-zb-watersensor-d0001.json
@@ -9,7 +9,7 @@
   "name": "ADEO ZB-WaterSensor-D0001",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4727,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/adurosmart-eria-ad-rgbw3001.json
+++ b/tests/data/devices/adurosmart-eria-ad-rgbw3001.json
@@ -9,7 +9,7 @@
   "name": "AduroSmart Eria AD-RGBW3001",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4653,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/adurosmart-eria-vms-adurolight.json
+++ b/tests/data/devices/adurosmart-eria-vms-adurolight.json
@@ -9,7 +9,7 @@
   "name": "AduroSmart Eria VMS_ADUROLIGHT",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4653,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/aqara-lumi-airrtc-aeu001.json
+++ b/tests/data/devices/aqara-lumi-airrtc-aeu001.json
@@ -9,7 +9,7 @@
   "name": "Aqara lumi.airrtc.aeu001",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Mains",
   "lqi": 184,

--- a/tests/data/devices/aqara-lumi-light-agl003.json
+++ b/tests/data/devices/aqara-lumi-light-agl003.json
@@ -9,7 +9,7 @@
   "name": "Aqara lumi.light.agl003",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Mains",
   "lqi": 65,

--- a/tests/data/devices/aqara-lumi-light-agl005.json
+++ b/tests/data/devices/aqara-lumi-light-agl005.json
@@ -9,7 +9,7 @@
   "name": "Aqara lumi.light.agl005",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Mains",
   "lqi": 65,

--- a/tests/data/devices/aqara-lumi-lunar-acn01.json
+++ b/tests/data/devices/aqara-lumi-lunar-acn01.json
@@ -9,7 +9,7 @@
   "name": "aqara lumi.lunar.acn01",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4660,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/aqara-lumi-motion-ac01.json
+++ b/tests/data/devices/aqara-lumi-motion-ac01.json
@@ -9,7 +9,7 @@
   "name": "aqara lumi.motion.ac01",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.motion_ac01.AqaraLumiMotionAc01",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4660,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/aqara-lumi-switch-acn047.json
+++ b/tests/data/devices/aqara-lumi-switch-acn047.json
@@ -9,7 +9,7 @@
   "name": "Aqara lumi.switch.acn047",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.switch_acn047.AqaraT2Relay",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Mains",
   "lqi": 108,

--- a/tests/data/devices/aqara-lumi-switch-aeu003.json
+++ b/tests/data/devices/aqara-lumi-switch-aeu003.json
@@ -9,7 +9,7 @@
   "name": "Aqara lumi.switch.aeu003",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Mains",
   "lqi": 196,

--- a/tests/data/devices/aqara-lumi-switch-agl010.json
+++ b/tests/data/devices/aqara-lumi-switch-agl010.json
@@ -9,7 +9,7 @@
   "name": "Aqara lumi.switch.agl010",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Mains",
   "lqi": 81,

--- a/tests/data/devices/aug-winkhaus-gmbh-co-kg-fm-v-zb.json
+++ b/tests/data/devices/aug-winkhaus-gmbh-co-kg-fm-v-zb.json
@@ -9,7 +9,7 @@
   "name": "Aug. Winkhaus GmbH & Co. KG FM.V.ZB",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/awox-esmlfzm-w6-dimm.json
+++ b/tests/data/devices/awox-esmlfzm-w6-dimm.json
@@ -9,7 +9,7 @@
   "name": "AwoX ESMLFzm_w6_Dimm",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/awox-tlsr82xx.json
+++ b/tests/data/devices/awox-tlsr82xx.json
@@ -9,7 +9,7 @@
   "name": "AwoX TLSR82xx",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/bosch-rbsh-mms-zb-eu.json
+++ b/tests/data/devices/bosch-rbsh-mms-zb-eu.json
@@ -9,7 +9,7 @@
   "name": "Bosch BMCT-SLZ",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4617,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/bosch-rbsh-rth0-bat-zb-eu.json
+++ b/tests/data/devices/bosch-rbsh-rth0-bat-zb-eu.json
@@ -9,7 +9,7 @@
   "name": "Bosch RBSH-RTH0-BAT-ZB-EU",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4617,
   "power_source": "Battery or Unknown",
   "lqi": 255,

--- a/tests/data/devices/bosch-rbsh-rth0-zb-eu.json
+++ b/tests/data/devices/bosch-rbsh-rth0-zb-eu.json
@@ -9,7 +9,7 @@
   "name": "Bosch RBSH-RTH0-ZB-EU",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4617,
   "power_source": "Mains",
   "lqi": 164,

--- a/tests/data/devices/bosch-rbsh-trv0-zb-eu.json
+++ b/tests/data/devices/bosch-rbsh-trv0-zb-eu.json
@@ -9,7 +9,7 @@
   "name": "BOSCH RBSH-TRV0-ZB-EU",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4617,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/bosch-rbsh-us4btn-zb-eu.json
+++ b/tests/data/devices/bosch-rbsh-us4btn-zb-eu.json
@@ -9,7 +9,7 @@
   "name": "Bosch RBSH-US4BTN-ZB-EU",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4617,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/candeo-c-zb-lc20-dim.json
+++ b/tests/data/devices/candeo-c-zb-lc20-dim.json
@@ -9,7 +9,7 @@
   "name": "Candeo C-ZB-LC20-Dim",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4687,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/candeo-c-zb-lc20-rgb.json
+++ b/tests/data/devices/candeo-c-zb-lc20-rgb.json
@@ -9,7 +9,7 @@
   "name": "Candeo C-ZB-LC20-RGB",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4687,
   "power_source": "Mains",
   "lqi": 196,

--- a/tests/data/devices/centralite-3320-l.json
+++ b/tests/data/devices/centralite-3320-l.json
@@ -9,7 +9,7 @@
   "name": "CentraLite 3320-L",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.centralite.ias.CentraLiteIASSensor",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 49887,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/centralite-3326-l.json
+++ b/tests/data/devices/centralite-3326-l.json
@@ -9,7 +9,7 @@
   "name": "CentraLite 3326-L",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.centralite.motion.CentraLiteMotionSensor",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 49887,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/centralite-3405-l.json
+++ b/tests/data/devices/centralite-3405-l.json
@@ -9,7 +9,7 @@
   "name": "CentraLite 3405-L",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4174,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/centralite-systems-3156105.json
+++ b/tests/data/devices/centralite-systems-3156105.json
@@ -9,7 +9,7 @@
   "name": "CentraLite Systems 3156105",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 49887,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/climaxtechnology-sd8sc-00-00-03-12tc.json
+++ b/tests/data/devices/climaxtechnology-sd8sc-00-00-03-12tc.json
@@ -9,7 +9,7 @@
   "name": "ClimaxTechnology SD8SC_00.00.03.12TC",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 0,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/danfoss-etrv0103.json
+++ b/tests/data/devices/danfoss-etrv0103.json
@@ -9,7 +9,9 @@
   "name": "Danfoss eTRV0103",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.danfoss.thermostat.DanfossThermostat",
-  "quirk_id": "danfoss.ally_thermostat",
+  "exposes_features": [
+    "danfoss.ally_thermostat"
+  ],
   "manufacturer_code": 4678,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/develco-products-a-s-zhemi-zigbee-external-meter-interface.json
+++ b/tests/data/devices/develco-products-a-s-zhemi-zigbee-external-meter-interface.json
@@ -9,7 +9,7 @@
   "name": "Develco Products A/S ZHEMI - ZigBee External Meter Interface",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 0,
   "power_source": "Battery or Unknown",
   "lqi": 87,

--- a/tests/data/devices/digi-xbee3.json
+++ b/tests/data/devices/digi-xbee3.json
@@ -9,7 +9,7 @@
   "name": "Digi XBee3",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xbee.xbee3_io.XBee3Sensor",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4126,
   "power_source": "Mains",
   "lqi": 255,

--- a/tests/data/devices/ecodim-bv-eco-dim-05-zigbee.json
+++ b/tests/data/devices/ecodim-bv-eco-dim-05-zigbee.json
@@ -9,7 +9,7 @@
   "name": "EcoDim BV Eco-Dim.05 Zigbee",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Mains",
   "lqi": 179,

--- a/tests/data/devices/ecolink-4655bc0-r.json
+++ b/tests/data/devices/ecolink-4655bc0-r.json
@@ -9,7 +9,7 @@
   "name": "Ecolink 4655BC0-R",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.ecolink.contact.Ecolink4655BC0R",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4335,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/enktro-acmidea.json
+++ b/tests/data/devices/enktro-acmidea.json
@@ -9,7 +9,7 @@
   "name": "enktro ACmidea",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4660,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/ericsity-gl-c-008p.json
+++ b/tests/data/devices/ericsity-gl-c-008p.json
@@ -9,7 +9,7 @@
   "name": "ERICSITY GL-C-008P",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4687,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/ericsity-gl-c-009p.json
+++ b/tests/data/devices/ericsity-gl-c-009p.json
@@ -9,7 +9,7 @@
   "name": "ERICSITY GL-C-009P",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4687,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/espressif-zigbeeanalogdevice.json
+++ b/tests/data/devices/espressif-zigbeeanalogdevice.json
@@ -9,7 +9,7 @@
   "name": "Espressif ZigbeeAnalogDevice",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4660,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/espressif-zigbeebinaryoutputdevice.json
+++ b/tests/data/devices/espressif-zigbeebinaryoutputdevice.json
@@ -9,7 +9,7 @@
   "name": "Espressif ZigbeeBinaryAnalogDevice",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4660,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/espressif-zigbeecarbondioxidesensor.json
+++ b/tests/data/devices/espressif-zigbeecarbondioxidesensor.json
@@ -9,7 +9,7 @@
   "name": "Espressif ZigbeeCarbonDioxideSensor",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4660,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/eurotronic-spzb0001.json
+++ b/tests/data/devices/eurotronic-spzb0001.json
@@ -9,7 +9,7 @@
   "name": "Eurotronic SPZB0001",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4151,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/ewelink-ck-bl702-al-01-7009-z102lg03-1.json
+++ b/tests/data/devices/ewelink-ck-bl702-al-01-7009-z102lg03-1.json
@@ -9,7 +9,7 @@
   "name": "eWeLink CK-BL702-AL-01(7009_Z102LG03-1)",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4742,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/ewelink-ds01.json
+++ b/tests/data/devices/ewelink-ds01.json
@@ -9,7 +9,7 @@
   "name": "eWeLink DS01",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 0,
   "power_source": "Battery or Unknown",
   "lqi": 232,

--- a/tests/data/devices/ewelink-sa-003-zigbee.json
+++ b/tests/data/devices/ewelink-sa-003-zigbee.json
@@ -9,7 +9,7 @@
   "name": "eWeLink SA-003-Zigbee",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 0,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/ewelink-snzb-01p.json
+++ b/tests/data/devices/ewelink-snzb-01p.json
@@ -9,7 +9,7 @@
   "name": "eWeLink SNZB-01P",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4742,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/ewelink-snzb-02p.json
+++ b/tests/data/devices/ewelink-snzb-02p.json
@@ -9,7 +9,7 @@
   "name": "eWeLink SNZB-02P",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4742,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/ewelink-snzb-04p.json
+++ b/tests/data/devices/ewelink-snzb-04p.json
@@ -9,7 +9,7 @@
   "name": "eWeLink SNZB-04P",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4742,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/ewelink-th01.json
+++ b/tests/data/devices/ewelink-th01.json
@@ -9,7 +9,7 @@
   "name": "eWeLink TH01",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 0,
   "power_source": "Battery or Unknown",
   "lqi": 192,

--- a/tests/data/devices/ewelink-wb01.json
+++ b/tests/data/devices/ewelink-wb01.json
@@ -9,7 +9,7 @@
   "name": "eWeLink WB01",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 0,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/ewelink-zb-sw02.json
+++ b/tests/data/devices/ewelink-zb-sw02.json
@@ -9,7 +9,7 @@
   "name": "eWeLink ZB-SW02",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 0,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/ezviz-cs-t55-r100-g.json
+++ b/tests/data/devices/ezviz-cs-t55-r100-g.json
@@ -9,7 +9,7 @@
   "name": "EZVIZ CS-T55-R100-G",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4451,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/feibit-inc-co-fzb56-zcw27lx1-0.json
+++ b/tests/data/devices/feibit-inc-co-fzb56-zcw27lx1-0.json
@@ -9,7 +9,7 @@
   "name": "Feibit Inc co.   FZB56-ZCW27LX1.0",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 0,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/frient-a-s-aqszb-110.json
+++ b/tests/data/devices/frient-a-s-aqszb-110.json
@@ -9,7 +9,7 @@
   "name": "frient A/S AQSZB-110",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4117,
   "power_source": "Battery or Unknown",
   "lqi": 255,

--- a/tests/data/devices/frient-a-s-emizb-141.json
+++ b/tests/data/devices/frient-a-s-emizb-141.json
@@ -9,7 +9,7 @@
   "name": "frient A/S EMIZB-141",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.develco.ManufacturerDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4117,
   "power_source": "Battery or Unknown",
   "lqi": 255,

--- a/tests/data/devices/frient-a-s-emizb-151.json
+++ b/tests/data/devices/frient-a-s-emizb-151.json
@@ -9,7 +9,7 @@
   "name": "frient A/S EMIZB-151",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4117,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/frient-a-s-flszb-110.json
+++ b/tests/data/devices/frient-a-s-flszb-110.json
@@ -9,7 +9,7 @@
   "name": "frient A/S FLSZB-110",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4117,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/frient-a-s-hmszb-120.json
+++ b/tests/data/devices/frient-a-s-hmszb-120.json
@@ -9,7 +9,7 @@
   "name": "frient A/S HMSZB-120",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4117,
   "power_source": "Battery or Unknown",
   "lqi": 255,

--- a/tests/data/devices/frient-a-s-iomzb-110.json
+++ b/tests/data/devices/frient-a-s-iomzb-110.json
@@ -9,7 +9,7 @@
   "name": "frient A/S IOMZB-110",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4117,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/frient-a-s-kepzb-110.json
+++ b/tests/data/devices/frient-a-s-kepzb-110.json
@@ -9,7 +9,7 @@
   "name": "frient A/S KEPZB-110",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4117,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/frient-a-s-moszb-153.json
+++ b/tests/data/devices/frient-a-s-moszb-153.json
@@ -9,7 +9,7 @@
   "name": "frient A/S MOSZB-153",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4117,
   "power_source": "Battery or Unknown",
   "lqi": 255,

--- a/tests/data/devices/frient-a-s-sbtzb-110.json
+++ b/tests/data/devices/frient-a-s-sbtzb-110.json
@@ -9,7 +9,7 @@
   "name": "frient A/S SBTZB-110",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4117,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/frient-a-s-sirzb-111.json
+++ b/tests/data/devices/frient-a-s-sirzb-111.json
@@ -9,7 +9,7 @@
   "name": "frient A/S SIRZB-111",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4117,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/frient-a-s-smszb-120.json
+++ b/tests/data/devices/frient-a-s-smszb-120.json
@@ -9,7 +9,7 @@
   "name": "frient A/S SMSZB-120",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4117,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/frient-a-s-splzb-141.json
+++ b/tests/data/devices/frient-a-s-splzb-141.json
@@ -9,7 +9,7 @@
   "name": "frient A/S SPLZB-141",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4117,
   "power_source": "Mains",
   "lqi": 255,

--- a/tests/data/devices/frient-a-s-wiszb-131.json
+++ b/tests/data/devices/frient-a-s-wiszb-131.json
@@ -9,7 +9,7 @@
   "name": "frient A/S WISZB-131",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4117,
   "power_source": "Battery or Unknown",
   "lqi": 255,

--- a/tests/data/devices/gledopto-gl-b-008p.json
+++ b/tests/data/devices/gledopto-gl-b-008p.json
@@ -9,7 +9,7 @@
   "name": "GLEDOPTO GL-B-008P",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4687,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/hive-mbr1.json
+++ b/tests/data/devices/hive-mbr1.json
@@ -9,7 +9,7 @@
   "name": "Hive MBR1",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4153,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/hobeian-zg-101zl.json
+++ b/tests/data/devices/hobeian-zg-101zl.json
@@ -9,7 +9,7 @@
   "name": "HOBEIAN ZG-101ZL",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4742,
   "power_source": "Battery or Unknown",
   "lqi": 124,

--- a/tests/data/devices/hobeian-zg-102zm.json
+++ b/tests/data/devices/hobeian-zg-102zm.json
@@ -9,7 +9,7 @@
   "name": "HOBEIAN ZG-102ZM",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4742,
   "power_source": "Battery or Unknown",
   "lqi": 240,

--- a/tests/data/devices/hobeian-zg-204zv.json
+++ b/tests/data/devices/hobeian-zg-204zv.json
@@ -9,7 +9,7 @@
   "name": "HOBEIAN ZG-204ZV",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4742,
   "power_source": "Battery or Unknown",
   "lqi": 184,

--- a/tests/data/devices/homr-hrmsn01.json
+++ b/tests/data/devices/homr-hrmsn01.json
@@ -9,7 +9,7 @@
   "name": "Homr HRMSN01",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4660,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/ikea-of-sweden-badring-water-leakage-sensor.json
+++ b/tests/data/devices/ikea-of-sweden-badring-water-leakage-sensor.json
@@ -9,7 +9,7 @@
   "name": "IKEA of Sweden BADRING Water Leakage Sensor",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/ikea-of-sweden-fyrtur-block-out-roller-blind.json
+++ b/tests/data/devices/ikea-of-sweden-fyrtur-block-out-roller-blind.json
@@ -9,7 +9,7 @@
   "name": "IKEA of Sweden FYRTUR block-out roller blind",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.ikea.blinds.IkeaTradfriRollerBlinds",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/ikea-of-sweden-inspelning-smart-plug.json
+++ b/tests/data/devices/ikea-of-sweden-inspelning-smart-plug.json
@@ -9,7 +9,7 @@
   "name": "IKEA of Sweden INSPELNING Smart plug",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/ikea-of-sweden-ormanas-led-strip.json
+++ b/tests/data/devices/ikea-of-sweden-ormanas-led-strip.json
@@ -9,7 +9,7 @@
   "name": "IKEA of Sweden ORMANAS LED Strip",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Mains",
   "lqi": 204,

--- a/tests/data/devices/ikea-of-sweden-parasoll-door-window-sensor.json
+++ b/tests/data/devices/ikea-of-sweden-parasoll-door-window-sensor.json
@@ -9,7 +9,7 @@
   "name": "IKEA of Sweden PARASOLL Door/Window Sensor",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/ikea-of-sweden-praktlysing-cellular-blind.json
+++ b/tests/data/devices/ikea-of-sweden-praktlysing-cellular-blind.json
@@ -9,7 +9,7 @@
   "name": "IKEA of Sweden PRAKTLYSING cellular blind",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.ikea.blinds.IkeaTradfriRollerBlinds",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/ikea-of-sweden-remote-control-n2.json
+++ b/tests/data/devices/ikea-of-sweden-remote-control-n2.json
@@ -9,7 +9,7 @@
   "name": "IKEA of Sweden Remote Control N2",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/ikea-of-sweden-rodret-dimmer.json
+++ b/tests/data/devices/ikea-of-sweden-rodret-dimmer.json
@@ -9,7 +9,7 @@
   "name": "IKEA of Sweden RODRET Dimmer",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.ikea.twobtnremote.IkeaRodretRemote2Btn",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/ikea-of-sweden-rodret-wireless-dimmer.json
+++ b/tests/data/devices/ikea-of-sweden-rodret-wireless-dimmer.json
@@ -9,7 +9,7 @@
   "name": "IKEA of Sweden RODRET wireless dimmer",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.ikea.twobtnremote.IkeaRodretRemote2BtnNew",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Battery or Unknown",
   "lqi": 39,

--- a/tests/data/devices/ikea-of-sweden-somrig-shortcut-button.json
+++ b/tests/data/devices/ikea-of-sweden-somrig-shortcut-button.json
@@ -9,7 +9,7 @@
   "name": "IKEA of Sweden SOMRIG shortcut button",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.ikea.somrigsmartbtn.IkeaSomrigSmartButton",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Battery or Unknown",
   "lqi": 180,

--- a/tests/data/devices/ikea-of-sweden-starkvind-air-purifier.json
+++ b/tests/data/devices/ikea-of-sweden-starkvind-air-purifier.json
@@ -9,7 +9,7 @@
   "name": "IKEA of Sweden STARKVIND Air purifier",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.ikea.starkvind.IkeaSTARKVIND",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/ikea-of-sweden-symfonisk-sound-remote-gen2.json
+++ b/tests/data/devices/ikea-of-sweden-symfonisk-sound-remote-gen2.json
@@ -9,7 +9,7 @@
   "name": "IKEA of Sweden SYMFONISK sound remote gen2",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.ikea.symfonisk2.IkeaSymfoniskGen2v1",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Battery or Unknown",
   "lqi": 255,

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-w-op-ch-400lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-w-op-ch-400lm.json
@@ -9,7 +9,7 @@
   "name": "IKEA of Sweden TRADFRI bulb E12 W op/ch 400lm",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-ws-opal-400lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-ws-opal-400lm.json
@@ -9,7 +9,7 @@
   "name": "IKEA of Sweden TRADFRI bulb E12 WS opal 400lm",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e14-ws-globe-470lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e14-ws-globe-470lm.json
@@ -9,7 +9,7 @@
   "name": "IKEA of Sweden TRADFRI bulb E14 WS globe 470lm",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Mains",
   "lqi": 160,

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-opal-1000lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-opal-1000lm.json
@@ -9,7 +9,7 @@
   "name": "IKEA of Sweden TRADFRI bulb E26 opal 1000lm",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-w-opal-1000lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-w-opal-1000lm.json
@@ -9,7 +9,7 @@
   "name": "IKEA of Sweden TRADFRI bulb E26 W opal 1000lm",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-ws-opal-980lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-ws-opal-980lm.json
@@ -9,7 +9,7 @@
   "name": "IKEA of Sweden TRADFRI bulb E26 WS opal 980lm",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e27-ww-g95-cl-470lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e27-ww-g95-cl-470lm.json
@@ -9,7 +9,7 @@
   "name": "IKEA of Sweden TRADFRI bulb E27 WW G95 CL 470lm",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-gu10-ws-400lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-gu10-ws-400lm.json
@@ -9,7 +9,7 @@
   "name": "IKEA of Sweden TRADFRI bulb GU10 WS 400lm",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/ikea-of-sweden-tradfri-control-outlet.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-control-outlet.json
@@ -9,7 +9,7 @@
   "name": "IKEA of Sweden TRADFRI control outlet",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/ikea-of-sweden-tradfri-motion-sensor.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-motion-sensor.json
@@ -9,7 +9,7 @@
   "name": "IKEA of Sweden TRADFRI motion sensor",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.ikea.motionzha.IkeaTradfriMotionE1745_Var02",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/ikea-of-sweden-tradfri-on-off-switch.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-on-off-switch.json
@@ -9,7 +9,7 @@
   "name": "IKEA of Sweden TRADFRI on/off switch",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.ikea.twobtnremote.IkeaTradfriRemote2Btn",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/ikea-of-sweden-tradfri-open-close-remote.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-open-close-remote.json
@@ -9,7 +9,7 @@
   "name": "IKEA of Sweden TRADFRI open/close remote",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.ikea.opencloseremote.IkeaTradfriOpenCloseRemote",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/ikea-of-sweden-tradfri-remote-control.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-remote-control.json
@@ -9,7 +9,7 @@
   "name": "IKEA of Sweden TRADFRI remote control",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.ikea.fivebtnremote.IkeaTradfriRemote1",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/ikea-of-sweden-tradfri-wireless-dimmer.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-wireless-dimmer.json
@@ -9,7 +9,7 @@
   "name": "IKEA of Sweden TRADFRI wireless dimmer",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.ikea.dimmer.IkeaDimmer",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/ikea-of-sweden-vallhorn-wireless-motion-sensor.json
+++ b/tests/data/devices/ikea-of-sweden-vallhorn-wireless-motion-sensor.json
@@ -9,7 +9,7 @@
   "name": "IKEA of Sweden VALLHORN Wireless Motion Sensor",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/innr-ae-280-c.json
+++ b/tests/data/devices/innr-ae-280-c.json
@@ -9,7 +9,7 @@
   "name": "innr AE 280 C",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4454,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/innr-rb-285-c.json
+++ b/tests/data/devices/innr-rb-285-c.json
@@ -9,7 +9,7 @@
   "name": "innr RB 285 C",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4454,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/innr-sp-120.json
+++ b/tests/data/devices/innr-sp-120.json
@@ -9,7 +9,7 @@
   "name": "innr SP 120",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.innr.innr_sp120_plug.SP120",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4454,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/innr-sp-234.json
+++ b/tests/data/devices/innr-sp-234.json
@@ -9,7 +9,7 @@
   "name": "innr SP 234",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.innr.innr_sp234_plug.SP234",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4454,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/innr-sp-240.json
+++ b/tests/data/devices/innr-sp-240.json
@@ -9,7 +9,7 @@
   "name": "innr SP 240",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.innr.innr_sp240_plug.SP240",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4454,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/innr-sp-242.json
+++ b/tests/data/devices/innr-sp-242.json
@@ -9,7 +9,7 @@
   "name": "innr SP 242",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4454,
   "power_source": "Mains",
   "lqi": 172,

--- a/tests/data/devices/inovelli-vzm30-sn.json
+++ b/tests/data/devices/inovelli-vzm30-sn.json
@@ -9,7 +9,7 @@
   "name": "Inovelli VZM30-SN",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4655,
   "power_source": "Mains",
   "lqi": 192,

--- a/tests/data/devices/inovelli-vzm31-sn.json
+++ b/tests/data/devices/inovelli-vzm31-sn.json
@@ -9,7 +9,7 @@
   "name": "Inovelli VZM31-SN",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4655,
   "power_source": "Mains",
   "lqi": 112,

--- a/tests/data/devices/inovelli-vzm35-sn.json
+++ b/tests/data/devices/inovelli-vzm35-sn.json
@@ -9,7 +9,7 @@
   "name": "Inovelli VZM35-SN",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4655,
   "power_source": "Mains",
   "lqi": 184,

--- a/tests/data/devices/isilentllc-dog-feeder.json
+++ b/tests/data/devices/isilentllc-dog-feeder.json
@@ -9,7 +9,7 @@
   "name": "iSilentLLC Dog Feeder",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4126,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/isilentllc-doorbell.json
+++ b/tests/data/devices/isilentllc-doorbell.json
@@ -9,7 +9,7 @@
   "name": "iSilentLLC DoorBell",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4126,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/isilentllc-freezer-monitor.json
+++ b/tests/data/devices/isilentllc-freezer-monitor.json
@@ -9,7 +9,7 @@
   "name": "iSilentLLC Freezer Monitor",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4660,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/isilentllc-home-energy-monitor.json
+++ b/tests/data/devices/isilentllc-home-energy-monitor.json
@@ -9,7 +9,7 @@
   "name": "iSilentLLC Home Energy Monitor",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4126,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/isilentllc-masterbed-light-controller.json
+++ b/tests/data/devices/isilentllc-masterbed-light-controller.json
@@ -9,7 +9,7 @@
   "name": "iSilentLLC MasterBed Light Controller",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4126,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/isilentllc-safe.json
+++ b/tests/data/devices/isilentllc-safe.json
@@ -9,7 +9,7 @@
   "name": "iSilentLLC Safe",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4126,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/isilentllc-test-device.json
+++ b/tests/data/devices/isilentllc-test-device.json
@@ -9,7 +9,7 @@
   "name": "iSilentLLC Test Device",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4660,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/isilentllc-test-mule.json
+++ b/tests/data/devices/isilentllc-test-mule.json
@@ -9,7 +9,7 @@
   "name": "iSilentLLC Test Mule",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4660,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/isilentllc-water-heater.json
+++ b/tests/data/devices/isilentllc-water-heater.json
@@ -9,7 +9,7 @@
   "name": "iSilentLLC Water Heater",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4126,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/jasco-products-45856.json
+++ b/tests/data/devices/jasco-products-45856.json
@@ -9,7 +9,7 @@
   "name": "Jasco Products 45856",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4388,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/jasco-products-45857.json
+++ b/tests/data/devices/jasco-products-45857.json
@@ -9,7 +9,7 @@
   "name": "Jasco Products 45857",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4388,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/ke-tradfri-open-close-remote.json
+++ b/tests/data/devices/ke-tradfri-open-close-remote.json
@@ -9,7 +9,7 @@
   "name": "\u0002KE TRADFRI open/close remote",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.ikea.opencloseremote.IkeaTradfriOpenCloseRemote",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4476,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/keen-home-inc-sv01-410-mp-1-1.json
+++ b/tests/data/devices/keen-home-inc-sv01-410-mp-1-1.json
@@ -9,7 +9,7 @@
   "name": "Keen Home Inc SV01-410-MP-1.1",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.keenhome.sv02612mp13.KeenHomeSmartVent",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4443,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/keen-home-inc-sv02-610-mp-1-3.json
+++ b/tests/data/devices/keen-home-inc-sv02-610-mp-1-3.json
@@ -9,7 +9,7 @@
   "name": "Keen Home Inc SV02-610-MP-1.3",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.keenhome.sv02612mp13.KeenHomeSmartVent",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4443,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/keen-home-inc-sv02-612-mp-1-3.json
+++ b/tests/data/devices/keen-home-inc-sv02-612-mp-1-3.json
@@ -9,7 +9,7 @@
   "name": "Keen Home Inc SV02-612-MP-1.3",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.keenhome.sv02612mp13.KeenHomeSmartVent",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4443,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/king-of-fans-inc-hbuniversalcfremote.json
+++ b/tests/data/devices/king-of-fans-inc-hbuniversalcfremote.json
@@ -9,7 +9,7 @@
   "name": "King Of Fans,  Inc. HBUniversalCFRemote",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.kof.kof_mr101z.CeilingFan",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/king-of-fans-inc-hdc52eastwindfan.json
+++ b/tests/data/devices/king-of-fans-inc-hdc52eastwindfan.json
@@ -9,7 +9,7 @@
   "name": "King Of Fans,  Inc. HDC52EastwindFan",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.kof.kof_mr101z.CeilingFan",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/konke-3afe140103020000.json
+++ b/tests/data/devices/konke-3afe140103020000.json
@@ -9,7 +9,7 @@
   "name": "Konke 3AFE140103020000",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.konke.temp.KonkeTempHumidity",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/konke-3afe220103020000.json
+++ b/tests/data/devices/konke-3afe220103020000.json
@@ -9,7 +9,7 @@
   "name": "Konke 3AFE220103020000",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.konke.temp.KonkeTempHumidity",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4712,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/konke-3afe270104020015.json
+++ b/tests/data/devices/konke-3afe270104020015.json
@@ -9,7 +9,7 @@
   "name": "Konke 3AFE270104020015",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.konke.magnet.KonkeMagnet",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4712,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/konke-3afe280100510001.json
+++ b/tests/data/devices/konke-3afe280100510001.json
@@ -9,7 +9,9 @@
   "name": "Konke 3AFE280100510001",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.konke.button.KonkeButtonRemote1",
-  "quirk_id": "konke.button_remote",
+  "exposes_features": [
+    "konke.button_remote"
+  ],
   "manufacturer_code": 4712,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/konke-3afe28010402000d.json
+++ b/tests/data/devices/konke-3afe28010402000d.json
@@ -9,7 +9,7 @@
   "name": "Konke 3AFE28010402000D",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.konke.motion.KonkeMotion",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4712,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/kwikset-smartcode-convert-gen1.json
+++ b/tests/data/devices/kwikset-smartcode-convert-gen1.json
@@ -9,7 +9,7 @@
   "name": "Kwikset SMARTCODE_CONVERT_GEN1",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4242,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lds-zb-onoffplug-d0005.json
+++ b/tests/data/devices/lds-zb-onoffplug-d0005.json
@@ -9,7 +9,7 @@
   "name": "LDS ZB-ONOFFPlug-D0005",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4456,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/lds-zbt-cctswitch-d0001.json
+++ b/tests/data/devices/lds-zbt-cctswitch-d0001.json
@@ -9,7 +9,7 @@
   "name": "LDS ZBT-CCTSwitch-D0001",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.lds.cctswitch.CCTSwitch",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4456,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/ledvance-flex-rgbw.json
+++ b/tests/data/devices/ledvance-flex-rgbw.json
@@ -9,7 +9,7 @@
   "name": "LEDVANCE FLEX RGBW",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.ledvance.flexrgbw.FlexRGBW",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4489,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/ledvance-outdoor-accent-light-rgb.json
+++ b/tests/data/devices/ledvance-outdoor-accent-light-rgb.json
@@ -9,7 +9,7 @@
   "name": "LEDVANCE Outdoor Accent Light RGB",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4489,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/ledvance-plug.json
+++ b/tests/data/devices/ledvance-plug.json
@@ -9,7 +9,7 @@
   "name": "LEDVANCE PLUG",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4489,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/legrand-contactor.json
+++ b/tests/data/devices/legrand-contactor.json
@@ -9,7 +9,7 @@
   "name": " Legrand  Contactor",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4129,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/legrand-dimmer-switch-w-o-neutral.json
+++ b/tests/data/devices/legrand-dimmer-switch-w-o-neutral.json
@@ -9,7 +9,7 @@
   "name": " Legrand  Dimmer switch w/o neutral",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.legrand.dimmer.DimmerWithoutNeutralAndBallast",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4129,
   "power_source": "Mains",
   "lqi": 57,

--- a/tests/data/devices/legrand-double-gangs-remote-switch.json
+++ b/tests/data/devices/legrand-double-gangs-remote-switch.json
@@ -9,7 +9,7 @@
   "name": " Legrand  Double gangs remote switch",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4129,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/legrand-light-switch-with-neutral.json
+++ b/tests/data/devices/legrand-light-switch-with-neutral.json
@@ -9,7 +9,7 @@
   "name": " Legrand  Light switch with neutral",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4129,
   "power_source": "Mains",
   "lqi": 220,

--- a/tests/data/devices/level-home-b2.json
+++ b/tests/data/devices/level-home-b2.json
@@ -9,7 +9,7 @@
   "name": "Level Home B2",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4660,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/level-home-bolt.json
+++ b/tests/data/devices/level-home-bolt.json
@@ -9,7 +9,7 @@
   "name": "Level Home Bolt",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4660,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lk-zb-doorsensor-d0003.json
+++ b/tests/data/devices/lk-zb-doorsensor-d0003.json
@@ -9,7 +9,7 @@
   "name": "lk ZB-DoorSensor-D0003",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4456,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lk-zbt-dimswitch-d0001.json
+++ b/tests/data/devices/lk-zbt-dimswitch-d0001.json
@@ -9,7 +9,7 @@
   "name": "lk ZBT-DIMSwitch-D0001",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4456,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lk-zbt-onoffplug-d0001.json
+++ b/tests/data/devices/lk-zbt-onoffplug-d0001.json
@@ -9,7 +9,7 @@
   "name": "lk ZBT-OnOffPlug-D0001",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4456,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-airmonitor-acn01.json
+++ b/tests/data/devices/lumi-lumi-airmonitor-acn01.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.airmonitor.acn01",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.tvoc.TVOCMonitor",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-airrtc-agl001.json
+++ b/tests/data/devices/lumi-lumi-airrtc-agl001.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.airrtc.agl001",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-curtain-acn002.json
+++ b/tests/data/devices/lumi-lumi-curtain-acn002.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.curtain.acn002",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-curtain-agl001.json
+++ b/tests/data/devices/lumi-lumi-curtain-agl001.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.curtain.agl001",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.driver_curtain_e1.DriverE1",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-flood-acn001.json
+++ b/tests/data/devices/lumi-lumi-flood-acn001.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.flood.acn001",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.water_acn001.WaterE1",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-flood-agl02.json
+++ b/tests/data/devices/lumi-lumi-flood-agl02.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.flood.agl02",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.water_agl02.WaterT1",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-light-aqcn02.json
+++ b/tests/data/devices/lumi-lumi-light-aqcn02.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.light.aqcn02",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-magnet-ac01.json
+++ b/tests/data/devices/lumi-lumi-magnet-ac01.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.magnet.ac01",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.magnet_ac01.LumiMagnetAC01",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-magnet-acn001.json
+++ b/tests/data/devices/lumi-lumi-magnet-acn001.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.magnet.acn001",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.magnet_acn001.MagnetE1",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-magnet-agl02.json
+++ b/tests/data/devices/lumi-lumi-magnet-agl02.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.magnet.agl02",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.magnet_agl02.MagnetT1",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Battery or Unknown",
   "lqi": 255,

--- a/tests/data/devices/lumi-lumi-motion-ac02.json
+++ b/tests/data/devices/lumi-lumi-motion-ac02.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.motion.ac02",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.motion_ac02.LumiMotionAC02",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-motion-agl02.json
+++ b/tests/data/devices/lumi-lumi-motion-agl02.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.motion.agl02",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.motion_agl02.MotionT1",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-motion-agl04.json
+++ b/tests/data/devices/lumi-lumi-motion-agl04.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.motion.agl04",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.motion_agl04.LumiLumiMotionAgl04",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-plug-maus01.json
+++ b/tests/data/devices/lumi-lumi-plug-maus01.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.plug.maus01",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.plug_maus01.Plug",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-relay-c2acn01.json
+++ b/tests/data/devices/lumi-lumi-relay-c2acn01.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.relay.c2acn01",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.relay_c2acn01.Relay",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4151,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-remote-b286opcn01.json
+++ b/tests/data/devices/lumi-lumi-remote-b286opcn01.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.remote.b286opcn01",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.opple_remote.RemoteB286OPCN01V4",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-remote-b486opcn01.json
+++ b/tests/data/devices/lumi-lumi-remote-b486opcn01.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.remote.b486opcn01",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.opple_remote.RemoteB486OPCN01V2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-remote-b686opcn01.json
+++ b/tests/data/devices/lumi-lumi-remote-b686opcn01.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.remote.b686opcn01",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.opple_remote.RemoteB686OPCN01V3",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-remote-cagl02.json
+++ b/tests/data/devices/lumi-lumi-remote-cagl02.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.remote.cagl02",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.cube_aqgl01.CubeCAGL02",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-sen-ill-mgl01.json
+++ b/tests/data/devices/lumi-lumi-sen-ill-mgl01.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.sen_ill.mgl01",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.illumination.Illumination",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-sensor-86sw2.json
+++ b/tests/data/devices/lumi-lumi-sensor-86sw2.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.sensor_86sw2",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.remote_b286acn01.RemoteB286ACN01",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4151,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-sensor-ht-agl02.json
+++ b/tests/data/devices/lumi-lumi-sensor-ht-agl02.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.sensor_ht.agl02",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.sensor_ht_agl02.LumiSensorHtAgl02",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-sensor-magnet-aq2.json
+++ b/tests/data/devices/lumi-lumi-sensor-magnet-aq2.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.sensor_magnet.aq2",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.magnet_aq2.MagnetAQ2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4151,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-sensor-motion-aq2.json
+++ b/tests/data/devices/lumi-lumi-sensor-motion-aq2.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.sensor_motion.aq2",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.motion_aq2.MotionAQ2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4151,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-sensor-smoke-acn03.json
+++ b/tests/data/devices/lumi-lumi-sensor-smoke-acn03.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.sensor_smoke.acn03",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.smoke.LumiSensorSmokeAcn03",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-sensor-smoke.json
+++ b/tests/data/devices/lumi-lumi-sensor-smoke.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.sensor_smoke",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.mija.smoke.MijiaHoneywellSmokeDetectorSensor",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4151,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-sensor-switch-aq2.json
+++ b/tests/data/devices/lumi-lumi-sensor-switch-aq2.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.sensor_switch.aq2",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.switch_aq2.SwitchAQ2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4151,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-sensor-switch-aq3.json
+++ b/tests/data/devices/lumi-lumi-sensor-switch-aq3.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.sensor_switch.aq3",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.sensor_switch_aq3.SwitchAQ3",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4151,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-sensor-switch.json
+++ b/tests/data/devices/lumi-lumi-sensor-switch.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.sensor_switch",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.mija.sensor_switch.MijaButton",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4151,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-switch-b1laus01.json
+++ b/tests/data/devices/lumi-lumi-switch-b1laus01.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.switch.b1laus01",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-switch-b1naus01.json
+++ b/tests/data/devices/lumi-lumi-switch-b1naus01.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.switch.b1naus01",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-switch-l1aeu1.json
+++ b/tests/data/devices/lumi-lumi-switch-l1aeu1.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.switch.l1aeu1",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Battery or Unknown",
   "lqi": 240,

--- a/tests/data/devices/lumi-lumi-switch-l2aeu1.json
+++ b/tests/data/devices/lumi-lumi-switch-l2aeu1.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.switch.l2aeu1",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Battery or Unknown",
   "lqi": 220,

--- a/tests/data/devices/lumi-lumi-switch-n0agl1.json
+++ b/tests/data/devices/lumi-lumi-switch-n0agl1.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.switch.n0agl1",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.switch_t1.SwitchT1Alt3",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Mains",
   "lqi": 255,

--- a/tests/data/devices/lumi-lumi-vibration-agl01.json
+++ b/tests/data/devices/lumi-lumi-vibration-agl01.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.vibration.agl01",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4447,
   "power_source": "Battery or Unknown",
   "lqi": 108,

--- a/tests/data/devices/lumi-lumi-vibration-aq1.json
+++ b/tests/data/devices/lumi-lumi-vibration-aq1.json
@@ -9,7 +9,9 @@
   "name": "LUMI lumi.vibration.aq1",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.vibration_aq1.VibrationAQ1",
-  "quirk_id": "xiaomi.aqara_vibration_aq1",
+  "exposes_features": [
+    "xiaomi.aqara_vibration_aq1"
+  ],
   "manufacturer_code": 4151,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lumi-lumi-weather.json
+++ b/tests/data/devices/lumi-lumi-weather.json
@@ -9,7 +9,7 @@
   "name": "LUMI lumi.weather",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.xiaomi.aqara.weather.Weather",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4151,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lutron-lzl4bwhl01-remote.json
+++ b/tests/data/devices/lutron-lzl4bwhl01-remote.json
@@ -9,7 +9,7 @@
   "name": " Lutron LZL4BWHL01 Remote",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.lutron.lzl4bwhl01remote.LutronLZL4BWHL01Remote",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4420,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/lutron-z3-1brl.json
+++ b/tests/data/devices/lutron-z3-1brl.json
@@ -9,7 +9,7 @@
   "name": "Lutron Z3-1BRL",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4420,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/mli-tint-extendedcolor.json
+++ b/tests/data/devices/mli-tint-extendedcolor.json
@@ -9,7 +9,7 @@
   "name": "MLI tint-ExtendedColor",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.mli.tintE14rgbcct.TintRGBCCTLight",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4635,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/mli-zbt-remote-all-rgbw.json
+++ b/tests/data/devices/mli-zbt-remote-all-rgbw.json
@@ -9,7 +9,7 @@
   "name": "MLI ZBT-Remote-ALL-RGBW",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.mli.tint.TintRemote",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4635,
   "power_source": "Battery or Unknown",
   "lqi": 255,

--- a/tests/data/devices/nabu-casa-ha-connect-zbt-1.json
+++ b/tests/data/devices/nabu-casa-ha-connect-zbt-1.json
@@ -9,7 +9,7 @@
   "name": "HA Connect ZBT-1",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 43981,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/namron-as-4512785.json
+++ b/tests/data/devices/namron-as-4512785.json
@@ -9,7 +9,7 @@
   "name": "Namron AS 4512785",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4714,
   "power_source": "Mains",
   "lqi": 255,

--- a/tests/data/devices/neuhaus-lighting-group-nlg-remote.json
+++ b/tests/data/devices/neuhaus-lighting-group-nlg-remote.json
@@ -9,7 +9,7 @@
   "name": "Neuhaus Lighting Group NLG-remote",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4151,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/nodon-sin-4-rs-20.json
+++ b/tests/data/devices/nodon-sin-4-rs-20.json
@@ -9,7 +9,7 @@
   "name": "NodOn SIN-4-RS-20",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4747,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/osram-switch-4x-lightify.json
+++ b/tests/data/devices/osram-switch-4x-lightify.json
@@ -9,7 +9,7 @@
   "name": "OSRAM Switch 4x-LIGHTIFY",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.osram.lightifyx4.LightifyX4",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4364,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/ou-rui-bo-cf31218e11c547179c9c9ade6a492799.json
+++ b/tests/data/devices/ou-rui-bo-cf31218e11c547179c9c9ade6a492799.json
@@ -9,7 +9,7 @@
   "name": "\u6b27\u745e\u535a cf31218e11c547179c9c9ade6a492799",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 0,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/philips-7602031u7.json
+++ b/tests/data/devices/philips-7602031u7.json
@@ -9,7 +9,7 @@
   "name": "Philips Hue Go",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4107,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/philips-lct014.json
+++ b/tests/data/devices/philips-lct014.json
@@ -9,7 +9,7 @@
   "name": "Philips LCT014",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4107,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/philips-llc020.json
+++ b/tests/data/devices/philips-llc020.json
@@ -9,7 +9,7 @@
   "name": "Philips LLC020",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4107,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/philips-lst002.json
+++ b/tests/data/devices/philips-lst002.json
@@ -9,7 +9,7 @@
   "name": "Philips LST002",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4107,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/philips-rom001.json
+++ b/tests/data/devices/philips-rom001.json
@@ -9,7 +9,7 @@
   "name": "Philips ROM001",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.philips.rom001.PhilipsROM001",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4107,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/philips-rwl020.json
+++ b/tests/data/devices/philips-rwl020.json
@@ -9,7 +9,7 @@
   "name": "Philips RWL020",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.philips.rwlfirstgen.PhilipsRWLFirstGen",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4107,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/philips-sml001.json
+++ b/tests/data/devices/philips-sml001.json
@@ -9,7 +9,7 @@
   "name": "Philips SML001",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.philips.motion.PhilipsMotion",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4107,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/plaid-systems-ps-sprzms-slp3.json
+++ b/tests/data/devices/plaid-systems-ps-sprzms-slp3.json
@@ -9,7 +9,7 @@
   "name": "PLAID SYSTEMS PS-SPRZMS-SLP3",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/samjin-button.json
+++ b/tests/data/devices/samjin-button.json
@@ -9,7 +9,7 @@
   "name": "Samjin button",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.samjin.button.SamjinButton",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4673,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/samjin-multi.json
+++ b/tests/data/devices/samjin-multi.json
@@ -9,7 +9,7 @@
   "name": "Samjin multi",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.smartthings.multi.SmartthingsMultiPurposeSensor",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4673,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/schneider-electric-evsckt-outlet-1.json
+++ b/tests/data/devices/schneider-electric-evsckt-outlet-1.json
@@ -9,7 +9,7 @@
   "name": "Schneider Electric EVSCKT/OUTLET/1",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4190,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/schneider-electric-puck-shutter-1.json
+++ b/tests/data/devices/schneider-electric-puck-shutter-1.json
@@ -9,7 +9,7 @@
   "name": "Schneider Electric PUCK/SHUTTER/1",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4190,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/schneider-electric-s520619.json
+++ b/tests/data/devices/schneider-electric-s520619.json
@@ -9,7 +9,7 @@
   "name": "Schneider Electric S520619",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4190,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/securifi-ltd-unk-model.json
+++ b/tests/data/devices/securifi-ltd-unk-model.json
@@ -9,7 +9,7 @@
   "name": "Securifi Ltd. unk_model",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/sengled-e11-g13.json
+++ b/tests/data/devices/sengled-e11-g13.json
@@ -9,7 +9,7 @@
   "name": "sengled E11-G13",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4448,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/sengled-e12-n14.json
+++ b/tests/data/devices/sengled-e12-n14.json
@@ -9,7 +9,7 @@
   "name": "sengled E12-N14",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4448,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/sengled-e12-n1e.json
+++ b/tests/data/devices/sengled-e12-n1e.json
@@ -9,7 +9,7 @@
   "name": "sengled E12-N1E",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4448,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/sengled-e1c-nb6.json
+++ b/tests/data/devices/sengled-e1c-nb6.json
@@ -9,7 +9,7 @@
   "name": "sengled E1C-NB6",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4448,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/sengled-e1c-nb7.json
+++ b/tests/data/devices/sengled-e1c-nb7.json
@@ -9,7 +9,7 @@
   "name": "sengled E1C-NB7",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4448,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/sengled-e1f-n9g.json
+++ b/tests/data/devices/sengled-e1f-n9g.json
@@ -9,7 +9,7 @@
   "name": "sengled E1F-N9G",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4448,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/sengled-e1g-g8e.json
+++ b/tests/data/devices/sengled-e1g-g8e.json
@@ -9,7 +9,7 @@
   "name": "sengled E1G-G8E",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4448,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/sengled-e21-n1ea.json
+++ b/tests/data/devices/sengled-e21-n1ea.json
@@ -9,7 +9,7 @@
   "name": "sengled E21-N1EA",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4448,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/sengled-z01-a19nae26.json
+++ b/tests/data/devices/sengled-z01-a19nae26.json
@@ -9,7 +9,7 @@
   "name": "sengled Z01-A19NAE26",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4448,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/shelly-mini1pm.json
+++ b/tests/data/devices/shelly-mini1pm.json
@@ -9,7 +9,7 @@
   "name": "Shelly Mini1PM",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 5264,
   "power_source": "Mains",
   "lqi": 153,

--- a/tests/data/devices/signify-netherlands-b-v-lca001.json
+++ b/tests/data/devices/signify-netherlands-b-v-lca001.json
@@ -9,7 +9,7 @@
   "name": "Signify Netherlands B.V. LCA001",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4107,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/signify-netherlands-b-v-lca005.json
+++ b/tests/data/devices/signify-netherlands-b-v-lca005.json
@@ -9,7 +9,7 @@
   "name": "Signify Netherlands B.V. LCA005",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4107,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/signify-netherlands-b-v-lca007.json
+++ b/tests/data/devices/signify-netherlands-b-v-lca007.json
@@ -9,7 +9,7 @@
   "name": "Signify Netherlands B.V. LCA007",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4107,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/signify-netherlands-b-v-lcb001.json
+++ b/tests/data/devices/signify-netherlands-b-v-lcb001.json
@@ -9,7 +9,7 @@
   "name": "Signify Netherlands B.V. LCB001",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4107,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/signify-netherlands-b-v-lcb002.json
+++ b/tests/data/devices/signify-netherlands-b-v-lcb002.json
@@ -9,7 +9,7 @@
   "name": "Signify Netherlands B.V. LCB002",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4107,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/signify-netherlands-b-v-lce001.json
+++ b/tests/data/devices/signify-netherlands-b-v-lce001.json
@@ -9,7 +9,7 @@
   "name": "Signify Netherlands B.V. LCE001",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4107,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/signify-netherlands-b-v-lcx004.json
+++ b/tests/data/devices/signify-netherlands-b-v-lcx004.json
@@ -9,7 +9,7 @@
   "name": "Signify Netherlands B.V. LCX004",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4107,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/signify-netherlands-b-v-lta010.json
+++ b/tests/data/devices/signify-netherlands-b-v-lta010.json
@@ -9,7 +9,7 @@
   "name": "Signify Netherlands B.V. LTA010",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4107,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/signify-netherlands-b-v-ltb003.json
+++ b/tests/data/devices/signify-netherlands-b-v-ltb003.json
@@ -9,7 +9,7 @@
   "name": "Philips Hue White Ambiance BR30 E26",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4107,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/signify-netherlands-b-v-lwa003.json
+++ b/tests/data/devices/signify-netherlands-b-v-lwa003.json
@@ -9,7 +9,7 @@
   "name": "Signify Netherlands B.V. LWA003",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4107,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/signify-netherlands-b-v-rdm001.json
+++ b/tests/data/devices/signify-netherlands-b-v-rdm001.json
@@ -9,7 +9,7 @@
   "name": "Signify Netherlands B.V. RDM001",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.philips.wall_switch.PhilipsWallSwitch",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4107,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/signify-netherlands-b-v-rdm002.json
+++ b/tests/data/devices/signify-netherlands-b-v-rdm002.json
@@ -9,7 +9,7 @@
   "name": "Signify Netherlands B.V. RDM002",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.philips.rdm002.PhilipsRDM002",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4107,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/signify-netherlands-b-v-rwl022.json
+++ b/tests/data/devices/signify-netherlands-b-v-rwl022.json
@@ -9,7 +9,7 @@
   "name": "Signify Netherlands B.V. RWL022",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.philips.rwl022.PhilipsRWL022",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4107,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/signify-netherlands-b-v-sml003.json
+++ b/tests/data/devices/signify-netherlands-b-v-sml003.json
@@ -9,7 +9,7 @@
   "name": "Signify Netherlands B.V. SML003",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.philips.motion.SignifyMotion",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4107,
   "power_source": "Battery or Unknown",
   "lqi": 61,

--- a/tests/data/devices/signify-netherlands-b-v-sml004.json
+++ b/tests/data/devices/signify-netherlands-b-v-sml004.json
@@ -9,7 +9,7 @@
   "name": "Signify Netherlands B.V. SML004",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.philips.motion.SignifyMotion",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4107,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/sinope-technologies-va4220zb.json
+++ b/tests/data/devices/sinope-technologies-va4220zb.json
@@ -9,7 +9,7 @@
   "name": "Sinope Technologies VA4220ZB",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4508,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/smartthings-tagv4.json
+++ b/tests/data/devices/smartthings-tagv4.json
@@ -9,7 +9,7 @@
   "name": "SmartThings tagv4",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.smartthings.tag_v4.SmartThingsTagV4",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4362,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/smartwings-wm25-l-z.json
+++ b/tests/data/devices/smartwings-wm25-l-z.json
@@ -9,7 +9,7 @@
   "name": "Smartwings WM25/L-Z",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.smartwings.wm25lz.WM25LBlinds",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/somfy-situo-4-zigbee.json
+++ b/tests/data/devices/somfy-situo-4-zigbee.json
@@ -9,7 +9,7 @@
   "name": "SOMFY Situo 4 Zigbee",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4640,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/somfy-sonesse-28-wf-li-ion-roller.json
+++ b/tests/data/devices/somfy-sonesse-28-wf-li-ion-roller.json
@@ -9,7 +9,7 @@
   "name": "SOMFY Sonesse 28 WF Li-Ion Roller",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4640,
   "power_source": "Battery or Unknown",
   "lqi": 176,

--- a/tests/data/devices/somfy-ysia-5-hp-zigbee.json
+++ b/tests/data/devices/somfy-ysia-5-hp-zigbee.json
@@ -9,7 +9,7 @@
   "name": "SOMFY Ysia 5 HP Zigbee",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4640,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/sonoff-01minizb.json
+++ b/tests/data/devices/sonoff-01minizb.json
@@ -9,7 +9,7 @@
   "name": "SONOFF 01MINIZB",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4742,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/sonoff-basiczbr3.json
+++ b/tests/data/devices/sonoff-basiczbr3.json
@@ -9,7 +9,7 @@
   "name": "SONOFF BASICZBR3",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 0,
   "power_source": "Mains",
   "lqi": 172,

--- a/tests/data/devices/sonoff-dongle-e-r.json
+++ b/tests/data/devices/sonoff-dongle-e-r.json
@@ -9,7 +9,7 @@
   "name": "SONOFF DONGLE-E_R",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4742,
   "power_source": "Mains",
   "lqi": 212,

--- a/tests/data/devices/sonoff-mini-zbrbs.json
+++ b/tests/data/devices/sonoff-mini-zbrbs.json
@@ -9,7 +9,7 @@
   "name": "SONOFF MINI-ZBRBS",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4742,
   "power_source": "Mains",
   "lqi": 184,

--- a/tests/data/devices/sonoff-s26r2zb.json
+++ b/tests/data/devices/sonoff-s26r2zb.json
@@ -9,7 +9,7 @@
   "name": "SONOFF S26R2ZB",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4742,
   "power_source": "Mains",
   "lqi": 128,

--- a/tests/data/devices/sonoff-s31-lite-zb.json
+++ b/tests/data/devices/sonoff-s31-lite-zb.json
@@ -9,7 +9,7 @@
   "name": "SONOFF S31 Lite zb",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 0,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/sonoff-s60zbtpg.json
+++ b/tests/data/devices/sonoff-s60zbtpg.json
@@ -9,7 +9,7 @@
   "name": "SONOFF S60ZBTPG",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4742,
   "power_source": "Mains",
   "lqi": 54,

--- a/tests/data/devices/sonoff-snzb-02d.json
+++ b/tests/data/devices/sonoff-snzb-02d.json
@@ -9,7 +9,7 @@
   "name": "SONOFF SNZB-02D",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4742,
   "power_source": "Battery or Unknown",
   "lqi": 204,

--- a/tests/data/devices/sonoff-snzb-05p.json
+++ b/tests/data/devices/sonoff-snzb-05p.json
@@ -9,7 +9,7 @@
   "name": "SONOFF SNZB-05P",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4742,
   "power_source": "Battery or Unknown",
   "lqi": 212,

--- a/tests/data/devices/sonoff-snzb-06p.json
+++ b/tests/data/devices/sonoff-snzb-06p.json
@@ -9,7 +9,7 @@
   "name": "SONOFF SNZB-06P",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.sonoff.snzb06p.SonoffPresenceSenorSNZB06P",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4742,
   "power_source": "Mains",
   "lqi": 240,

--- a/tests/data/devices/sonoff-swv.json
+++ b/tests/data/devices/sonoff-swv.json
@@ -9,7 +9,7 @@
   "name": "SONOFF SWV",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4742,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/sonoff-trvzb.json
+++ b/tests/data/devices/sonoff-trvzb.json
@@ -9,7 +9,7 @@
   "name": "SONOFF TRVZB",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4742,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/sonoff-zbmicro.json
+++ b/tests/data/devices/sonoff-zbmicro.json
@@ -9,7 +9,7 @@
   "name": "SONOFF ZBMicro",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4742,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/sonoff-zbminil2.json
+++ b/tests/data/devices/sonoff-zbminil2.json
@@ -9,7 +9,7 @@
   "name": "SONOFF ZBMINIL2",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4742,
   "power_source": "Battery or Unknown",
   "lqi": 168,

--- a/tests/data/devices/sonoff-zbminir2.json
+++ b/tests/data/devices/sonoff-zbminir2.json
@@ -9,7 +9,7 @@
   "name": "SONOFF ZBMINIR2",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4742,
   "power_source": "Mains",
   "lqi": 43,

--- a/tests/data/devices/sunricher-hk-ln-dim-a.json
+++ b/tests/data/devices/sunricher-hk-ln-dim-a.json
@@ -9,7 +9,7 @@
   "name": "Sunricher HK-LN-DIM-A",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4644,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/sunricher-on-off-2ch.json
+++ b/tests/data/devices/sunricher-on-off-2ch.json
@@ -9,7 +9,7 @@
   "name": "Sunricher ON/OFF(2CH)",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4107,
   "power_source": "Mains",
   "lqi": 164,

--- a/tests/data/devices/texas-instruments-cc2652.json
+++ b/tests/data/devices/texas-instruments-cc2652.json
@@ -9,7 +9,7 @@
   "name": "Texas Instruments CC2652",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 0,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/texasinstruments-ti-router.json
+++ b/tests/data/devices/texasinstruments-ti-router.json
@@ -9,7 +9,7 @@
   "name": "TexasInstruments ti.router",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.texasinstruments.router.TiRouter",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 0,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/the-home-depot-ecosmart-zbt-a19-cct-bulb.json
+++ b/tests/data/devices/the-home-depot-ecosmart-zbt-a19-cct-bulb.json
@@ -9,7 +9,7 @@
   "name": "The Home Depot Ecosmart-ZBT-A19-CCT-Bulb",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4688,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/third-reality-inc-3rds17bz.json
+++ b/tests/data/devices/third-reality-inc-3rds17bz.json
@@ -9,7 +9,7 @@
   "name": "Third Reality, Inc 3RDS17BZ",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4659,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/third-reality-inc-3rms16bz.json
+++ b/tests/data/devices/third-reality-inc-3rms16bz.json
@@ -9,7 +9,7 @@
   "name": "Third Reality, Inc 3RMS16BZ",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4659,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/third-reality-inc-3rsb015bz.json
+++ b/tests/data/devices/third-reality-inc-3rsb015bz.json
@@ -9,7 +9,7 @@
   "name": "Third Reality, Inc 3RSB015BZ",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4659,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/third-reality-inc-3rsb22bz.json
+++ b/tests/data/devices/third-reality-inc-3rsb22bz.json
@@ -9,7 +9,7 @@
   "name": "Third Reality, Inc 3RSB22BZ",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.thirdreality.button.Button",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4659,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/third-reality-inc-3rsm0147z.json
+++ b/tests/data/devices/third-reality-inc-3rsm0147z.json
@@ -9,7 +9,7 @@
   "name": "Third Reality, Inc 3RSM0147Z",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 5127,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/third-reality-inc-3rsnl02043z.json
+++ b/tests/data/devices/third-reality-inc-3rsnl02043z.json
@@ -9,7 +9,7 @@
   "name": "Third Reality, Inc 3RSNL02043Z",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.thirdreality.night_light.Nightlight",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4877,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/third-reality-inc-3rsp019bz.json
+++ b/tests/data/devices/third-reality-inc-3rsp019bz.json
@@ -9,7 +9,7 @@
   "name": "Third Reality, Inc 3RSP019BZ",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4659,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/third-reality-inc-3rsp02028bz.json
+++ b/tests/data/devices/third-reality-inc-3rsp02028bz.json
@@ -9,7 +9,7 @@
   "name": "Third Reality, Inc 3RSP02028BZ",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4659,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/third-reality-inc-3rss007z.json
+++ b/tests/data/devices/third-reality-inc-3rss007z.json
@@ -9,7 +9,7 @@
   "name": "Third Reality, Inc 3RSS007Z",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4659,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/third-reality-inc-3rss009z.json
+++ b/tests/data/devices/third-reality-inc-3rss009z.json
@@ -9,7 +9,7 @@
   "name": "Third Reality, Inc 3RSS009Z",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4659,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/third-reality-inc-3rths24bz.json
+++ b/tests/data/devices/third-reality-inc-3rths24bz.json
@@ -9,7 +9,7 @@
   "name": "Third Reality, Inc 3RTHS24BZ",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4659,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/third-reality-inc-3rvs01031z.json
+++ b/tests/data/devices/third-reality-inc-3rvs01031z.json
@@ -9,7 +9,7 @@
   "name": "Third Reality, Inc 3RVS01031Z",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.thirdreality.vibrate.Vibrate",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4659,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/third-reality-inc-3rws18bz.json
+++ b/tests/data/devices/third-reality-inc-3rws18bz.json
@@ -9,7 +9,7 @@
   "name": "Third Reality, Inc 3RWS18BZ",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4659,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tubeszb-tubeszb-router.json
+++ b/tests/data/devices/tubeszb-tubeszb-router.json
@@ -9,7 +9,7 @@
   "name": "TubesZB tubeszb.router",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 0,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tuyatec-gqhxixyk-rh3052.json
+++ b/tests/data/devices/tuyatec-gqhxixyk-rh3052.json
@@ -9,7 +9,7 @@
   "name": "TUYATEC-gqhxixyk RH3052",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 0,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tuyatec-r9hgssol-rh3001.json
+++ b/tests/data/devices/tuyatec-r9hgssol-rh3001.json
@@ -9,7 +9,7 @@
   "name": "TUYATEC-r9hgssol RH3001",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 0,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tuyatec-rkqiqvcs-rh3001.json
+++ b/tests/data/devices/tuyatec-rkqiqvcs-rh3001.json
@@ -9,7 +9,7 @@
   "name": "TUYATEC-rkqiqvcs RH3001",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 0,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tuyatec-yg5dcbfu-rh3052.json
+++ b/tests/data/devices/tuyatec-yg5dcbfu-rh3052.json
@@ -9,7 +9,7 @@
   "name": "TUYATEC-yg5dcbfu RH3052",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 0,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tyst11-i5j6ifxj-5j6ifxj.json
+++ b/tests/data/devices/tyst11-i5j6ifxj-5j6ifxj.json
@@ -9,7 +9,7 @@
   "name": "_TYST11_i5j6ifxj 5j6ifxj",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 0,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tyzb01-1xktopx6-ts0041a.json
+++ b/tests/data/devices/tyzb01-1xktopx6-ts0041a.json
@@ -9,7 +9,7 @@
   "name": "_TYZB01_1xktopx6 TS0041A",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.ts0041.TuyaSmartRemote0041_var04",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Battery or Unknown",
   "lqi": 204,

--- a/tests/data/devices/tyzb01-o63ssaah-ts0207.json
+++ b/tests/data/devices/tyzb01-o63ssaah-ts0207.json
@@ -9,7 +9,7 @@
   "name": "_TYZB01_o63ssaah TS0207",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tyzb01-qm6djpta-ts0215.json
+++ b/tests/data/devices/tyzb01-qm6djpta-ts0215.json
@@ -9,7 +9,7 @@
   "name": "_TYZB01_qm6djpta TS0215",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4619,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tyzb01-rifa0wlb-ts0011.json
+++ b/tests/data/devices/tyzb01-rifa0wlb-ts0011.json
@@ -9,7 +9,7 @@
   "name": "_TYZB01_rifa0wlb TS0011",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tyzb01-vkwryfdr-ts0115.json
+++ b/tests/data/devices/tyzb01-vkwryfdr-ts0115.json
@@ -9,7 +9,7 @@
   "name": "_TYZB01_vkwryfdr TS0115",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tyzb01-zanh6v1o-ts0121.json
+++ b/tests/data/devices/tyzb01-zanh6v1o-ts0121.json
@@ -9,7 +9,7 @@
   "name": "_TYZB01_zanh6v1o TS0121",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 0,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tz3000-09gto2zn-ts0013.json
+++ b/tests/data/devices/tz3000-09gto2zn-ts0013.json
@@ -9,7 +9,7 @@
   "name": "_TZ3000_09gto2zn TS0013",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tz3000-1dd0d5yi-ts130f.json
+++ b/tests/data/devices/tz3000-1dd0d5yi-ts130f.json
@@ -9,7 +9,7 @@
   "name": "_TZ3000_1dd0d5yi TS130F",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.ts130f.TuyaTS130FTI2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Mains",
   "lqi": 255,

--- a/tests/data/devices/tz3000-1o6x1bl0-ts0201.json
+++ b/tests/data/devices/tz3000-1o6x1bl0-ts0201.json
@@ -9,7 +9,7 @@
   "name": "_TZ3000_1o6x1bl0 TS0201",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": 185,

--- a/tests/data/devices/tz3000-2xlvlnez-ts011f.json
+++ b/tests/data/devices/tz3000-2xlvlnez-ts011f.json
@@ -9,7 +9,7 @@
   "name": "_TZ3000_2xlvlnez TS011F",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4660,
   "power_source": "Mains",
   "lqi": 184,

--- a/tests/data/devices/tz3000-3ias4w4o-ts011f.json
+++ b/tests/data/devices/tz3000-3ias4w4o-ts011f.json
@@ -9,7 +9,7 @@
   "name": "_TZ3000_3ias4w4o TS011F",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tz3000-5ity3zyu-ts0121.json
+++ b/tests/data/devices/tz3000-5ity3zyu-ts0121.json
@@ -9,7 +9,7 @@
   "name": "_TZ3000_5ity3zyu TS0121",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tz3000-8nkb7mof-ts0121.json
+++ b/tests/data/devices/tz3000-8nkb7mof-ts0121.json
@@ -9,7 +9,9 @@
   "name": "_TZ3000_8nkb7mof TS0121",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.ts0121_plug.TS0121B",
-  "quirk_id": "tuya.plug_on_off_attributes",
+  "exposes_features": [
+    "tuya.plug_on_off_attributes"
+  ],
   "manufacturer_code": 4098,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tz3000-8yhypbo7-ts0203.json
+++ b/tests/data/devices/tz3000-8yhypbo7-ts0203.json
@@ -9,7 +9,7 @@
   "name": "_TZ3000_8yhypbo7 TS0203",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tz3000-bguser20-ts0201.json
+++ b/tests/data/devices/tz3000-bguser20-ts0201.json
@@ -9,7 +9,7 @@
   "name": "_TZ3000_bguser20 TS0201",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tz3000-cehuw1lw-ts011f.json
+++ b/tests/data/devices/tz3000-cehuw1lw-ts011f.json
@@ -9,7 +9,7 @@
   "name": "_TZ3000_cehuw1lw TS011F",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tz3000-f2bw0b6k-ts0201.json
+++ b/tests/data/devices/tz3000-f2bw0b6k-ts0201.json
@@ -9,7 +9,7 @@
   "name": "_TZ3000_f2bw0b6k TS0201",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tz3000-gbm10jnj-ts0043.json
+++ b/tests/data/devices/tz3000-gbm10jnj-ts0043.json
@@ -9,7 +9,7 @@
   "name": "_TZ3000_gbm10jnj TS0043",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tz3000-gjpgagal-ts0049.json
+++ b/tests/data/devices/tz3000-gjpgagal-ts0049.json
@@ -9,7 +9,7 @@
   "name": "_TZ3000_gjpgagal TS0049",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tz3000-gwkzibhs-ts004f.json
+++ b/tests/data/devices/tz3000-gwkzibhs-ts004f.json
@@ -9,7 +9,7 @@
   "name": "_TZ3000_gwkzibhs TS004F",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.ts004f.TuyaSmartRemote004FROK",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4742,
   "power_source": "Battery or Unknown",
   "lqi": 182,

--- a/tests/data/devices/tz3000-hafsqare-ts0011.json
+++ b/tests/data/devices/tz3000-hafsqare-ts0011.json
@@ -9,7 +9,7 @@
   "name": "_TZ3000_hafsqare TS0011",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tz3000-idhkkbqj-ts0012.json
+++ b/tests/data/devices/tz3000-idhkkbqj-ts0012.json
@@ -9,7 +9,7 @@
   "name": "_TZ3000_idhkkbqj TS0012",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.ts001x.TuyaDoubleNoNeutralSwitch",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Battery or Unknown",
   "lqi": 109,

--- a/tests/data/devices/tz3000-itnrsufe-ts0201.json
+++ b/tests/data/devices/tz3000-itnrsufe-ts0201.json
@@ -9,7 +9,7 @@
   "name": "_TZ3000_itnrsufe TS0201",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.ts0201.MoesTemperatureHumidtySensorWithScreen",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tz3000-kjfzuycl-ts004f.json
+++ b/tests/data/devices/tz3000-kjfzuycl-ts004f.json
@@ -9,7 +9,7 @@
   "name": "_TZ3000_kjfzuycl TS004F",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.ts004f.TuyaSmartRemote004FSK",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tz3000-mugyhz0q-ts0207.json
+++ b/tests/data/devices/tz3000-mugyhz0q-ts0207.json
@@ -9,7 +9,7 @@
   "name": "_TZ3000_mugyhz0q TS0207",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tz3000-o1jzcxou-ts011f.json
+++ b/tests/data/devices/tz3000-o1jzcxou-ts011f.json
@@ -9,7 +9,9 @@
   "name": "_TZ3000_o1jzcxou TS011F",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.ts011f_plug.Plug_v7",
-  "quirk_id": "tuya.plug_on_off_attributes",
+  "exposes_features": [
+    "tuya.plug_on_off_attributes"
+  ],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": 204,

--- a/tests/data/devices/tz3000-o4mkahkc-ts0202.json
+++ b/tests/data/devices/tz3000-o4mkahkc-ts0202.json
@@ -9,7 +9,7 @@
   "name": "_TZ3000_o4mkahkc TS0202",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tz3000-rbl8c85w-ts0012.json
+++ b/tests/data/devices/tz3000-rbl8c85w-ts0012.json
@@ -9,7 +9,7 @@
   "name": "_TZ3000_rbl8c85w TS0012",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.ts001x.Tuya_Double_Var06",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Battery or Unknown",
   "lqi": 47,

--- a/tests/data/devices/tz3000-sgb0xhwn-ts011f.json
+++ b/tests/data/devices/tz3000-sgb0xhwn-ts011f.json
@@ -9,7 +9,9 @@
   "name": "_TZ3000_sgb0xhwn TS011F",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.ts011f_plug.Plug_2AC_var05",
-  "quirk_id": "tuya.plug_on_off_attributes",
+  "exposes_features": [
+    "tuya.plug_on_off_attributes"
+  ],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": 208,

--- a/tests/data/devices/tz3000-tgddllx4-ts0001.json
+++ b/tests/data/devices/tz3000-tgddllx4-ts0001.json
@@ -9,7 +9,7 @@
   "name": "_TZ3000_tgddllx4 TS0001",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4660,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tz3000-typdpbpg-ts011f.json
+++ b/tests/data/devices/tz3000-typdpbpg-ts011f.json
@@ -9,7 +9,9 @@
   "name": "_TZ3000_typdpbpg TS011F",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.ts011f_plug.Plug_v3",
-  "quirk_id": "tuya.plug_on_off_attributes",
+  "exposes_features": [
+    "tuya.plug_on_off_attributes"
+  ],
   "manufacturer_code": 4107,
   "power_source": "Mains",
   "lqi": 132,

--- a/tests/data/devices/tz3000-u4kojtqz-ts0002.json
+++ b/tests/data/devices/tz3000-u4kojtqz-ts0002.json
@@ -9,7 +9,7 @@
   "name": "_TZ3000_u4kojtqz TS0002",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4107,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tz3000-uwkja6z1-ts011f.json
+++ b/tests/data/devices/tz3000-uwkja6z1-ts011f.json
@@ -9,7 +9,7 @@
   "name": "_TZ3000_uwkja6z1 TS011F",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tz3000-w0qqde0g-ts011f.json
+++ b/tests/data/devices/tz3000-w0qqde0g-ts011f.json
@@ -9,7 +9,9 @@
   "name": "_TZ3000_w0qqde0g TS011F",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.ts011f_plug.Plug_v2",
-  "quirk_id": "tuya.plug_on_off_attributes",
+  "exposes_features": [
+    "tuya.plug_on_off_attributes"
+  ],
   "manufacturer_code": 4660,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tz3000-xa9g7rxs-ts1002.json
+++ b/tests/data/devices/tz3000-xa9g7rxs-ts1002.json
@@ -9,7 +9,7 @@
   "name": "_TZ3000_xa9g7rxs TS1002",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tz3000-zl1kmjqx.json
+++ b/tests/data/devices/tz3000-zl1kmjqx.json
@@ -9,7 +9,7 @@
   "name": "_TZ3000_zl1kmjqx ",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.builder.EnchantedDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tz3000-zw7yf6yk-ts0001.json
+++ b/tests/data/devices/tz3000-zw7yf6yk-ts0001.json
@@ -9,7 +9,7 @@
   "name": "_TZ3000_zw7yf6yk TS0001",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tz3002-vaq2bfcu-ts0726.json
+++ b/tests/data/devices/tz3002-vaq2bfcu-ts0726.json
@@ -9,7 +9,7 @@
   "name": "_TZ3002_vaq2bfcu TS0726",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tz3040-bb6xaihh-ts0202.json
+++ b/tests/data/devices/tz3040-bb6xaihh-ts0202.json
@@ -9,7 +9,7 @@
   "name": "_TZ3040_bb6xaihh TS0202",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": 136,

--- a/tests/data/devices/tz3210-09hzmirw-ts0502b.json
+++ b/tests/data/devices/tz3210-09hzmirw-ts0502b.json
@@ -9,7 +9,7 @@
   "name": "_TZ3210_09hzmirw TS0502B",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tz3210-0jxeoadc-ts0049.json
+++ b/tests/data/devices/tz3210-0jxeoadc-ts0049.json
@@ -9,7 +9,7 @@
   "name": "_TZ3210_0jxeoadc TS0049",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.builder.EnchantedDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tz3210-3mpwqzuu-ts110e.json
+++ b/tests/data/devices/tz3210-3mpwqzuu-ts110e.json
@@ -9,7 +9,7 @@
   "name": "_TZ3210_3mpwqzuu TS110E",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": 176,

--- a/tests/data/devices/tz3210-bfwvfyx1-ts0505b.json
+++ b/tests/data/devices/tz3210-bfwvfyx1-ts0505b.json
@@ -9,7 +9,7 @@
   "name": "_TZ3210_bfwvfyx1 TS0505B",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": 160,

--- a/tests/data/devices/tz3210-comkuwws-ts0502b.json
+++ b/tests/data/devices/tz3210-comkuwws-ts0502b.json
@@ -9,7 +9,7 @@
   "name": "_TZ3210_comkuwws TS0502B",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tz3210-ehcanwyc-ts0502b.json
+++ b/tests/data/devices/tz3210-ehcanwyc-ts0502b.json
@@ -9,7 +9,7 @@
   "name": "_TZ3210_ehcanwyc TS0502B",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": 160,

--- a/tests/data/devices/tz3210-ekjc2rzh-ts0225.json
+++ b/tests/data/devices/tz3210-ekjc2rzh-ts0225.json
@@ -9,7 +9,7 @@
   "name": "_TZ3210_ekjc2rzh TS0225",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tz3210-j4pdtz9v-ts0001.json
+++ b/tests/data/devices/tz3210-j4pdtz9v-ts0001.json
@@ -9,7 +9,7 @@
   "name": "_TZ3210_j4pdtz9v TS0001",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.builder.EnchantedDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tz3210-jaap6jeb-ts0505b.json
+++ b/tests/data/devices/tz3210-jaap6jeb-ts0505b.json
@@ -9,7 +9,7 @@
   "name": "_TZ3210_jaap6jeb TS0505B",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tz3210-k1msuvg6-ts110e.json
+++ b/tests/data/devices/tz3210-k1msuvg6-ts110e.json
@@ -9,7 +9,7 @@
   "name": "_TZ3210_k1msuvg6 TS110E",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": 176,

--- a/tests/data/devices/tz3210-kjafhwd2-ts0210.json
+++ b/tests/data/devices/tz3210-kjafhwd2-ts0210.json
@@ -9,7 +9,7 @@
   "name": "_TZ3210_kjafhwd2 TS0210",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": 224,

--- a/tests/data/devices/tz3210-r5afgmkl-ts0505b.json
+++ b/tests/data/devices/tz3210-r5afgmkl-ts0505b.json
@@ -9,7 +9,7 @@
   "name": "_TZ3210_r5afgmkl TS0505B",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4107,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tz3210-ru41azca-ts0049.json
+++ b/tests/data/devices/tz3210-ru41azca-ts0049.json
@@ -9,7 +9,7 @@
   "name": "_TZ3210_ru41azca TS0049",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tz3210-sb8x2xci-ts0001.json
+++ b/tests/data/devices/tz3210-sb8x2xci-ts0001.json
@@ -9,7 +9,7 @@
   "name": "_TZ3210_sb8x2xci TS0001",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tz3210-tgvtvdoc-ts0207.json
+++ b/tests/data/devices/tz3210-tgvtvdoc-ts0207.json
@@ -9,7 +9,7 @@
   "name": "_TZ3210_tgvtvdoc TS0207",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tz3210-u1dreag7-ts0502b.json
+++ b/tests/data/devices/tz3210-u1dreag7-ts0502b.json
@@ -9,7 +9,7 @@
   "name": "_TZ3210_u1dreag7 TS0502B",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": 160,

--- a/tests/data/devices/tz3218-7fiyo3kv-ts000f.json
+++ b/tests/data/devices/tz3218-7fiyo3kv-ts000f.json
@@ -9,7 +9,7 @@
   "name": "_TZ3218_7fiyo3kv TS000F",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tz3218-t9ynfz4x-ts0225.json
+++ b/tests/data/devices/tz3218-t9ynfz4x-ts0225.json
@@ -9,7 +9,7 @@
   "name": "_TZ3218_t9ynfz4x TS0225",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tz3218-ya5d6wth-ts000f.json
+++ b/tests/data/devices/tz3218-ya5d6wth-ts000f.json
@@ -9,7 +9,7 @@
   "name": "_TZ3218_ya5d6wth TS000F",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tz3290-7v1k4vufotpowp9z-ts1201.json
+++ b/tests/data/devices/tz3290-7v1k4vufotpowp9z-ts1201.json
@@ -9,7 +9,7 @@
   "name": "_TZ3290_7v1k4vufotpowp9z TS1201",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.ts1201.ZosungIRBlaster_ZS06",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tz3290-ot6ewjvmejq5ekhl-ts1201.json
+++ b/tests/data/devices/tz3290-ot6ewjvmejq5ekhl-ts1201.json
@@ -9,7 +9,7 @@
   "name": "_TZ3290_ot6ewjvmejq5ekhl TS1201",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.ts1201.ZosungIRBlaster",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Battery or Unknown",
   "lqi": 120,

--- a/tests/data/devices/tz6210-duv6fhwt-ts0601.json
+++ b/tests/data/devices/tz6210-duv6fhwt-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZ6210_duv6fhwt TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4619,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze200-2aaelwxk-ts0225.json
+++ b/tests/data/devices/tze200-2aaelwxk-ts0225.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_2aaelwxk TS0225",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze200-3towulqd-ts0601.json
+++ b/tests/data/devices/tze200-3towulqd-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_3towulqd TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze200-3ylew7b4-ts0601.json
+++ b/tests/data/devices/tze200-3ylew7b4-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_3ylew7b4 TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Mains",
   "lqi": 128,

--- a/tests/data/devices/tze200-8whfphjv-ts0601.json
+++ b/tests/data/devices/tze200-8whfphjv-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_8whfphjv TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze200-9caxna4s-ts0301.json
+++ b/tests/data/devices/tze200-9caxna4s-ts0301.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_9caxna4s TS0301",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze200-9xfjixap-ts0601.json
+++ b/tests/data/devices/tze200-9xfjixap-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_9xfjixap TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze200-akjefhj5-ts0601.json
+++ b/tests/data/devices/tze200-akjefhj5-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_akjefhj5 TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze200-b6wax7g0-ts0601.json
+++ b/tests/data/devices/tze200-b6wax7g0-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_b6wax7g0 TS0601",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.ts0601_trv.MoesHY368_Type1new",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": 0,

--- a/tests/data/devices/tze200-bkkmqmyo-ts0601.json
+++ b/tests/data/devices/tze200-bkkmqmyo-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_bkkmqmyo TS0601",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.ts0601_din_power.HikingPowerMeter",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Mains",
   "lqi": 160,

--- a/tests/data/devices/tze200-c88teujp-ts0601.json
+++ b/tests/data/devices/tze200-c88teujp-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_c88teujp TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze200-crq3r3la-ck-bl702-mws-01-7016.json
+++ b/tests/data/devices/tze200-crq3r3la-ck-bl702-mws-01-7016.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_crq3r3la CK-BL702-MWS-01(7016)",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": 255,

--- a/tests/data/devices/tze200-e5hpkc6d-ts0601.json
+++ b/tests/data/devices/tze200-e5hpkc6d-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_e5hpkc6d TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze200-gjldowol-ts0601.json
+++ b/tests/data/devices/tze200-gjldowol-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_gjldowol TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze200-gkfbdvyx-ts0601.json
+++ b/tests/data/devices/tze200-gkfbdvyx-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_gkfbdvyx TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4660,
   "power_source": "Mains",
   "lqi": 172,

--- a/tests/data/devices/tze200-guvc7pdy-ts0601.json
+++ b/tests/data/devices/tze200-guvc7pdy-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_guvc7pdy TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": 104,

--- a/tests/data/devices/tze200-h4cgnbzg-ts0601.json
+++ b/tests/data/devices/tze200-h4cgnbzg-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_h4cgnbzg TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze200-hhrtiq0x-ts0601.json
+++ b/tests/data/devices/tze200-hhrtiq0x-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_hhrtiq0x TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze200-hr0tdd47-ts0601.json
+++ b/tests/data/devices/tze200-hr0tdd47-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_hr0tdd47 TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze200-iba1ckek-ts0601.json
+++ b/tests/data/devices/tze200-iba1ckek-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_iba1ckek TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4742,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze200-ijey4q29-ts0601.json
+++ b/tests/data/devices/tze200-ijey4q29-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_ijey4q29 TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze200-kb5noeto-ts0601.json
+++ b/tests/data/devices/tze200-kb5noeto-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_kb5noeto TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4742,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze200-laqjm8qd-ts0601.json
+++ b/tests/data/devices/tze200-laqjm8qd-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_laqjm8qd TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze200-locansqn-ts0601.json
+++ b/tests/data/devices/tze200-locansqn-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_locansqn TS0601",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.builder.EnchantedDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze200-moycceze-ts0601.json
+++ b/tests/data/devices/tze200-moycceze-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_moycceze TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze200-myd45weu-ts0601.json
+++ b/tests/data/devices/tze200-myd45weu-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_myd45weu TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze200-mzik0ov2-ts0601.json
+++ b/tests/data/devices/tze200-mzik0ov2-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_mzik0ov2 TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze200-npj9bug3-ts0601.json
+++ b/tests/data/devices/tze200-npj9bug3-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_npj9bug3 TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4742,
   "power_source": "Battery or Unknown",
   "lqi": 180,

--- a/tests/data/devices/tze200-ntcy3xu1-ts0601.json
+++ b/tests/data/devices/tze200-ntcy3xu1-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_ntcy3xu1 TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze200-ny94onlb-ts0601.json
+++ b/tests/data/devices/tze200-ny94onlb-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_ny94onlb TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze200-pay2byax-ts0601.json
+++ b/tests/data/devices/tze200-pay2byax-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_pay2byax TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4742,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze200-qrztc3ev-ts0601.json
+++ b/tests/data/devices/tze200-qrztc3ev-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_qrztc3ev TS0601",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.builder.EnchantedDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4742,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze200-qyflbnbj-ts0601.json
+++ b/tests/data/devices/tze200-qyflbnbj-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_qyflbnbj TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze200-udank5zs-ts0601.json
+++ b/tests/data/devices/tze200-udank5zs-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_udank5zs TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze200-uf1qujxj-ts0601.json
+++ b/tests/data/devices/tze200-uf1qujxj-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_uf1qujxj TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze200-vvmbj46n-ts0601.json
+++ b/tests/data/devices/tze200-vvmbj46n-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_vvmbj46n TS0601",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.builder.EnchantedDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze200-wdfurkoa-ts0601.json
+++ b/tests/data/devices/tze200-wdfurkoa-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_wdfurkoa TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Battery or Unknown",
   "lqi": 40,

--- a/tests/data/devices/tze200-wfxuhoea-ts0601.json
+++ b/tests/data/devices/tze200-wfxuhoea-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_wfxuhoea TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze200-wqashyqo-ts0601.json
+++ b/tests/data/devices/tze200-wqashyqo-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_wqashyqo TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4742,
   "power_source": "Battery or Unknown",
   "lqi": 96,

--- a/tests/data/devices/tze200-ya4ft0w4-ts0601.json
+++ b/tests/data/devices/tze200-ya4ft0w4-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_ya4ft0w4 TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4660,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze200-yjjdcqsq-ts0601.json
+++ b/tests/data/devices/tze200-yjjdcqsq-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_yjjdcqsq TS0601",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.builder.EnchantedDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze200-yw7cahqs-ts0601.json
+++ b/tests/data/devices/tze200-yw7cahqs-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_yw7cahqs TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze204-1v1dxkck-ts0601.json
+++ b/tests/data/devices/tze204-1v1dxkck-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_1v1dxkck TS0601",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.ts0601_dimmer.TuyaTripleSwitchDimmerGP",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-1youk3hj-ts0601.json
+++ b/tests/data/devices/tze204-1youk3hj-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_1youk3hj TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-58of2pfn-ts0601.json
+++ b/tests/data/devices/tze204-58of2pfn-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_58of2pfn TS0601",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.ts0601_switch.TuyaQuadrupleSwitchGP",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": 164,

--- a/tests/data/devices/tze204-5slehgeo-ts0601.json
+++ b/tests/data/devices/tze204-5slehgeo-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_5slehgeo TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": 136,

--- a/tests/data/devices/tze204-81yrt3lo-ts0601.json
+++ b/tests/data/devices/tze204-81yrt3lo-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_81yrt3lo TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-a2jcoyuk-ts0601.json
+++ b/tests/data/devices/tze204-a2jcoyuk-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_a2jcoyuk TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-ai4rqhky-ts0601.json
+++ b/tests/data/devices/tze204-ai4rqhky-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_ai4rqhky TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze204-aoclfnxz-ts0601.json
+++ b/tests/data/devices/tze204-aoclfnxz-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_aoclfnxz TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-c2fmom5z-ts0601.json
+++ b/tests/data/devices/tze204-c2fmom5z-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_c2fmom5z TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-dwcarsat-ts0601.json
+++ b/tests/data/devices/tze204-dwcarsat-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_dwcarsat TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-ex3rcdha-ts0601.json
+++ b/tests/data/devices/tze204-ex3rcdha-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_ex3rcdha TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-fhvdgeuh-ts0601.json
+++ b/tests/data/devices/tze204-fhvdgeuh-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_fhvdgeuh TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-goecjd1t-ts0601.json
+++ b/tests/data/devices/tze204-goecjd1t-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_goecjd1t TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-gops3slb-ts0601.json
+++ b/tests/data/devices/tze204-gops3slb-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_gops3slb TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": 224,

--- a/tests/data/devices/tze204-iaeejhvf-ts0601.json
+++ b/tests/data/devices/tze204-iaeejhvf-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_iaeejhvf TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-jrcfsaa3-ts0601.json
+++ b/tests/data/devices/tze204-jrcfsaa3-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_jrcfsaa3 TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-l8xiyymq-ts0601.json
+++ b/tests/data/devices/tze204-l8xiyymq-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_l8xiyymq TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-lb0fsvba-ts0601.json
+++ b/tests/data/devices/tze204-lb0fsvba-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_lb0fsvba TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": 188,

--- a/tests/data/devices/tze204-lbbg34rj-ts0601.json
+++ b/tests/data/devices/tze204-lbbg34rj-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_lbbg34rj TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-lpedvtvr-ts0601.json
+++ b/tests/data/devices/tze204-lpedvtvr-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_lpedvtvr TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-ltwbm23f-ts0601.json
+++ b/tests/data/devices/tze204-ltwbm23f-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_ltwbm23f TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze204-m64smti7-ts0601.json
+++ b/tests/data/devices/tze204-m64smti7-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_m64smti7 TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-m9dzckna-ts0601.json
+++ b/tests/data/devices/tze204-m9dzckna-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_m9dzckna TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": 216,

--- a/tests/data/devices/tze204-mtoaryre-ts0601.json
+++ b/tests/data/devices/tze204-mtoaryre-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_mtoaryre TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-mwomyz5n-ts0601.json
+++ b/tests/data/devices/tze204-mwomyz5n-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_mwomyz5n TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-nbkshs6k-ts0601.json
+++ b/tests/data/devices/tze204-nbkshs6k-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_nbkshs6k TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-nklqjk62-ts0601.json
+++ b/tests/data/devices/tze204-nklqjk62-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_nklqjk62 TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-nlrfgpny-ts0601.json
+++ b/tests/data/devices/tze204-nlrfgpny-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_nlrfgpny TS0601",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.builder.EnchantedDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze204-nqqylykc-ts0601.json
+++ b/tests/data/devices/tze204-nqqylykc-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_nqqylykc TS0601",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.ts0601_dimmer.TuyaSingleSwitchDimmerGP",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-nvxorhcj-ts0601.json
+++ b/tests/data/devices/tze204-nvxorhcj-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_nvxorhcj TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": 58,

--- a/tests/data/devices/tze204-ogx8u5z6-ts0601.json
+++ b/tests/data/devices/tze204-ogx8u5z6-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_ogx8u5z6 TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze204-pcdmj88b-ts0601.json
+++ b/tests/data/devices/tze204-pcdmj88b-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_pcdmj88b TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze204-pxbjch8m-ts0601.json
+++ b/tests/data/devices/tze204-pxbjch8m-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_pxbjch8m TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-qasjif9e-ts0601.json
+++ b/tests/data/devices/tze204-qasjif9e-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_qasjif9e TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-qtnjuoae-ts0601.json
+++ b/tests/data/devices/tze204-qtnjuoae-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_qtnjuoae TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze204-qvxrkeif-ts0601.json
+++ b/tests/data/devices/tze204-qvxrkeif-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_qvxrkeif TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": 255,

--- a/tests/data/devices/tze204-qyr2m29i-ts0601.json
+++ b/tests/data/devices/tze204-qyr2m29i-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_qyr2m29i TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze204-r32ctezx-ts0601.json
+++ b/tests/data/devices/tze204-r32ctezx-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_r32ctezx TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-rtrmfadk-ts0601.json
+++ b/tests/data/devices/tze204-rtrmfadk-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_rtrmfadk TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze204-tdhnhhiy-ts0601.json
+++ b/tests/data/devices/tze204-tdhnhhiy-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_tdhnhhiy TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": 25,

--- a/tests/data/devices/tze204-upagmta9-ts0601.json
+++ b/tests/data/devices/tze204-upagmta9-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_upagmta9 TS0601",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.builder.EnchantedDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze204-uxllnywp-ts0601.json
+++ b/tests/data/devices/tze204-uxllnywp-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_uxllnywp TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-w1wwxoja-ts0601.json
+++ b/tests/data/devices/tze204-w1wwxoja-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_w1wwxoja TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-wbhaespm-ts0601.json
+++ b/tests/data/devices/tze204-wbhaespm-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_wbhaespm TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-xalsoe3m-ts0601.json
+++ b/tests/data/devices/tze204-xalsoe3m-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_xalsoe3m TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-xlppj4f5-ts0601.json
+++ b/tests/data/devices/tze204-xlppj4f5-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_xlppj4f5 TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze204-xnbkhhdr-ts0601.json
+++ b/tests/data/devices/tze204-xnbkhhdr-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_xnbkhhdr TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze204-ya4ft0w4-ts0601.json
+++ b/tests/data/devices/tze204-ya4ft0w4-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_ya4ft0w4 TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-yvx5lh6k-ts0601.json
+++ b/tests/data/devices/tze204-yvx5lh6k-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_yvx5lh6k TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze204-zxkwaztm-ts0601.json
+++ b/tests/data/devices/tze204-zxkwaztm-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE204_zxkwaztm TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": 180,

--- a/tests/data/devices/tze20c-zka46xbw-ts0601.json
+++ b/tests/data/devices/tze20c-zka46xbw-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE20C_zka46xbw TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze284-2gi1hy8s-ts0601.json
+++ b/tests/data/devices/tze284-2gi1hy8s-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_2gi1hy8s TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze284-7zazvlyn-ts0601.json
+++ b/tests/data/devices/tze284-7zazvlyn-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_7zazvlyn TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze284-81yrt3lo-ts0601.json
+++ b/tests/data/devices/tze284-81yrt3lo-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_81yrt3lo TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze284-a2xewxoo-ts0601.json
+++ b/tests/data/devices/tze284-a2xewxoo-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_a2xewxoo TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": 255,

--- a/tests/data/devices/tze284-aao3yzhs-ts0601.json
+++ b/tests/data/devices/tze284-aao3yzhs-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_aao3yzhs TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze284-c6wv4xyo-ts0601.json
+++ b/tests/data/devices/tze284-c6wv4xyo-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_c6wv4xyo TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze284-cjbofhxw-ts0601.json
+++ b/tests/data/devices/tze284-cjbofhxw-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_cjbofhxw TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze284-dmckrsxg-ts0601.json
+++ b/tests/data/devices/tze284-dmckrsxg-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_dmckrsxg TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": 132,

--- a/tests/data/devices/tze284-f5efvtbv-ts0601.json
+++ b/tests/data/devices/tze284-f5efvtbv-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_f5efvtbv TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": 200,

--- a/tests/data/devices/tze284-fhvpaltk-ts0601.json
+++ b/tests/data/devices/tze284-fhvpaltk-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_fhvpaltk TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Battery or Unknown",
   "lqi": 196,

--- a/tests/data/devices/tze284-iadro9bf-ts0601.json
+++ b/tests/data/devices/tze284-iadro9bf-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_iadro9bf TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/tze284-kyyu8rbj-ts0601.json
+++ b/tests/data/devices/tze284-kyyu8rbj-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_kyyu8rbj TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze284-l8xiyymq-ts0601.json
+++ b/tests/data/devices/tze284-l8xiyymq-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_l8xiyymq TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Mains",
   "lqi": 58,

--- a/tests/data/devices/tze284-ltwbm23f-ts0601.json
+++ b/tests/data/devices/tze284-ltwbm23f-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_ltwbm23f TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze284-myd45weu-ts0601.json
+++ b/tests/data/devices/tze284-myd45weu-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_myd45weu TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze284-ne4pikwm-ts0601.json
+++ b/tests/data/devices/tze284-ne4pikwm-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_ne4pikwm TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze284-nklqjk62-ts0601.json
+++ b/tests/data/devices/tze284-nklqjk62-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_nklqjk62 TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Mains",
   "lqi": 148,

--- a/tests/data/devices/tze284-nnhwcvbk-ts0601.json
+++ b/tests/data/devices/tze284-nnhwcvbk-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_nnhwcvbk TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": 88,

--- a/tests/data/devices/tze284-o3x45p96-ts0601.json
+++ b/tests/data/devices/tze284-o3x45p96-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_o3x45p96 TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze284-ogx8u5z6-ts0601.json
+++ b/tests/data/devices/tze284-ogx8u5z6-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_ogx8u5z6 TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze284-oitavov2-ts0601.json
+++ b/tests/data/devices/tze284-oitavov2-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_oitavov2 TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": 184,

--- a/tests/data/devices/tze284-qyflbnbj-ts0601.json
+++ b/tests/data/devices/tze284-qyflbnbj-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_qyflbnbj TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze284-rjxqso4a-ts0601.json
+++ b/tests/data/devices/tze284-rjxqso4a-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_rjxqso4a TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze284-rqcuwlsa-ts0601.json
+++ b/tests/data/devices/tze284-rqcuwlsa-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_rqcuwlsa TS0601",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.builder.EnchantedDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze284-upagmta9-ts0601.json
+++ b/tests/data/devices/tze284-upagmta9-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_upagmta9 TS0601",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.tuya.builder.EnchantedDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": 255,

--- a/tests/data/devices/tze284-vawy74yh-ts0601.json
+++ b/tests/data/devices/tze284-vawy74yh-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_vawy74yh TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": 255,

--- a/tests/data/devices/tze284-vuwtqx0t-ts0601.json
+++ b/tests/data/devices/tze284-vuwtqx0t-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_vuwtqx0t TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": 255,

--- a/tests/data/devices/tze284-wtikaxzs-ts0601.json
+++ b/tests/data/devices/tze284-wtikaxzs-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_wtikaxzs TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze284-zjhoqbrd-ts0601.json
+++ b/tests/data/devices/tze284-zjhoqbrd-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_zjhoqbrd TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": 255,

--- a/tests/data/devices/tze284-zm8zpwas-ts0601.json
+++ b/tests/data/devices/tze284-zm8zpwas-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_zm8zpwas TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/tze284-znvwzxkq-ts0601.json
+++ b/tests/data/devices/tze284-znvwzxkq-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE284_znvwzxkq TS0601",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4098,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/data/devices/xiaomi-lywsd03mmc.json
+++ b/tests/data/devices/xiaomi-lywsd03mmc.json
@@ -9,7 +9,7 @@
   "name": "Xiaomi LYWSD03MMC",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/xiaoyan-terncy-sd01.json
+++ b/tests/data/devices/xiaoyan-terncy-sd01.json
@@ -9,7 +9,7 @@
   "name": "Xiaoyan TERNCY-SD01",
   "quirk_applied": true,
   "quirk_class": "zhaquirks.terncy.sd01.TerncyKnobSmartDimmer",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4648,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/xyzroe-diy-zintercom.json
+++ b/tests/data/devices/xyzroe-diy-zintercom.json
@@ -9,7 +9,7 @@
   "name": "xyzroe DIY_Zintercom",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 0,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/yale-yrd256-tsdb.json
+++ b/tests/data/devices/yale-yrd256-tsdb.json
@@ -9,7 +9,7 @@
   "name": "Yale YRD256 TSDB",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4125,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/yooksmart-d10110.json
+++ b/tests/data/devices/yooksmart-d10110.json
@@ -9,7 +9,7 @@
   "name": "yooksmart D10110",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4169,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/yunding-ford.json
+++ b/tests/data/devices/yunding-ford.json
@@ -9,7 +9,7 @@
   "name": "Yunding Ford",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4698,
   "power_source": "Battery or Unknown",
   "lqi": null,

--- a/tests/data/devices/zbeacon-ts0001.json
+++ b/tests/data/devices/zbeacon-ts0001.json
@@ -9,7 +9,7 @@
   "name": "Zbeacon TS0001",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4107,
   "power_source": "Mains",
   "lqi": 140,

--- a/tests/data/devices/zbeacon-ts0505.json
+++ b/tests/data/devices/zbeacon-ts0505.json
@@ -9,7 +9,7 @@
   "name": "zbeacon TS0505",
   "quirk_applied": false,
   "quirk_class": "zigpy.device.Device",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4660,
   "power_source": "Mains",
   "lqi": null,

--- a/tests/test_cluster_handlers.py
+++ b/tests/test_cluster_handlers.py
@@ -545,7 +545,7 @@ def test_cluster_handler_registry() -> None:
         for model_quirk_list in manufacturer.values():
             for quirk in model_quirk_list:
                 qid: set[str] | str = getattr(quirk, ATTR_QUIRK_ID, set())
-                quirk_id: set[str] = {qid} if isinstance(qid, str) else qid
+                quirk_ids: set[str] = {qid} if isinstance(qid, str) else qid
 
                 device_description: dict[str, dict[str, Any]] = getattr(
                     quirk, "replacement", None
@@ -562,7 +562,7 @@ def test_cluster_handler_registry() -> None:
                             cluster_id = cluster_id.cluster_id
                         if cluster_id not in cluster_quirk_id_map:
                             cluster_quirk_id_map[cluster_id] = {None}
-                        cluster_quirk_id_map[cluster_id].update(quirk_id)
+                        cluster_quirk_id_map[cluster_id].update(quirk_ids)
 
     for (
         cluster_id,

--- a/tests/test_cluster_handlers.py
+++ b/tests/test_cluster_handlers.py
@@ -525,10 +525,10 @@ async def test_out_cluster_handler_config(
 def test_cluster_handler_registry() -> None:
     """Test ZIGBEE cluster handler Registry."""
 
-    # get all quirk ID from zigpy quirks registry
-    cluster_quirk_id_map: dict[int, set[str | None]] = {}
+    # get all exposed features from zigpy quirks registry
+    cluster_exposed_feature_map: dict[int, set[str | None]] = {}
     for cluster_id in CLUSTERS_BY_ID:
-        cluster_quirk_id_map[cluster_id] = {None}
+        cluster_exposed_feature_map[cluster_id] = {None}
 
     # loop over custom clusters in v2 quirks registry
     for quirks in _DEVICE_REGISTRY.registry_v2.values():
@@ -538,14 +538,14 @@ def test_cluster_handler_registry() -> None:
                 rm.add for rm in quirk_reg_entry.replaces_metadata
             }
             for metadata in all_metadata:
-                cluster_quirk_id_map[metadata.cluster.cluster_id] = {None}
+                cluster_exposed_feature_map[metadata.cluster.cluster_id] = {None}
 
     # loop over custom clusters in v1 quirks registry
     for manufacturer in _DEVICE_REGISTRY.registry_v1.values():
         for model_quirk_list in manufacturer.values():
             for quirk in model_quirk_list:
                 qid: set[str] | str = getattr(quirk, ATTR_QUIRK_ID, set())
-                quirk_ids: set[str] = {qid} if isinstance(qid, str) else set(qid)
+                exposed_features: set[str] = {qid} if isinstance(qid, str) else set(qid)
 
                 device_description: dict[str, dict[str, Any]] = getattr(
                     quirk, "replacement", None
@@ -560,9 +560,9 @@ def test_cluster_handler_registry() -> None:
                     for cluster_id in cluster_ids:
                         if not isinstance(cluster_id, int):
                             cluster_id = cluster_id.cluster_id
-                        if cluster_id not in cluster_quirk_id_map:
-                            cluster_quirk_id_map[cluster_id] = {None}
-                        cluster_quirk_id_map[cluster_id].update(quirk_ids)
+                        if cluster_id not in cluster_exposed_feature_map:
+                            cluster_exposed_feature_map[cluster_id] = {None}
+                        cluster_exposed_feature_map[cluster_id].update(exposed_features)
 
     for (
         cluster_id,
@@ -573,16 +573,17 @@ def test_cluster_handler_registry() -> None:
         assert 0 <= cluster_id <= 0xFFFF
 
         # test all registered clusters are used in zigpy or quirks
-        assert cluster_id in cluster_quirk_id_map
+        assert cluster_id in cluster_exposed_feature_map
 
         assert isinstance(cluster_handler_classes, dict)
-        for quirk_id, cluster_handler in cluster_handler_classes.items():
-            # test cluster handler is not quirk specific or only has a single quirk ID
-            assert quirk_id is None or isinstance(quirk_id, str)
+        for ch_exposed_feature, cluster_handler in cluster_handler_classes.items():
+            # test cluster handler is not quirk specific
+            # or only has a single exposed feature
+            assert ch_exposed_feature is None or isinstance(ch_exposed_feature, str)
             assert issubclass(cluster_handler, ClusterHandler)
 
-            # test cluster handler quirk ID is used in quirk with that cluster
-            assert quirk_id in cluster_quirk_id_map[cluster_id]
+            # test cluster handler exposed feature is used in quirk with that cluster
+            assert ch_exposed_feature in cluster_exposed_feature_map[cluster_id]
 
 
 def test_epch_unclaimed_cluster_handlers(cluster_handler) -> None:
@@ -820,7 +821,7 @@ async def test_ep_cluster_handlers_configure(cluster_handler) -> None:
     )
     zha_dev = mock.MagicMock(spec=Device)
     zha_dev.unique_id = "00:11:22:33:44:55:66:77"
-    type(zha_dev).quirk_id = mock.PropertyMock(return_value=set())
+    type(zha_dev).exposes_features = mock.PropertyMock(return_value=set())
     endpoint = Endpoint.new(endpoint_mock, zha_dev)
 
     claimed = {ch_1.id: ch_1, ch_2.id: ch_2, ch_3.id: ch_3}
@@ -1023,7 +1024,7 @@ async def test_invalid_cluster_handler(zha_gateway: Gateway, caplog) -> None:  #
     )
 
     mock_zha_device = mock.AsyncMock(spec=Device)
-    mock_zha_device.quirk_id = set()
+    mock_zha_device.exposes_features = set()
     mock_zha_device.unique_id = "aa:bb:cc:dd:11:22:33:44"
 
     zha_endpoint = Endpoint(zigpy_ep, mock_zha_device)
@@ -1068,14 +1069,14 @@ async def test_standard_cluster_handler(
     )
 
     mock_zha_device = mock.AsyncMock(spec=Device)
-    mock_zha_device.quirk_id = set()
+    mock_zha_device.exposes_features = set()
     mock_zha_device.unique_id = "aa:bb:cc:dd:11:22:33:44"
 
     zha_endpoint = Endpoint(zigpy_ep, mock_zha_device)
 
     with patch.dict(
         CLUSTER_HANDLER_REGISTRY[cluster.cluster_id],
-        {"__test_quirk_id": TestZigbeeClusterHandler},
+        {"__exposed_feature_id": TestZigbeeClusterHandler},
     ):
         zha_endpoint.add_all_cluster_handlers()
 
@@ -1085,10 +1086,10 @@ async def test_standard_cluster_handler(
     )
 
 
-async def test_quirk_id_cluster_handler(
+async def test_exposed_feature_cluster_handler(
     zha_gateway: Gateway,
 ) -> None:  # pylint: disable=unused-argument
-    """Test setting up a cluster handler that matches a standard cluster."""
+    """Test setting up a cluster handler with an exposed feature."""
 
     class TestZigbeeClusterHandler(ColorClusterHandler):
         """Test cluster handler that matches a standard cluster."""
@@ -1109,12 +1110,12 @@ async def test_quirk_id_cluster_handler(
 
     mock_zha_device = mock.AsyncMock(spec=Device)
     mock_zha_device.unique_id = "aa:bb:cc:dd:11:22:33:44"
-    mock_zha_device.quirk_id = {"__test_quirk_id"}
+    mock_zha_device.exposes_features = {"__exposed_feature_id"}
     zha_endpoint = Endpoint(zigpy_ep, mock_zha_device)
 
     with patch.dict(
         CLUSTER_HANDLER_REGISTRY[cluster.cluster_id],
-        {"__test_quirk_id": TestZigbeeClusterHandler},
+        {"__exposed_feature_id": TestZigbeeClusterHandler},
     ):
         zha_endpoint.add_all_cluster_handlers()
 

--- a/tests/test_cluster_handlers.py
+++ b/tests/test_cluster_handlers.py
@@ -545,7 +545,7 @@ def test_cluster_handler_registry() -> None:
         for model_quirk_list in manufacturer.values():
             for quirk in model_quirk_list:
                 qid: set[str] | str = getattr(quirk, ATTR_QUIRK_ID, set())
-                quirk_ids: set[str] = {qid} if isinstance(qid, str) else qid
+                quirk_ids: set[str] = {qid} if isinstance(qid, str) else set(qid)
 
                 device_description: dict[str, dict[str, Any]] = getattr(
                     quirk, "replacement", None

--- a/tests/test_cluster_handlers.py
+++ b/tests/test_cluster_handlers.py
@@ -544,7 +544,9 @@ def test_cluster_handler_registry() -> None:
     for manufacturer in _DEVICE_REGISTRY.registry_v1.values():
         for model_quirk_list in manufacturer.values():
             for quirk in model_quirk_list:
-                quirk_id = getattr(quirk, ATTR_QUIRK_ID, None)
+                qid: set[str] | str = getattr(quirk, ATTR_QUIRK_ID, set())
+                quirk_id: set[str] = {qid} if isinstance(qid, str) else qid
+
                 device_description: dict[str, dict[str, Any]] = getattr(
                     quirk, "replacement", None
                 ) or getattr(quirk, "signature", None)
@@ -560,19 +562,26 @@ def test_cluster_handler_registry() -> None:
                             cluster_id = cluster_id.cluster_id
                         if cluster_id not in cluster_quirk_id_map:
                             cluster_quirk_id_map[cluster_id] = {None}
-                        cluster_quirk_id_map[cluster_id].add(quirk_id)
+                        cluster_quirk_id_map[cluster_id].update(quirk_id)
 
     for (
         cluster_id,
         cluster_handler_classes,
     ) in CLUSTER_HANDLER_REGISTRY.items():
+        # test cluster_id is valid
         assert isinstance(cluster_id, int)
         assert 0 <= cluster_id <= 0xFFFF
+
+        # test all registered clusters are used in zigpy or quirks
         assert cluster_id in cluster_quirk_id_map
+
         assert isinstance(cluster_handler_classes, dict)
         for quirk_id, cluster_handler in cluster_handler_classes.items():
+            # test cluster handler is not quirk specific or only has a single quirk ID
             assert quirk_id is None or isinstance(quirk_id, str)
             assert issubclass(cluster_handler, ClusterHandler)
+
+            # test cluster handler quirk ID is used in quirk with that cluster
             assert quirk_id in cluster_quirk_id_map[cluster_id]
 
 
@@ -811,7 +820,7 @@ async def test_ep_cluster_handlers_configure(cluster_handler) -> None:
     )
     zha_dev = mock.MagicMock(spec=Device)
     zha_dev.unique_id = "00:11:22:33:44:55:66:77"
-    type(zha_dev).quirk_id = mock.PropertyMock(return_value=None)
+    type(zha_dev).quirk_id = mock.PropertyMock(return_value=set())
     endpoint = Endpoint.new(endpoint_mock, zha_dev)
 
     claimed = {ch_1.id: ch_1, ch_2.id: ch_2, ch_3.id: ch_3}
@@ -1014,7 +1023,7 @@ async def test_invalid_cluster_handler(zha_gateway: Gateway, caplog) -> None:  #
     )
 
     mock_zha_device = mock.AsyncMock(spec=Device)
-    mock_zha_device.quirk_id = None
+    mock_zha_device.quirk_id = set()
     mock_zha_device.unique_id = "aa:bb:cc:dd:11:22:33:44"
 
     zha_endpoint = Endpoint(zigpy_ep, mock_zha_device)
@@ -1059,7 +1068,7 @@ async def test_standard_cluster_handler(
     )
 
     mock_zha_device = mock.AsyncMock(spec=Device)
-    mock_zha_device.quirk_id = None
+    mock_zha_device.quirk_id = set()
     mock_zha_device.unique_id = "aa:bb:cc:dd:11:22:33:44"
 
     zha_endpoint = Endpoint(zigpy_ep, mock_zha_device)
@@ -1100,7 +1109,7 @@ async def test_quirk_id_cluster_handler(
 
     mock_zha_device = mock.AsyncMock(spec=Device)
     mock_zha_device.unique_id = "aa:bb:cc:dd:11:22:33:44"
-    mock_zha_device.quirk_id = "__test_quirk_id"
+    mock_zha_device.quirk_id = {"__test_quirk_id"}
     zha_endpoint = Endpoint(zigpy_ep, mock_zha_device)
 
     with patch.dict(

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -545,13 +545,13 @@ def test_quirk_classes() -> None:
             raise ValueError(f"Quirk ID '{value}' does not exist.")
 
     # get all quirk ID from zigpy quirks registry
-    all_quirk_ids = []
+    all_quirk_ids: set[str] = set()
     for manufacturer in zigpy_quirks._DEVICE_REGISTRY.registry_v1.values():
         for model_quirk_list in manufacturer.values():
             for quirk in model_quirk_list:
-                quirk_id = getattr(quirk, ATTR_QUIRK_ID, None)
-                if quirk_id is not None and quirk_id not in all_quirk_ids:
-                    all_quirk_ids.append(quirk_id)
+                qid: set[str] | str = getattr(quirk, ATTR_QUIRK_ID, set())
+                device_quirk_ids: set[str] = {qid} if isinstance(qid, str) else qid
+                all_quirk_ids.update(device_quirk_ids)
 
     # validate all quirk IDs used in component match rules
     for rule, _ in iter_all_rules():

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -550,7 +550,7 @@ def test_quirk_classes() -> None:
         for model_quirk_list in manufacturer.values():
             for quirk in model_quirk_list:
                 qid: set[str] | str = getattr(quirk, ATTR_QUIRK_ID, set())
-                device_quirk_ids: set[str] = {qid} if isinstance(qid, str) else qid
+                device_quirk_ids: set[str] = {qid} if isinstance(qid, str) else set(qid)
                 all_quirk_ids.update(device_quirk_ids)
 
     # validate all quirk IDs used in component match rules

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -199,7 +199,8 @@ def cluster_handlers(cluster_handler):
 def test_registry_matching(rule, matched, cluster_handlers) -> None:
     """Test strict rule matching."""
     assert (
-        rule.strict_matched(MANUFACTURER, MODEL, cluster_handlers, QUIRK_ID) is matched
+        rule.strict_matched(MANUFACTURER, MODEL, cluster_handlers, {QUIRK_ID})
+        is matched
     )
 
 
@@ -305,7 +306,7 @@ def test_registry_matching(rule, matched, cluster_handlers) -> None:
 def test_registry_loose_matching(rule, matched, cluster_handlers) -> None:
     """Test loose rule matching."""
     assert (
-        rule.loose_matched(MANUFACTURER, MODEL, cluster_handlers, QUIRK_ID) is matched
+        rule.loose_matched(MANUFACTURER, MODEL, cluster_handlers, {QUIRK_ID}) is matched
     )
 
 
@@ -434,7 +435,7 @@ def test_weighted_match(
     ch_level = cluster_handler("level", 8)
 
     match, claimed = entity_registry.get_entity(
-        s.component, manufacturer, model, [ch_on_off, ch_level], quirk_id
+        s.component, manufacturer, model, [ch_on_off, ch_level], {quirk_id}
     )
 
     assert match.__name__ == match_name
@@ -462,7 +463,7 @@ def test_multi_sensor_match(
         "manufacturer",
         "model",
         cluster_handlers=[ch_se, ch_illuminati],
-        quirk_id="quirk_id",
+        quirk_ids={"quirk_id"},
     )
 
     assert s.binary_sensor in match
@@ -492,7 +493,7 @@ def test_multi_sensor_match(
         "manufacturer",
         "model",
         cluster_handlers={ch_se, ch_illuminati},
-        quirk_id="quirk_id",
+        quirk_ids={"quirk_id"},
     )
 
     assert s.binary_sensor in match

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -99,6 +99,7 @@ def cluster_handlers(cluster_handler):
         ),
         (MatchRule(exposed_features=EXPOSED_FEATURE), True),
         (MatchRule(exposed_features="no match"), False),
+        (MatchRule(exposed_features={"no match for this yet", EXPOSED_FEATURE}), True),
         (
             MatchRule(
                 exposed_features=EXPOSED_FEATURE,

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -25,7 +25,7 @@ from zha.application.registries import (
 MANUFACTURER = "mock manufacturer"
 MODEL = "mock model"
 QUIRK_CLASS = "mock.test.quirk.class"
-QUIRK_ID = "quirk_id"
+EXPOSED_FEATURE = "EXPOSED_FEATURE_ID"
 
 
 @pytest.fixture
@@ -97,14 +97,19 @@ def cluster_handlers(cluster_handler):
             MatchRule(models="no match", aux_cluster_handlers="aux_cluster_handler"),
             False,
         ),
-        (MatchRule(quirk_ids=QUIRK_ID), True),
-        (MatchRule(quirk_ids="no match"), False),
+        (MatchRule(exposed_features=EXPOSED_FEATURE), True),
+        (MatchRule(exposed_features="no match"), False),
         (
-            MatchRule(quirk_ids=QUIRK_ID, aux_cluster_handlers="aux_cluster_handler"),
+            MatchRule(
+                exposed_features=EXPOSED_FEATURE,
+                aux_cluster_handlers="aux_cluster_handler",
+            ),
             True,
         ),
         (
-            MatchRule(quirk_ids="no match", aux_cluster_handlers="aux_cluster_handler"),
+            MatchRule(
+                exposed_features="no match", aux_cluster_handlers="aux_cluster_handler"
+            ),
             False,
         ),
         # match everything
@@ -114,7 +119,7 @@ def cluster_handlers(cluster_handler):
                 cluster_handler_names={"on_off", "level"},
                 manufacturers=MANUFACTURER,
                 models=MODEL,
-                quirk_ids=QUIRK_ID,
+                exposed_features=EXPOSED_FEATURE,
             ),
             True,
         ),
@@ -167,31 +172,33 @@ def cluster_handlers(cluster_handler):
         (
             MatchRule(
                 cluster_handler_names="on_off",
-                quirk_ids={"random quirk", QUIRK_ID},
+                exposed_features={"random quirk", EXPOSED_FEATURE},
             ),
             True,
         ),
         (
             MatchRule(
                 cluster_handler_names="on_off",
-                quirk_ids={"random quirk", "another quirk"},
+                exposed_features={"random quirk", "another quirk"},
             ),
             False,
         ),
         (
             MatchRule(
-                cluster_handler_names="on_off", quirk_ids=lambda x: x == QUIRK_ID
+                cluster_handler_names="on_off",
+                exposed_features=lambda x: x == EXPOSED_FEATURE,
             ),
             True,
         ),
         (
             MatchRule(
-                cluster_handler_names="on_off", quirk_ids=lambda x: x != QUIRK_ID
+                cluster_handler_names="on_off",
+                exposed_features=lambda x: x != EXPOSED_FEATURE,
             ),
             False,
         ),
         (
-            MatchRule(cluster_handler_names="on_off", quirk_ids=QUIRK_ID),
+            MatchRule(cluster_handler_names="on_off", exposed_features=EXPOSED_FEATURE),
             True,
         ),
     ],
@@ -199,7 +206,7 @@ def cluster_handlers(cluster_handler):
 def test_registry_matching(rule, matched, cluster_handlers) -> None:
     """Test strict rule matching."""
     assert (
-        rule.strict_matched(MANUFACTURER, MODEL, cluster_handlers, {QUIRK_ID})
+        rule.strict_matched(MANUFACTURER, MODEL, cluster_handlers, {EXPOSED_FEATURE})
         is matched
     )
 
@@ -288,8 +295,8 @@ def test_registry_matching(rule, matched, cluster_handlers) -> None:
         (MatchRule(manufacturers=MANUFACTURER), True),
         (MatchRule(models=MODEL), True),
         (MatchRule(models="no match"), False),
-        (MatchRule(quirk_ids=QUIRK_ID), True),
-        (MatchRule(quirk_ids="no match"), False),
+        (MatchRule(exposed_features=EXPOSED_FEATURE), True),
+        (MatchRule(exposed_features="no match"), False),
         # match everything
         (
             MatchRule(
@@ -297,7 +304,7 @@ def test_registry_matching(rule, matched, cluster_handlers) -> None:
                 cluster_handler_names={"on_off", "level"},
                 manufacturers=MANUFACTURER,
                 models=MODEL,
-                quirk_ids=QUIRK_ID,
+                exposed_features=EXPOSED_FEATURE,
             ),
             True,
         ),
@@ -306,7 +313,8 @@ def test_registry_matching(rule, matched, cluster_handlers) -> None:
 def test_registry_loose_matching(rule, matched, cluster_handlers) -> None:
     """Test loose rule matching."""
     assert (
-        rule.loose_matched(MANUFACTURER, MODEL, cluster_handlers, {QUIRK_ID}) is matched
+        rule.loose_matched(MANUFACTURER, MODEL, cluster_handlers, {EXPOSED_FEATURE})
+        is matched
     )
 
 
@@ -370,12 +378,12 @@ def entity_registry():
 
 
 @pytest.mark.parametrize(
-    ("manufacturer", "model", "quirk_id", "match_name"),
+    ("manufacturer", "model", "exposes_features", "match_name"),
     [
         ("random manufacturer", "random model", "random.class", "OnOff"),
         ("random manufacturer", MODEL, "random.class", "OnOffModel"),
         (MANUFACTURER, "random model", "random.class", "OnOffManufacturer"),
-        ("random manufacturer", "random model", QUIRK_ID, "OnOffQuirk"),
+        ("random manufacturer", "random model", EXPOSED_FEATURE, "OnOffQuirk"),
         (MANUFACTURER, MODEL, "random.class", "OnOffModelManufacturer"),
         (MANUFACTURER, "some model", "random.class", "OnOffMultimodel"),
     ],
@@ -385,7 +393,7 @@ def test_weighted_match(
     entity_registry: PlatformEntityRegistry,
     manufacturer,
     model,
-    quirk_id,
+    exposes_features,
     match_name,
 ) -> None:
     """Test weightedd match."""
@@ -426,7 +434,7 @@ def test_weighted_match(
         """OnOff model and manufacturer cluster handler."""
 
     @entity_registry.strict_match(
-        s.component, cluster_handler_names="on_off", quirk_ids=QUIRK_ID
+        s.component, cluster_handler_names="on_off", exposed_features=EXPOSED_FEATURE
     )
     class OnOffQuirk:  # pylint: disable=unused-variable
         """OnOff quirk cluster handler."""
@@ -435,7 +443,7 @@ def test_weighted_match(
     ch_level = cluster_handler("level", 8)
 
     match, claimed = entity_registry.get_entity(
-        s.component, manufacturer, model, [ch_on_off, ch_level], {quirk_id}
+        s.component, manufacturer, model, [ch_on_off, ch_level], {exposes_features}
     )
 
     assert match.__name__ == match_name
@@ -463,7 +471,7 @@ def test_multi_sensor_match(
         "manufacturer",
         "model",
         cluster_handlers=[ch_se, ch_illuminati],
-        quirk_ids={"quirk_id"},
+        exposes_features={"exposed_feature_id"},
     )
 
     assert s.binary_sensor in match
@@ -493,7 +501,7 @@ def test_multi_sensor_match(
         "manufacturer",
         "model",
         cluster_handlers={ch_se, ch_illuminati},
-        quirk_ids={"quirk_id"},
+        exposes_features={"exposed_feature_id"},
     )
 
     assert s.binary_sensor in match
@@ -541,21 +549,23 @@ def test_quirk_classes() -> None:
                 quirk_class_validator(v)
             return
 
-        if value not in all_quirk_ids:
-            raise ValueError(f"Quirk ID '{value}' does not exist.")
+        if value not in all_exposed_features:
+            raise ValueError(f"Exposed feature '{value}' does not exist.")
 
     # get all quirk ID from zigpy quirks registry
-    all_quirk_ids: set[str] = set()
+    all_exposed_features: set[str] = set()
     for manufacturer in zigpy_quirks._DEVICE_REGISTRY.registry_v1.values():
         for model_quirk_list in manufacturer.values():
             for quirk in model_quirk_list:
                 qid: set[str] | str = getattr(quirk, ATTR_QUIRK_ID, set())
-                device_quirk_ids: set[str] = {qid} if isinstance(qid, str) else set(qid)
-                all_quirk_ids.update(device_quirk_ids)
+                device_exposed_features: set[str] = (
+                    {qid} if isinstance(qid, str) else set(qid)
+                )
+                all_exposed_features.update(device_exposed_features)
 
     # validate all quirk IDs used in component match rules
     for rule, _ in iter_all_rules():
-        quirk_class_validator(rule.quirk_ids)
+        quirk_class_validator(rule.exposed_features)
 
 
 def test_entity_names() -> None:

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -408,7 +408,7 @@ class EndpointProbe:
                 endpoint.device.manufacturer,
                 endpoint.device.model,
                 cluster_handlers,
-                endpoint.device.quirk_ids,
+                endpoint.device.exposes_features,
             )
             if entity_class is None:
                 return
@@ -437,7 +437,7 @@ class EndpointProbe:
             endpoint.device.manufacturer,
             endpoint.device.model,
             [cluster_handler],
-            endpoint.device.quirk_ids,
+            endpoint.device.exposes_features,
         )
         if entity_class is None:
             return
@@ -500,15 +500,16 @@ class EndpointProbe:
                 cluster_id, {None: ClusterHandler}
             )
 
-            # get first quirk id from device that matches a registered cluster handler
-            cluster_quirk_id: str | None = None
-            for qid in endpoint.device.quirk_ids:
-                if qid in cluster_handler_classes:
-                    cluster_quirk_id = qid
+            # get first exposed feature from device
+            # that matches a registered cluster handler
+            cluster_exposed_feature: str | None = None
+            for exposed_features in endpoint.device.exposes_features:
+                if exposed_features in cluster_handler_classes:
+                    cluster_exposed_feature = exposed_features
                     break
 
             cluster_handler_class = cluster_handler_classes.get(
-                cluster_quirk_id, ClusterHandler
+                cluster_exposed_feature, ClusterHandler
             )
 
             cluster_handler = cluster_handler_class(cluster, endpoint)
@@ -540,14 +541,14 @@ class EndpointProbe:
                 device.manufacturer,
                 device.model,
                 cluster_handlers,
-                device.quirk_ids,
+                device.exposes_features,
             )
         else:
             matches, claimed = PLATFORM_ENTITIES.get_multi_entity(
                 device.manufacturer,
                 device.model,
                 endpoint.unclaimed_cluster_handlers(),
-                device.quirk_ids,
+                device.exposes_features,
             )
 
         endpoint.claim_cluster_handlers(claimed)

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -500,14 +500,15 @@ class EndpointProbe:
                 cluster_id, {None: ClusterHandler}
             )
 
-            quirk_id = (
-                endpoint.device.quirk_id
-                if endpoint.device.quirk_id in cluster_handler_classes
-                else None
-            )
+            # get first quirk id from device that matches a registered cluster handler
+            cluster_quirk_id: str | None = None
+            for qid in endpoint.device.quirk_id:
+                if qid in cluster_handler_classes:
+                    cluster_quirk_id = qid
+                    break
 
             cluster_handler_class = cluster_handler_classes.get(
-                quirk_id, ClusterHandler
+                cluster_quirk_id, ClusterHandler
             )
 
             cluster_handler = cluster_handler_class(cluster, endpoint)

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -408,7 +408,7 @@ class EndpointProbe:
                 endpoint.device.manufacturer,
                 endpoint.device.model,
                 cluster_handlers,
-                endpoint.device.quirk_id,
+                endpoint.device.quirk_ids,
             )
             if entity_class is None:
                 return
@@ -437,7 +437,7 @@ class EndpointProbe:
             endpoint.device.manufacturer,
             endpoint.device.model,
             [cluster_handler],
-            endpoint.device.quirk_id,
+            endpoint.device.quirk_ids,
         )
         if entity_class is None:
             return
@@ -502,7 +502,7 @@ class EndpointProbe:
 
             # get first quirk id from device that matches a registered cluster handler
             cluster_quirk_id: str | None = None
-            for qid in endpoint.device.quirk_id:
+            for qid in endpoint.device.quirk_ids:
                 if qid in cluster_handler_classes:
                     cluster_quirk_id = qid
                     break
@@ -540,14 +540,14 @@ class EndpointProbe:
                 device.manufacturer,
                 device.model,
                 cluster_handlers,
-                device.quirk_id,
+                device.quirk_ids,
             )
         else:
             matches, claimed = PLATFORM_ENTITIES.get_multi_entity(
                 device.manufacturer,
                 device.model,
                 endpoint.unclaimed_cluster_handlers(),
-                device.quirk_id,
+                device.quirk_ids,
             )
 
         endpoint.claim_cluster_handlers(claimed)

--- a/zha/application/platforms/binary_sensor/__init__.py
+++ b/zha/application/platforms/binary_sensor/__init__.py
@@ -398,7 +398,7 @@ class AqaraE1CurtainMotorOpenedByHandBinarySensor(BinarySensor):
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
-    quirk_ids={DANFOSS_ALLY_THERMOSTAT},
+    exposed_features={DANFOSS_ALLY_THERMOSTAT},
 )
 class DanfossMountingModeActive(BinarySensor):
     """Danfoss TRV proprietary attribute exposing whether in mounting mode."""
@@ -412,7 +412,7 @@ class DanfossMountingModeActive(BinarySensor):
 
 @MULTI_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
-    quirk_ids={DANFOSS_ALLY_THERMOSTAT},
+    exposed_features={DANFOSS_ALLY_THERMOSTAT},
 )
 class DanfossHeatRequired(BinarySensor):
     """Danfoss TRV proprietary attribute exposing whether heat is required."""
@@ -424,7 +424,7 @@ class DanfossHeatRequired(BinarySensor):
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
-    quirk_ids={DANFOSS_ALLY_THERMOSTAT},
+    exposed_features={DANFOSS_ALLY_THERMOSTAT},
 )
 class DanfossPreheatStatus(BinarySensor):
     """Danfoss TRV proprietary attribute exposing whether in pre-heating mode."""

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -920,7 +920,7 @@ class MinHeatSetpointLimit(ZCLHeatSetpointLimitEntity):
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
-    quirk_ids={DANFOSS_ALLY_THERMOSTAT},
+    exposed_features={DANFOSS_ALLY_THERMOSTAT},
 )
 class DanfossExerciseTriggerTime(NumberConfigurationEntity):
     """Danfoss proprietary attribute to set the time to exercise the valve."""
@@ -936,7 +936,7 @@ class DanfossExerciseTriggerTime(NumberConfigurationEntity):
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
-    quirk_ids={DANFOSS_ALLY_THERMOSTAT},
+    exposed_features={DANFOSS_ALLY_THERMOSTAT},
 )
 class DanfossExternalMeasuredRoomSensor(ZCLTemperatureEntity):
     """Danfoss proprietary attribute to communicate the value of the external temperature sensor."""
@@ -950,7 +950,7 @@ class DanfossExternalMeasuredRoomSensor(ZCLTemperatureEntity):
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
-    quirk_ids={DANFOSS_ALLY_THERMOSTAT},
+    exposed_features={DANFOSS_ALLY_THERMOSTAT},
 )
 class DanfossLoadRoomMean(NumberConfigurationEntity):
     """Danfoss proprietary attribute to set a value for the load."""
@@ -965,7 +965,7 @@ class DanfossLoadRoomMean(NumberConfigurationEntity):
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
-    quirk_ids={DANFOSS_ALLY_THERMOSTAT},
+    exposed_features={DANFOSS_ALLY_THERMOSTAT},
 )
 class DanfossRegulationSetpointOffset(NumberConfigurationEntity):
     """Danfoss proprietary attribute to set the regulation setpoint offset."""

--- a/zha/application/platforms/select.py
+++ b/zha/application/platforms/select.py
@@ -283,10 +283,10 @@ class TuyaPowerOnState(types.enum8):
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
-    cluster_handler_names=CLUSTER_HANDLER_ON_OFF, quirk_ids=TUYA_PLUG_ONOFF
+    cluster_handler_names=CLUSTER_HANDLER_ON_OFF, exposed_features=TUYA_PLUG_ONOFF
 )
 @CONFIG_DIAGNOSTIC_MATCH(
-    cluster_handler_names="tuya_manufacturer", quirk_ids=TUYA_PLUG_MANUFACTURER
+    cluster_handler_names="tuya_manufacturer", exposed_features=TUYA_PLUG_MANUFACTURER
 )
 class TuyaPowerOnStateSelectEntity(ZCLEnumSelectEntity):
     """Representation of a ZHA power on state select entity."""
@@ -306,7 +306,7 @@ class TuyaBacklightMode(types.enum8):
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
-    cluster_handler_names=CLUSTER_HANDLER_ON_OFF, quirk_ids=TUYA_PLUG_ONOFF
+    cluster_handler_names=CLUSTER_HANDLER_ON_OFF, exposed_features=TUYA_PLUG_ONOFF
 )
 class TuyaBacklightModeSelectEntity(ZCLEnumSelectEntity):
     """Representation of a ZHA backlight mode select entity."""
@@ -327,7 +327,7 @@ class MoesBacklightMode(types.enum8):
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
-    cluster_handler_names="tuya_manufacturer", quirk_ids=TUYA_PLUG_MANUFACTURER
+    cluster_handler_names="tuya_manufacturer", exposed_features=TUYA_PLUG_MANUFACTURER
 )
 class MoesBacklightModeSelectEntity(ZCLEnumSelectEntity):
     """Moes devices have a different backlight mode select options."""
@@ -733,7 +733,7 @@ class KeypadLockout(ZCLEnumSelectEntity):
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
-    quirk_ids={DANFOSS_ALLY_THERMOSTAT},
+    exposed_features={DANFOSS_ALLY_THERMOSTAT},
 )
 class DanfossExerciseDayOfTheWeek(ZCLEnumSelectEntity):
     """Danfoss proprietary attribute for setting the day of the week for exercising."""
@@ -753,7 +753,7 @@ class DanfossOrientationEnum(types.enum8):
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
-    quirk_ids={DANFOSS_ALLY_THERMOSTAT},
+    exposed_features={DANFOSS_ALLY_THERMOSTAT},
 )
 class DanfossOrientation(ZCLEnumSelectEntity):
     """Danfoss proprietary attribute for setting the orientation of the valve.
@@ -770,7 +770,7 @@ class DanfossOrientation(ZCLEnumSelectEntity):
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
-    quirk_ids={DANFOSS_ALLY_THERMOSTAT},
+    exposed_features={DANFOSS_ALLY_THERMOSTAT},
 )
 class DanfossAdaptationRunControl(ZCLEnumSelectEntity):
     """Danfoss proprietary attribute for controlling the current adaptation run."""
@@ -808,7 +808,7 @@ class DanfossControlAlgorithmScaleFactorEnum(types.enum8):
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
-    quirk_ids={DANFOSS_ALLY_THERMOSTAT},
+    exposed_features={DANFOSS_ALLY_THERMOSTAT},
 )
 class DanfossControlAlgorithmScaleFactor(ZCLEnumSelectEntity):
     """Danfoss proprietary attribute for setting the scale factor of the setpoint filter time constant."""
@@ -821,7 +821,7 @@ class DanfossControlAlgorithmScaleFactor(ZCLEnumSelectEntity):
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names="thermostat_ui",
-    quirk_ids={DANFOSS_ALLY_THERMOSTAT},
+    exposed_features={DANFOSS_ALLY_THERMOSTAT},
 )
 class DanfossViewingDirection(ZCLEnumSelectEntity):
     """Danfoss proprietary attribute for setting the viewing direction of the screen."""

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -1972,7 +1972,7 @@ class BitMapSensor(Sensor):
 
 @MULTI_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
-    quirk_ids={DANFOSS_ALLY_THERMOSTAT},
+    exposed_features={DANFOSS_ALLY_THERMOSTAT},
 )
 class DanfossOpenWindowDetection(EnumSensor):
     """Danfoss proprietary attribute.
@@ -1988,7 +1988,7 @@ class DanfossOpenWindowDetection(EnumSensor):
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
-    quirk_ids={DANFOSS_ALLY_THERMOSTAT},
+    exposed_features={DANFOSS_ALLY_THERMOSTAT},
 )
 class DanfossLoadEstimate(Sensor):
     """Danfoss proprietary attribute for communicating its estimate of the radiator load."""
@@ -2001,7 +2001,7 @@ class DanfossLoadEstimate(Sensor):
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
-    quirk_ids={DANFOSS_ALLY_THERMOSTAT},
+    exposed_features={DANFOSS_ALLY_THERMOSTAT},
 )
 class DanfossAdaptationRunStatus(BitMapSensor):
     """Danfoss proprietary attribute for showing the status of the adaptation run."""
@@ -2015,7 +2015,7 @@ class DanfossAdaptationRunStatus(BitMapSensor):
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
-    quirk_ids={DANFOSS_ALLY_THERMOSTAT},
+    exposed_features={DANFOSS_ALLY_THERMOSTAT},
 )
 class DanfossPreheatTime(Sensor):
     """Danfoss proprietary attribute for communicating the time when it starts pre-heating."""
@@ -2029,7 +2029,7 @@ class DanfossPreheatTime(Sensor):
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_DIAGNOSTIC,
-    quirk_ids={DANFOSS_ALLY_THERMOSTAT},
+    exposed_features={DANFOSS_ALLY_THERMOSTAT},
 )
 class DanfossSoftwareErrorCode(BitMapSensor):
     """Danfoss proprietary attribute for communicating the error code."""
@@ -2043,7 +2043,7 @@ class DanfossSoftwareErrorCode(BitMapSensor):
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_DIAGNOSTIC,
-    quirk_ids={DANFOSS_ALLY_THERMOSTAT},
+    exposed_features={DANFOSS_ALLY_THERMOSTAT},
 )
 class DanfossMotorStepCounter(Sensor):
     """Danfoss proprietary attribute for communicating the motor step counter."""

--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -628,7 +628,7 @@ class AqaraPetFeederChildLock(ConfigurableAttributeSwitch):
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
-    cluster_handler_names=CLUSTER_HANDLER_ON_OFF, quirk_ids=TUYA_PLUG_ONOFF
+    cluster_handler_names=CLUSTER_HANDLER_ON_OFF, exposed_features=TUYA_PLUG_ONOFF
 )
 class TuyaChildLockSwitch(ConfigurableAttributeSwitch):
     """Representation of a child lock configuration entity."""
@@ -812,7 +812,7 @@ class AqaraE1CurtainMotorHooksLockedSwitch(ConfigurableAttributeSwitch):
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
-    quirk_ids={DANFOSS_ALLY_THERMOSTAT},
+    exposed_features={DANFOSS_ALLY_THERMOSTAT},
 )
 class DanfossExternalOpenWindowDetected(ConfigurableAttributeSwitch):
     """Danfoss proprietary attribute for communicating an open window."""
@@ -824,7 +824,7 @@ class DanfossExternalOpenWindowDetected(ConfigurableAttributeSwitch):
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
-    quirk_ids={DANFOSS_ALLY_THERMOSTAT},
+    exposed_features={DANFOSS_ALLY_THERMOSTAT},
 )
 class DanfossWindowOpenFeature(ConfigurableAttributeSwitch):
     """Danfoss proprietary attribute enabling open window detection."""
@@ -836,7 +836,7 @@ class DanfossWindowOpenFeature(ConfigurableAttributeSwitch):
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
-    quirk_ids={DANFOSS_ALLY_THERMOSTAT},
+    exposed_features={DANFOSS_ALLY_THERMOSTAT},
 )
 class DanfossMountingModeControl(ConfigurableAttributeSwitch):
     """Danfoss proprietary attribute for switching to mounting mode."""
@@ -848,7 +848,7 @@ class DanfossMountingModeControl(ConfigurableAttributeSwitch):
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
-    quirk_ids={DANFOSS_ALLY_THERMOSTAT},
+    exposed_features={DANFOSS_ALLY_THERMOSTAT},
 )
 class DanfossRadiatorCovered(ConfigurableAttributeSwitch):
     """Danfoss proprietary attribute for communicating full usage of the external temperature sensor."""
@@ -860,7 +860,7 @@ class DanfossRadiatorCovered(ConfigurableAttributeSwitch):
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
-    quirk_ids={DANFOSS_ALLY_THERMOSTAT},
+    exposed_features={DANFOSS_ALLY_THERMOSTAT},
 )
 class DanfossHeatAvailable(ConfigurableAttributeSwitch):
     """Danfoss proprietary attribute for communicating available heat."""
@@ -872,7 +872,7 @@ class DanfossHeatAvailable(ConfigurableAttributeSwitch):
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
-    quirk_ids={DANFOSS_ALLY_THERMOSTAT},
+    exposed_features={DANFOSS_ALLY_THERMOSTAT},
 )
 class DanfossLoadBalancingEnable(ConfigurableAttributeSwitch):
     """Danfoss proprietary attribute for enabling load balancing."""
@@ -884,7 +884,7 @@ class DanfossLoadBalancingEnable(ConfigurableAttributeSwitch):
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
-    quirk_ids={DANFOSS_ALLY_THERMOSTAT},
+    exposed_features={DANFOSS_ALLY_THERMOSTAT},
 )
 class DanfossAdaptationRunSettings(ConfigurableAttributeSwitch):
     """Danfoss proprietary attribute for enabling daily adaptation run.

--- a/zha/application/registries.py
+++ b/zha/application/registries.py
@@ -189,7 +189,7 @@ class MatchRule:
         manufacturer: str,
         model: str,
         cluster_handlers: list,
-        quirk_id: str | None,
+        quirk_id: set[str],
     ) -> bool:
         """Return True if this device matches the criteria."""
         return all(self._matched(manufacturer, model, cluster_handlers, quirk_id))
@@ -199,7 +199,7 @@ class MatchRule:
         manufacturer: str,
         model: str,
         cluster_handlers: list,
-        quirk_id: str | None,
+        quirk_id: set[str],
     ) -> bool:
         """Return True if this device matches the criteria."""
         return any(self._matched(manufacturer, model, cluster_handlers, quirk_id))
@@ -209,7 +209,7 @@ class MatchRule:
         manufacturer: str,
         model: str,
         cluster_handlers: list,
-        quirk_id: str | None,
+        quirk_id: set[str],
     ) -> list:
         """Return a list of field matches."""
         if not any(
@@ -247,9 +247,9 @@ class MatchRule:
 
         if self.quirk_ids:
             if callable(self.quirk_ids):
-                matches.append(self.quirk_ids(quirk_id))
+                matches.append(any(self.quirk_ids(qid) for qid in quirk_id))
             else:
-                matches.append(quirk_id in self.quirk_ids)
+                matches.append(any(qid in self.quirk_ids for qid in quirk_id))
 
         return matches
 
@@ -290,7 +290,7 @@ class PlatformEntityRegistry:
         manufacturer: str,
         model: str,
         cluster_handlers: list[ClusterHandler],
-        quirk_id: str | None,
+        quirk_id: set[str],
         default: type[PlatformEntity] | None = None,
     ) -> tuple[type[PlatformEntity] | None, list[ClusterHandler]]:
         """Match a ZHA ClusterHandler to a ZHA Entity class."""
@@ -307,7 +307,7 @@ class PlatformEntityRegistry:
         manufacturer: str,
         model: str,
         cluster_handlers: list[ClusterHandler],
-        quirk_id: str | None,
+        quirk_id: set[str],
     ) -> tuple[
         dict[Platform, list[EntityClassAndClusterHandlers]], list[ClusterHandler]
     ]:
@@ -340,7 +340,7 @@ class PlatformEntityRegistry:
         manufacturer: str,
         model: str,
         cluster_handlers: list[ClusterHandler],
-        quirk_id: str | None,
+        quirk_id: set[str],
     ) -> tuple[
         dict[Platform, list[EntityClassAndClusterHandlers]], list[ClusterHandler]
     ]:

--- a/zha/application/registries.py
+++ b/zha/application/registries.py
@@ -119,7 +119,7 @@ class MatchRule:
     manufacturers: frozenset[str] | Callable[[str], bool] = frozenset()
     models: frozenset[str] | Callable[[str], bool] = frozenset()
     aux_cluster_handlers: frozenset[str] | Callable[[str], bool] = frozenset()
-    quirk_ids: frozenset[str] | Callable[[str], bool] = frozenset()
+    exposed_features: frozenset[str] | Callable[[str], bool] = frozenset()
 
     def __post_init__(self) -> None:
         """Convert passed arguments to a set or a callable."""
@@ -132,7 +132,9 @@ class MatchRule:
         object.__setattr__(
             self, "aux_cluster_handlers", set_or_callable(self.aux_cluster_handlers)
         )
-        object.__setattr__(self, "quirk_ids", set_or_callable(self.quirk_ids))
+        object.__setattr__(
+            self, "exposed_features", set_or_callable(self.exposed_features)
+        )
 
     @property
     def weight(self) -> int:
@@ -148,8 +150,10 @@ class MatchRule:
         multiple cluster handlers a better priority over rules matching a single cluster handler.
         """
         weight = 0
-        if self.quirk_ids:
-            weight += 501 - (1 if callable(self.quirk_ids) else len(self.quirk_ids))
+        if self.exposed_features:
+            weight += 501 - (
+                1 if callable(self.exposed_features) else len(self.exposed_features)
+            )
 
         if self.models:
             weight += 401 - (1 if callable(self.models) else len(self.models))
@@ -189,27 +193,31 @@ class MatchRule:
         manufacturer: str,
         model: str,
         cluster_handlers: list,
-        quirk_ids: set[str],
+        exposes_features: set[str],
     ) -> bool:
         """Return True if this device matches the criteria."""
-        return all(self._matched(manufacturer, model, cluster_handlers, quirk_ids))
+        return all(
+            self._matched(manufacturer, model, cluster_handlers, exposes_features)
+        )
 
     def loose_matched(
         self,
         manufacturer: str,
         model: str,
         cluster_handlers: list,
-        quirk_ids: set[str],
+        exposes_features: set[str],
     ) -> bool:
         """Return True if this device matches the criteria."""
-        return any(self._matched(manufacturer, model, cluster_handlers, quirk_ids))
+        return any(
+            self._matched(manufacturer, model, cluster_handlers, exposes_features)
+        )
 
     def _matched(
         self,
         manufacturer: str,
         model: str,
         cluster_handlers: list,
-        quirk_ids: set[str],
+        exposes_features: set[str],
     ) -> list:
         """Return a list of field matches."""
         if not any(
@@ -219,7 +227,7 @@ class MatchRule:
                 self.manufacturers,
                 self.models,
                 self.aux_cluster_handlers,
-                self.quirk_ids,
+                self.exposed_features,
             ]
         ):
             return [False]
@@ -245,11 +253,15 @@ class MatchRule:
             else:
                 matches.append(model in self.models)
 
-        if self.quirk_ids:
-            if callable(self.quirk_ids):
-                matches.append(any(self.quirk_ids(qid) for qid in quirk_ids))
+        if self.exposed_features:
+            if callable(self.exposed_features):
+                matches.append(
+                    any(self.exposed_features(qid) for qid in exposes_features)
+                )
             else:
-                matches.append(any(qid in self.quirk_ids for qid in quirk_ids))
+                matches.append(
+                    any(qid in self.exposed_features for qid in exposes_features)
+                )
 
         return matches
 
@@ -290,13 +302,15 @@ class PlatformEntityRegistry:
         manufacturer: str,
         model: str,
         cluster_handlers: list[ClusterHandler],
-        quirk_ids: set[str],
+        exposes_features: set[str],
         default: type[PlatformEntity] | None = None,
     ) -> tuple[type[PlatformEntity] | None, list[ClusterHandler]]:
         """Match a ZHA ClusterHandler to a ZHA Entity class."""
         matches = self._strict_registry[platform]
         for match in sorted(matches, key=WEIGHT_ATTR, reverse=True):
-            if match.strict_matched(manufacturer, model, cluster_handlers, quirk_ids):
+            if match.strict_matched(
+                manufacturer, model, cluster_handlers, exposes_features
+            ):
                 claimed = match.claim_cluster_handlers(cluster_handlers)
                 return self._strict_registry[platform][match], claimed
 
@@ -307,7 +321,7 @@ class PlatformEntityRegistry:
         manufacturer: str,
         model: str,
         cluster_handlers: list[ClusterHandler],
-        quirk_ids: set[str],
+        exposes_features: set[str],
     ) -> tuple[
         dict[Platform, list[EntityClassAndClusterHandlers]], list[ClusterHandler]
     ]:
@@ -321,7 +335,7 @@ class PlatformEntityRegistry:
                 sorted_matches = sorted(matches, key=WEIGHT_ATTR, reverse=True)
                 for match in sorted_matches:
                     if match.strict_matched(
-                        manufacturer, model, cluster_handlers, quirk_ids
+                        manufacturer, model, cluster_handlers, exposes_features
                     ):
                         claimed = match.claim_cluster_handlers(cluster_handlers)
                         for ent_class in matches[match]:
@@ -340,7 +354,7 @@ class PlatformEntityRegistry:
         manufacturer: str,
         model: str,
         cluster_handlers: list[ClusterHandler],
-        quirk_ids: set[str],
+        exposes_features: set[str],
     ) -> tuple[
         dict[Platform, list[EntityClassAndClusterHandlers]], list[ClusterHandler]
     ]:
@@ -357,7 +371,7 @@ class PlatformEntityRegistry:
                 sorted_matches = sorted(matches, key=WEIGHT_ATTR, reverse=True)
                 for match in sorted_matches:
                     if match.strict_matched(
-                        manufacturer, model, cluster_handlers, quirk_ids
+                        manufacturer, model, cluster_handlers, exposes_features
                     ):
                         claimed = match.claim_cluster_handlers(cluster_handlers)
                         for ent_class in matches[match]:
@@ -383,7 +397,7 @@ class PlatformEntityRegistry:
         manufacturers: Callable | set[str] | str | None = None,
         models: Callable | set[str] | str | None = None,
         aux_cluster_handlers: Callable | set[str] | str | None = None,
-        quirk_ids: set[str] | str | None = None,
+        exposed_features: set[str] | str | None = None,
     ) -> Callable[[type[PlatformEntity]], type[PlatformEntity]]:
         """Decorate a strict match rule."""
 
@@ -393,7 +407,7 @@ class PlatformEntityRegistry:
             manufacturers,
             models,
             aux_cluster_handlers,
-            quirk_ids,
+            exposed_features,
         )
 
         def decorator(zha_ent: type[PlatformEntity]) -> type[PlatformEntity]:
@@ -415,7 +429,7 @@ class PlatformEntityRegistry:
         models: Callable | set[str] | str | None = None,
         aux_cluster_handlers: Callable | set[str] | str | None = None,
         stop_on_match_group: int | str | None = None,
-        quirk_ids: set[str] | str | None = None,
+        exposed_features: set[str] | str | None = None,
     ) -> Callable[[type[PlatformEntity]], type[PlatformEntity]]:
         """Decorate a loose match rule."""
 
@@ -425,7 +439,7 @@ class PlatformEntityRegistry:
             manufacturers,
             models,
             aux_cluster_handlers,
-            quirk_ids,
+            exposed_features,
         )
 
         def decorator(zha_entity: type[PlatformEntity]) -> type[PlatformEntity]:
@@ -450,7 +464,7 @@ class PlatformEntityRegistry:
         models: Callable | set[str] | str | None = None,
         aux_cluster_handlers: Callable | set[str] | str | None = None,
         stop_on_match_group: int | str | None = None,
-        quirk_ids: set[str] | str | None = None,
+        exposed_features: set[str] | str | None = None,
     ) -> Callable[[type[PlatformEntity]], type[PlatformEntity]]:
         """Decorate a loose match rule."""
 
@@ -460,7 +474,7 @@ class PlatformEntityRegistry:
             manufacturers,
             models,
             aux_cluster_handlers,
-            quirk_ids,
+            exposed_features,
         )
 
         def decorator(zha_entity: type[PlatformEntity]) -> type[PlatformEntity]:

--- a/zha/application/registries.py
+++ b/zha/application/registries.py
@@ -189,27 +189,27 @@ class MatchRule:
         manufacturer: str,
         model: str,
         cluster_handlers: list,
-        quirk_id: set[str],
+        quirk_ids: set[str],
     ) -> bool:
         """Return True if this device matches the criteria."""
-        return all(self._matched(manufacturer, model, cluster_handlers, quirk_id))
+        return all(self._matched(manufacturer, model, cluster_handlers, quirk_ids))
 
     def loose_matched(
         self,
         manufacturer: str,
         model: str,
         cluster_handlers: list,
-        quirk_id: set[str],
+        quirk_ids: set[str],
     ) -> bool:
         """Return True if this device matches the criteria."""
-        return any(self._matched(manufacturer, model, cluster_handlers, quirk_id))
+        return any(self._matched(manufacturer, model, cluster_handlers, quirk_ids))
 
     def _matched(
         self,
         manufacturer: str,
         model: str,
         cluster_handlers: list,
-        quirk_id: set[str],
+        quirk_ids: set[str],
     ) -> list:
         """Return a list of field matches."""
         if not any(
@@ -247,9 +247,9 @@ class MatchRule:
 
         if self.quirk_ids:
             if callable(self.quirk_ids):
-                matches.append(any(self.quirk_ids(qid) for qid in quirk_id))
+                matches.append(any(self.quirk_ids(qid) for qid in quirk_ids))
             else:
-                matches.append(any(qid in self.quirk_ids for qid in quirk_id))
+                matches.append(any(qid in self.quirk_ids for qid in quirk_ids))
 
         return matches
 
@@ -290,13 +290,13 @@ class PlatformEntityRegistry:
         manufacturer: str,
         model: str,
         cluster_handlers: list[ClusterHandler],
-        quirk_id: set[str],
+        quirk_ids: set[str],
         default: type[PlatformEntity] | None = None,
     ) -> tuple[type[PlatformEntity] | None, list[ClusterHandler]]:
         """Match a ZHA ClusterHandler to a ZHA Entity class."""
         matches = self._strict_registry[platform]
         for match in sorted(matches, key=WEIGHT_ATTR, reverse=True):
-            if match.strict_matched(manufacturer, model, cluster_handlers, quirk_id):
+            if match.strict_matched(manufacturer, model, cluster_handlers, quirk_ids):
                 claimed = match.claim_cluster_handlers(cluster_handlers)
                 return self._strict_registry[platform][match], claimed
 
@@ -307,7 +307,7 @@ class PlatformEntityRegistry:
         manufacturer: str,
         model: str,
         cluster_handlers: list[ClusterHandler],
-        quirk_id: set[str],
+        quirk_ids: set[str],
     ) -> tuple[
         dict[Platform, list[EntityClassAndClusterHandlers]], list[ClusterHandler]
     ]:
@@ -321,7 +321,7 @@ class PlatformEntityRegistry:
                 sorted_matches = sorted(matches, key=WEIGHT_ATTR, reverse=True)
                 for match in sorted_matches:
                     if match.strict_matched(
-                        manufacturer, model, cluster_handlers, quirk_id
+                        manufacturer, model, cluster_handlers, quirk_ids
                     ):
                         claimed = match.claim_cluster_handlers(cluster_handlers)
                         for ent_class in matches[match]:
@@ -340,7 +340,7 @@ class PlatformEntityRegistry:
         manufacturer: str,
         model: str,
         cluster_handlers: list[ClusterHandler],
-        quirk_id: set[str],
+        quirk_ids: set[str],
     ) -> tuple[
         dict[Platform, list[EntityClassAndClusterHandlers]], list[ClusterHandler]
     ]:
@@ -357,7 +357,7 @@ class PlatformEntityRegistry:
                 sorted_matches = sorted(matches, key=WEIGHT_ATTR, reverse=True)
                 for match in sorted_matches:
                     if match.strict_matched(
-                        manufacturer, model, cluster_handlers, quirk_id
+                        manufacturer, model, cluster_handlers, quirk_ids
                     ):
                         claimed = match.claim_cluster_handlers(cluster_handlers)
                         for ent_class in matches[match]:

--- a/zha/zigbee/cluster_handlers/general.py
+++ b/zha/zigbee/cluster_handlers/general.py
@@ -545,7 +545,7 @@ class OnOffClusterHandler(ClusterHandler):
         super().__init__(cluster, endpoint)
         self._off_listener: asyncio.TimerHandle | None = None
 
-        if TUYA_PLUG_ONOFF in endpoint.device.quirk_id:
+        if TUYA_PLUG_ONOFF in endpoint.device.quirk_ids:
             self.ZCL_INIT_ATTRS = self.ZCL_INIT_ATTRS.copy()
             self.ZCL_INIT_ATTRS["backlight_mode"] = True
             self.ZCL_INIT_ATTRS["power_on_state"] = True

--- a/zha/zigbee/cluster_handlers/general.py
+++ b/zha/zigbee/cluster_handlers/general.py
@@ -545,7 +545,7 @@ class OnOffClusterHandler(ClusterHandler):
         super().__init__(cluster, endpoint)
         self._off_listener: asyncio.TimerHandle | None = None
 
-        if TUYA_PLUG_ONOFF in endpoint.device.quirk_ids:
+        if TUYA_PLUG_ONOFF in endpoint.device.exposes_features:
             self.ZCL_INIT_ATTRS = self.ZCL_INIT_ATTRS.copy()
             self.ZCL_INIT_ATTRS["backlight_mode"] = True
             self.ZCL_INIT_ATTRS["power_on_state"] = True

--- a/zha/zigbee/cluster_handlers/general.py
+++ b/zha/zigbee/cluster_handlers/general.py
@@ -545,7 +545,7 @@ class OnOffClusterHandler(ClusterHandler):
         super().__init__(cluster, endpoint)
         self._off_listener: asyncio.TimerHandle | None = None
 
-        if endpoint.device.quirk_id == TUYA_PLUG_ONOFF:
+        if TUYA_PLUG_ONOFF in endpoint.device.quirk_id:
             self.ZCL_INIT_ATTRS = self.ZCL_INIT_ATTRS.copy()
             self.ZCL_INIT_ATTRS["backlight_mode"] = True
             self.ZCL_INIT_ATTRS["power_on_state"] = True

--- a/zha/zigbee/cluster_handlers/manufacturerspecific.py
+++ b/zha/zigbee/cluster_handlers/manufacturerspecific.py
@@ -111,7 +111,7 @@ class TuyaClusterHandler(ClusterHandler):
     def __init__(self, cluster: zigpy.zcl.Cluster, endpoint: Endpoint) -> None:
         """Initialize TuyaClusterHandler."""
         super().__init__(cluster, endpoint)
-        if TUYA_PLUG_MANUFACTURER in endpoint.device.quirk_ids:
+        if TUYA_PLUG_MANUFACTURER in endpoint.device.exposes_features:
             self.ZCL_INIT_ATTRS = {
                 "backlight_mode": True,
                 "power_on_state": True,

--- a/zha/zigbee/cluster_handlers/manufacturerspecific.py
+++ b/zha/zigbee/cluster_handlers/manufacturerspecific.py
@@ -111,7 +111,7 @@ class TuyaClusterHandler(ClusterHandler):
     def __init__(self, cluster: zigpy.zcl.Cluster, endpoint: Endpoint) -> None:
         """Initialize TuyaClusterHandler."""
         super().__init__(cluster, endpoint)
-        if TUYA_PLUG_MANUFACTURER in endpoint.device.quirk_id:
+        if TUYA_PLUG_MANUFACTURER in endpoint.device.quirk_ids:
             self.ZCL_INIT_ATTRS = {
                 "backlight_mode": True,
                 "power_on_state": True,

--- a/zha/zigbee/cluster_handlers/manufacturerspecific.py
+++ b/zha/zigbee/cluster_handlers/manufacturerspecific.py
@@ -111,7 +111,7 @@ class TuyaClusterHandler(ClusterHandler):
     def __init__(self, cluster: zigpy.zcl.Cluster, endpoint: Endpoint) -> None:
         """Initialize TuyaClusterHandler."""
         super().__init__(cluster, endpoint)
-        if endpoint.device.quirk_id == TUYA_PLUG_MANUFACTURER:
+        if TUYA_PLUG_MANUFACTURER in endpoint.device.quirk_id:
             self.ZCL_INIT_ATTRS = {
                 "backlight_mode": True,
                 "power_on_state": True,

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -268,7 +268,7 @@ class Device(LogMixin, EventBase):
             f"{self._zigpy_device.__class__.__name__}"
         )
         qid: set[str] | str = getattr(self._zigpy_device, ATTR_QUIRK_ID, set())
-        self.quirk_ids: set[str] = {qid} if isinstance(qid, str) else qid
+        self.quirk_ids: set[str] = {qid} if isinstance(qid, str) else set(qid)
 
         self._power_config_ch: ClusterHandler | None = None
         self._identify_ch: ClusterHandler | None = None

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -187,7 +187,7 @@ class DeviceInfo:
     name: str
     quirk_applied: bool
     quirk_class: str
-    quirk_id: str | None
+    quirk_id: set[str]
     manufacturer_code: int | None
     power_source: str
     lqi: int
@@ -267,7 +267,9 @@ class Device(LogMixin, EventBase):
             f"{self._zigpy_device.__class__.__module__}."
             f"{self._zigpy_device.__class__.__name__}"
         )
-        self.quirk_id: str | None = getattr(self._zigpy_device, ATTR_QUIRK_ID, None)
+        qid: set[str] | str = getattr(self._zigpy_device, ATTR_QUIRK_ID, set())
+        self.quirk_id: set[str] = {qid} if isinstance(qid, str) else qid
+
         self._power_config_ch: ClusterHandler | None = None
         self._identify_ch: ClusterHandler | None = None
         self._basic_ch: ClusterHandler | None = None

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -187,7 +187,7 @@ class DeviceInfo:
     name: str
     quirk_applied: bool
     quirk_class: str
-    quirk_id: set[str]
+    quirk_ids: set[str]
     manufacturer_code: int | None
     power_source: str
     lqi: int
@@ -268,7 +268,7 @@ class Device(LogMixin, EventBase):
             f"{self._zigpy_device.__class__.__name__}"
         )
         qid: set[str] | str = getattr(self._zigpy_device, ATTR_QUIRK_ID, set())
-        self.quirk_id: set[str] = {qid} if isinstance(qid, str) else qid
+        self.quirk_ids: set[str] = {qid} if isinstance(qid, str) else qid
 
         self._power_config_ch: ClusterHandler | None = None
         self._identify_ch: ClusterHandler | None = None
@@ -314,7 +314,7 @@ class Device(LogMixin, EventBase):
             f"{repr(self._zigpy_device)} - "
             f"quirk_applied: {self.quirk_applied} - "
             f"quirk_or_device_class: {self.quirk_class} - "
-            f"quirk_id: {self.quirk_id}"
+            f"quirk_ids: {self.quirk_ids}"
         )
 
     @property
@@ -742,7 +742,7 @@ class Device(LogMixin, EventBase):
             name=self.name,
             quirk_applied=self.quirk_applied,
             quirk_class=self.quirk_class,
-            quirk_id=self.quirk_id,
+            quirk_ids=self.quirk_ids,
             manufacturer_code=self.manufacturer_code,
             power_source=self.power_source,
             lqi=self.lqi,
@@ -1433,7 +1433,7 @@ class Device(LogMixin, EventBase):
         info["name"] = self.name
         info["quirk_applied"] = self.quirk_applied
         info["quirk_class"] = self.quirk_class
-        info["quirk_id"] = self.quirk_id
+        info["quirk_ids"] = self.quirk_ids
         info["manufacturer_code"] = self.manufacturer_code
         info["power_source"] = self.power_source
         info["lqi"] = self.lqi

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -187,7 +187,7 @@ class DeviceInfo:
     name: str
     quirk_applied: bool
     quirk_class: str
-    quirk_ids: set[str]
+    exposes_features: set[str]
     manufacturer_code: int | None
     power_source: str
     lqi: int
@@ -267,8 +267,10 @@ class Device(LogMixin, EventBase):
             f"{self._zigpy_device.__class__.__module__}."
             f"{self._zigpy_device.__class__.__name__}"
         )
+
+        # add v1 quirk exposed features (and legacy quirk id)
         qid: set[str] | str = getattr(self._zigpy_device, ATTR_QUIRK_ID, set())
-        self.quirk_ids: set[str] = {qid} if isinstance(qid, str) else set(qid)
+        self.exposes_features: set[str] = {qid} if isinstance(qid, str) else set(qid)
 
         self._power_config_ch: ClusterHandler | None = None
         self._identify_ch: ClusterHandler | None = None
@@ -314,7 +316,7 @@ class Device(LogMixin, EventBase):
             f"{repr(self._zigpy_device)} - "
             f"quirk_applied: {self.quirk_applied} - "
             f"quirk_or_device_class: {self.quirk_class} - "
-            f"quirk_ids: {self.quirk_ids}"
+            f"exposes_features: {self.exposes_features}"
         )
 
     @property
@@ -742,7 +744,7 @@ class Device(LogMixin, EventBase):
             name=self.name,
             quirk_applied=self.quirk_applied,
             quirk_class=self.quirk_class,
-            quirk_ids=self.quirk_ids,
+            exposes_features=self.exposes_features,
             manufacturer_code=self.manufacturer_code,
             power_source=self.power_source,
             lqi=self.lqi,
@@ -1433,7 +1435,7 @@ class Device(LogMixin, EventBase):
         info["name"] = self.name
         info["quirk_applied"] = self.quirk_applied
         info["quirk_class"] = self.quirk_class
-        info["quirk_ids"] = self.quirk_ids
+        info["exposes_features"] = self.exposes_features
         info["manufacturer_code"] = self.manufacturer_code
         info["power_source"] = self.power_source
         info["lqi"] = self.lqi

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -268,7 +268,7 @@ class Device(LogMixin, EventBase):
             f"{self._zigpy_device.__class__.__name__}"
         )
 
-        # add v1 quirk exposed features (and legacy quirk id)
+        # add v1 quirk exposed features (legacy quirk id)
         qid: set[str] | str = getattr(self._zigpy_device, ATTR_QUIRK_ID, set())
         self.exposes_features: set[str] = {qid} if isinstance(qid, str) else set(qid)
 

--- a/zha/zigbee/endpoint.py
+++ b/zha/zigbee/endpoint.py
@@ -150,15 +150,16 @@ class Endpoint:
                 cluster_id, {None: ClusterHandler}
             )
 
-            # get first quirk id from device that matches a registered cluster handler
-            cluster_quirk_id: str | None = None
-            for qid in self.device.quirk_ids:
-                if qid in cluster_handler_classes:
-                    cluster_quirk_id = qid
+            # get first exposed feature from device
+            # that matches a registered cluster handler
+            cluster_exposed_features: str | None = None
+            for exposed_features in self.device.exposes_features:
+                if exposed_features in cluster_handler_classes:
+                    cluster_exposed_features = exposed_features
                     break
 
             cluster_handler_class = cluster_handler_classes.get(
-                cluster_quirk_id, ClusterHandler
+                cluster_exposed_features, ClusterHandler
             )
 
             # Allow cluster handler to filter out bad matches

--- a/zha/zigbee/endpoint.py
+++ b/zha/zigbee/endpoint.py
@@ -152,7 +152,7 @@ class Endpoint:
 
             # get first quirk id from device that matches a registered cluster handler
             cluster_quirk_id: str | None = None
-            for qid in self.device.quirk_id:
+            for qid in self.device.quirk_ids:
                 if qid in cluster_handler_classes:
                     cluster_quirk_id = qid
                     break

--- a/zha/zigbee/endpoint.py
+++ b/zha/zigbee/endpoint.py
@@ -149,13 +149,16 @@ class Endpoint:
             cluster_handler_classes = CLUSTER_HANDLER_REGISTRY.get(
                 cluster_id, {None: ClusterHandler}
             )
-            quirk_id = (
-                self.device.quirk_id
-                if self.device.quirk_id in cluster_handler_classes
-                else None
-            )
+
+            # get first quirk id from device that matches a registered cluster handler
+            cluster_quirk_id: str | None = None
+            for qid in self.device.quirk_id:
+                if qid in cluster_handler_classes:
+                    cluster_quirk_id = qid
+                    break
+
             cluster_handler_class = cluster_handler_classes.get(
-                quirk_id, ClusterHandler
+                cluster_quirk_id, ClusterHandler
             )
 
             # Allow cluster handler to filter out bad matches


### PR DESCRIPTION
### Proposed change

This renames `quirk_id` to `exposes_features` internally and allows quirks to set multiple exposed features.

### Why

This will be useful for a number of issues, including Frient sensors that expose other IAS bits (alarm 1/2 + tamper + test bit), so we don't have to use custom quirks v2 entities for all devices using standard ZCL functionality. It's also useful to remove certain features we currently expose for all siren entities, like a lot of the siren specific parameters or the configuration entities.

In v1/v2 quirks, we can simply add a line that's something like `.exposes_feature(IAS_TAMPER_FEATURE)` or `.exposes_feature(SIREN_LIMITED_FEATURE)` and ZHA will add or change the behavior of some entities for those devices.

### Other notes

For now, I've left the attribute we check for the exposed features in v1 quirks called `quirk_id`. A previous iteration of this PR only renamed all internal references to `quirk_ids`, but I think we can just go ahead and rename it to `exposes_features` like done in this PR.
A small follow-up PR would add support from specifying exposed features in v2 quirks.

`quirk_id` can be a `set[str]`/`list[str]` or `str` as before, to make sure we don't break existing integrated v1 quirks or custom v1 quirks that may be used for some Tuya (plug) devices.

### Additional information

Addresses (see for more background info):
- https://github.com/zigpy/zha/issues/311

Other related issues:
- https://github.com/zigpy/backlog/issues/62 (with future PRs)
- https://github.com/zigpy/backlog/issues/61 (with future PRs)

For a diff without the regenerated diagnostics, see: https://github.com/zigpy/zha/compare/dev...TheJulianJES:zha:tjj/multiple_quirk_id_without_diagnostics