### PR TITLE
Update diagnostics to fix CI

### DIFF
--- a/tests/data/devices/tze200-a7sghmms-ts0601.json
+++ b/tests/data/devices/tze200-a7sghmms-ts0601.json
@@ -9,7 +9,7 @@
   "name": "_TZE200_a7sghmms TS0601",
   "quirk_applied": true,
   "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
-  "quirk_id": null,
+  "exposes_features": [],
   "manufacturer_code": 4417,
   "power_source": "Battery or Unknown",
   "lqi": null,


### PR DESCRIPTION
This also changes `quirk_id` to `exposes_features` in Tuya valve quirk, fixing CI.

- https://github.com/zigpy/zha/pull/575 should have been rebased again after https://github.com/zigpy/zha/pull/565 was merged, as that included new diagnostics. 😅 