### PR TITLE
Pass through Home Assistant country code to zigpy

### DIFF
--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock, call, patch
 
 import pytest
 from zigpy.application import ControllerApplication
+from zigpy.config import CONF_NWK, CONF_NWK_COUNTRY_CODE
 from zigpy.profiles import zha
 import zigpy.types
 from zigpy.zcl.clusters import general, lighting
@@ -806,6 +807,34 @@ def test_radio_type():
 
     with pytest.raises(ValueError):
         RadioType.get_by_description("Invalid description")
+
+
+@pytest.mark.parametrize(
+    ("country_code", "yaml_config", "expected_country_code"),
+    [
+        (None, {}, None),
+        ("US", {}, "US"),
+        ("GB", {}, "GB"),
+        ("US", {CONF_NWK: {}}, "US"),
+        ("US", {CONF_NWK: {CONF_NWK_COUNTRY_CODE: "GB"}}, "GB"),
+    ],
+)
+async def test_country_code_passthrough(
+    zha_data: ZHAData,
+    country_code: str | None,
+    yaml_config: dict,
+    expected_country_code: str | None,
+) -> None:
+    """Test country code passthrough from Home Assistant to zigpy."""
+    zha_data.country_code = country_code
+    zha_data.zigpy_config = yaml_config
+
+    gateway = Gateway(zha_data)
+    _, app_config = gateway.get_application_controller_data()
+
+    assert (
+        app_config.get(CONF_NWK, {}).get(CONF_NWK_COUNTRY_CODE) == expected_country_code
+    )
 
 
 async def test_gateway_network_scan(zha_gateway: Gateway) -> None:

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -19,6 +19,8 @@ from zigpy.config import (
     CONF_DEVICE_BAUDRATE,
     CONF_DEVICE_FLOW_CONTROL,
     CONF_DEVICE_PATH,
+    CONF_NWK,
+    CONF_NWK_COUNTRY_CODE,
     CONF_NWK_VALIDATE_SETTINGS,
 )
 import zigpy.device
@@ -203,6 +205,14 @@ class Gateway(AsyncUtilMixin, EventBase):
             CONF_DEVICE_BAUDRATE: self.config.config.coordinator_configuration.baudrate,
             CONF_DEVICE_FLOW_CONTROL: self.config.config.coordinator_configuration.flow_control,
         }
+
+        if (
+            self.config.country_code is not None
+            and CONF_NWK_COUNTRY_CODE not in app_config.get(CONF_NWK, {})
+        ):
+            app_config.setdefault(CONF_NWK, {})[CONF_NWK_COUNTRY_CODE] = (
+                self.config.country_code
+            )
 
         if CONF_NWK_VALIDATE_SETTINGS not in app_config:
             app_config[CONF_NWK_VALIDATE_SETTINGS] = True

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -210,9 +210,8 @@ class Gateway(AsyncUtilMixin, EventBase):
             self.config.country_code is not None
             and CONF_NWK_COUNTRY_CODE not in app_config.get(CONF_NWK, {})
         ):
-            app_config.setdefault(CONF_NWK, {})[CONF_NWK_COUNTRY_CODE] = (
-                self.config.country_code
-            )
+            app_config.setdefault(CONF_NWK, {})
+            app_config[CONF_NWK][CONF_NWK_COUNTRY_CODE] = self.config.country_code
 
         if CONF_NWK_VALIDATE_SETTINGS not in app_config:
             app_config[CONF_NWK_VALIDATE_SETTINGS] = True

--- a/zha/application/helpers.py
+++ b/zha/application/helpers.py
@@ -389,6 +389,7 @@ class ZHAData:
     )
     allow_polling: bool = dataclasses.field(default=False)
     local_timezone: datetime.tzinfo = dataclasses.field(default=datetime.UTC)
+    country_code: str | None = None
 
 
 class GlobalUpdater:


### PR DESCRIPTION
To support querying the adapter for regulatory limit data, we need to pass country code data through from Home Assistant Core and into zigpy. This requires a tiny change on the Core side:

```diff
diff --git a/homeassistant/components/zha/__init__.py b/homeassistant/components/zha/__init__.py
index 4009936a50a..16c64fd9016 100644
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -253,6 +253,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     def update_config(event: Event) -> None:
         """Handle Core config update."""
         zha_gateway.config.local_timezone = ZoneInfo(hass.config.time_zone)
+        zha_gateway.config.country_code = hass.config.country
 
     config_entry.async_on_unload(
         hass.bus.async_listen(EVENT_CORE_CONFIG_UPDATE, update_config)
diff --git a/homeassistant/components/zha/helpers.py b/homeassistant/components/zha/helpers.py
index bde0d636a97..aed55eb6085 100644
--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -1370,6 +1370,7 @@ def create_zha_config(hass: HomeAssistant, ha_zha_data: HAZHAData) -> ZHAData:
             device_overrides=overrides_config,
         ),
         local_timezone=ZoneInfo(hass.config.time_zone),
+        country_code=hass.config.country,
     )
```