### PR TITLE
Fix zigpy semaphore `max_value` deprecation warning

### DIFF
--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -348,7 +348,9 @@ class Gateway(AsyncUtilMixin, EventBase):
     @property
     def radio_concurrency(self) -> int:
         """Maximum configured radio concurrency."""
-        return self.application_controller._concurrent_requests_semaphore.max_value  # pylint: disable=protected-access
+        return (
+            self.application_controller._concurrent_requests_semaphore.max_concurrency
+        )  # pylint: disable=protected-access
 
     async def async_fetch_updated_state_mains(self) -> None:
         """Fetch updated state for mains powered devices."""


### PR DESCRIPTION
`RequestLimiter.max_value` is deprecated and causes a bunch of warnings in actions/test logs.
This PR switches over to using the non-deprecated `max_concurrency`.