### PR TITLE
Fix test compatibility with looptime 0.7

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -12,6 +12,6 @@ pytest
 python-slugify
 zigpy>=0.65.2
 ruff
-looptime
+looptime>=0.7
 freezegun
 coloredlogs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import threading
 from types import TracebackType
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import looptime
 import pytest
 import zigpy
 from zigpy.application import ControllerApplication
@@ -300,6 +301,7 @@ class TestGateway:
         """Start the ZHA gateway."""
 
         with (
+            looptime.enabled(),
             patch(
                 "bellows.zigbee.application.ControllerApplication.new",
                 return_value=self.app,
@@ -322,8 +324,9 @@ class TestGateway:
     ) -> None:
         """Shutdown the ZHA gateway."""
         INSTANCES.remove(self.zha_gateway)
-        await self.zha_gateway.shutdown()
-        await asyncio.sleep(0)
+        with looptime.enabled():
+            await self.zha_gateway.shutdown()
+            await asyncio.sleep(0)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Proposed change

`TestGateway` calls are now wrapped with `looptime.enabled()` to temporarily enable looptime time compaction during fixture setup and teardown.


## Additional information

- [looptime 0.3](https://github.com/nolar/looptime/releases/tag/0.3) (https://github.com/nolar/looptime/pull/9) intended to run fixtures in real wall-clock time while only test functions use mocked time. However, a bug caused fixtures to use a fake zero-based clock instead.
- [looptime 0.6](https://github.com/nolar/looptime/releases/tag/0.6) (https://github.com/nolar/looptime/pull/20) added `looptime.enabled()` as an explicit workaround for fixtures needing mocked time.
- [looptime 0.7](https://github.com/nolar/looptime/releases/tag/0.7) (https://github.com/nolar/looptime/pull/23) fixed the bug so fixtures now correctly use real wall-clock time, breaking our tests as we apparently relied on the buggy behavior somewhat.

It also seems like tests are running a bit quicker now.