### PR TITLE
Add config option to use `zigpy-ota` beta channel

### DIFF
--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -5,7 +5,15 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock, call, patch
 
 import pytest
 from zigpy.application import ControllerApplication
-from zigpy.config import CONF_NWK, CONF_NWK_COUNTRY_CODE
+from zigpy.config import (
+    CONF_NWK,
+    CONF_NWK_COUNTRY_CODE,
+    CONF_OTA,
+    CONF_OTA_EXTRA_PROVIDERS,
+    CONF_OTA_PROVIDER_CHANNEL,
+    CONF_OTA_PROVIDER_OVERRIDE_PREVIOUS,
+    CONF_OTA_PROVIDER_TYPE,
+)
 from zigpy.profiles import zha
 import zigpy.types
 from zigpy.zcl.clusters import general, lighting
@@ -835,6 +843,97 @@ async def test_country_code_passthrough(
     assert (
         app_config.get(CONF_NWK, {}).get(CONF_NWK_COUNTRY_CODE) == expected_country_code
     )
+
+
+@pytest.mark.parametrize(
+    ("use_beta_channel", "yaml_config", "expected_extra_providers"),
+    [
+        # Beta channel disabled (default) - no extra providers added
+        (False, {}, None),
+        # Beta channel enabled - zigpy_ota provider with beta channel added
+        (
+            True,
+            {},
+            [
+                {
+                    CONF_OTA_PROVIDER_TYPE: "zigpy_ota",
+                    CONF_OTA_PROVIDER_CHANNEL: "beta",
+                    CONF_OTA_PROVIDER_OVERRIDE_PREVIOUS: True,
+                }
+            ],
+        ),
+        # Beta channel enabled with existing OTA config - provider appended
+        (
+            True,
+            {CONF_OTA: {}},
+            [
+                {
+                    CONF_OTA_PROVIDER_TYPE: "zigpy_ota",
+                    CONF_OTA_PROVIDER_CHANNEL: "beta",
+                    CONF_OTA_PROVIDER_OVERRIDE_PREVIOUS: True,
+                }
+            ],
+        ),
+        # Beta channel enabled with existing non-zigpy_ota extra_providers - provider appended
+        (
+            True,
+            {CONF_OTA: {CONF_OTA_EXTRA_PROVIDERS: [{CONF_OTA_PROVIDER_TYPE: "ikea"}]}},
+            [
+                {CONF_OTA_PROVIDER_TYPE: "ikea"},
+                {
+                    CONF_OTA_PROVIDER_TYPE: "zigpy_ota",
+                    CONF_OTA_PROVIDER_CHANNEL: "beta",
+                    CONF_OTA_PROVIDER_OVERRIDE_PREVIOUS: True,
+                },
+            ],
+        ),
+        # Beta channel enabled but zigpy_ota already in YAML - YAML takes precedence
+        (
+            True,
+            {
+                CONF_OTA: {
+                    CONF_OTA_EXTRA_PROVIDERS: [
+                        {
+                            CONF_OTA_PROVIDER_TYPE: "zigpy_ota",
+                            CONF_OTA_PROVIDER_CHANNEL: "dev",
+                            CONF_OTA_PROVIDER_OVERRIDE_PREVIOUS: True,
+                        }
+                    ]
+                }
+            },
+            [
+                {
+                    CONF_OTA_PROVIDER_TYPE: "zigpy_ota",
+                    CONF_OTA_PROVIDER_CHANNEL: "dev",
+                    CONF_OTA_PROVIDER_OVERRIDE_PREVIOUS: True,
+                }
+            ],
+        ),
+    ],
+)
+async def test_ota_beta_channel_passthrough(
+    zha_data: ZHAData,
+    use_beta_channel: bool,
+    yaml_config: dict,
+    expected_extra_providers: list | None,
+) -> None:
+    """Test OTA beta channel config passthrough to zigpy."""
+    zha_data.config.ota_configuration.use_beta_channel = use_beta_channel
+    zha_data.zigpy_config = yaml_config
+
+    gateway = Gateway(zha_data)
+    _, app_config = gateway.get_application_controller_data()
+
+    if expected_extra_providers is None:
+        assert (
+            CONF_OTA not in app_config
+            or CONF_OTA_EXTRA_PROVIDERS not in app_config.get(CONF_OTA, {})
+        )
+    else:
+        assert (
+            app_config.get(CONF_OTA, {}).get(CONF_OTA_EXTRA_PROVIDERS)
+            == expected_extra_providers
+        )
 
 
 async def test_gateway_network_scan(zha_gateway: Gateway) -> None:

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -22,6 +22,11 @@ from zigpy.config import (
     CONF_NWK,
     CONF_NWK_COUNTRY_CODE,
     CONF_NWK_VALIDATE_SETTINGS,
+    CONF_OTA,
+    CONF_OTA_EXTRA_PROVIDERS,
+    CONF_OTA_PROVIDER_CHANNEL,
+    CONF_OTA_PROVIDER_OVERRIDE_PREVIOUS,
+    CONF_OTA_PROVIDER_TYPE,
 )
 import zigpy.device
 import zigpy.endpoint
@@ -224,6 +229,24 @@ class Gateway(AsyncUtilMixin, EventBase):
             and app_config[CONF_DEVICE][CONF_DEVICE_PATH].startswith("socket://")
         ):
             app_config[CONF_USE_THREAD] = False
+
+        # Configure zigpy-ota beta channel if enabled, preferring explicit YAML config
+        if self.config.config.ota_configuration.use_beta_channel:
+            extra_providers = app_config.get(CONF_OTA, {}).get(
+                CONF_OTA_EXTRA_PROVIDERS, []
+            )
+            has_zigpy_ota = any(
+                p.get(CONF_OTA_PROVIDER_TYPE) == "zigpy_ota" for p in extra_providers
+            )
+            if not has_zigpy_ota:
+                app_config.setdefault(CONF_OTA, {})
+                app_config[CONF_OTA].setdefault(CONF_OTA_EXTRA_PROVIDERS, []).append(
+                    {
+                        CONF_OTA_PROVIDER_TYPE: "zigpy_ota",
+                        CONF_OTA_PROVIDER_CHANNEL: "beta",
+                        CONF_OTA_PROVIDER_OVERRIDE_PREVIOUS: True,
+                    }
+                )
 
         return self.radio_type.controller, app_config
 

--- a/zha/application/helpers.py
+++ b/zha/application/helpers.py
@@ -348,6 +348,13 @@ class QuirksConfiguration:
 
 
 @dataclass(kw_only=True, slots=True)
+class OTAConfiguration:
+    """ZHA OTA firmware configuration."""
+
+    use_beta_channel: bool = dataclasses.field(default=False)
+
+
+@dataclass(kw_only=True, slots=True)
 class DeviceOverridesConfiguration:
     """ZHA device overrides configuration."""
 
@@ -363,6 +370,9 @@ class ZHAConfiguration:
     )
     quirks_configuration: QuirksConfiguration = dataclasses.field(
         default_factory=QuirksConfiguration
+    )
+    ota_configuration: OTAConfiguration = dataclasses.field(
+        default_factory=OTAConfiguration
     )
     device_overrides: dict[str, DeviceOverridesConfiguration] = dataclasses.field(
         default_factory=dict


### PR DESCRIPTION
### WIP - see "questions" at the bottom

## Proposed change

This adds an `OTAConfiguration` dataclass to allow Home Assistant Core to provide a config option that enables beta updates for the [zigpy-ota](https://github.com/zigpy/zigpy-ota) provider.
ZHA passes this option to zigpy by adding another zigpy-ota provider with the `beta` channel and `override_previous` options set (to remove the default `stable` OTA provider added in zigpy).

If any zigpy-ota provider is specified in YAML config, that takes precedence and this code doesn't add the overriding beta channel OTA provider.

## Additional information

To show this option in Home Assistant Core, some changes will be needed there: https://github.com/home-assistant/core/compare/dev...TheJulianJES:core:tjj/zha_zigpy_ota_beta_channel_config

There's also a `dev` zigpy-ota provider channel that's updated with new images, as soon as a new update/PR is merged, but I don't want to expose that in the UI. It can still be enabled via HA's YAML `configuration.yaml`, as described [here](https://github.com/zigpy/zigpy-ota#using-pre-release-channels).

## Questions

I've only added a `use_beta_channel` flag to `OTAConfiguration`. If we make this an enum/str with channels, we could have ZHA pass through more options for zigpy-ota. If we do that, we could always override the default zigpy-ota provider enabled in zigpy. But since we wouldn't allow enabling `dev` channel support via the ZHA UI, we'd still have to check for `dev` `extra_providers` to allow that via YAML. Or should we disable the zigpy-ota provider by default in zigpy and only enable it through ZHA here?

Not sure if I'm fully happy with this, yet..