### PR TITLE
Remove legacy hardcoded attributes for lumi.airrtc.agl001

### DIFF
--- a/zha/application/platforms/binary_sensor/__init__.py
+++ b/zha/application/platforms/binary_sensor/__init__.py
@@ -331,49 +331,6 @@ class XiaomiPlugConsumerConnected(BinarySensor):
     _attr_translation_key: str = "consumer_connected"
 
 
-@MULTI_MATCH(cluster_handler_names="opple_cluster", models={"lumi.airrtc.agl001"})
-class AqaraThermostatWindowOpen(BinarySensor):
-    """ZHA Aqara thermostat window open binary sensor."""
-
-    _attribute_name = "window_open"
-    _unique_id_suffix = "window_open"
-    _attr_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.WINDOW
-
-
-@MULTI_MATCH(cluster_handler_names="opple_cluster", models={"lumi.airrtc.agl001"})
-class AqaraThermostatValveAlarm(BinarySensor):
-    """ZHA Aqara thermostat valve alarm binary sensor."""
-
-    _attribute_name = "valve_alarm"
-    _unique_id_suffix = "valve_alarm"
-    _attr_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.PROBLEM
-    _attr_translation_key: str = "valve_alarm"
-
-
-@CONFIG_DIAGNOSTIC_MATCH(
-    cluster_handler_names="opple_cluster", models={"lumi.airrtc.agl001"}
-)
-class AqaraThermostatCalibrated(BinarySensor):
-    """ZHA Aqara thermostat calibrated binary sensor."""
-
-    _attribute_name = "calibrated"
-    _unique_id_suffix = "calibrated"
-    _attr_entity_category: EntityCategory = EntityCategory.DIAGNOSTIC
-    _attr_translation_key: str = "calibrated"
-
-
-@CONFIG_DIAGNOSTIC_MATCH(
-    cluster_handler_names="opple_cluster", models={"lumi.airrtc.agl001"}
-)
-class AqaraThermostatExternalSensor(BinarySensor):
-    """ZHA Aqara thermostat external sensor binary sensor."""
-
-    _attribute_name = "sensor"
-    _unique_id_suffix = "sensor"
-    _attr_entity_category: EntityCategory = EntityCategory.DIAGNOSTIC
-    _attr_translation_key: str = "external_sensor"
-
-
 @MULTI_MATCH(cluster_handler_names="opple_cluster", models={"lumi.sensor_smoke.acn03"})
 class AqaraLinkageAlarmState(BinarySensor):
     """ZHA Aqara linkage alarm state binary sensor."""

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -758,24 +758,6 @@ class AqaraPetFeederPortionWeight(NumberConfigurationEntity):
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
-    cluster_handler_names="opple_cluster", models={"lumi.airrtc.agl001"}
-)
-class AqaraThermostatAwayTemp(NumberConfigurationEntity):
-    """Aqara away preset temperature configuration entity."""
-
-    _unique_id_suffix = "away_preset_temperature"
-    _attr_entity_category = EntityCategory.CONFIG
-    _attr_native_min_value: float = 5
-    _attr_native_max_value: float = 30
-    _multiplier: float = 0.01
-    _attribute_name = "away_preset_temperature"
-    _attr_translation_key: str = "away_preset_temperature"
-
-    _attr_mode: NumberMode = NumberMode.SLIDER
-    _attr_native_unit_of_measurement: str = UnitOfTemperature.CELSIUS
-
-
-@CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
     stop_on_match_group=CLUSTER_HANDLER_THERMOSTAT,
 )

--- a/zha/application/platforms/select.py
+++ b/zha/application/platforms/select.py
@@ -667,26 +667,6 @@ class AqaraPetFeederMode(ZCLEnumSelectEntity):
     _attr_translation_key: str = "feeding_mode"
 
 
-class AqaraThermostatPresetMode(types.enum8):
-    """Thermostat preset mode."""
-
-    Manual = 0x00
-    Auto = 0x01
-    Away = 0x02
-
-
-@CONFIG_DIAGNOSTIC_MATCH(
-    cluster_handler_names="opple_cluster", models={"lumi.airrtc.agl001"}
-)
-class AqaraThermostatPreset(ZCLEnumSelectEntity):
-    """Representation of an Aqara thermostat preset configuration entity."""
-
-    _unique_id_suffix = "preset"
-    _attribute_name = "preset"
-    _enum = AqaraThermostatPresetMode
-    _attr_translation_key: str = "preset"
-
-
 class SonoffPresenceDetectionSensitivityEnum(types.enum8):
     """Enum for detection sensitivity select entity."""
 

--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -654,39 +654,6 @@ class TuyaChildLockSwitch(ConfigurableAttributeSwitch):
 
 
 @CONFIG_DIAGNOSTIC_MATCH(
-    cluster_handler_names="opple_cluster", models={"lumi.airrtc.agl001"}
-)
-class AqaraThermostatWindowDetection(ConfigurableAttributeSwitch):
-    """Representation of an Aqara thermostat window detection configuration entity."""
-
-    _unique_id_suffix = "window_detection"
-    _attribute_name = "window_detection"
-    _attr_translation_key = "window_detection"
-
-
-@CONFIG_DIAGNOSTIC_MATCH(
-    cluster_handler_names="opple_cluster", models={"lumi.airrtc.agl001"}
-)
-class AqaraThermostatValveDetection(ConfigurableAttributeSwitch):
-    """Representation of an Aqara thermostat valve detection configuration entity."""
-
-    _unique_id_suffix = "valve_detection"
-    _attribute_name = "valve_detection"
-    _attr_translation_key = "valve_detection"
-
-
-@CONFIG_DIAGNOSTIC_MATCH(
-    cluster_handler_names="opple_cluster", models={"lumi.airrtc.agl001"}
-)
-class AqaraThermostatChildLock(ConfigurableAttributeSwitch):
-    """Representation of an Aqara thermostat child lock configuration entity."""
-
-    _unique_id_suffix = "child_lock"
-    _attribute_name = "child_lock"
-    _attr_translation_key = "child_lock"
-
-
-@CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names="opple_cluster", models={"lumi.sensor_smoke.acn03"}
 )
 class AqaraHeartbeatIndicator(ConfigurableAttributeSwitch):

--- a/zha/zigbee/cluster_handlers/manufacturerspecific.py
+++ b/zha/zigbee/cluster_handlers/manufacturerspecific.py
@@ -162,20 +162,6 @@ class OppleRemoteClusterHandler(ClusterHandler):
                 "serving_size": True,
                 "portion_weight": True,
             }
-        elif self.cluster.endpoint.model == "lumi.airrtc.agl001":
-            self.ZCL_INIT_ATTRS = {
-                "system_mode": True,
-                "preset": True,
-                "window_detection": True,
-                "valve_detection": True,
-                "valve_alarm": True,
-                "child_lock": True,
-                "away_preset_temperature": True,
-                "window_open": True,
-                "calibrated": True,
-                "schedule": True,
-                "sensor": True,
-            }
         elif self.cluster.endpoint.model == "lumi.sensor_smoke.acn03":
             self.ZCL_INIT_ATTRS = {
                 "buzzer_manual_mute": True,


### PR DESCRIPTION
## Summary

Removes legacy hardcoded entity definitions for the Aqara E1 TRV (`lumi.airrtc.agl001`).

The device now has a proper quirk in zha-device-handlers that defines all necessary entities using the quirks v2 API (see zigpy/zha-device-handlers#4604).

## Problem

These legacy definitions create duplicate entities alongside the quirk-defined ones:
- Legacy entities have translated names (e.g., "Kindersicherung", "Fenstererkennung")
- Quirk entities have English names (e.g., "Child lock", "Window detection")

This confuses users who see both sets of entities for the same functionality.

## Changes

**Removed from `manufacturerspecific.py`:**
- `ZCL_INIT_ATTRS` block for `lumi.airrtc.agl001` in `OppleRemoteClusterHandler`

**Removed from platform files:**

| File | Removed Classes |
|------|-----------------|
| `binary_sensor/__init__.py` | `AqaraThermostatWindowOpen`, `AqaraThermostatValveAlarm`, `AqaraThermostatCalibrated`, `AqaraThermostatExternalSensor` |
| `switch.py` | `AqaraThermostatWindowDetection`, `AqaraThermostatValveDetection`, `AqaraThermostatChildLock` |
| `select.py` | `AqaraThermostatPresetMode` (enum), `AqaraThermostatPreset` |
| `number/__init__.py` | `AqaraThermostatAwayTemp` |

**Total: 128 lines removed**

## Test Plan

- [x] Verified quirk provides all entities (zigpy/zha-device-handlers#4604)
- [ ] Test with real device after both PRs merged

## Related

- Closes #620
- Companion PR: zigpy/zha-device-handlers#4604 (improved Aqara E1 TRV quirk)

Thanks to @TheJulianJES for explaining that `ZCL_INIT_ATTRS` alone doesn't create entities - the actual entity classes in platform files needed to be removed as well!