### PR TITLE
Update default precision for instantaneous demand + current

### DIFF
--- a/tests/data/devices/adeo-sin-4-fp-21-equ.json
+++ b/tests/data/devices/adeo-sin-4-fp-21-equ.json
@@ -552,7 +552,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {

--- a/tests/data/devices/aurora-doublesocket50au.json
+++ b/tests/data/devices/aurora-doublesocket50au.json
@@ -867,7 +867,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -1159,7 +1159,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/bituo-technik-spm01x001.json
+++ b/tests/data/devices/bituo-technik-spm01x001.json
@@ -763,7 +763,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/bosch-rbsh-mms-zb-eu.json
+++ b/tests/data/devices/bosch-rbsh-mms-zb-eu.json
@@ -1387,7 +1387,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {

--- a/tests/data/devices/datek-pop.json
+++ b/tests/data/devices/datek-pop.json
@@ -767,7 +767,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/develco-products-a-s-zhemi-zigbee-external-meter-interface.json
+++ b/tests/data/devices/develco-products-a-s-zhemi-zigbee-external-meter-interface.json
@@ -461,7 +461,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {

--- a/tests/data/devices/frient-a-s-emizb-141.json
+++ b/tests/data/devices/frient-a-s-emizb-141.json
@@ -642,7 +642,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {

--- a/tests/data/devices/frient-a-s-emizb-151.json
+++ b/tests/data/devices/frient-a-s-emizb-151.json
@@ -1391,7 +1391,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {
@@ -1694,7 +1694,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -1743,7 +1743,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -1792,7 +1792,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/frient-a-s-splzb-141.json
+++ b/tests/data/devices/frient-a-s-splzb-141.json
@@ -732,7 +732,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {
@@ -978,7 +978,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/ikea-of-sweden-inspelning-smart-plug.json
+++ b/tests/data/devices/ikea-of-sweden-inspelning-smart-plug.json
@@ -838,7 +838,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/innr-sp-120.json
+++ b/tests/data/devices/innr-sp-120.json
@@ -889,7 +889,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/innr-sp-234.json
+++ b/tests/data/devices/innr-sp-234.json
@@ -764,7 +764,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/innr-sp-240.json
+++ b/tests/data/devices/innr-sp-240.json
@@ -897,7 +897,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/innr-sp-242.json
+++ b/tests/data/devices/innr-sp-242.json
@@ -1122,7 +1122,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/inovelli-vzm30-sn.json
+++ b/tests/data/devices/inovelli-vzm30-sn.json
@@ -1361,7 +1361,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/isilentllc-home-energy-monitor.json
+++ b/tests/data/devices/isilentllc-home-energy-monitor.json
@@ -4311,7 +4311,7 @@
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -4603,7 +4603,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -4895,7 +4895,7 @@
           "endpoint_id": 12,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -5187,7 +5187,7 @@
           "endpoint_id": 13,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -5479,7 +5479,7 @@
           "endpoint_id": 14,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -5771,7 +5771,7 @@
           "endpoint_id": 15,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -6063,7 +6063,7 @@
           "endpoint_id": 16,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -6355,7 +6355,7 @@
           "endpoint_id": 17,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -6647,7 +6647,7 @@
           "endpoint_id": 18,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -6939,7 +6939,7 @@
           "endpoint_id": 19,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -7231,7 +7231,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -7523,7 +7523,7 @@
           "endpoint_id": 20,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -7815,7 +7815,7 @@
           "endpoint_id": 21,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -8107,7 +8107,7 @@
           "endpoint_id": 22,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -8399,7 +8399,7 @@
           "endpoint_id": 23,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -8691,7 +8691,7 @@
           "endpoint_id": 24,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -8983,7 +8983,7 @@
           "endpoint_id": 25,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -9275,7 +9275,7 @@
           "endpoint_id": 26,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -9567,7 +9567,7 @@
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -9859,7 +9859,7 @@
           "endpoint_id": 4,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -10151,7 +10151,7 @@
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -10443,7 +10443,7 @@
           "endpoint_id": 6,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -10735,7 +10735,7 @@
           "endpoint_id": 7,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -11027,7 +11027,7 @@
           "endpoint_id": 8,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -11319,7 +11319,7 @@
           "endpoint_id": 9,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/isilentllc-water-heater.json
+++ b/tests/data/devices/isilentllc-water-heater.json
@@ -491,7 +491,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/jasco-products-45856.json
+++ b/tests/data/devices/jasco-products-45856.json
@@ -562,7 +562,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {

--- a/tests/data/devices/jasco-products-45857.json
+++ b/tests/data/devices/jasco-products-45857.json
@@ -681,7 +681,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {

--- a/tests/data/devices/lds-zb-onoffplug-d0005.json
+++ b/tests/data/devices/lds-zb-onoffplug-d0005.json
@@ -709,7 +709,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/legrand-contactor.json
+++ b/tests/data/devices/legrand-contactor.json
@@ -929,7 +929,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/legrand-mobile-outlet.json
+++ b/tests/data/devices/legrand-mobile-outlet.json
@@ -1021,7 +1021,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-plug-maeu01.json
+++ b/tests/data/devices/lumi-lumi-plug-maeu01.json
@@ -556,7 +556,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-plug-maus01.json
+++ b/tests/data/devices/lumi-lumi-plug-maus01.json
@@ -706,7 +706,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {
@@ -995,7 +995,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-relay-c2acn01.json
+++ b/tests/data/devices/lumi-lumi-relay-c2acn01.json
@@ -707,7 +707,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {

--- a/tests/data/devices/namron-as-4512785.json
+++ b/tests/data/devices/namron-as-4512785.json
@@ -1015,7 +1015,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/nodon-sin-4-fp-21.json
+++ b/tests/data/devices/nodon-sin-4-fp-21.json
@@ -725,7 +725,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {

--- a/tests/data/devices/schneider-electric-eko07259.json
+++ b/tests/data/devices/schneider-electric-eko07259.json
@@ -3071,7 +3071,7 @@
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {

--- a/tests/data/devices/schneider-electric-evsckt-outlet-1.json
+++ b/tests/data/devices/schneider-electric-evsckt-outlet-1.json
@@ -657,7 +657,7 @@
           "endpoint_id": 6,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {
@@ -761,7 +761,7 @@
           "endpoint_id": 6,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/schneider-electric-s520619.json
+++ b/tests/data/devices/schneider-electric-s520619.json
@@ -1201,7 +1201,7 @@
           "endpoint_id": 5,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {

--- a/tests/data/devices/schneider-electric-socket-outlet-1.json
+++ b/tests/data/devices/schneider-electric-socket-outlet-1.json
@@ -747,7 +747,7 @@
           "endpoint_id": 6,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {
@@ -851,7 +851,7 @@
           "endpoint_id": 6,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/schneider-electric-socket-outlet-2.json
+++ b/tests/data/devices/schneider-electric-socket-outlet-2.json
@@ -747,7 +747,7 @@
           "endpoint_id": 6,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {
@@ -851,7 +851,7 @@
           "endpoint_id": 6,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/securifi-ltd-unk-model.json
+++ b/tests/data/devices/securifi-ltd-unk-model.json
@@ -674,7 +674,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/sengled-e11-g13.json
+++ b/tests/data/devices/sengled-e11-g13.json
@@ -613,7 +613,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {

--- a/tests/data/devices/sengled-e12-n14.json
+++ b/tests/data/devices/sengled-e12-n14.json
@@ -607,7 +607,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {

--- a/tests/data/devices/sengled-e12-n1e.json
+++ b/tests/data/devices/sengled-e12-n1e.json
@@ -680,7 +680,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {

--- a/tests/data/devices/sengled-e1c-nb7.json
+++ b/tests/data/devices/sengled-e1c-nb7.json
@@ -495,7 +495,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {

--- a/tests/data/devices/sengled-e1f-n9g.json
+++ b/tests/data/devices/sengled-e1f-n9g.json
@@ -625,7 +625,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {

--- a/tests/data/devices/sengled-e1g-g8e.json
+++ b/tests/data/devices/sengled-e1g-g8e.json
@@ -686,7 +686,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {

--- a/tests/data/devices/sengled-e21-n1ea.json
+++ b/tests/data/devices/sengled-e21-n1ea.json
@@ -829,7 +829,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {

--- a/tests/data/devices/sengled-z01-a19nae26.json
+++ b/tests/data/devices/sengled-z01-a19nae26.json
@@ -707,7 +707,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {

--- a/tests/data/devices/sercomm-corp-sz-esw01-au.json
+++ b/tests/data/devices/sercomm-corp-sz-esw01-au.json
@@ -791,7 +791,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {
@@ -1042,7 +1042,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/shelly-mini1pm.json
+++ b/tests/data/devices/shelly-mini1pm.json
@@ -876,7 +876,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/sinope-technologies-va4220zb.json
+++ b/tests/data/devices/sinope-technologies-va4220zb.json
@@ -845,7 +845,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "l/h"
         },
         "state": {

--- a/tests/data/devices/sonoff-s60zbtpg.json
+++ b/tests/data/devices/sonoff-s60zbtpg.json
@@ -842,7 +842,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/sunricher-on-off-2ch.json
+++ b/tests/data/devices/sunricher-on-off-2ch.json
@@ -1146,7 +1146,7 @@
           "endpoint_id": 11,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/third-reality-inc-3rsp02028bz.json
+++ b/tests/data/devices/third-reality-inc-3rsp02028bz.json
@@ -902,7 +902,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tyzb01-zanh6v1o-ts0121.json
+++ b/tests/data/devices/tyzb01-zanh6v1o-ts0121.json
@@ -671,7 +671,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-2putqrmw-ts011f.json
+++ b/tests/data/devices/tz3000-2putqrmw-ts011f.json
@@ -735,7 +735,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-2xlvlnez-ts011f.json
+++ b/tests/data/devices/tz3000-2xlvlnez-ts011f.json
@@ -804,7 +804,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-303avxxt-ts011f.json
+++ b/tests/data/devices/tz3000-303avxxt-ts011f.json
@@ -840,7 +840,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-3ias4w4o-ts011f.json
+++ b/tests/data/devices/tz3000-3ias4w4o-ts011f.json
@@ -791,7 +791,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-5ity3zyu-ts0121.json
+++ b/tests/data/devices/tz3000-5ity3zyu-ts0121.json
@@ -665,7 +665,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-6l1pjfqe-ts011f.json
+++ b/tests/data/devices/tz3000-6l1pjfqe-ts011f.json
@@ -738,7 +738,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-8nkb7mof-ts0121.json
+++ b/tests/data/devices/tz3000-8nkb7mof-ts0121.json
@@ -812,7 +812,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-cehuw1lw-ts011f.json
+++ b/tests/data/devices/tz3000-cehuw1lw-ts011f.json
@@ -707,7 +707,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-cicwjqth-ts011f.json
+++ b/tests/data/devices/tz3000-cicwjqth-ts011f.json
@@ -649,7 +649,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-fdxihpp7-ts0001.json
+++ b/tests/data/devices/tz3000-fdxihpp7-ts0001.json
@@ -806,7 +806,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-gjrubzje-ts0001.json
+++ b/tests/data/devices/tz3000-gjrubzje-ts0001.json
@@ -803,7 +803,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-kqvb5akv-ts0001.json
+++ b/tests/data/devices/tz3000-kqvb5akv-ts0001.json
@@ -877,7 +877,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-lepzuhto-ts011f.json
+++ b/tests/data/devices/tz3000-lepzuhto-ts011f.json
@@ -737,7 +737,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-lotmgthb-ts011f.json
+++ b/tests/data/devices/tz3000-lotmgthb-ts011f.json
@@ -735,7 +735,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-mkhkxx1p-ts0001.json
+++ b/tests/data/devices/tz3000-mkhkxx1p-ts0001.json
@@ -800,7 +800,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-npzfdcof-ts0001.json
+++ b/tests/data/devices/tz3000-npzfdcof-ts0001.json
@@ -793,7 +793,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-okaz9tjs-ts011f.json
+++ b/tests/data/devices/tz3000-okaz9tjs-ts011f.json
@@ -721,7 +721,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-pl5v1yyy-ts011f.json
+++ b/tests/data/devices/tz3000-pl5v1yyy-ts011f.json
@@ -1054,7 +1054,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-r6buo8ba-ts011f.json
+++ b/tests/data/devices/tz3000-r6buo8ba-ts011f.json
@@ -665,7 +665,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-sgb0xhwn-ts011f.json
+++ b/tests/data/devices/tz3000-sgb0xhwn-ts011f.json
@@ -998,7 +998,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-tgddllx4-ts0001.json
+++ b/tests/data/devices/tz3000-tgddllx4-ts0001.json
@@ -711,7 +711,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-tqlv4ug4-ts0001.json
+++ b/tests/data/devices/tz3000-tqlv4ug4-ts0001.json
@@ -998,7 +998,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-typdpbpg-ts011f.json
+++ b/tests/data/devices/tz3000-typdpbpg-ts011f.json
@@ -993,7 +993,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-uwkja6z1-ts011f.json
+++ b/tests/data/devices/tz3000-uwkja6z1-ts011f.json
@@ -996,7 +996,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -1192,7 +1192,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-w0qqde0g-ts011f.json
+++ b/tests/data/devices/tz3000-w0qqde0g-ts011f.json
@@ -784,7 +784,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-xkap8wtb-ts000f.json
+++ b/tests/data/devices/tz3000-xkap8wtb-ts000f.json
@@ -859,7 +859,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-ynmowqk2-ts011f.json
+++ b/tests/data/devices/tz3000-ynmowqk2-ts011f.json
@@ -694,7 +694,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-zv6x8bt2-ts011f.json
+++ b/tests/data/devices/tz3000-zv6x8bt2-ts011f.json
@@ -946,7 +946,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tz3000-zw7yf6yk-ts0001.json
+++ b/tests/data/devices/tz3000-zw7yf6yk-ts0001.json
@@ -763,7 +763,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tze200-byzdayie-ts0601.json
+++ b/tests/data/devices/tze200-byzdayie-ts0601.json
@@ -719,7 +719,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tze200-ewxhg6o9-ts0601.json
+++ b/tests/data/devices/tze200-ewxhg6o9-ts0601.json
@@ -657,7 +657,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tze200-ny94onlb-ts0601.json
+++ b/tests/data/devices/tze200-ny94onlb-ts0601.json
@@ -1178,7 +1178,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -1226,7 +1226,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -1274,7 +1274,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -1514,7 +1514,7 @@
           "endpoint_id": 10,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -1658,7 +1658,7 @@
           "endpoint_id": 20,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -1802,7 +1802,7 @@
           "endpoint_id": 30,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tze200-v9hkz2yn-ts0601.json
+++ b/tests/data/devices/tze200-v9hkz2yn-ts0601.json
@@ -486,7 +486,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {
@@ -780,7 +780,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -828,7 +828,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -876,7 +876,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tze204-81yrt3lo-ts0601.json
+++ b/tests/data/devices/tze204-81yrt3lo-ts0601.json
@@ -1033,7 +1033,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {
@@ -1380,7 +1380,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -1478,7 +1478,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {
@@ -1776,7 +1776,7 @@
           "endpoint_id": 2,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {
@@ -1825,7 +1825,7 @@
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {
@@ -2075,7 +2075,7 @@
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tze204-bkkmqmyo-ts0601.json
+++ b/tests/data/devices/tze204-bkkmqmyo-ts0601.json
@@ -804,7 +804,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/tze204-xlppj4f5-ts0601.json
+++ b/tests/data/devices/tze204-xlppj4f5-ts0601.json
@@ -343,7 +343,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "l/h"
         },
         "state": {

--- a/tests/data/devices/ubisys-s1-5501.json
+++ b/tests/data/devices/ubisys-s1-5501.json
@@ -904,7 +904,7 @@
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": "W"
         },
         "state": {
@@ -1251,7 +1251,7 @@
           "endpoint_id": 3,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/tests/data/devices/zbeacon-ts0505.json
+++ b/tests/data/devices/zbeacon-ts0505.json
@@ -856,7 +856,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": null,
+          "suggested_display_precision": 1,
           "unit": null
         },
         "state": {
@@ -1146,7 +1146,7 @@
           "endpoint_id": 1,
           "available": true,
           "group_id": null,
-          "suggested_display_precision": 1,
+          "suggested_display_precision": 2,
           "unit": "A"
         },
         "state": {

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -907,6 +907,7 @@ class ElectricalMeasurementApparentPower(BaseElectricalMeasurement):
 class ElectricalMeasurementRMSCurrent(BaseElectricalMeasurement):
     """RMS current measurement."""
 
+    _attr_suggested_display_precision = 2
     _attribute_name = "rms_current"
     _unique_id_suffix = "rms_current"
     _attr_max_attribute_name = "rms_current_max"

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -1219,6 +1219,7 @@ class SmartEnergyMetering(PollableSensor):
 
     entity_description: SmartEnergyMeteringEntityDescription
     _use_custom_polling: bool = False
+    _attr_suggested_display_precision = 1
     _attribute_name = "instantaneous_demand"
     _attr_translation_key: str = "instantaneous_demand"
     _attr_extra_state_attribute_names: set[str] = {


### PR DESCRIPTION
This updates the suggested display precision for the instantaneous demand entity and the RMS current entity.

The instantaneous demand entity then aligns with the EM active power entities (suggested precision 1).
The RMS current entity uses suggested precision 2 to not cut off low-power draw devices, often attached to smart plugs. HA would already use 2 by default, but we currently override this to 1 in the Base EM sensor class, which is not ideal.