### PR TITLE
Combine OTA release notes when possible

### DIFF
--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -620,7 +620,7 @@ async def test_firmware_update_latest_version_even_if_downgrade(
 async def test_firmware_update_metadata(zha_gateway: Gateway) -> None:
     """Test ZHA update platform - firmware metadata (changelog, release_notes, release_url)."""
     zigpy_device = zigpy_device_mock(zha_gateway)
-    zha_device, ota_cluster, fw_image, installed_fw_version = await setup_test_data(
+    zha_device, ota_cluster, _, installed_fw_version = await setup_test_data(
         zha_gateway, zigpy_device
     )
 
@@ -668,6 +668,79 @@ async def test_firmware_update_metadata(zha_gateway: Gateway) -> None:
         entity.state[ATTR_LATEST_VERSION]
         == f"0x{fw_image.firmware.header.file_version:08x}"
     )
-    assert entity.state[ATTR_RELEASE_SUMMARY] == "This is a test changelog!"
-    assert entity.state[ATTR_RELEASE_NOTES] == "These are the full release notes."
     assert entity.state[ATTR_RELEASE_URL] == "https://example.com/releases/v1.0"
+    assert entity.state[ATTR_RELEASE_SUMMARY] == "This is a test changelog!"
+
+    # release notes should NOT have version header with a single upgrade
+    assert entity.state[ATTR_RELEASE_NOTES] == "These are the full release notes."
+
+
+async def test_firmware_update_multiple_upgrades_combined_release_notes(
+    zha_gateway: Gateway,
+) -> None:
+    """Test ZHA update platform - multiple upgrades combine release notes with version headers."""
+    zigpy_device = zigpy_device_mock(zha_gateway)
+    zha_device, ota_cluster, _, installed_fw_version = await setup_test_data(
+        zha_gateway, zigpy_device
+    )
+
+    # Create multiple firmware images (newest to oldest)
+    # Note: fw_image_v2 has no release notes and should be skipped
+    fw_image_v3 = create_fw_image(
+        installed_fw_version + 30,
+        changelog="Latest changelog",
+        release_notes="Release notes for v3.",
+        release_url="https://example.com/releases/v3",
+    )
+    fw_image_v2 = create_fw_image(
+        installed_fw_version + 20,
+        release_notes=None,  # No release notes for this version
+    )
+    fw_image_v1 = create_fw_image(
+        installed_fw_version + 10,
+        release_notes="Release notes for v1.",
+    )
+
+    zigpy_device.application.ota.get_ota_images = AsyncMock(
+        return_value=OtaImagesResult(
+            upgrades=(fw_image_v3, fw_image_v2, fw_image_v1),
+            downgrades=(),
+        )
+    )
+
+    entity = get_entity(zha_device, platform=Platform.UPDATE)
+
+    # simulate an image available notification
+    await ota_cluster._handle_query_next_image(
+        foundation.ZCLHeader.cluster(
+            tsn=0x12, command_id=general.Ota.ServerCommandDefs.query_next_image.id
+        ),
+        general.QueryNextImageCommand(
+            field_control=fw_image_v3.firmware.header.field_control,
+            manufacturer_code=zha_device.manufacturer_code,
+            image_type=fw_image_v3.firmware.header.image_type,
+            current_file_version=installed_fw_version,
+            hardware_version=1,
+        ),
+    )
+
+    await zha_gateway.async_block_till_done()
+
+    # Verify latest version is the newest firmware
+    assert (
+        entity.state[ATTR_LATEST_VERSION]
+        == f"0x{fw_image_v3.firmware.header.file_version:08x}"
+    )
+    # Only latest firmware provides URL and release summary
+    assert entity.state[ATTR_RELEASE_URL] == "https://example.com/releases/v3"
+    assert entity.state[ATTR_RELEASE_SUMMARY] == "Latest changelog"
+
+    # Release notes should be combined with version headers
+    # fw_image_v2 is skipped because it has no release notes
+    expected_release_notes = (
+        f"## 0x{fw_image_v3.firmware.header.file_version:08x}\n"
+        "Release notes for v3.\n\n"
+        f"## 0x{fw_image_v1.firmware.header.file_version:08x}\n"
+        "Release notes for v1."
+    )
+    assert entity.state[ATTR_RELEASE_NOTES] == expected_release_notes

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -671,8 +671,11 @@ async def test_firmware_update_metadata(zha_gateway: Gateway) -> None:
     assert entity.state[ATTR_RELEASE_URL] == "https://example.com/releases/v1.0"
     assert entity.state[ATTR_RELEASE_SUMMARY] == "This is a test changelog!"
 
-    # release notes should NOT have version header with a single upgrade
-    assert entity.state[ATTR_RELEASE_NOTES] == "These are the full release notes."
+    # release notes include version header
+    assert entity.state[ATTR_RELEASE_NOTES] == (
+        f"## 0x{fw_image.firmware.header.file_version:08x}\n"
+        "These are the full release notes."
+    )
 
 
 async def test_firmware_update_multiple_upgrades_combined_release_notes(

--- a/zha/application/platforms/update.py
+++ b/zha/application/platforms/update.py
@@ -199,8 +199,23 @@ class BaseFirmwareUpdateEntity(PlatformEntity):
             latest_firmware = images_result.upgrades[0]
             self._attr_latest_version = f"0x{latest_firmware.version:08x}"
             self._attr_release_summary = latest_firmware.metadata.changelog or None
-            self._attr_release_notes = latest_firmware.metadata.release_notes or None
             self._attr_release_url = latest_firmware.metadata.release_url or None
+
+            # Combine release notes from all upgrades (newest to oldest)
+            if len(images_result.upgrades) > 1:
+                release_notes_parts = []
+                for firmware in images_result.upgrades:
+                    if firmware.metadata.release_notes:
+                        release_notes_parts.append(
+                            f"## 0x{firmware.version:08x}\n{firmware.metadata.release_notes}"
+                        )
+                self._attr_release_notes = (
+                    "\n\n".join(release_notes_parts) if release_notes_parts else None
+                )
+            else:
+                self._attr_release_notes = (
+                    latest_firmware.metadata.release_notes or None
+                )
         elif images_result.downgrades:
             # If not, note the version of the most recent firmware
             latest_firmware = None

--- a/zha/application/platforms/update.py
+++ b/zha/application/platforms/update.py
@@ -202,20 +202,15 @@ class BaseFirmwareUpdateEntity(PlatformEntity):
             self._attr_release_url = latest_firmware.metadata.release_url or None
 
             # Combine release notes from all upgrades (newest to oldest)
-            if len(images_result.upgrades) > 1:
-                release_notes_parts = []
-                for firmware in images_result.upgrades:
-                    if firmware.metadata.release_notes:
-                        release_notes_parts.append(
-                            f"## 0x{firmware.version:08x}\n{firmware.metadata.release_notes}"
-                        )
-                self._attr_release_notes = (
-                    "\n\n".join(release_notes_parts) if release_notes_parts else None
-                )
-            else:
-                self._attr_release_notes = (
-                    latest_firmware.metadata.release_notes or None
-                )
+            release_notes_parts = []
+            for firmware in images_result.upgrades:
+                if firmware.metadata.release_notes:
+                    release_notes_parts.append(
+                        f"## 0x{firmware.version:08x}\n{firmware.metadata.release_notes}"
+                    )
+            self._attr_release_notes = (
+                "\n\n".join(release_notes_parts) if release_notes_parts else None
+            )
         elif images_result.downgrades:
             # If not, note the version of the most recent firmware
             latest_firmware = None


### PR DESCRIPTION
## Proposed change

This changes the update entity to combine the release notes of multiple updates when we jump to the most recent one, 
skipping an install of an intermediate update. A test for this is also added. 

A header with the hex version of the update is also added in the update entity release notes.


## Additional information

This is useful for the zigpy-ota OTA provider, as it keeps a history of all images in the zigpy index, even older ones.
Zigpy will only install the newest image possible, but we still list older release notes now.

### Notes

- Do note there could still be a newer update that shows after this one is installed, e.g. due to `min_file_version` constraints. It's expected that those release notes don't show up during the first install, since that update isn't installed. They'll show up when updates are checked for again. But I guess this is obvious.
- Also note that the friendly version strings ("1.2.3") in the screenshots below are part of the release notes. They are not saved in the index, since there's no consistent way to extract them from OTA info nor are they consistently provided by manufacturers. If we have them, we can try to include them in the release notes directly, like we did with Innr images and in the example screenshots below.
  Only the headers with the hex version strings are included automatically.
- The release notes are ordered from newest to oldest. I think this is what HA also does for add-on updates.

### Screenshots

Changelog with three firmware versions that are skipped | Changelog with one firmware version that is skipped | Changelog with no firmware versions that are skipped (no header) (not done in this PR now) | Changelog with no firmware versions that are skipped (with header) (done in this PR now)
--- | --- | --- | ---
<img width="568" height="1096" alt="Bildschirmfoto 2026-01-16 um 02 15 59" src="https://github.com/user-attachments/assets/e22e4d7d-bc99-486b-9705-863e6bd82cd1" /> | <img width="566" height="668" alt="Bildschirmfoto 2026-01-16 um 02 19 29" src="https://github.com/user-attachments/assets/28c938ac-c680-415e-be51-9a991c635a25" /> | <img width="562" height="487" alt="Bildschirmfoto 2026-01-16 um 02 18 26" src="https://github.com/user-attachments/assets/64762b55-ed62-4ecd-a6bf-a02c1f377fb0" /> | <img width="562" height="536" alt="Bildschirmfoto 2026-01-16 um 03 14 13" src="https://github.com/user-attachments/assets/f77632e6-610d-4136-a935-fa729b573831" />


### Markdown example of what we pass to HA

```markdown
## 0x12345696
Release notes for v3.

## 0x1234568c
Release notes for v1.
```