### PR TITLE
Update ZHA manufacturer code handling for zigpy 0.91.x

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -127,30 +127,75 @@ def make_attribute(attrid: int, value: Any, status: int = 0) -> zcl_f.Attribute:
 
 
 async def send_attributes_report(
-    zha_gateway: Gateway, cluster: zigpy.zcl.Cluster, attributes: dict
+    zha_gateway: Gateway,
+    cluster: zigpy.zcl.Cluster,
+    attributes: dict[str | int | zcl_f.ZCLAttributeDef, Any],
+    *,
+    tsn: int | None = None,
 ) -> None:
-    """Cause the sensor to receive an attribute report from the network.
+    """Mock attribute reports on a cluster."""
+    reports = []
+    manufacturer_codes: set[int | None] = set()
 
-    This is to simulate the normal device communication that happens when a
-    device is paired to the zigbee network.
-    """
-    attrs = []
-
-    for attrid, value in attributes.items():
-        if isinstance(attrid, str):
-            attrid = cluster.attributes_by_name[attrid].id
+    for attr, value in attributes.items():
+        if isinstance(attr, int):
+            # Raw attribute ID for unknown attributes
+            manufacturer_codes.add(None)
+            reports.append(
+                zcl_f.Attribute(
+                    attrid=attr,
+                    value=zcl_f.TypeValue(
+                        type=zcl_f.DataType.from_python_type(type(value)).type_id,
+                        value=value,
+                    ),
+                )
+            )
         else:
-            attrid = zigpy.types.uint16_t(attrid)
+            attr_def = cluster.find_attribute(attr)
+            manufacturer_codes.add(cluster._get_effective_manufacturer_code(attr_def))
 
-        attrs.append(make_attribute(attrid, value))
+            reports.append(
+                zcl_f.Attribute(
+                    attrid=attr_def.id,
+                    value=zcl_f.TypeValue(type=attr_def.zcl_type, value=value),
+                )
+            )
 
-    msg = zcl_f.GENERAL_COMMANDS[zcl_f.GeneralCommand.Report_Attributes].schema(
-        attribute_reports=attrs
+    if len(manufacturer_codes) != 1:
+        raise ValueError(
+            f"All attributes must have the same manufacturer code, got {manufacturer_codes}"
+        )
+
+    if tsn is None:
+        tsn = cluster.endpoint.device.get_sequence()
+
+    manufacturer: int | None = manufacturer_codes.pop()
+
+    frame_control = zcl_f.FrameControl(
+        frame_type=zcl_f.FrameType.GLOBAL_COMMAND,
+        is_manufacturer_specific=(manufacturer is not None),
+        direction=(
+            zcl_f.Direction.Client_to_Server
+            if cluster.is_client
+            else zcl_f.Direction.Server_to_Client
+        ),
+        disable_default_response=False,
+        reserved=0b000,
     )
 
-    hdr = make_zcl_header(zcl_f.GeneralCommand.Report_Attributes)
-    hdr.frame_control = hdr.frame_control.replace(disable_default_response=True)
-    cluster.handle_message(hdr, msg)
+    hdr = zcl_f.ZCLHeader(
+        frame_control=frame_control,
+        manufacturer=manufacturer,
+        tsn=tsn,
+        command_id=zcl_f.GeneralCommand.Report_Attributes,
+    )
+
+    command = zcl_f.GENERAL_COMMANDS[zcl_f.GeneralCommand.Report_Attributes].schema(
+        attribute_reports=reports
+    )
+
+    cluster.handle_cluster_general_request(hdr, command)
+
     await zha_gateway.async_block_till_done()
 
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -234,7 +234,7 @@ async def test_smarttthings_multi(
 
     st_ch.emit_zha_event = MagicMock(wraps=st_ch.emit_zha_event)
 
-    await send_attributes_report(zha_gateway, st_ch.cluster, {0x0012: 120})
+    await send_attributes_report(zha_gateway, st_ch.cluster, {"x_axis": 120})
 
     assert st_ch.emit_zha_event.call_count == 1
     assert st_ch.emit_zha_event.mock_calls == [

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -9,6 +9,7 @@ from zigpy.profiles import zha
 import zigpy.profiles.zha
 from zigpy.quirks import DeviceRegistry
 from zigpy.quirks.v2 import CustomDeviceV2, QuirkBuilder
+from zigpy.typing import UNDEFINED
 from zigpy.zcl.clusters import general, measurement, security
 from zigpy.zcl.clusters.general import OnOff
 
@@ -107,7 +108,7 @@ async def async_test_binary_sensor_occupancy(
     await zha_gateway.async_block_till_done()
     assert cluster.read_attributes.await_count == 1
     assert cluster.read_attributes.await_args == call(
-        ["occupancy"], allow_cache=True, only_cache=True, manufacturer=None
+        ["occupancy"], allow_cache=True, only_cache=True, manufacturer=UNDEFINED
     )
     assert entity.is_on
 
@@ -143,7 +144,7 @@ async def async_test_iaszone_on_off(
     await zha_gateway.async_block_till_done()
     assert cluster.read_attributes.await_count == 1
     assert cluster.read_attributes.await_args == call(
-        ["zone_status"], allow_cache=False, only_cache=False, manufacturer=None
+        ["zone_status"], allow_cache=False, only_cache=False, manufacturer=UNDEFINED
     )
     assert entity.is_on
 

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -18,6 +18,7 @@ from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice, DeviceRegistry
 from zigpy.quirks.v2 import CustomDeviceV2, QuirkBuilder
 import zigpy.types as t
+from zigpy.typing import UNDEFINED
 from zigpy.zcl.clusters import general, security
 from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
 import zigpy.zcl.foundation as zcl_f
@@ -155,7 +156,7 @@ async def test_frost_unlock(
     await entity.async_press()
     await zha_gateway.async_block_till_done()
     assert cluster.write_attributes.mock_calls == [
-        call({"frost_lock_reset": 0}, manufacturer=None)
+        call({"frost_lock_reset": 0}, manufacturer=UNDEFINED)
     ]
 
     cluster.write_attributes.reset_mock()
@@ -167,9 +168,9 @@ async def test_frost_unlock(
 
     # There are three retries
     assert cluster.write_attributes.mock_calls == [
-        call({"frost_lock_reset": 0}, manufacturer=None),
-        call({"frost_lock_reset": 0}, manufacturer=None),
-        call({"frost_lock_reset": 0}, manufacturer=None),
+        call({"frost_lock_reset": 0}, manufacturer=UNDEFINED),
+        call({"frost_lock_reset": 0}, manufacturer=UNDEFINED),
+        call({"frost_lock_reset": 0}, manufacturer=UNDEFINED),
     ]
 
 
@@ -290,7 +291,7 @@ async def test_quirks_write_attr_button(
         await entity.async_press()
         await zha_gateway.async_block_till_done()
         assert cluster.write_attributes.mock_calls == [
-            call({cluster.AttributeDefs.feed.name: 2}, manufacturer=None)
+            call({cluster.AttributeDefs.feed.name: 2}, manufacturer=UNDEFINED)
         ]
 
     assert cluster.get(cluster.AttributeDefs.feed.name) == 2

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -19,6 +19,7 @@ from zigpy.quirks.v2 import (
 from zigpy.quirks.v2.homeassistant import EntityType
 from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
 import zigpy.types
+from zigpy.typing import UNDEFINED
 from zigpy.zcl import ClusterType
 from zigpy.zcl.clusters import general
 from zigpy.zcl.clusters.general import Ota, PowerConfiguration
@@ -554,7 +555,7 @@ async def test_write_zigbee_attribute(
         {
             general.OnOff.AttributeDefs.start_up_on_off.id: general.OnOff.StartUpOnOff.PreviousValue
         },
-        manufacturer=None,
+        manufacturer=UNDEFINED,
     )
 
     cluster.write_attributes.reset_mock()

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -11,6 +11,7 @@ import zhaquirks
 from zigpy.device import Device as ZigpyDevice
 from zigpy.exceptions import ZigbeeException
 from zigpy.profiles import zha
+from zigpy.typing import UNDEFINED
 from zigpy.zcl.clusters import general, hvac
 import zigpy.zcl.foundation as zcl_f
 import zigpy.zdo.types as zdo_t
@@ -159,7 +160,7 @@ async def test_fan(
     await async_turn_on(zha_gateway, entity)
     assert len(cluster.write_attributes.mock_calls) == 1
     assert cluster.write_attributes.call_args == call(
-        {"fan_mode": 2}, manufacturer=None
+        {"fan_mode": 2}, manufacturer=UNDEFINED
     )
     assert entity.state["is_on"] is True
 
@@ -168,7 +169,7 @@ async def test_fan(
     await async_turn_off(zha_gateway, entity)
     assert len(cluster.write_attributes.mock_calls) == 1
     assert cluster.write_attributes.call_args == call(
-        {"fan_mode": 0}, manufacturer=None
+        {"fan_mode": 0}, manufacturer=UNDEFINED
     )
     assert entity.state["is_on"] is False
 
@@ -177,7 +178,7 @@ async def test_fan(
     await async_set_speed(zha_gateway, entity, speed=SPEED_HIGH)
     assert len(cluster.write_attributes.mock_calls) == 1
     assert cluster.write_attributes.call_args == call(
-        {"fan_mode": 3}, manufacturer=None
+        {"fan_mode": 3}, manufacturer=UNDEFINED
     )
     assert entity.state["is_on"] is True
     assert entity.state["speed"] == SPEED_HIGH
@@ -187,7 +188,7 @@ async def test_fan(
     await async_set_preset_mode(zha_gateway, entity, preset_mode=PRESET_MODE_ON)
     assert len(cluster.write_attributes.mock_calls) == 1
     assert cluster.write_attributes.call_args == call(
-        {"fan_mode": 4}, manufacturer=None
+        {"fan_mode": 4}, manufacturer=UNDEFINED
     )
     assert entity.state["is_on"] is True
     assert entity.state["preset_mode"] == PRESET_MODE_ON
@@ -198,7 +199,7 @@ async def test_fan(
     await zha_gateway.async_block_till_done()
     assert len(cluster.write_attributes.mock_calls) == 1
     assert cluster.write_attributes.call_args == call(
-        {"fan_mode": 2}, manufacturer=None
+        {"fan_mode": 2}, manufacturer=UNDEFINED
     )
     # this is converted to a ranged value
     assert entity.state["percentage"] == 66
@@ -566,42 +567,42 @@ async def test_fan_ikea(
     cluster.write_attributes.reset_mock()
     await async_turn_on(zha_gateway, entity)
     assert cluster.write_attributes.mock_calls == [
-        call({"fan_mode": 1}, manufacturer=None)
+        call({"fan_mode": 1}, manufacturer=UNDEFINED)
     ]
 
     # turn on with set speed from HA
     cluster.write_attributes.reset_mock()
     await async_turn_on(zha_gateway, entity, speed="high")
     assert cluster.write_attributes.mock_calls == [
-        call({"fan_mode": 10}, manufacturer=None)
+        call({"fan_mode": 10}, manufacturer=UNDEFINED)
     ]
 
     # turn off from HA
     cluster.write_attributes.reset_mock()
     await async_turn_off(zha_gateway, entity)
     assert cluster.write_attributes.mock_calls == [
-        call({"fan_mode": 0}, manufacturer=None)
+        call({"fan_mode": 0}, manufacturer=UNDEFINED)
     ]
 
     # change speed from HA
     cluster.write_attributes.reset_mock()
     await async_set_percentage(zha_gateway, entity, percentage=100)
     assert cluster.write_attributes.mock_calls == [
-        call({"fan_mode": 10}, manufacturer=None)
+        call({"fan_mode": 10}, manufacturer=UNDEFINED)
     ]
 
     # skip 10% when set from HA
     cluster.write_attributes.reset_mock()
     await async_set_percentage(zha_gateway, entity, percentage=10)
     assert cluster.write_attributes.mock_calls == [
-        call({"fan_mode": 2}, manufacturer=None)
+        call({"fan_mode": 2}, manufacturer=UNDEFINED)
     ]
 
     # change preset_mode from HA
     cluster.write_attributes.reset_mock()
     await async_set_preset_mode(zha_gateway, entity, preset_mode=PRESET_MODE_AUTO)
     assert cluster.write_attributes.mock_calls == [
-        call({"fan_mode": 1}, manufacturer=None)
+        call({"fan_mode": 1}, manufacturer=UNDEFINED)
     ]
 
     # set invalid preset_mode from HA
@@ -750,28 +751,28 @@ async def test_fan_kof(
     cluster.write_attributes.reset_mock()
     await async_turn_on(zha_gateway, entity)
     assert cluster.write_attributes.mock_calls == [
-        call({"fan_mode": 2}, manufacturer=None)
+        call({"fan_mode": 2}, manufacturer=UNDEFINED)
     ]
 
     # turn off from HA
     cluster.write_attributes.reset_mock()
     await async_turn_off(zha_gateway, entity)
     assert cluster.write_attributes.mock_calls == [
-        call({"fan_mode": 0}, manufacturer=None)
+        call({"fan_mode": 0}, manufacturer=UNDEFINED)
     ]
 
     # change speed from HA
     cluster.write_attributes.reset_mock()
     await async_set_percentage(zha_gateway, entity, percentage=100)
     assert cluster.write_attributes.mock_calls == [
-        call({"fan_mode": 4}, manufacturer=None)
+        call({"fan_mode": 4}, manufacturer=UNDEFINED)
     ]
 
     # change preset_mode from HA
     cluster.write_attributes.reset_mock()
     await async_set_preset_mode(zha_gateway, entity, preset_mode=PRESET_MODE_SMART)
     assert cluster.write_attributes.mock_calls == [
-        call({"fan_mode": 6}, manufacturer=None)
+        call({"fan_mode": 6}, manufacturer=UNDEFINED)
     ]
 
     # set invalid preset_mode from HA

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -7,6 +7,7 @@ from zigpy.device import Device as ZigpyDevice
 from zigpy.exceptions import ZigbeeException
 from zigpy.profiles import zha
 import zigpy.types
+from zigpy.typing import UNDEFINED
 from zigpy.zcl.clusters import general, lighting
 import zigpy.zdo.types as zdo_t
 
@@ -154,7 +155,7 @@ async def test_number(
 
     assert len(cluster.write_attributes.mock_calls) == 1
     assert cluster.write_attributes.call_args == call(
-        {"present_value": 30.0}, manufacturer=None
+        {"present_value": 30.0}, manufacturer=UNDEFINED
     )
     assert entity.state["state"] == 30.0
 
@@ -166,7 +167,7 @@ async def test_number(
     await zha_gateway.async_block_till_done()
     assert cluster.read_attributes.await_count == 1
     assert cluster.read_attributes.await_args == call(
-        ["present_value"], allow_cache=False, only_cache=False, manufacturer=None
+        ["present_value"], allow_cache=False, only_cache=False, manufacturer=UNDEFINED
     )
     assert entity.state["state"] == 20.0
 
@@ -174,7 +175,7 @@ async def test_number(
     await zha_gateway.async_block_till_done()
     assert len(cluster.write_attributes.mock_calls) == 2
     assert cluster.write_attributes.call_args == call(
-        {"present_value": 30}, manufacturer=None
+        {"present_value": 30}, manufacturer=UNDEFINED
     )
     assert entity.state["state"] == 30.0
 
@@ -247,13 +248,13 @@ async def test_level_control_number(
             ],
             allow_cache=True,
             only_cache=False,
-            manufacturer=None,
+            manufacturer=UNDEFINED,
         ),
         call(
             ["start_up_current_level"],
             allow_cache=True,
             only_cache=False,
-            manufacturer=None,
+            manufacturer=UNDEFINED,
         ),
         call(
             [
@@ -261,7 +262,7 @@ async def test_level_control_number(
             ],
             allow_cache=False,
             only_cache=False,
-            manufacturer=None,
+            manufacturer=UNDEFINED,
         ),
     ]
 
@@ -278,7 +279,7 @@ async def test_level_control_number(
 
     await entity.async_set_native_value(new_value)
     assert level_control_cluster.write_attributes.mock_calls == [
-        call({attr: new_value}, manufacturer=None)
+        call({attr: new_value}, manufacturer=UNDEFINED)
     ]
 
     assert entity.state["state"] == new_value
@@ -292,7 +293,7 @@ async def test_level_control_number(
             [attr],
             allow_cache=False,
             only_cache=False,
-            manufacturer=None,
+            manufacturer=UNDEFINED,
         )
     ]
 
@@ -303,9 +304,9 @@ async def test_level_control_number(
         await entity.async_set_native_value(new_value)
 
     assert level_control_cluster.write_attributes.mock_calls == [
-        call({attr: new_value}, manufacturer=None),
-        call({attr: new_value}, manufacturer=None),
-        call({attr: new_value}, manufacturer=None),
+        call({attr: new_value}, manufacturer=UNDEFINED),
+        call({attr: new_value}, manufacturer=UNDEFINED),
+        call({attr: new_value}, manufacturer=UNDEFINED),
     ]
     assert entity.state["state"] == initial_value
 
@@ -323,7 +324,7 @@ async def test_level_control_number(
             ],
             allow_cache=False,
             only_cache=False,
-            manufacturer=None,
+            manufacturer=UNDEFINED,
         ),
     ]
     assert entity.state["state"] == new_value
@@ -371,7 +372,7 @@ async def test_color_number(
             ],
             allow_cache=True,
             only_cache=False,
-            manufacturer=None,
+            manufacturer=UNDEFINED,
         )
         in color_cluster.read_attributes.call_args_list
     )
@@ -397,7 +398,7 @@ async def test_color_number(
             [attr],
             allow_cache=False,
             only_cache=False,
-            manufacturer=None,
+            manufacturer=UNDEFINED,
         )
         in color_cluster.read_attributes.call_args_list
     )
@@ -409,9 +410,9 @@ async def test_color_number(
         await entity.async_set_native_value(new_value)
 
     assert color_cluster.write_attributes.mock_calls == [
-        call({attr: new_value}, manufacturer=None),
-        call({attr: new_value}, manufacturer=None),
-        call({attr: new_value}, manufacturer=None),
+        call({attr: new_value}, manufacturer=UNDEFINED),
+        call({attr: new_value}, manufacturer=UNDEFINED),
+        call({attr: new_value}, manufacturer=UNDEFINED),
     ]
     assert entity.state["state"] == initial_value
 
@@ -429,7 +430,7 @@ async def test_color_number(
             ],
             allow_cache=False,
             only_cache=False,
-            manufacturer=None,
+            manufacturer=UNDEFINED,
         ),
     ]
     assert entity.state["state"] == new_value

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -14,6 +14,7 @@ from zigpy.profiles import zha
 from zigpy.quirks import CustomCluster, CustomDevice, get_device
 from zigpy.quirks.v2 import CustomDeviceV2, QuirkBuilder
 import zigpy.types as t
+from zigpy.typing import UNDEFINED
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters import general, security
 from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
@@ -229,7 +230,8 @@ async def test_on_off_select_attribute_report_v2(
         assert entity.state["state"] == AqaraMotionSensitivities.Medium.name
         assert cluster.write_attributes.call_count == 1
         assert cluster.write_attributes.call_args == call(
-            {"motion_sensitivity": AqaraMotionSensitivities.Medium}, manufacturer=None
+            {"motion_sensitivity": AqaraMotionSensitivities.Medium},
+            manufacturer=UNDEFINED,
         )
 
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -17,6 +17,7 @@ from zigpy.profiles import zha
 from zigpy.quirks import DEVICE_REGISTRY, CustomCluster, CustomDevice
 from zigpy.quirks.v2 import CustomDeviceV2, QuirkBuilder
 import zigpy.types as t
+from zigpy.typing import UNDEFINED
 from zigpy.zcl.clusters import closures, general
 from zigpy.zcl.clusters.general import BinaryOutput
 from zigpy.zcl.clusters.manufacturer_specific import ManufacturerSpecificCluster
@@ -213,7 +214,7 @@ async def test_switch(zha_gateway: Gateway) -> None:
     await zha_gateway.async_block_till_done()
     assert cluster.read_attributes.await_count == 1
     assert cluster.read_attributes.await_args == call(
-        ["on_off"], allow_cache=False, only_cache=False, manufacturer=None
+        ["on_off"], allow_cache=False, only_cache=False, manufacturer=UNDEFINED
     )
     assert bool(entity.state["state"]) is True
 
@@ -412,7 +413,7 @@ async def test_switch_configurable(
         await entity.async_turn_on()
         await zha_gateway.async_block_till_done()
         assert cluster.write_attributes.mock_calls == [
-            call({"window_detection_function": True}, manufacturer=None)
+            call({"window_detection_function": True}, manufacturer=UNDEFINED)
         ]
 
     cluster.write_attributes.reset_mock()
@@ -426,7 +427,7 @@ async def test_switch_configurable(
         await entity.async_turn_off()
         await zha_gateway.async_block_till_done()
         assert cluster.write_attributes.mock_calls == [
-            call({"window_detection_function": False}, manufacturer=None)
+            call({"window_detection_function": False}, manufacturer=UNDEFINED)
         ]
 
     cluster.read_attributes.reset_mock()
@@ -442,7 +443,7 @@ async def test_switch_configurable(
             ],
             allow_cache=False,
             only_cache=False,
-            manufacturer=None,
+            manufacturer=UNDEFINED,
         )
     ] == cluster.read_attributes.call_args_list
 
@@ -454,9 +455,9 @@ async def test_switch_configurable(
         await zha_gateway.async_block_till_done()
 
     assert cluster.write_attributes.mock_calls == [
-        call({"window_detection_function": False}, manufacturer=None),
-        call({"window_detection_function": False}, manufacturer=None),
-        call({"window_detection_function": False}, manufacturer=None),
+        call({"window_detection_function": False}, manufacturer=UNDEFINED),
+        call({"window_detection_function": False}, manufacturer=UNDEFINED),
+        call({"window_detection_function": False}, manufacturer=UNDEFINED),
     ]
 
     cluster.write_attributes.side_effect = None
@@ -468,14 +469,14 @@ async def test_switch_configurable(
     await entity.async_turn_off()
     await zha_gateway.async_block_till_done()
     assert cluster.write_attributes.mock_calls == [
-        call({"window_detection_function": True}, manufacturer=None)
+        call({"window_detection_function": True}, manufacturer=UNDEFINED)
     ]
 
     cluster.write_attributes.reset_mock()
     await entity.async_turn_on()
     await zha_gateway.async_block_till_done()
     assert cluster.write_attributes.mock_calls == [
-        call({"window_detection_function": False}, manufacturer=None)
+        call({"window_detection_function": False}, manufacturer=UNDEFINED)
     ]
 
 
@@ -540,7 +541,7 @@ async def test_switch_configurable_custom_on_off_values(zha_gateway: Gateway) ->
         await entity.async_turn_on()
         await zha_gateway.async_block_till_done()
         assert cluster.write_attributes.mock_calls == [
-            call({"window_detection_function": 3}, manufacturer=None)
+            call({"window_detection_function": 3}, manufacturer=UNDEFINED)
         ]
         cluster.write_attributes.reset_mock()
 
@@ -553,7 +554,7 @@ async def test_switch_configurable_custom_on_off_values(zha_gateway: Gateway) ->
         await entity.async_turn_off()
         await zha_gateway.async_block_till_done()
         assert cluster.write_attributes.mock_calls == [
-            call({"window_detection_function": 5}, manufacturer=None)
+            call({"window_detection_function": 5}, manufacturer=UNDEFINED)
         ]
 
 
@@ -621,7 +622,7 @@ async def test_switch_configurable_custom_on_off_values_force_inverted(
         await entity.async_turn_on()
         await zha_gateway.async_block_till_done()
         assert cluster.write_attributes.mock_calls == [
-            call({"window_detection_function": 5}, manufacturer=None)
+            call({"window_detection_function": 5}, manufacturer=UNDEFINED)
         ]
         cluster.write_attributes.reset_mock()
 
@@ -634,7 +635,7 @@ async def test_switch_configurable_custom_on_off_values_force_inverted(
         await entity.async_turn_off()
         await zha_gateway.async_block_till_done()
         assert cluster.write_attributes.mock_calls == [
-            call({"window_detection_function": 3}, manufacturer=None)
+            call({"window_detection_function": 3}, manufacturer=UNDEFINED)
         ]
 
 
@@ -705,7 +706,7 @@ async def test_switch_configurable_custom_on_off_values_inverter_attribute(
         await entity.async_turn_on()
         await zha_gateway.async_block_till_done()
         assert cluster.write_attributes.mock_calls == [
-            call({"window_detection_function": 5}, manufacturer=None)
+            call({"window_detection_function": 5}, manufacturer=UNDEFINED)
         ]
         cluster.write_attributes.reset_mock()
 
@@ -718,7 +719,7 @@ async def test_switch_configurable_custom_on_off_values_inverter_attribute(
         await entity.async_turn_off()
         await zha_gateway.async_block_till_done()
         assert cluster.write_attributes.mock_calls == [
-            call({"window_detection_function": 3}, manufacturer=None)
+            call({"window_detection_function": 3}, manufacturer=UNDEFINED)
         ]
 
 
@@ -789,7 +790,7 @@ async def test_cover_inversion_switch(zha_gateway: Gateway) -> None:
                 WCAttrs.window_covering_mode.name: WCM.Motor_direction_reversed
                 | WCM.LEDs_display_feedback
             },
-            manufacturer=None,
+            manufacturer=UNDEFINED,
         )
 
         assert bool(entity.state["state"]) is True
@@ -805,7 +806,7 @@ async def test_cover_inversion_switch(zha_gateway: Gateway) -> None:
         assert cluster.write_attributes.call_count == 1
         assert cluster.write_attributes.call_args_list[0] == call(
             {WCAttrs.window_covering_mode.name: WCM.LEDs_display_feedback},
-            manufacturer=None,
+            manufacturer=UNDEFINED,
         )
 
         assert bool(entity.state["state"]) is False
@@ -870,7 +871,7 @@ async def test_binary_output_cluster(zha_gateway: Gateway) -> None:
     cluster.write_attributes.reset_mock()
     await switch_entity.async_turn_on()
     assert cluster.write_attributes.mock_calls == [
-        call({"present_value": True}, manufacturer=None)
+        call({"present_value": True}, manufacturer=UNDEFINED)
     ]
     assert switch_entity.state["state"] is True
 
@@ -878,7 +879,7 @@ async def test_binary_output_cluster(zha_gateway: Gateway) -> None:
     cluster.write_attributes.reset_mock()
     await switch_entity.async_turn_off()
     assert cluster.write_attributes.mock_calls == [
-        call({"present_value": False}, manufacturer=None)
+        call({"present_value": False}, manufacturer=UNDEFINED)
     ]
     assert switch_entity.state["state"] is False
 
@@ -902,6 +903,6 @@ async def test_binary_output_cluster(zha_gateway: Gateway) -> None:
             [BinaryOutput.AttributeDefs.present_value.name],
             allow_cache=False,
             only_cache=False,
-            manufacturer=None,
+            manufacturer=UNDEFINED,
         )
     ]

--- a/zha/application/helpers.py
+++ b/zha/application/helpers.py
@@ -19,8 +19,10 @@ from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
 import voluptuous as vol
 import zigpy.exceptions
 import zigpy.types
+from zigpy.typing import UNDEFINED, UndefinedType
 import zigpy.util
 import zigpy.zcl
+from zigpy.zcl import foundation
 from zigpy.zcl.foundation import CommandSchema
 import zigpy.zdo.types as zdo_types
 
@@ -64,10 +66,10 @@ class BindingPair:
 
 async def safe_read(
     cluster: zigpy.zcl.Cluster,
-    attributes: list[int | str],
+    attributes: list[int | str | foundation.ZCLAttributeDef],
     allow_cache: bool = True,
     only_cache: bool = False,
-    manufacturer=None,
+    manufacturer: int | UndefinedType | None = UNDEFINED,
 ):
     """Swallow all exceptions from network read.
 

--- a/zha/zigbee/cluster_handlers/__init__.py
+++ b/zha/zigbee/cluster_handlers/__init__.py
@@ -11,6 +11,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Final, ParamSpec, TypedDict
 
 import zigpy.exceptions
+from zigpy.typing import UNDEFINED, UndefinedType
 import zigpy.util
 import zigpy.zcl
 from zigpy.zcl import (
@@ -588,16 +589,11 @@ class ClusterHandler(LogMixin, EventBase):
 
     async def get_attribute_value(self, attribute, from_cache=True) -> Any:
         """Get the value for an attribute."""
-        manufacturer = None
-        manufacturer_code = self._endpoint.device.manufacturer_code
-        if self.cluster.cluster_id >= 0xFC00 and manufacturer_code:
-            manufacturer = manufacturer_code
         result = await safe_read(
             self._cluster,
             [attribute],
             allow_cache=from_cache,
             only_cache=from_cache,
-            manufacturer=manufacturer,
         )
         return result.get(attribute)
 
@@ -609,10 +605,6 @@ class ClusterHandler(LogMixin, EventBase):
         only_cache: bool = True,
     ) -> dict[int | str, Any]:
         """Get the values for a list of attributes."""
-        manufacturer = None
-        manufacturer_code = self._endpoint.device.manufacturer_code
-        if self.cluster.cluster_id >= 0xFC00 and manufacturer_code:
-            manufacturer = manufacturer_code
         chunk = attributes[:CLUSTER_READS_PER_REQ]
         rest = attributes[CLUSTER_READS_PER_REQ:]
         result = {}
@@ -625,7 +617,7 @@ class ClusterHandler(LogMixin, EventBase):
                     chunk,
                     allow_cache=from_cache,
                     only_cache=only_cache,
-                    manufacturer=manufacturer,
+                    manufacturer=UNDEFINED,  # some quirks override default with None
                 )
                 self.debug("Got attributes: %s", read)
                 result.update(read)
@@ -652,7 +644,9 @@ class ClusterHandler(LogMixin, EventBase):
         return await self._get_attributes(False, attributes, from_cache, only_cache)
 
     async def write_attributes_safe(
-        self, attributes: dict[str, Any], manufacturer: int | None = None
+        self,
+        attributes: dict[str, Any],
+        manufacturer: int | UndefinedType | None = UNDEFINED,
     ) -> None:
         """Wrap `write_attributes` to throw an exception on attribute write failure."""
 

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -22,6 +22,7 @@ import zigpy.quirks
 from zigpy.quirks.v2 import DeviceAlertMetadata, QuirksV2RegistryEntry
 from zigpy.types import uint1_t, uint8_t, uint16_t
 from zigpy.types.named import EUI64, NWK, ExtendedPanId
+from zigpy.typing import UNDEFINED, UndefinedType
 from zigpy.zcl.clusters import Cluster
 from zigpy.zcl.clusters.general import Groups, Identify
 from zigpy.zcl.foundation import (
@@ -1142,7 +1143,7 @@ class Device(LogMixin, EventBase):
         attribute: int | str,
         value: Any,
         cluster_type: str = CLUSTER_TYPE_IN,
-        manufacturer: int | None = None,
+        manufacturer: int | UndefinedType | None = UNDEFINED,
     ) -> WriteAttributesResponse | None:
         """Write a value to a zigbee attribute for a cluster in this entity."""
         try:


### PR DESCRIPTION
This PR fixes an issue where multiple read/write methods overwrote the default manufacturer code with `None`, even though we should now be using `UNDEFINED` with the recent zigpy 0.91.x changes.

Since we use the `UNDEFINED` default in ZHA for reading attributes (during initialization), this also works around the issue of quirks overriding `read_attributes` with `manufacturer=None` as the default. 

Due to the improved manufacturer code handling in zigpy, we do not need to determine the manufacturer code ourselves anymore. It should also fix an issue where batch-reading attributes during initialization always used a manufacturer code or not, messing up mixed reads.

`manufacturer=UNDEFINED` calls are expected in a lot of places in tests now.