### PR TITLE
Emit `OnOffClientClusterHandler` `attribute_updated` events first

### DIFF
--- a/tests/test_cluster_handlers.py
+++ b/tests/test_cluster_handlers.py
@@ -1242,8 +1242,8 @@ async def test_zha_send_event_from_quirk(zha_gateway: Gateway):
     on_off_ch.cluster_command(1, OnOff.ServerCommandDefs.on.id, [])
 
     assert on_off_ch.emit_zha_event.call_count == 2
+    # attribute_updated is emitted first, then the cluster command is forwarded
     assert on_off_ch.emit_zha_event.mock_calls == [
-        call("on", []),
         call(
             "attribute_updated",
             {
@@ -1253,6 +1253,7 @@ async def test_zha_send_event_from_quirk(zha_gateway: Gateway):
                 "value": t.Bool.true,
             },
         ),
+        call("on", []),
     ]
     on_off_ch.emit_zha_event.reset_mock()
 

--- a/zha/zigbee/cluster_handlers/general.py
+++ b/zha/zigbee/cluster_handlers/general.py
@@ -552,11 +552,9 @@ class OnOffClientClusterHandler(ClientClusterHandler):
 
     def cluster_command(self, tsn, command_id, args):
         """Handle commands received to this cluster."""
-        # for emitting ZHA event
-        super().cluster_command(tsn, command_id, args)
-
         cmd = parse_and_log_command(self, tsn, command_id, args)
 
+        # Process cluster commands, so attribute_updated events fire first
         if cmd in (
             OnOff.ServerCommandDefs.off.name,
             OnOff.ServerCommandDefs.off_with_effect.name,
@@ -587,6 +585,9 @@ class OnOffClientClusterHandler(ClientClusterHandler):
             self.cluster.update_attribute(
                 OnOff.AttributeDefs.on_off.id, not bool(self.on_off)
             )
+
+        # Emit ZHA event with cluster command
+        super().cluster_command(tsn, command_id, args)
 
     def set_to_off(self, *_):
         """Set the state to off."""


### PR DESCRIPTION
## Proposed change

This changes the `OnOffClientClusterHandler` to first process the event, updating attribute cache and emitting `attribute_updated` ZHA events, then forwarding the cluster command to emit the ZHA event.


## Additional information


### Issue

There are a lot of blueprints available that use the `restart` automation mode and unfortunately trigger on all ZHA events. Even if they're later ignored in the automations "action" section, the automation will still restart for them, aborting the existing run.

Ideally, the automation should only trigger for events that actually need to be processed (filter in triggers section or conditions section). But since this is not the case, we need to change our behavior to not break all of the blueprints.


### Previous behavior & alternative solutions

The previous behavior did not emit `attribute_updated` events at all for remotes, as the normal `ClusterHandler` was used, not the `ClientClusterHandler`. Only the latter class includes behavior to emit ZHA events for attribute updates:
https://github.com/zigpy/zha/blob/3adf2db4ffdeb7a75d75e8799f08007a316530a4/zha/zigbee/cluster_handlers/__init__.py#L753-L771

Alternatively, I'm thinking if we should just call `ClusterHandler._handle_attribute_updated_event()` instead, skipping the ZHA event being emitted in `ClientClusterHandler`. I think that should restore old behavior completely?

As a third solution, I can only think of skipping ZHA events being emitted depending on which entity is associated with that cluster handler (where the entity already depends on the device type). This likely won't work nicely though.


### Previous TODO:

Investigate not emitting `attribute_updated` events for entire `OnOff` cluster (`OnOffClientClusterHandler`).
See "Previous behavior & alternative solutions".

-> EDIT: See: https://github.com/zigpy/zha/pull/642#issuecomment-3836962832


#### Reported on Discord:
- https://discord.com/channels/330944238910963714/427516175237382144/1467538791588954164
- https://discord.com/channels/330944238910963714/427516175237382144/1467890986490265765


#### Related:
- https://github.com/zigpy/zha/pull/615 (original cause / removed special handling for `OnOff` remote handling) 
- https://github.com/zigpy/zha/pull/635 (PR reintroducing `OnOff` handling, now in `OnOffClientClusterHandler`)
