### PR TITLE
Fix platform overrides

### DIFF
--- a/tests/data/devices/tz3000-tqlv4ug4-ts0001.json
+++ b/tests/data/devices/tz3000-tqlv4ug4-ts0001.json
@@ -1,0 +1,1117 @@
+{
+  "version": 1,
+  "ieee": "ab:cd:ef:12:ab:aa:f0:9a",
+  "nwk": "0xE4EB",
+  "manufacturer": "_TZ3000_tqlv4ug4",
+  "model": "TS0001",
+  "friendly_manufacturer": "_TZ3000_tqlv4ug4",
+  "friendly_model": "TS0001",
+  "name": "_TZ3000_tqlv4ug4 TS0001",
+  "quirk_applied": true,
+  "quirk_class": "zhaquirks.tuya.ts000x.Switch_1G_Metering",
+  "exposes_features": [
+    "tuya.plug_on_off_attributes"
+  ],
+  "manufacturer_code": 4417,
+  "power_source": "Mains",
+  "lqi": 208,
+  "rssi": -59,
+  "last_seen": "2026-02-05T17:20:42.740383+00:00",
+  "available": true,
+  "device_type": "Router",
+  "active_coordinator": false,
+  "node_descriptor": {
+    "logical_type": "Router",
+    "complex_descriptor_available": false,
+    "user_descriptor_available": false,
+    "reserved": 0,
+    "aps_flags": 0,
+    "frequency_band": 8,
+    "mac_capability_flags": 142,
+    "manufacturer_code": 4417,
+    "maximum_buffer_size": 66,
+    "maximum_incoming_transfer_size": 66,
+    "server_mask": 10752,
+    "maximum_outgoing_transfer_size": 66,
+    "descriptor_capability_field": 0
+  },
+  "endpoints": {
+    "1": {
+      "profile_id": 260,
+      "device_type": {
+        "name": "ON_OFF_LIGHT",
+        "id": 256
+      },
+      "in_clusters": [
+        {
+          "cluster_id": "0x0000",
+          "endpoint_attribute": "basic",
+          "attributes": [
+            {
+              "id": "0x0001",
+              "name": "app_version",
+              "zcl_type": "uint8",
+              "value": 72
+            },
+            {
+              "id": "0x0004",
+              "name": "manufacturer",
+              "zcl_type": "string",
+              "value": "_TZ3000_tqlv4ug4"
+            },
+            {
+              "id": "0x0005",
+              "name": "model",
+              "zcl_type": "string",
+              "value": "TS0001"
+            },
+            {
+              "id": "0x0007",
+              "name": "power_source",
+              "zcl_type": "enum8",
+              "value": 1
+            },
+            {
+              "id": "0xfffe",
+              "name": "reporting_status",
+              "zcl_type": "enum8",
+              "value": 0
+            },
+            {
+              "id": "0x0000",
+              "name": "zcl_version",
+              "zcl_type": "uint8",
+              "value": 3
+            }
+          ]
+        },
+        {
+          "cluster_id": "0x0003",
+          "endpoint_attribute": "identify",
+          "attributes": []
+        },
+        {
+          "cluster_id": "0x0004",
+          "endpoint_attribute": "groups",
+          "attributes": []
+        },
+        {
+          "cluster_id": "0x0005",
+          "endpoint_attribute": "scenes",
+          "attributes": []
+        },
+        {
+          "cluster_id": "0x0006",
+          "endpoint_attribute": "on_off",
+          "attributes": [
+            {
+              "id": "0x8001",
+              "name": "backlight_mode",
+              "zcl_type": "enum8",
+              "value": 1
+            },
+            {
+              "id": "0x8000",
+              "name": "child_lock",
+              "zcl_type": "bool",
+              "unsupported": true
+            },
+            {
+              "id": "0x4002",
+              "name": "off_wait_time",
+              "zcl_type": "uint16",
+              "value": 0
+            },
+            {
+              "id": "0x0000",
+              "name": "on_off",
+              "zcl_type": "bool",
+              "value": 0
+            },
+            {
+              "id": "0x4001",
+              "name": "on_time",
+              "zcl_type": "uint16",
+              "value": 0
+            },
+            {
+              "id": "0x8002",
+              "name": "power_on_state",
+              "zcl_type": "enum8",
+              "value": 1
+            },
+            {
+              "id": "0x4003",
+              "name": "start_up_on_off",
+              "zcl_type": "enum8",
+              "unsupported": true
+            }
+          ]
+        },
+        {
+          "cluster_id": "0x0702",
+          "endpoint_attribute": "smartenergy_metering",
+          "attributes": [
+            {
+              "id": "0x0000",
+              "name": "current_summ_delivered",
+              "zcl_type": "uint48",
+              "value": 0
+            },
+            {
+              "id": "0x0001",
+              "name": "current_summ_received",
+              "zcl_type": "uint48",
+              "unsupported": true
+            },
+            {
+              "id": "0x0100",
+              "name": "current_tier1_summ_delivered",
+              "zcl_type": "uint48",
+              "unsupported": true
+            },
+            {
+              "id": "0x0102",
+              "name": "current_tier2_summ_delivered",
+              "zcl_type": "uint48",
+              "unsupported": true
+            },
+            {
+              "id": "0x0104",
+              "name": "current_tier3_summ_delivered",
+              "zcl_type": "uint48",
+              "unsupported": true
+            },
+            {
+              "id": "0x0106",
+              "name": "current_tier4_summ_delivered",
+              "zcl_type": "uint48",
+              "unsupported": true
+            },
+            {
+              "id": "0x0108",
+              "name": "current_tier5_summ_delivered",
+              "zcl_type": "uint48",
+              "unsupported": true
+            },
+            {
+              "id": "0x010a",
+              "name": "current_tier6_summ_delivered",
+              "zcl_type": "uint48",
+              "unsupported": true
+            },
+            {
+              "id": "0x0304",
+              "name": "demand_formatting",
+              "zcl_type": "map8",
+              "unsupported": true
+            },
+            {
+              "id": "0x0302",
+              "name": "divisor",
+              "zcl_type": "uint24",
+              "value": 100
+            },
+            {
+              "id": "0x0400",
+              "name": "instantaneous_demand",
+              "zcl_type": "int24",
+              "unsupported": true
+            },
+            {
+              "id": "0x0306",
+              "name": "metering_device_type",
+              "zcl_type": "map8",
+              "value": 0
+            },
+            {
+              "id": "0x0301",
+              "name": "multiplier",
+              "zcl_type": "uint24",
+              "value": 1
+            },
+            {
+              "id": "0x0200",
+              "name": "status",
+              "zcl_type": "map8",
+              "value": 0
+            },
+            {
+              "id": "0x0303",
+              "name": "summation_formatting",
+              "zcl_type": "map8",
+              "value": 0
+            },
+            {
+              "id": "0x0300",
+              "name": "unit_of_measure",
+              "zcl_type": "enum8",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "cluster_id": "0x0b04",
+          "endpoint_attribute": "electrical_measurement",
+          "attributes": [
+            {
+              "id": "0x0603",
+              "name": "ac_current_divisor",
+              "zcl_type": "uint16",
+              "value": 1000
+            },
+            {
+              "id": "0x0602",
+              "name": "ac_current_multiplier",
+              "zcl_type": "uint16",
+              "value": 1
+            },
+            {
+              "id": "0x0300",
+              "name": "ac_frequency",
+              "zcl_type": "uint16",
+              "unsupported": true
+            },
+            {
+              "id": "0x0401",
+              "name": "ac_frequency_divisor",
+              "zcl_type": "uint16",
+              "unsupported": true
+            },
+            {
+              "id": "0x0302",
+              "name": "ac_frequency_max",
+              "zcl_type": "uint16",
+              "unsupported": true
+            },
+            {
+              "id": "0x0400",
+              "name": "ac_frequency_multiplier",
+              "zcl_type": "uint16",
+              "unsupported": true
+            },
+            {
+              "id": "0x0605",
+              "name": "ac_power_divisor",
+              "zcl_type": "uint16",
+              "unsupported": true
+            },
+            {
+              "id": "0x0604",
+              "name": "ac_power_multiplier",
+              "zcl_type": "uint16",
+              "unsupported": true
+            },
+            {
+              "id": "0x0601",
+              "name": "ac_voltage_divisor",
+              "zcl_type": "uint16",
+              "unsupported": true
+            },
+            {
+              "id": "0x0600",
+              "name": "ac_voltage_multiplier",
+              "zcl_type": "uint16",
+              "unsupported": true
+            },
+            {
+              "id": "0x050b",
+              "name": "active_power",
+              "zcl_type": "int16",
+              "value": 0
+            },
+            {
+              "id": "0x050d",
+              "name": "active_power_max",
+              "zcl_type": "int16",
+              "unsupported": true
+            },
+            {
+              "id": "0x090d",
+              "name": "active_power_max_ph_b",
+              "zcl_type": "int16",
+              "unsupported": true
+            },
+            {
+              "id": "0x0a0d",
+              "name": "active_power_max_ph_c",
+              "zcl_type": "int16",
+              "unsupported": true
+            },
+            {
+              "id": "0x090b",
+              "name": "active_power_ph_b",
+              "zcl_type": "int16",
+              "unsupported": true
+            },
+            {
+              "id": "0x0a0b",
+              "name": "active_power_ph_c",
+              "zcl_type": "int16",
+              "unsupported": true
+            },
+            {
+              "id": "0x050f",
+              "name": "apparent_power",
+              "zcl_type": "uint16",
+              "unsupported": true
+            },
+            {
+              "id": "0x0000",
+              "name": "measurement_type",
+              "zcl_type": "map32",
+              "unsupported": true
+            },
+            {
+              "id": "0x0403",
+              "name": "power_divisor",
+              "zcl_type": "uint32",
+              "unsupported": true
+            },
+            {
+              "id": "0x0510",
+              "name": "power_factor",
+              "zcl_type": "int8",
+              "unsupported": true
+            },
+            {
+              "id": "0x0910",
+              "name": "power_factor_ph_b",
+              "zcl_type": "int8",
+              "unsupported": true
+            },
+            {
+              "id": "0x0a10",
+              "name": "power_factor_ph_c",
+              "zcl_type": "int8",
+              "unsupported": true
+            },
+            {
+              "id": "0x0402",
+              "name": "power_multiplier",
+              "zcl_type": "uint32",
+              "unsupported": true
+            },
+            {
+              "id": "0x0508",
+              "name": "rms_current",
+              "zcl_type": "uint16",
+              "value": 0
+            },
+            {
+              "id": "0x050a",
+              "name": "rms_current_max",
+              "zcl_type": "uint16",
+              "unsupported": true
+            },
+            {
+              "id": "0x090a",
+              "name": "rms_current_max_ph_b",
+              "zcl_type": "uint16",
+              "unsupported": true
+            },
+            {
+              "id": "0x0a0a",
+              "name": "rms_current_max_ph_c",
+              "zcl_type": "uint16",
+              "unsupported": true
+            },
+            {
+              "id": "0x0908",
+              "name": "rms_current_ph_b",
+              "zcl_type": "uint16",
+              "unsupported": true
+            },
+            {
+              "id": "0x0a08",
+              "name": "rms_current_ph_c",
+              "zcl_type": "uint16",
+              "unsupported": true
+            },
+            {
+              "id": "0x0505",
+              "name": "rms_voltage",
+              "zcl_type": "uint16",
+              "value": 0
+            },
+            {
+              "id": "0x0507",
+              "name": "rms_voltage_max",
+              "zcl_type": "uint16",
+              "unsupported": true
+            },
+            {
+              "id": "0x0907",
+              "name": "rms_voltage_max_ph_b",
+              "zcl_type": "uint16",
+              "unsupported": true
+            },
+            {
+              "id": "0x0a07",
+              "name": "rms_voltage_max_ph_c",
+              "zcl_type": "uint16",
+              "unsupported": true
+            },
+            {
+              "id": "0x0905",
+              "name": "rms_voltage_ph_b",
+              "zcl_type": "uint16",
+              "unsupported": true
+            },
+            {
+              "id": "0x0a05",
+              "name": "rms_voltage_ph_c",
+              "zcl_type": "uint16",
+              "unsupported": true
+            },
+            {
+              "id": "0x0304",
+              "name": "total_active_power",
+              "zcl_type": "int32",
+              "unsupported": true
+            }
+          ]
+        },
+        {
+          "cluster_id": "0xe000",
+          "endpoint_attribute": "tuya_manufacturer_specific_57344",
+          "attributes": []
+        },
+        {
+          "cluster_id": "0xe001",
+          "endpoint_attribute": "tuya_external_switch_type",
+          "attributes": [
+            {
+              "id": "0xd030",
+              "name": "external_switch_type",
+              "zcl_type": "enum8",
+              "value": 0
+            }
+          ]
+        }
+      ],
+      "out_clusters": [
+        {
+          "cluster_id": "0x000a",
+          "endpoint_attribute": "time",
+          "attributes": []
+        },
+        {
+          "cluster_id": "0x0019",
+          "endpoint_attribute": "ota",
+          "attributes": [
+            {
+              "id": "0x0002",
+              "name": "current_file_version",
+              "zcl_type": "uint32",
+              "value": 72
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "original_signature": {
+    "manufacturer": "_TZ3000_tqlv4ug4",
+    "model": "TS0001",
+    "node_desc": {
+      "logical_type": 1,
+      "complex_descriptor_available": 0,
+      "user_descriptor_available": 0,
+      "reserved": 0,
+      "aps_flags": 0,
+      "frequency_band": 8,
+      "mac_capability_flags": 142,
+      "manufacturer_code": 4417,
+      "maximum_buffer_size": 66,
+      "maximum_incoming_transfer_size": 66,
+      "server_mask": 10752,
+      "maximum_outgoing_transfer_size": 66,
+      "descriptor_capability_field": 0
+    },
+    "endpoints": {
+      "1": {
+        "profile_id": "0x0104",
+        "device_type": "0x0100",
+        "input_clusters": [
+          "0x0000",
+          "0x0003",
+          "0x0004",
+          "0x0005",
+          "0x0006",
+          "0x0702",
+          "0x0b04",
+          "0xe000",
+          "0xe001"
+        ],
+        "output_clusters": [
+          "0x000a",
+          "0x0019"
+        ]
+      },
+      "242": {
+        "profile_id": "0xa1e0",
+        "device_type": "0x0061",
+        "input_clusters": [],
+        "output_clusters": [
+          "0x0021"
+        ]
+      }
+    }
+  },
+  "zha_lib_entities": {
+    "button": [
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:ab:aa:f0:9a-1-3",
+          "migrate_unique_ids": [],
+          "platform": "button",
+          "class_name": "IdentifyButton",
+          "translation_key": null,
+          "translation_placeholders": null,
+          "device_class": "identify",
+          "state_class": null,
+          "entity_category": "diagnostic",
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "IdentifyClusterHandler",
+              "generic_id": "cluster_handler_0x0003",
+              "endpoint_id": 1,
+              "cluster": {
+                "id": 3,
+                "name": "Identify",
+                "type": "server"
+              },
+              "id": "1:0x0003",
+              "unique_id": "ab:cd:ef:12:ab:aa:f0:9a:1:0x0003",
+              "status": "INITIALIZED",
+              "value_attribute": null
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:ab:aa:f0:9a",
+          "endpoint_id": 1,
+          "available": true,
+          "group_id": null,
+          "command": "identify",
+          "args": [
+            5
+          ],
+          "kwargs": {}
+        },
+        "state": {
+          "class_name": "IdentifyButton",
+          "available": true
+        }
+      }
+    ],
+    "light": [
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:ab:aa:f0:9a-1",
+          "migrate_unique_ids": [],
+          "platform": "light",
+          "class_name": "Light",
+          "translation_key": "light",
+          "translation_placeholders": null,
+          "device_class": null,
+          "state_class": null,
+          "entity_category": null,
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": true,
+          "cluster_handlers": [
+            {
+              "class_name": "OnOffClusterHandler",
+              "generic_id": "cluster_handler_0x0006",
+              "endpoint_id": 1,
+              "cluster": {
+                "id": 6,
+                "name": "On/Off",
+                "type": "server"
+              },
+              "id": "1:0x0006",
+              "unique_id": "ab:cd:ef:12:ab:aa:f0:9a:1:0x0006",
+              "status": "INITIALIZED",
+              "value_attribute": "on_off"
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:ab:aa:f0:9a",
+          "endpoint_id": 1,
+          "available": true,
+          "group_id": null,
+          "effect_list": [
+            "off"
+          ],
+          "supported_features": 8,
+          "min_mireds": 153,
+          "max_mireds": 500
+        },
+        "state": {
+          "class_name": "Light",
+          "available": true,
+          "on": false,
+          "brightness": null,
+          "xy_color": null,
+          "color_temp": null,
+          "effect_list": [
+            "off"
+          ],
+          "effect": "off",
+          "supported_features": 8,
+          "color_mode": "onoff",
+          "supported_color_modes": [
+            "onoff"
+          ],
+          "off_with_transition": false,
+          "off_brightness": null
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
+      }
+    ],
+    "select": [
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:ab:aa:f0:9a-1-6-backlight_mode",
+          "migrate_unique_ids": [],
+          "platform": "select",
+          "class_name": "TuyaBacklightModeSelectEntity",
+          "translation_key": "backlight_mode",
+          "translation_placeholders": null,
+          "device_class": null,
+          "state_class": null,
+          "entity_category": "config",
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "OnOffClusterHandler",
+              "generic_id": "cluster_handler_0x0006",
+              "endpoint_id": 1,
+              "cluster": {
+                "id": 6,
+                "name": "On/Off",
+                "type": "server"
+              },
+              "id": "1:0x0006",
+              "unique_id": "ab:cd:ef:12:ab:aa:f0:9a:1:0x0006",
+              "status": "INITIALIZED",
+              "value_attribute": "on_off"
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:ab:aa:f0:9a",
+          "endpoint_id": 1,
+          "available": true,
+          "group_id": null,
+          "enum": "TuyaBacklightMode",
+          "options": [
+            "Off",
+            "LightWhenOn",
+            "LightWhenOff"
+          ]
+        },
+        "state": {
+          "class_name": "TuyaBacklightModeSelectEntity",
+          "available": true,
+          "state": "LightWhenOn"
+        }
+      },
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:ab:aa:f0:9a-1-6-power_on_state",
+          "migrate_unique_ids": [],
+          "platform": "select",
+          "class_name": "TuyaPowerOnStateSelectEntity",
+          "translation_key": "power_on_state",
+          "translation_placeholders": null,
+          "device_class": null,
+          "state_class": null,
+          "entity_category": "config",
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "OnOffClusterHandler",
+              "generic_id": "cluster_handler_0x0006",
+              "endpoint_id": 1,
+              "cluster": {
+                "id": 6,
+                "name": "On/Off",
+                "type": "server"
+              },
+              "id": "1:0x0006",
+              "unique_id": "ab:cd:ef:12:ab:aa:f0:9a:1:0x0006",
+              "status": "INITIALIZED",
+              "value_attribute": "on_off"
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:ab:aa:f0:9a",
+          "endpoint_id": 1,
+          "available": true,
+          "group_id": null,
+          "enum": "TuyaPowerOnState",
+          "options": [
+            "Off",
+            "On",
+            "LastState"
+          ]
+        },
+        "state": {
+          "class_name": "TuyaPowerOnStateSelectEntity",
+          "available": true,
+          "state": "On"
+        }
+      }
+    ],
+    "sensor": [
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:ab:aa:f0:9a-1-0-lqi",
+          "migrate_unique_ids": [],
+          "platform": "sensor",
+          "class_name": "LQISensor",
+          "translation_key": "lqi",
+          "translation_placeholders": null,
+          "device_class": null,
+          "state_class": "measurement",
+          "entity_category": "diagnostic",
+          "entity_registry_enabled_default": false,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "BasicClusterHandler",
+              "generic_id": "cluster_handler_0x0000",
+              "endpoint_id": 1,
+              "cluster": {
+                "id": 0,
+                "name": "Basic",
+                "type": "server"
+              },
+              "id": "1:0x0000",
+              "unique_id": "ab:cd:ef:12:ab:aa:f0:9a:1:0x0000",
+              "status": "INITIALIZED",
+              "value_attribute": null
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:ab:aa:f0:9a",
+          "endpoint_id": 1,
+          "available": true,
+          "group_id": null,
+          "suggested_display_precision": null,
+          "unit": null
+        },
+        "state": {
+          "class_name": "LQISensor",
+          "available": true,
+          "state": 208
+        }
+      },
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:ab:aa:f0:9a-1-0-rssi",
+          "migrate_unique_ids": [],
+          "platform": "sensor",
+          "class_name": "RSSISensor",
+          "translation_key": "rssi",
+          "translation_placeholders": null,
+          "device_class": "signal_strength",
+          "state_class": "measurement",
+          "entity_category": "diagnostic",
+          "entity_registry_enabled_default": false,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "BasicClusterHandler",
+              "generic_id": "cluster_handler_0x0000",
+              "endpoint_id": 1,
+              "cluster": {
+                "id": 0,
+                "name": "Basic",
+                "type": "server"
+              },
+              "id": "1:0x0000",
+              "unique_id": "ab:cd:ef:12:ab:aa:f0:9a:1:0x0000",
+              "status": "INITIALIZED",
+              "value_attribute": null
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:ab:aa:f0:9a",
+          "endpoint_id": 1,
+          "available": true,
+          "group_id": null,
+          "suggested_display_precision": null,
+          "unit": "dBm"
+        },
+        "state": {
+          "class_name": "RSSISensor",
+          "available": true,
+          "state": -59
+        }
+      },
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:ab:aa:f0:9a-1-1794-summation_delivered",
+          "migrate_unique_ids": [],
+          "platform": "sensor",
+          "class_name": "SmartEnergySummation",
+          "translation_key": "summation_delivered",
+          "translation_placeholders": null,
+          "device_class": "energy",
+          "state_class": "total_increasing",
+          "entity_category": null,
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "MeteringClusterHandler",
+              "generic_id": "cluster_handler_0x0702",
+              "endpoint_id": 1,
+              "cluster": {
+                "id": 1794,
+                "name": "TuyaZBMeteringCluster",
+                "type": "server"
+              },
+              "id": "1:0x0702",
+              "unique_id": "ab:cd:ef:12:ab:aa:f0:9a:1:0x0702",
+              "status": "INITIALIZED",
+              "value_attribute": "instantaneous_demand"
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:ab:aa:f0:9a",
+          "endpoint_id": 1,
+          "available": true,
+          "group_id": null,
+          "suggested_display_precision": 3,
+          "unit": "kWh"
+        },
+        "state": {
+          "class_name": "SmartEnergySummation",
+          "available": true,
+          "state": 0.0,
+          "device_type": "Electric Metering",
+          "status": "NO_ALARMS",
+          "zcl_unit_of_measurement": 0
+        },
+        "extra_state_attributes": [
+          "device_type",
+          "status",
+          "zcl_unit_of_measurement"
+        ]
+      },
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:ab:aa:f0:9a-1-2820",
+          "migrate_unique_ids": [],
+          "platform": "sensor",
+          "class_name": "PolledElectricalMeasurement",
+          "translation_key": null,
+          "translation_placeholders": null,
+          "device_class": "power",
+          "state_class": "measurement",
+          "entity_category": null,
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "ElectricalMeasurementClusterHandler",
+              "generic_id": "cluster_handler_0x0b04",
+              "endpoint_id": 1,
+              "cluster": {
+                "id": 2820,
+                "name": "Electrical Measurement",
+                "type": "server"
+              },
+              "id": "1:0x0b04",
+              "unique_id": "ab:cd:ef:12:ab:aa:f0:9a:1:0x0b04",
+              "status": "INITIALIZED",
+              "value_attribute": "ac_voltage_multiplier"
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:ab:aa:f0:9a",
+          "endpoint_id": 1,
+          "available": true,
+          "group_id": null,
+          "suggested_display_precision": 1,
+          "unit": "W"
+        },
+        "state": {
+          "class_name": "PolledElectricalMeasurement",
+          "available": true,
+          "state": 0.0
+        },
+        "extra_state_attributes": [
+          "active_power_max",
+          "measurement_type"
+        ]
+      },
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:ab:aa:f0:9a-1-2820-rms_current",
+          "migrate_unique_ids": [],
+          "platform": "sensor",
+          "class_name": "ElectricalMeasurementRMSCurrent",
+          "translation_key": null,
+          "translation_placeholders": null,
+          "device_class": "current",
+          "state_class": "measurement",
+          "entity_category": null,
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "ElectricalMeasurementClusterHandler",
+              "generic_id": "cluster_handler_0x0b04",
+              "endpoint_id": 1,
+              "cluster": {
+                "id": 2820,
+                "name": "Electrical Measurement",
+                "type": "server"
+              },
+              "id": "1:0x0b04",
+              "unique_id": "ab:cd:ef:12:ab:aa:f0:9a:1:0x0b04",
+              "status": "INITIALIZED",
+              "value_attribute": "ac_voltage_multiplier"
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:ab:aa:f0:9a",
+          "endpoint_id": 1,
+          "available": true,
+          "group_id": null,
+          "suggested_display_precision": 1,
+          "unit": "A"
+        },
+        "state": {
+          "class_name": "ElectricalMeasurementRMSCurrent",
+          "available": true,
+          "state": 0.0
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_current_max"
+        ]
+      },
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:ab:aa:f0:9a-1-2820-rms_voltage",
+          "migrate_unique_ids": [],
+          "platform": "sensor",
+          "class_name": "ElectricalMeasurementRMSVoltage",
+          "translation_key": null,
+          "translation_placeholders": null,
+          "device_class": "voltage",
+          "state_class": "measurement",
+          "entity_category": null,
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "ElectricalMeasurementClusterHandler",
+              "generic_id": "cluster_handler_0x0b04",
+              "endpoint_id": 1,
+              "cluster": {
+                "id": 2820,
+                "name": "Electrical Measurement",
+                "type": "server"
+              },
+              "id": "1:0x0b04",
+              "unique_id": "ab:cd:ef:12:ab:aa:f0:9a:1:0x0b04",
+              "status": "INITIALIZED",
+              "value_attribute": "ac_voltage_multiplier"
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:ab:aa:f0:9a",
+          "endpoint_id": 1,
+          "available": true,
+          "group_id": null,
+          "suggested_display_precision": 1,
+          "unit": "V"
+        },
+        "state": {
+          "class_name": "ElectricalMeasurementRMSVoltage",
+          "available": true,
+          "state": 0.0
+        },
+        "extra_state_attributes": [
+          "measurement_type",
+          "rms_voltage_max"
+        ]
+      }
+    ],
+    "update": [
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:ab:aa:f0:9a-1-25-firmware_update",
+          "migrate_unique_ids": [],
+          "platform": "update",
+          "class_name": "FirmwareUpdateEntity",
+          "translation_key": null,
+          "translation_placeholders": null,
+          "device_class": "firmware",
+          "state_class": null,
+          "entity_category": "config",
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "OtaClientClusterHandler",
+              "generic_id": "cluster_handler_0x0019_client",
+              "endpoint_id": 1,
+              "cluster": {
+                "id": 25,
+                "name": "Ota",
+                "type": "client"
+              },
+              "id": "1:0x0019_client",
+              "unique_id": "ab:cd:ef:12:ab:aa:f0:9a:1:0x0019_CLIENT",
+              "status": "INITIALIZED",
+              "value_attribute": null
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:ab:aa:f0:9a",
+          "endpoint_id": 1,
+          "available": true,
+          "group_id": null,
+          "supported_features": 7
+        },
+        "state": {
+          "class_name": "FirmwareUpdateEntity",
+          "available": true,
+          "installed_version": "0x00000048",
+          "in_progress": false,
+          "update_percentage": null,
+          "latest_version": null,
+          "release_summary": null,
+          "release_notes": null,
+          "release_url": null
+        }
+      }
+    ]
+  },
+  "neighbors": [],
+  "routes": []
+}

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -127,17 +127,22 @@ async def test_device_override_entities(zha_gateway: Gateway) -> None:
     }
 
     zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
+
+    # The light is gone
+    with pytest.raises(KeyError):
+        get_entity(zha_device, platform=Platform.LIGHT)
+
+    # And has been replaced by a switch with the same unique ID
+    switch = get_entity(zha_device, platform=Platform.SWITCH)
+    assert switch.unique_id == f"{zigpy_device.ieee}-1"
+
+    # All other entities and diagnostics stay the same
     loaded_device_data = json.loads(
         json.dumps(zha_device.get_diagnostics_json(), cls=ZhaJsonEncoder)
     )
 
     expected_loaded_device_data = device_data
-
-    # The light is gone
-    light_entities = expected_loaded_device_data["zha_lib_entities"].pop("light")
-    assert len(light_entities) == 1
-
-    # And has been replaced with a single switch
+    expected_loaded_device_data["zha_lib_entities"].pop("light")
     expected_loaded_device_data["zha_lib_entities"]["switch"] = [
         loaded_device_data["zha_lib_entities"]["switch"][0]
     ]

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -134,7 +134,8 @@ async def test_device_override_entities(zha_gateway: Gateway) -> None:
     expected_loaded_device_data = device_data
 
     # The light is gone
-    assert len(expected_loaded_device_data["zha_lib_entities"].pop("light")) == 1
+    light_entities = expected_loaded_device_data["zha_lib_entities"].pop("light")
+    assert len(light_entities) == 1
 
     # And has been replaced with a single switch
     expected_loaded_device_data["zha_lib_entities"]["switch"] = [

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -109,6 +109,39 @@ async def test_device_override(
         )
 
 
+async def test_device_override_entities(zha_gateway: Gateway) -> None:
+    """Test device discovery entity changes."""
+    device_data_text = await asyncio.get_running_loop().run_in_executor(
+        None, pathlib.Path("tests/data/devices/tz3000-tqlv4ug4-ts0001.json").read_text
+    )
+    device_data = json.loads(device_data_text)
+
+    zigpy_device = zigpy_device_from_device_data(
+        app=zha_gateway.application_controller, device_data=device_data
+    )
+
+    zha_gateway.config.config.device_overrides = {
+        f"{zigpy_device.ieee}-1": DeviceOverridesConfiguration(type=Platform.SWITCH)
+    }
+
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
+    loaded_device_data = json.loads(
+        json.dumps(zha_device.get_diagnostics_json(), cls=ZhaJsonEncoder)
+    )
+
+    expected_loaded_device_data = device_data
+
+    # The light is gone
+    assert len(expected_loaded_device_data["zha_lib_entities"].pop("light")) == 1
+
+    # And has been replaced with a single switch
+    expected_loaded_device_data["zha_lib_entities"]["switch"] = [
+        loaded_device_data["zha_lib_entities"]["switch"][0]
+    ]
+
+    assert loaded_device_data == expected_loaded_device_data
+
+
 async def test_quirks_v2_entity_discovery(
     zha_gateway: Gateway,  # pylint: disable=unused-argument
 ) -> None:

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -54,9 +54,11 @@ from tests.common import (
     zigpy_device_from_json,
 )
 from zha.application import Platform
+from zha.application.discovery import discover_device_entities
 from zha.application.gateway import Gateway
 from zha.application.helpers import DeviceOverridesConfiguration
 from zha.application.platforms import PlatformEntity, binary_sensor, sensor
+from zha.application.platforms.light import HueLight
 from zha.application.platforms.number import BaseNumber, NumberMode
 
 
@@ -140,6 +142,36 @@ async def test_device_override_entities(zha_gateway: Gateway) -> None:
     ]
 
     assert loaded_device_data == expected_loaded_device_data
+
+
+async def test_device_override_picks_highest_priority(
+    zha_gateway: Gateway,
+) -> None:
+    """Test that a device override selects only the highest-priority match."""
+
+    # A Philips light matches both Light (priority 0) and HueLight (priority 1) in the
+    # LIGHT_OR_SWITCH_OR_SHADE feature group. With a SWITCH override, only one Switch
+    # entity should be created, not duplicates from collecting all priority levels.
+    zigpy_device = await zigpy_device_from_json(
+        zha_gateway.application_controller,
+        "tests/data/devices/philips-lct014.json",
+    )
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
+
+    # Only one light entity will be discovered
+    entities = list(discover_device_entities(zha_device))
+    light_entities = [e for e in entities if e.PLATFORM == Platform.LIGHT]
+    assert len(light_entities) == 1
+    assert isinstance(light_entities[0], HueLight)
+
+    # With an override, it is going to be one switch
+    zha_gateway.config.config.device_overrides = {
+        f"{zigpy_device.ieee}-11": DeviceOverridesConfiguration(type=Platform.SWITCH)
+    }
+
+    entities = list(discover_device_entities(zha_device))
+    switch_entities = [e for e in entities if e.PLATFORM == Platform.SWITCH]
+    assert len(switch_entities) == 1
 
 
 async def test_quirks_v2_entity_discovery(

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -84,17 +84,16 @@ async def test_device_override(
     zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
 
     # The overridden entity exists
-    assert (
-        get_entity(
-            zha_device,
-            platform=override_platform,
-            qualifier_func=(
-                lambda entity: entity.cluster_handlers["on_off"].cluster
-                == zigpy_device.endpoints[1].on_off
-            ),
-        )
-        is not None
+    entity = get_entity(
+        zha_device,
+        platform=override_platform,
+        qualifier_func=(
+            lambda entity: entity.cluster_handlers["on_off"].cluster
+            == zigpy_device.endpoints[1].on_off
+        ),
     )
+    assert entity is not None
+    assert entity.unique_id == f"{zigpy_device.ieee}-1"
 
     # The original one does not
     with pytest.raises(KeyError):

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -174,6 +174,30 @@ async def test_device_override_picks_highest_priority(
     assert len(switch_entities) == 1
 
 
+async def test_device_override_filter_bypassing(
+    zha_gateway: Gateway,
+) -> None:
+    """Test that profile filtering is only bypassed for the override platform."""
+
+    # The sercomm device is an ON_OFF_LIGHT with a PowerConfiguration cluster.
+    # DeviceTracker matches PowerConfiguration but is restricted by profile_device_types
+    # to the SmartThings arrival sensor device type. A SWITCH override should not cause
+    # DeviceTracker to bypass that filter.
+    zigpy_device = await zigpy_device_from_json(
+        zha_gateway.application_controller,
+        "tests/data/devices/sercomm-corp-sz-esw01-au.json",
+    )
+
+    zha_gateway.config.config.device_overrides = {
+        f"{zigpy_device.ieee}-1": DeviceOverridesConfiguration(type=Platform.SWITCH)
+    }
+
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
+
+    with pytest.raises(KeyError):
+        get_entity(zha_device, platform=Platform.DEVICE_TRACKER)
+
+
 async def test_quirks_v2_entity_discovery(
     zha_gateway: Gateway,  # pylint: disable=unused-argument
 ) -> None:

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -452,15 +452,23 @@ def discover_entities_for_endpoint(endpoint: Endpoint) -> Iterator[PlatformEntit
                 endpoint.zigpy_endpoint.profile_id,
                 endpoint.zigpy_endpoint.device_type,
             )
-            if platform_override is None and (
+            if (
                 match.profile_device_types is not None
                 and profile_device_type not in match.profile_device_types
+                and not (
+                    platform_override is not None
+                    and platform_override == entity_class.PLATFORM
+                )
             ):
                 continue
 
-            if platform_override is None and (
+            if (
                 match.not_profile_device_types is not None
                 and profile_device_type in match.not_profile_device_types
+                and not (
+                    platform_override is not None
+                    and platform_override == entity_class.PLATFORM
+                )
             ):
                 continue
 

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -475,6 +475,7 @@ def discover_entities_for_endpoint(endpoint: Endpoint) -> Iterator[PlatformEntit
             if (
                 platform_override is not None
                 and platform_override == entity_class.PLATFORM
+                and feature is not None
             ):
                 priority += 1000
 

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -452,13 +452,13 @@ def discover_entities_for_endpoint(endpoint: Endpoint) -> Iterator[PlatformEntit
                 endpoint.zigpy_endpoint.profile_id,
                 endpoint.zigpy_endpoint.device_type,
             )
-            if (
+            if platform_override is None and (
                 match.profile_device_types is not None
                 and profile_device_type not in match.profile_device_types
             ):
                 continue
 
-            if (
+            if platform_override is None and (
                 match.not_profile_device_types is not None
                 and profile_device_type in match.not_profile_device_types
             ):

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -477,6 +477,26 @@ def discover_entities_for_endpoint(endpoint: Endpoint) -> Iterator[PlatformEntit
     # Then, we process the matches and discard entities with lower weights (when
     # feature groups are used)
     for feature, matches_by_priority in matches_by_feature_and_priority.items():
+        # Use platform overrides to replace the results of the normal priority scoring
+        # system when competing entities are part of the same feature group
+        if platform_override is not None and feature is not None:
+            override_by_priority: defaultdict[
+                int, list[tuple[ClusterHandlerMatch, type[PlatformEntity]]]
+            ] = defaultdict(list)
+
+            for priority, priority_matches in matches_by_priority.items():
+                platform_matches = [
+                    (match, entity)
+                    for match, entity in priority_matches
+                    if platform_override == entity.PLATFORM
+                ]
+                if platform_matches:
+                    override_by_priority[priority] = platform_matches
+
+            # Replace matches with overrides
+            if override_by_priority:
+                matches_by_priority = override_by_priority
+
         highest_priority = max(matches_by_priority.keys())
 
         if _LOGGER.getEffectiveLevel() <= logging.DEBUG:
@@ -493,21 +513,9 @@ def discover_entities_for_endpoint(endpoint: Endpoint) -> Iterator[PlatformEntit
                     ignored_matches,
                 )
 
-        selected_matches = matches_by_priority[highest_priority]
+        matches = matches_by_priority[highest_priority]
 
-        # Use platform overrides to replace the results of the normal priority scoring
-        # system when competing entities are part of the same feature group
-        if platform_override is not None and feature is not None:
-            override_matches = [
-                (match, entity)
-                for priority_matches in matches_by_priority.values()
-                for match, entity in priority_matches
-                if platform_override == entity.PLATFORM
-            ]
-            if override_matches:
-                selected_matches = override_matches
-
-        for match, entity_class in selected_matches:
+        for match, entity_class in matches:
             server_handlers = set(match.cluster_handlers)
 
             for optional in match.optional_cluster_handlers:

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -470,15 +470,6 @@ def discover_entities_for_endpoint(endpoint: Endpoint) -> Iterator[PlatformEntit
                 feature = None
                 priority = 0
 
-            # Finally, account for `platform_override` by boosting the priority of
-            # matching platforms
-            if (
-                platform_override is not None
-                and platform_override == entity_class.PLATFORM
-                and feature is not None
-            ):
-                priority += 1000
-
             matches_by_feature_and_priority[feature][priority].append(
                 (match, entity_class)
             )
@@ -502,7 +493,21 @@ def discover_entities_for_endpoint(endpoint: Endpoint) -> Iterator[PlatformEntit
                     ignored_matches,
                 )
 
-        for match, entity_class in matches_by_priority[highest_priority]:
+        selected_matches = matches_by_priority[highest_priority]
+
+        # Use platform overrides to replace the results of the normal priority scoring
+        # system when competing entities are part of the same feature group
+        if platform_override is not None and feature is not None:
+            override_matches = [
+                (match, entity)
+                for priority_matches in matches_by_priority.values()
+                for match, entity in priority_matches
+                if platform_override == entity.PLATFORM
+            ]
+            if override_matches:
+                selected_matches = override_matches
+
+        for match, entity_class in selected_matches:
             server_handlers = set(match.cluster_handlers)
 
             for optional in match.optional_cluster_handlers:

--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -28,6 +28,7 @@ from zha.application.platforms import (
     register_entity,
     register_group_entity,
 )
+from zha.application.platforms.light.const import LIGHT_PROFILE_DEVICE_TYPES
 from zha.zigbee.cluster_handlers import ClusterAttributeUpdatedEvent
 from zha.zigbee.cluster_handlers.const import (
     AQARA_OPPLE_CLUSTER,
@@ -143,6 +144,13 @@ class Switch(PlatformEntity, BaseSwitch):
                 (zha.PROFILE_ID, zha.DeviceType.SMART_PLUG),
                 (zll.PROFILE_ID, zll.DeviceType.ON_OFF_PLUGIN_UNIT),
             }
+            | (
+                # For platform overrides, to account for the `unique_id` format from the
+                # Light platform, Switch needs to be aware of the device types that
+                # trigger the old "{ieee}-{ep}" format instead of the "{ieee}-{ep}-
+                # {cluster}" format.
+                LIGHT_PROFILE_DEVICE_TYPES
+            )
             else f"{endpoint.device.ieee}-{endpoint.id}-{int(OnOff.cluster_id)}"
         )
 


### PR DESCRIPTION
The discovery rewrite this release introduced a few bugs:
- The unique ID computation from the Light platform was not used when switching to a Switch, causing the swapped entities to be recreated.
- Overrides were applied to entities not belonging to a feature group and ended up replacing the entire set of entities without a feature group.

This PR removes the weight based boosting system and replaces it with explicit override logic.