### PR TITLE
Fix configuring attribute reporting

### DIFF
--- a/tests/test_cluster_handlers.py
+++ b/tests/test_cluster_handlers.py
@@ -33,6 +33,7 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.homeautomation import Diagnostic
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement
+from zigpy.zcl.helpers import ReportingConfig
 import zigpy.zdo.types as zdo_t
 
 from tests.common import (
@@ -303,7 +304,7 @@ async def test_in_cluster_handler_config(
     reported_attrs = set()
 
     for mock_call in cluster.configure_reporting_multiple.mock_calls:
-        reported_attrs.update(mock_call.args[0].keys())
+        reported_attrs.update(attr_def.name for attr_def in mock_call.args[0])
 
     assert attrs == reported_attrs
     assert cluster.configure_reporting.call_count == 0
@@ -941,18 +942,19 @@ async def test_configure_reporting(zha_gateway: Gateway) -> None:
     cluster_handler = TestZigbeeClusterHandler(cluster, endpoint)
     await cluster_handler.async_configure()
 
-    # Since we request reporting for five attributes, we need to make two calls (3 + 1)
+    # Since we request reporting for four attributes, we need to make two calls (3 + 1)
+    Color = zigpy.zcl.clusters.lighting.Color
     assert cluster.configure_reporting_multiple.mock_calls == [
         mock.call(
             {
-                "current_x": (1, 60, 1),
-                "current_hue": (1, 60, 2),
-                "color_temperature": (1, 60, 3),
+                Color.AttributeDefs.current_x: ReportingConfig(1, 60, 1),
+                Color.AttributeDefs.current_hue: ReportingConfig(1, 60, 2),
+                Color.AttributeDefs.color_temperature: ReportingConfig(1, 60, 3),
             }
         ),
         mock.call(
             {
-                "current_y": (1, 60, 4),
+                Color.AttributeDefs.current_y: ReportingConfig(1, 60, 4),
             }
         ),
     ]

--- a/tests/test_cluster_handlers.py
+++ b/tests/test_cluster_handlers.py
@@ -33,6 +33,7 @@ from zigpy.zcl.clusters.general import (
     PowerConfiguration,
 )
 from zigpy.zcl.clusters.homeautomation import Diagnostic
+from zigpy.zcl.clusters.lighting import Color
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 from zigpy.zcl.helpers import ReportingConfig
 import zigpy.zdo.types as zdo_t
@@ -177,7 +178,7 @@ def endpoint_mock(zigpy_coordinator_device: ZigpyDevice) -> Endpoint:
         ),
         (zigpy.zcl.clusters.hvac.Fan.cluster_id, 1, {"fan_mode"}),
         (
-            zigpy.zcl.clusters.lighting.Color.cluster_id,
+            Color.cluster_id,
             1,
             {
                 "current_x",
@@ -926,7 +927,7 @@ async def test_configure_reporting(zha_gateway: Gateway) -> None:
     mock_ep.profile_id = zigpy.profiles.zha.PROFILE_ID
     mock_ep.device.zdo = AsyncMock()
 
-    cluster = zigpy.zcl.clusters.lighting.Color(mock_ep)
+    cluster = Color(mock_ep)
     cluster.bind = AsyncMock(
         spec_set=cluster.bind,
         return_value=[zdo_t.Status.SUCCESS],  # ZDOCmd.Bind_rsp
@@ -944,7 +945,7 @@ async def test_configure_reporting(zha_gateway: Gateway) -> None:
     await cluster_handler.async_configure()
 
     # Since we request reporting for four attributes, we need to make two calls (3 + 1)
-    Color = zigpy.zcl.clusters.lighting.Color
+
     assert cluster.configure_reporting_multiple.mock_calls == [
         mock.call(
             {
@@ -1054,7 +1055,7 @@ async def test_invalid_cluster_handler(zha_gateway: Gateway, caplog) -> None:  #
     zigpy_ep = zigpy.endpoint.Endpoint(mock_device, endpoint_id=1)
     zigpy_ep.profile_id = zigpy.profiles.zha.PROFILE_ID
 
-    cluster = zigpy_ep.add_input_cluster(zigpy.zcl.clusters.lighting.Color.cluster_id)
+    cluster = zigpy_ep.add_input_cluster(Color.cluster_id)
     cluster.configure_reporting_multiple = AsyncMock(
         spec_set=cluster.configure_reporting_multiple,
         return_value=[
@@ -1099,7 +1100,7 @@ async def test_standard_cluster_handler(
     zigpy_ep = zigpy.endpoint.Endpoint(mock_device, endpoint_id=1)
     zigpy_ep.profile_id = zigpy.profiles.zha.PROFILE_ID
 
-    cluster = zigpy_ep.add_input_cluster(zigpy.zcl.clusters.lighting.Color.cluster_id)
+    cluster = zigpy_ep.add_input_cluster(Color.cluster_id)
     cluster.configure_reporting_multiple = AsyncMock(
         spec_set=cluster.configure_reporting_multiple,
         return_value=[
@@ -1139,7 +1140,7 @@ async def test_exposed_feature_cluster_handler(
     zigpy_ep = zigpy.endpoint.Endpoint(mock_device, endpoint_id=1)
     zigpy_ep.profile_id = zigpy.profiles.zha.PROFILE_ID
 
-    cluster = zigpy_ep.add_input_cluster(zigpy.zcl.clusters.lighting.Color.cluster_id)
+    cluster = zigpy_ep.add_input_cluster(Color.cluster_id)
     cluster.configure_reporting_multiple = AsyncMock(
         spec_set=cluster.configure_reporting_multiple,
         return_value=[

--- a/tests/test_cluster_handlers.py
+++ b/tests/test_cluster_handlers.py
@@ -971,18 +971,6 @@ async def test_configure_reporting(zha_gateway: Gateway) -> None:
 @pytest.mark.parametrize(
     ("response", "expected_statuses"),
     [
-        # Exception result: all attributes marked as FAILURE
-        (
-            zigpy.exceptions.ZigbeeException("timeout"),
-            {"current_x": "FAILURE", "current_y": "FAILURE"},
-        ),
-        # Single ConfigureReportingResponseRecord: all attributes marked as FAILURE
-        (
-            foundation.ConfigureReportingResponseRecord(
-                status=foundation.Status.SUCCESS
-            ),
-            {"current_x": "FAILURE", "current_y": "FAILURE"},
-        ),
         # Single SUCCESS in a list: all attributes marked as SUCCESS (ZCL 2.5.8.1.3)
         (
             [
@@ -1013,8 +1001,6 @@ async def test_configure_reporting(zha_gateway: Gateway) -> None:
         ),
     ],
     ids=[
-        "exception",
-        "single_record",
         "single_success_list",
         "empty_list",
         "mixed_per_attribute",

--- a/tests/test_cluster_handlers.py
+++ b/tests/test_cluster_handlers.py
@@ -968,14 +968,14 @@ async def test_configure_reporting(zha_gateway: Gateway) -> None:
         # Exception result: all attributes marked as FAILURE
         (
             zigpy.exceptions.ZigbeeException("timeout"),
-            {"on_off": "FAILURE"},
+            {"current_x": "FAILURE", "current_y": "FAILURE"},
         ),
         # Single ConfigureReportingResponseRecord: all attributes marked as FAILURE
         (
             foundation.ConfigureReportingResponseRecord(
                 status=foundation.Status.SUCCESS
             ),
-            {"on_off": "FAILURE"},
+            {"current_x": "FAILURE", "current_y": "FAILURE"},
         ),
         # Single SUCCESS in a list: all attributes marked as SUCCESS (ZCL 2.5.8.1.3)
         (
@@ -984,19 +984,27 @@ async def test_configure_reporting(zha_gateway: Gateway) -> None:
                     status=foundation.Status.SUCCESS
                 )
             ],
-            {"on_off": "SUCCESS"},
+            {"current_x": "SUCCESS", "current_y": "SUCCESS"},
         ),
         # Empty list: all attributes assumed successful (no failures reported)
         (
             [],
-            {"on_off": "SUCCESS"},
+            {"current_x": "SUCCESS", "current_y": "SUCCESS"},
         ),
-    ],
-    ids=[
-        "exception",
-        "single_record",
-        "single_success_list",
-        "empty_list",
+        # Per-attribute results: mixed success/failure
+        (
+            [
+                foundation.ConfigureReportingResponseRecord(
+                    status=foundation.Status.SUCCESS,
+                    attrid=Color.AttributeDefs.current_x.id,
+                ),
+                foundation.ConfigureReportingResponseRecord(
+                    status=foundation.Status.UNSUPPORTED_ATTRIBUTE,
+                    attrid=Color.AttributeDefs.current_y.id,
+                ),
+            ],
+            {"current_x": "SUCCESS", "current_y": "UNSUPPORTED_ATTRIBUTE"},
+        ),
     ],
 )
 async def test_configure_reporting_status(
@@ -1006,11 +1014,18 @@ async def test_configure_reporting_status(
     zigpy_coordinator_device: ZigpyDevice = zigpy_coordinator_device_mock(zha_gateway)
     endpoint: Endpoint = endpoint_mock(zigpy_coordinator_device)
 
+    class TestClusterHandler(ClusterHandler):
+        BIND = True
+        REPORT_CONFIG = (
+            AttrReportConfig(attr="current_x", config=(1, 60, 1)),
+            AttrReportConfig(attr="current_y", config=(1, 60, 2)),
+        )
+
     mock_ep = mock.AsyncMock()
     mock_ep.profile_id = zigpy.profiles.zha.PROFILE_ID
     mock_ep.device.zdo = AsyncMock()
 
-    cluster = OnOff(mock_ep)
+    cluster = Color(mock_ep)
     cluster.bind = AsyncMock(
         spec_set=cluster.bind,
         return_value=[zdo_t.Status.SUCCESS],
@@ -1020,11 +1035,7 @@ async def test_configure_reporting_status(
         return_value=response,
     )
 
-    cluster_handler_class = CLUSTER_HANDLER_REGISTRY.get(
-        OnOff.cluster_id, {None, ClusterHandler}
-    ).get(None)
-    assert cluster_handler_class is not None
-    cluster_handler = cluster_handler_class(cluster, endpoint)
+    cluster_handler = TestClusterHandler(cluster, endpoint)
 
     mock_emit = MagicMock()
     cluster_handler._endpoint.device.emit = mock_emit

--- a/tests/test_cluster_handlers.py
+++ b/tests/test_cluster_handlers.py
@@ -15,6 +15,7 @@ from zhaquirks.centralite.cl_3130 import CentraLite3130
 from zhaquirks.xiaomi.aqara.sensor_switch_aq3 import BUTTON_DEVICE_TYPE, SwitchAQ3
 from zigpy.device import Device as ZigpyDevice
 from zigpy.endpoint import Endpoint as ZigpyEndpoint
+import zigpy.exceptions
 import zigpy.profiles.zha
 from zigpy.quirks import DEVICE_REGISTRY
 import zigpy.types as t
@@ -48,7 +49,7 @@ from tests.common import (
     zigpy_device_from_json,
 )
 from zha.application import Platform
-from zha.application.const import ATTR_QUIRK_ID
+from zha.application.const import ATTR_QUIRK_ID, ZHA_CLUSTER_HANDLER_MSG_CFG_RPT
 from zha.application.gateway import Gateway
 from zha.application.platforms.button import IdentifyButton
 from zha.exceptions import ZHAException
@@ -958,6 +959,87 @@ async def test_configure_reporting(zha_gateway: Gateway) -> None:
             }
         ),
     ]
+
+
+@pytest.mark.parametrize(
+    ("response", "expected_statuses"),
+    [
+        # Exception result: all attributes marked as FAILURE
+        (
+            zigpy.exceptions.ZigbeeException("timeout"),
+            {"on_off": "FAILURE"},
+        ),
+        # Single ConfigureReportingResponseRecord: all attributes marked as FAILURE
+        (
+            foundation.ConfigureReportingResponseRecord(
+                status=foundation.Status.SUCCESS
+            ),
+            {"on_off": "FAILURE"},
+        ),
+        # Single SUCCESS in a list: all attributes marked as SUCCESS (ZCL 2.5.8.1.3)
+        (
+            [
+                foundation.ConfigureReportingResponseRecord(
+                    status=foundation.Status.SUCCESS
+                )
+            ],
+            {"on_off": "SUCCESS"},
+        ),
+        # Empty list: all attributes assumed successful (no failures reported)
+        (
+            [],
+            {"on_off": "SUCCESS"},
+        ),
+    ],
+    ids=[
+        "exception",
+        "single_record",
+        "single_success_list",
+        "empty_list",
+    ],
+)
+async def test_configure_reporting_status(
+    zha_gateway: Gateway, response, expected_statuses
+) -> None:
+    """Test configure reporting status parsing via async_configure."""
+    zigpy_coordinator_device: ZigpyDevice = zigpy_coordinator_device_mock(zha_gateway)
+    endpoint: Endpoint = endpoint_mock(zigpy_coordinator_device)
+
+    mock_ep = mock.AsyncMock()
+    mock_ep.profile_id = zigpy.profiles.zha.PROFILE_ID
+    mock_ep.device.zdo = AsyncMock()
+
+    cluster = OnOff(mock_ep)
+    cluster.bind = AsyncMock(
+        spec_set=cluster.bind,
+        return_value=[zdo_t.Status.SUCCESS],
+    )
+    cluster.configure_reporting_multiple = AsyncMock(
+        spec_set=cluster.configure_reporting_multiple,
+        return_value=response,
+    )
+
+    cluster_handler_class = CLUSTER_HANDLER_REGISTRY.get(
+        OnOff.cluster_id, {None, ClusterHandler}
+    ).get(None)
+    assert cluster_handler_class is not None
+    cluster_handler = cluster_handler_class(cluster, endpoint)
+
+    mock_emit = MagicMock()
+    cluster_handler._endpoint.device.emit = mock_emit
+
+    await cluster_handler.async_configure()
+
+    cfg_rpt_calls = [
+        c
+        for c in mock_emit.call_args_list
+        if c.args[0] == ZHA_CLUSTER_HANDLER_MSG_CFG_RPT
+    ]
+    assert len(cfg_rpt_calls) == 1
+    attributes = cfg_rpt_calls[0].args[1].attributes
+
+    for attr_name, expected_status in expected_statuses.items():
+        assert attributes[attr_name]["status"] == expected_status
 
 
 async def test_invalid_cluster_handler(zha_gateway: Gateway, caplog) -> None:  # pylint: disable=unused-argument

--- a/tests/test_cluster_handlers.py
+++ b/tests/test_cluster_handlers.py
@@ -50,13 +50,19 @@ from tests.common import (
     zigpy_device_from_json,
 )
 from zha.application import Platform
-from zha.application.const import ATTR_QUIRK_ID, ZHA_CLUSTER_HANDLER_MSG_CFG_RPT
+from zha.application.const import (
+    ATTR_QUIRK_ID,
+    ZHA_CLUSTER_HANDLER_MSG_BIND,
+    ZHA_CLUSTER_HANDLER_MSG_CFG_RPT,
+)
 from zha.application.gateway import Gateway
 from zha.application.platforms.button import IdentifyButton
 from zha.exceptions import ZHAException
 from zha.zigbee.cluster_handlers import (
     AttrReportConfig,
     ClientClusterHandler,
+    ClusterBindEvent,
+    ClusterConfigureReportingEvent,
     ClusterHandler,
     ClusterHandlerStatus,
     parse_and_log_command,
@@ -1049,16 +1055,38 @@ async def test_configure_reporting_status(
 
     await cluster_handler.async_configure()
 
-    cfg_rpt_calls = [
-        c
-        for c in mock_emit.call_args_list
-        if c.args[0] == ZHA_CLUSTER_HANDLER_MSG_CFG_RPT
+    assert mock_emit.call_args_list == [
+        mock.call(
+            ZHA_CLUSTER_HANDLER_MSG_BIND,
+            ClusterBindEvent(
+                cluster_name=cluster.name,
+                cluster_id=cluster.cluster_id,
+                cluster_handler_unique_id=cluster_handler.unique_id,
+                success=True,
+            ),
+        ),
+        mock.call(
+            ZHA_CLUSTER_HANDLER_MSG_CFG_RPT,
+            ClusterConfigureReportingEvent(
+                cluster_name=cluster.name,
+                cluster_id=cluster.cluster_id,
+                cluster_handler_unique_id=cluster_handler.unique_id,
+                attributes={
+                    attr_name: {
+                        "min": 1,
+                        "max": 60,
+                        "id": attr_name,
+                        "name": attr_name,
+                        "change": idx + 1,
+                        "status": expected_status,
+                    }
+                    for idx, (attr_name, expected_status) in enumerate(
+                        expected_statuses.items()
+                    )
+                },
+            ),
+        ),
     ]
-    assert len(cfg_rpt_calls) == 1
-    attributes = cfg_rpt_calls[0].args[1].attributes
-
-    for attr_name, expected_status in expected_statuses.items():
-        assert attributes[attr_name]["status"] == expected_status
 
 
 async def test_invalid_cluster_handler(zha_gateway: Gateway, caplog) -> None:  # pylint: disable=unused-argument

--- a/tests/test_cluster_handlers.py
+++ b/tests/test_cluster_handlers.py
@@ -992,10 +992,10 @@ async def test_configure_reporting(zha_gateway: Gateway) -> None:
             ],
             {"current_x": "SUCCESS", "current_y": "SUCCESS"},
         ),
-        # Empty list: all attributes assumed successful (no failures reported)
+        # Empty list: unexpected response, all attributes marked as FAILURE
         (
             [],
-            {"current_x": "SUCCESS", "current_y": "SUCCESS"},
+            {"current_x": "FAILURE", "current_y": "FAILURE"},
         ),
         # Per-attribute results: mixed success/failure
         (

--- a/tests/test_cluster_handlers.py
+++ b/tests/test_cluster_handlers.py
@@ -1006,6 +1006,13 @@ async def test_configure_reporting(zha_gateway: Gateway) -> None:
             {"current_x": "SUCCESS", "current_y": "UNSUPPORTED_ATTRIBUTE"},
         ),
     ],
+    ids=[
+        "exception",
+        "single_record",
+        "single_success_list",
+        "empty_list",
+        "mixed_per_attribute",
+    ],
 )
 async def test_configure_reporting_status(
     zha_gateway: Gateway, response, expected_statuses

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -23,7 +23,9 @@ from zigpy.typing import UNDEFINED
 from zigpy.zcl import ClusterType
 from zigpy.zcl.clusters import general
 from zigpy.zcl.clusters.general import Ota, PowerConfiguration
+from zigpy.zcl.clusters.measurement import CarbonDioxideConcentration
 from zigpy.zcl.foundation import Status, WriteAttributesResponse
+from zigpy.zcl.helpers import ReportingConfig
 import zigpy.zdo.types as zdo_t
 
 from tests.common import (
@@ -1176,7 +1178,13 @@ async def test_join_binding_reporting(zha_gateway: Gateway) -> None:
 
     assert mock_bind.mock_calls == [call()]
     assert mock_reporting_config.mock_calls == [
-        call({"measured_value": (30, 900, 1e-6)})
+        call(
+            {
+                CarbonDioxideConcentration.AttributeDefs.measured_value: ReportingConfig(
+                    30, 900, 1e-6
+                )
+            }
+        )
     ]
 
 

--- a/zha/zigbee/cluster_handlers/__init__.py
+++ b/zha/zigbee/cluster_handlers/__init__.py
@@ -430,7 +430,7 @@ class ClusterHandler(LogMixin, EventBase):
     def _configure_reporting_status(
         self,
         attrs: dict[ZCLAttributeDef, ReportingConfig],
-        res: list | tuple,
+        res: list[ConfigureReportingResponseRecord],
         event_data: dict[str, dict[str, Any]],
     ) -> None:
         """Parse configure reporting result."""

--- a/zha/zigbee/cluster_handlers/__init__.py
+++ b/zha/zigbee/cluster_handlers/__init__.py
@@ -370,11 +370,6 @@ class ClusterHandler(LogMixin, EventBase):
         """
         event_data = {}
         kwargs = {}
-        if (
-            self.cluster.cluster_id >= 0xFC00
-            and self._endpoint.device.manufacturer_code
-        ):
-            kwargs["manufacturer"] = self._endpoint.device.manufacturer_code
 
         for attr_report in self.REPORT_CONFIG:
             attr, config = attr_report["attr"], attr_report["config"]

--- a/zha/zigbee/cluster_handlers/__init__.py
+++ b/zha/zigbee/cluster_handlers/__init__.py
@@ -435,7 +435,7 @@ class ClusterHandler(LogMixin, EventBase):
     ) -> None:
         """Parse configure reporting result."""
         attr_names = {attr_def.name for attr_def in attrs}
-        if isinstance(res, (Exception, ConfigureReportingResponseRecord)):
+        if not res or isinstance(res, (Exception, ConfigureReportingResponseRecord)):
             # assume default response
             self.debug(
                 "attr reporting for '%s' on '%s': %s",

--- a/zha/zigbee/cluster_handlers/__init__.py
+++ b/zha/zigbee/cluster_handlers/__init__.py
@@ -446,7 +446,7 @@ class ClusterHandler(LogMixin, EventBase):
             for attr_name in attr_names:
                 event_data[attr_name]["status"] = Status.FAILURE.name
             return
-        if res[0].status == Status.SUCCESS and len(res) == 1:
+        if len(res) == 1 and res[0].status == Status.SUCCESS:
             self.debug(
                 "Successfully configured reporting for '%s' on '%s' cluster: %s",
                 attr_names,

--- a/zha/zigbee/cluster_handlers/__init__.py
+++ b/zha/zigbee/cluster_handlers/__init__.py
@@ -26,6 +26,7 @@ from zigpy.zcl.foundation import (
     Status,
     ZCLAttributeDef,
 )
+from zigpy.zcl.helpers import ReportingConfig
 
 from zha.application.const import (
     ZHA_CLUSTER_HANDLER_MSG,
@@ -369,7 +370,6 @@ class ClusterHandler(LogMixin, EventBase):
         devices are unreachable.
         """
         event_data = {}
-        kwargs = {}
 
         for attr_report in self.REPORT_CONFIG:
             attr, config = attr_report["attr"], attr_report["config"]
@@ -394,12 +394,17 @@ class ClusterHandler(LogMixin, EventBase):
             to_configure[REPORT_CONFIG_ATTR_PER_REQ:],
         )
         while chunk:
-            reports = {rec["attr"]: rec["config"] for rec in chunk}
+            reports = {
+                self.cluster.find_attribute(rec["attr"]): ReportingConfig(
+                    *rec["config"]
+                )
+                for rec in chunk
+            }
             try:
                 res = await RETRYABLE_REQUEST_DECORATOR(
                     self.cluster.configure_reporting_multiple
-                )(reports, **kwargs)
-                self._configure_reporting_status(reports, res[0], event_data)
+                )(reports)
+                self._configure_reporting_status(reports, res, event_data)
             except (zigpy.exceptions.ZigbeeException, TimeoutError) as ex:
                 self.debug(
                     "failed to set reporting on '%s' cluster for: %s",
@@ -424,26 +429,27 @@ class ClusterHandler(LogMixin, EventBase):
 
     def _configure_reporting_status(
         self,
-        attrs: dict[str, tuple[int, int, float | int]],
+        attrs: dict[ZCLAttributeDef, ReportingConfig],
         res: list | tuple,
         event_data: dict[str, dict[str, Any]],
     ) -> None:
         """Parse configure reporting result."""
+        attr_names = {attr_def.name for attr_def in attrs}
         if isinstance(res, (Exception, ConfigureReportingResponseRecord)):
             # assume default response
             self.debug(
                 "attr reporting for '%s' on '%s': %s",
-                attrs,
+                attr_names,
                 self.name,
                 res,
             )
-            for attr in attrs:
-                event_data[attr]["status"] = Status.FAILURE.name
+            for attr_name in attr_names:
+                event_data[attr_name]["status"] = Status.FAILURE.name
             return
         if res[0].status == Status.SUCCESS and len(res) == 1:
             self.debug(
                 "Successfully configured reporting for '%s' on '%s' cluster: %s",
-                attrs,
+                attr_names,
                 self.name,
                 res,
             )
@@ -453,8 +459,8 @@ class ClusterHandler(LogMixin, EventBase):
             # attributes, in order to save bandwidth. In the case of successful configuration of all attributes,
             # only a single attribute status record SHALL be included in the command, with the status field set to
             # SUCCESS and the direction and attribute identifier fields omitted.
-            for attr in attrs:
-                event_data[attr]["status"] = Status.SUCCESS.name
+            for attr_name in attr_names:
+                event_data[attr_name]["status"] = Status.SUCCESS.name
             return
 
         for record in res:
@@ -472,14 +478,14 @@ class ClusterHandler(LogMixin, EventBase):
             self.name,
             res,
         )
-        success = set(attrs) - set(failed)
+        success = attr_names - set(failed)
         self.debug(
             "Successfully configured reporting for '%s' on '%s' cluster",
-            set(attrs) - set(failed),
+            success,
             self.name,
         )
-        for attr in success:
-            event_data[attr]["status"] = Status.SUCCESS.name
+        for attr_name in success:
+            event_data[attr_name]["status"] = Status.SUCCESS.name
 
     async def async_configure(self) -> None:
         """Set cluster binding and attribute reporting."""

--- a/zha/zigbee/cluster_handlers/__init__.py
+++ b/zha/zigbee/cluster_handlers/__init__.py
@@ -435,8 +435,7 @@ class ClusterHandler(LogMixin, EventBase):
     ) -> None:
         """Parse configure reporting result."""
         attr_names = {attr_def.name for attr_def in attrs}
-        if not res or isinstance(res, (Exception, ConfigureReportingResponseRecord)):
-            # assume default response
+        if not res:
             self.debug(
                 "attr reporting for '%s' on '%s': %s",
                 attr_names,


### PR DESCRIPTION
## Proposed change

This fixes configuration of attribute reporting after the recent zigpy manufacturer code changes.
- `configure_reporting_multiple` is now called with `ZCLAttributeDef` and `ReportingConfig`, instead of the attribute name (`str`) and a tuple containing min/max/reportable change int values.
- `_configure_reporting_status` was updated to get the attribute name from `ZCLAttributeDef`.
- The `cluster_id >= 0xFC00` check for using the manufacturer code is removed, as zigpy now does this better and automatically, grouping respective attributes properly. 
- The tests were updated to expect the new `configure_reporting_multiple` calls.
- The condition `res[0].status == Status.SUCCESS and len(res) == 1` was updated to `len(res) == 1 and res[0].status == Status.SUCCESS`. This should now properly work with empty lists.
  - EDIT:  Zigpy should never send us an empty list though. I think it's still fine to not catastrophically break in the case zigpy sends something unexpected though, as that's just for the reporting status. We'll just mark the reports as failed then.
- A test was added for `configure_reporting_status`, which sends reports on attribute reports used by HA frontend.

This change was tested with an IKEA motion sensor, where attribute reporting is now correctly configured for the `PowerConfiguration` cluster again. This is also represented in the HA frontend.


## Additional information

Related PRs:
- https://github.com/zigpy/zigpy/pull/1719
- https://github.com/zigpy/zha/pull/605
- https://github.com/zigpy/zha/pull/637