### PR TITLE
Re-add `CLUSTER_HANDLER_ONLY_CLUSTERS` handling for binding

### DIFF
--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -60,6 +60,7 @@ from zha.application.helpers import DeviceOverridesConfiguration
 from zha.application.platforms import PlatformEntity, binary_sensor, sensor
 from zha.application.platforms.light import HueLight
 from zha.application.platforms.number import BaseNumber, NumberMode
+from zha.zigbee.cluster_handlers.const import PHILLIPS_REMOTE_CLUSTER
 
 
 def _get_identify_cluster(zigpy_device):
@@ -772,3 +773,20 @@ async def test_devices_from_files(
                     manufacturer=None,
                 )
             ]
+
+
+async def test_cluster_handler_only_clusters_are_bound(zha_gateway: Gateway) -> None:
+    """Test CLUSTER_HANDLER_ONLY_CLUSTERS causes binds even without entities."""
+    zigpy_device = await zigpy_device_from_json(
+        zha_gateway.application_controller,
+        "tests/data/devices/signify-netherlands-b-v-rwl022.json",
+    )
+
+    # The Philips remote cluster (0xFC00) is in CLUSTER_HANDLER_ONLY_CLUSTERS: it
+    # doesn't produce any entities but must still be bound
+    philips_cluster = zigpy_device.endpoints[1].in_clusters[PHILLIPS_REMOTE_CLUSTER]
+
+    await join_zigpy_device(zha_gateway, zigpy_device)
+    await zha_gateway.async_block_till_done(wait_background_tasks=True)
+
+    assert len(philips_cluster.bind.mock_calls) == 1

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -65,6 +65,7 @@ from zha.zigbee.cluster_handlers import (  # noqa: F401 pylint: disable=unused-i
     security,
     smartenergy,
 )
+from zha.zigbee.cluster_handlers.registries import CLUSTER_HANDLER_ONLY_CLUSTERS
 from zha.zigbee.group import Group
 
 if TYPE_CHECKING:
@@ -562,3 +563,13 @@ def discover_entities_for_endpoint(endpoint: Endpoint) -> Iterator[PlatformEntit
                 endpoint=endpoint,
                 device=device,
             )
+
+    # Claim any remaining unclaimed cluster handlers that don't produce entities but
+    # still need to be configured for bare events (bound, reporting set up, etc.)
+    for cluster_handler in endpoint.all_cluster_handlers.values():
+        if (
+            cluster_handler.id not in endpoint.claimed_cluster_handlers
+            and cluster_handler.cluster.cluster_id in CLUSTER_HANDLER_ONLY_CLUSTERS
+        ):
+            _LOGGER.debug("Claiming entityless cluster handler %s", cluster_handler)
+            endpoint.claim_cluster_handlers([cluster_handler])


### PR DESCRIPTION
This feature was accidentally removed during the recent discovery refactor. Without it, binding and reporting does not happen for cluster handlers not claimed by any entity. In this case, it introduced a regression for a Hue remote (and other similar devices).