### PR TITLE
Fix `import_diagnostics` `fetch_updated_state` race condition

### DIFF
--- a/tools/import_diagnostics.py
+++ b/tools/import_diagnostics.py
@@ -324,6 +324,7 @@ async def create_zha_gateway():
             data=make_zha_data(),
             app=zigpy_app_controller,
         ) as zha_gateway:
+            await zha_gateway.async_block_till_done(wait_background_tasks=True)
             yield zha_gateway
 
 


### PR DESCRIPTION
Please enjoy this mostly AI generated summary. 😅 

## Summary
- Fix a race condition in `import_diagnostics` where a background `fetch_updated_state` task runs `dev.async_initialize()` concurrently with `_async_device_joined`'s `async_configure()`, causing `ClusterHandler.info_object` to cache a stale `CONFIGURED` status instead of `INITIALIZED`
- Drain all background tasks in `create_zha_gateway()` before yielding, so devices are joined on a quiescent event loop


## Problem
When importing diagnostics, the tool joins a device, captures its diagnostics JSON, removes it, re-joins it, and compares the two JSONs. This comparison was always failing because every cluster handler status showed `CONFIGURED` in the first join but `INITIALIZED` in the second.

**Root cause:** `TestGateway.__aenter__()` calls `async_initialize_devices_and_entities()`, which spawns a background `fetch_updated_state` task. This task polls all mains-powered devices via `dev.async_initialize(from_cache=False)`.

When a new device is joined before this task completes, the background task's `async_initialize()` races with the join's `async_configure()`. Since `ClusterHandler.info_object` is a `@functools.cached_property` that snapshots `self._status` on first access, the status gets frozen at `CONFIGURED` during this race.

The second join doesn't hit this because the background task has already drained by then.


## Fix
Add `await zha_gateway.async_block_till_done(wait_background_tasks=True)` after gateway setup, ensuring the background `fetch_updated_state` task completes before any devices are joined (with only the coordinator device).

### Alternative

Alternatively, we could likely also disable `enable_mains_startup_polling` (in `make_zha_data()`), as we don't really need it.


## Note on `ClusterHandler.info_object`

`ClusterHandler.info_object` is a `@functools.cached_property` that snapshots `self._status.name` on first access and never updates. This is a latent bug: `_status` transitions through `CREATED` -> `CONFIGURED` -> `INITIALIZED`, but the cached property freezes whichever value was current at first access.

On the platform entity level, we already have `_compute_primary_entity` execute `del entity.info_object` to invalidate caches. We don't do the same for the underlying `ClusterHandler.info_object`.

A more robust fix would be to either make `status` dynamic or invalidate `info_object` whenever `_status` changes.