### PR TITLE
Add exposed feature for SE summation polling

### DIFF
--- a/tests/data/devices/ubisys-s1-5501.json
+++ b/tests/data/devices/ubisys-s1-5501.json
@@ -994,7 +994,7 @@
           "unique_id": "ab:cd:ef:12:e4:d6:5c:c2-3-1794-summation_delivered",
           "migrate_unique_ids": [],
           "platform": "sensor",
-          "class_name": "SmartEnergySummation",
+          "class_name": "ExposedFeaturePolledSmartEnergySummation",
           "translation_key": "summation_delivered",
           "translation_placeholders": null,
           "device_class": "energy",
@@ -1027,7 +1027,7 @@
           "unit": "kWh"
         },
         "state": {
-          "class_name": "SmartEnergySummation",
+          "class_name": "ExposedFeaturePolledSmartEnergySummation",
           "available": true,
           "state": 0.0,
           "status": "NO_ALARMS",
@@ -1045,7 +1045,7 @@
           "unique_id": "ab:cd:ef:12:e4:d6:5c:c2-3-1794-summation_received",
           "migrate_unique_ids": [],
           "platform": "sensor",
-          "class_name": "SmartEnergySummationReceived",
+          "class_name": "ExposedFeaturePolledSmartEnergySummationReceived",
           "translation_key": "summation_received",
           "translation_placeholders": null,
           "device_class": "energy",
@@ -1078,7 +1078,7 @@
           "unit": "kWh"
         },
         "state": {
-          "class_name": "SmartEnergySummationReceived",
+          "class_name": "ExposedFeaturePolledSmartEnergySummationReceived",
           "available": true,
           "state": 0.0,
           "status": "NO_ALARMS",

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -66,6 +66,9 @@ class PlatformFeatureGroup(StrEnum):
     # Model-specific overrides for Smart Energy Summation
     SMART_ENERGY_SUMMATION = "smart_energy_summation"
 
+    # Overrides for Smart Energy Summation Received
+    SMART_ENERGY_SUMMATION_RECEIVED = "smart_energy_summation_received"
+
     # Model-specific overrides for local temperature calibration
     LOCAL_TEMPERATURE_CALIBRATION = "local_temperature_calibration"
 

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -1480,6 +1480,17 @@ class PolledSmartEnergySummation(SmartEnergySummation):
 
 
 @register_entity(Metering.cluster_id)
+class ExposedFeaturePolledSmartEnergySummation(PolledSmartEnergySummation):
+    """Polled Smart Energy Metering summation sensor via exposed feature."""
+
+    _cluster_handler_match = ClusterHandlerMatch(
+        cluster_handlers=frozenset({CLUSTER_HANDLER_SMARTENERGY_METERING}),
+        exposed_features=frozenset({"se_poll_summation"}),
+        feature_priority=(PlatformFeatureGroup.SMART_ENERGY_SUMMATION, 1),
+    )
+
+
+@register_entity(Metering.cluster_id)
 class Tier1SmartEnergySummation(PolledSmartEnergySummation):
     """Tier 1 Smart Energy Metering summation sensor."""
 
@@ -1595,6 +1606,20 @@ class SmartEnergySummationReceived(PolledSmartEnergySummation):
 
     _cluster_handler_match = ClusterHandlerMatch(
         cluster_handlers=frozenset({CLUSTER_HANDLER_SMARTENERGY_METERING}),
+        feature_priority=(PlatformFeatureGroup.SMART_ENERGY_SUMMATION_RECEIVED, 0),
+    )
+
+
+@register_entity(Metering.cluster_id)
+class ExposedFeaturePolledSmartEnergySummationReceived(SmartEnergySummationReceived):
+    """Polled Smart Energy Metering summation received sensor via exposed feature."""
+
+    _use_custom_polling = True
+
+    _cluster_handler_match = ClusterHandlerMatch(
+        cluster_handlers=frozenset({CLUSTER_HANDLER_SMARTENERGY_METERING}),
+        exposed_features=frozenset({"se_poll_summation"}),
+        feature_priority=(PlatformFeatureGroup.SMART_ENERGY_SUMMATION_RECEIVED, 1),
     )
 
 

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -15,7 +15,7 @@ import typing
 from typing import TYPE_CHECKING, Any, cast
 
 from zhaquirks.danfoss import thermostat as danfoss_thermostat
-from zhaquirks.quirk_ids import DANFOSS_ALLY_THERMOSTAT
+from zhaquirks.quirk_ids import DANFOSS_ALLY_THERMOSTAT, SE_POLL_SUMMATION
 from zigpy import types
 from zigpy.quirks.v2 import ZCLEnumMetadata, ZCLSensorMetadata
 from zigpy.state import Counter, State
@@ -1485,7 +1485,7 @@ class ExposedFeaturePolledSmartEnergySummation(PolledSmartEnergySummation):
 
     _cluster_handler_match = ClusterHandlerMatch(
         cluster_handlers=frozenset({CLUSTER_HANDLER_SMARTENERGY_METERING}),
-        exposed_features=frozenset({"se_poll_summation"}),
+        exposed_features=frozenset({SE_POLL_SUMMATION}),
         feature_priority=(PlatformFeatureGroup.SMART_ENERGY_SUMMATION, 1),
     )
 
@@ -1618,7 +1618,7 @@ class ExposedFeaturePolledSmartEnergySummationReceived(SmartEnergySummationRecei
 
     _cluster_handler_match = ClusterHandlerMatch(
         cluster_handlers=frozenset({CLUSTER_HANDLER_SMARTENERGY_METERING}),
-        exposed_features=frozenset({"se_poll_summation"}),
+        exposed_features=frozenset({SE_POLL_SUMMATION}),
         feature_priority=(PlatformFeatureGroup.SMART_ENERGY_SUMMATION_RECEIVED, 1),
     )
 


### PR DESCRIPTION
## Proposed change

This adds separate entity classes based on an exposed quirks feature/hint, so that the Smart Metering's `current_summ_delivered` and `current_summ_received` attributes are polled automatically by ZHA then.

## Additional information

The `"se_poll_summation"` exposed feature will be added to zha-quirks. Then, this PR will be changed to use that exposed feature constant.

Weirdly enough, the Zigbee spec doesn't specify that these two attributes are reportable, yet some devices seem to support it. For the EM cluster, we always poll by default. For the SE cluster, we only poll for select models `"TS011F", "ZLinky_TIC", "TICMeter"`. These can (mostly) be switched to instead expose the polling feature/hint in quirks soon.

Ubisys diagnostics will be added soon. That should be enough to cover these new entities IMO, since the polling is the same and already tested elsewhere. The diagnostics will contain the class name, so check if the exposed feature matching works in this case.