### PR TITLE
Fix downloading diagnostics more than once

### DIFF
--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -753,13 +753,6 @@ async def test_devices_from_files(
         )
         assert loaded_device_data == device_data
 
-        # Calling get_diagnostics_json() a second time should produce the same
-        # result because the original_signature dict must not be mutated.
-        loaded_device_data_2 = json.loads(
-            json.dumps(zha_device.get_diagnostics_json(), cls=ZhaJsonEncoder)
-        )
-        assert loaded_device_data_2 == loaded_device_data
-
         # Assert identify called on join for devices that support it
         cluster_identify = _get_identify_cluster(zha_device.device)
         if cluster_identify and not zha_device.skip_configuration:
@@ -780,6 +773,23 @@ async def test_devices_from_files(
                     manufacturer=None,
                 )
             ]
+
+
+async def test_get_diagnostics_json_repeated_calls(zha_gateway: Gateway) -> None:
+    """Test that calling get_diagnostics_json twice produces the same result."""
+    zigpy_device = await zigpy_device_from_json(
+        zha_gateway.application_controller,
+        "tests/data/devices/jasco-products-45856.json",
+    )
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
+
+    first = json.loads(
+        json.dumps(zha_device.get_diagnostics_json(), cls=ZhaJsonEncoder)
+    )
+    second = json.loads(
+        json.dumps(zha_device.get_diagnostics_json(), cls=ZhaJsonEncoder)
+    )
+    assert first == second
 
 
 async def test_cluster_handler_only_clusters_are_bound(zha_gateway: Gateway) -> None:

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -753,6 +753,13 @@ async def test_devices_from_files(
         )
         assert loaded_device_data == device_data
 
+        # Calling get_diagnostics_json() a second time should produce the same
+        # result because the original_signature dict must not be mutated.
+        loaded_device_data_2 = json.loads(
+            json.dumps(zha_device.get_diagnostics_json(), cls=ZhaJsonEncoder)
+        )
+        assert loaded_device_data_2 == loaded_device_data
+
         # Assert identify called on join for devices that support it
         cluster_identify = _get_identify_cluster(zha_device.device)
         if cluster_identify and not zha_device.skip_configuration:

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import asyncio
 from collections import defaultdict
 from collections.abc import Callable, Iterable
+import copy
 import dataclasses
 from dataclasses import dataclass
 from enum import Enum
@@ -1515,7 +1516,7 @@ class Device(LogMixin, EventBase):
                 ],
             }
 
-        original_signature = self.device.original_signature
+        original_signature = copy.deepcopy(self.device.original_signature)
 
         # if we have a quirked device we add the original signature to the output and
         # convert the profile_id, device_type, input_clusters and output_clusters to hex


### PR DESCRIPTION
## Proposed change

This PR makes a `deepcopy` of the device's `original_signature` before modifying the it for a friendlier version in the JSON.
Otherwise, we modify the original `device.original_signature` and fail with the error below when trying to download diagnostics for the same device a second time.

This fixes the following error when downloading diagnostics:
```python
ep["profile_id"] = f"0x{ep['profile_id']:04x}"                                                                                                                                                                                                                                            
                           ^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                                                                             
ValueError: Unknown format code 'x' for object of type 'str'
```

## Additional information

We can also test the diagnostics stay the same for every device, but that seems a bit overkill: [`6d3c660` (this PR)](https://github.com/zigpy/zha/pull/661/commits/6d3c6602f647df6f2ab5fd7615eda113112694b7)
Now, the PR only tests it for one device (which has an `original_signature`). The test is in `test_discover.py`, which isn't great, but just creating `test_diagnostics.py` for this seems a bit overkill? But I can do that, of course.
It's under the existing diagnostics usage in `test_discover.py` for now.