### PR TITLE
Migrate all platforms to abstract base classes

### DIFF
--- a/zha/application/platforms/alarm_control_panel/__init__.py
+++ b/zha/application/platforms/alarm_control_panel/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 import functools
 import logging
@@ -53,12 +54,74 @@ class AlarmControlPanelEntityInfo(BaseEntityInfo):
     translation_key: str
 
 
+class BaseAlarmControlPanel(PlatformEntity, ABC):
+    """Abstract base class for ZHA alarm control panel entities."""
+
+    PLATFORM = Platform.ALARM_CONTROL_PANEL
+
+    @property
+    def state(self) -> dict[str, Any]:
+        """Get the state of the alarm control panel."""
+        response = super().state
+        response["state"] = self.alarm_state
+        return response
+
+    @property
+    @abstractmethod
+    def alarm_state(self) -> AlarmState:
+        """Return the current alarm state."""
+
+    @property
+    @abstractmethod
+    def code_arm_required(self) -> bool:
+        """Whether the code is required for arm actions."""
+
+    @property
+    @abstractmethod
+    def code_format(self) -> CodeFormat:
+        """Code format or None if no code is required."""
+
+    @property
+    @abstractmethod
+    def supported_features(self) -> int:
+        """Return the list of supported features."""
+
+    @functools.cached_property
+    def info_object(self) -> AlarmControlPanelEntityInfo:
+        """Return a representation of the alarm control panel."""
+        return AlarmControlPanelEntityInfo(
+            **super().info_object.__dict__,
+            code_arm_required=self.code_arm_required,
+            code_format=self.code_format,
+            supported_features=self.supported_features,
+        )
+
+    @abstractmethod
+    async def async_alarm_disarm(self, code: str | None = None) -> None:
+        """Send disarm command."""
+
+    @abstractmethod
+    async def async_alarm_arm_home(self, code: str | None = None) -> None:
+        """Send arm home command."""
+
+    @abstractmethod
+    async def async_alarm_arm_away(self, code: str | None = None) -> None:
+        """Send arm away command."""
+
+    @abstractmethod
+    async def async_alarm_arm_night(self, code: str | None = None) -> None:
+        """Send arm night command."""
+
+    @abstractmethod
+    async def async_alarm_trigger(self, code: str | None = None) -> None:
+        """Send alarm trigger command."""
+
+
 @register_entity(IasAce.cluster_id)
-class AlarmControlPanel(PlatformEntity):
+class AlarmControlPanel(BaseAlarmControlPanel):
     """Entity for ZHA alarm control devices."""
 
     _attr_translation_key: str = "alarm_control_panel"
-    PLATFORM = Platform.ALARM_CONTROL_PANEL
 
     _cluster_handler_match = ClusterHandlerMatch(
         client_cluster_handlers=frozenset({CLUSTER_HANDLER_IAS_ACE}),
@@ -107,24 +170,12 @@ class AlarmControlPanel(PlatformEntity):
             )
         )
 
-    @functools.cached_property
-    def info_object(self) -> AlarmControlPanelEntityInfo:
-        """Return a representation of the alarm control panel."""
-        return AlarmControlPanelEntityInfo(
-            **super().info_object.__dict__,
-            code_arm_required=self.code_arm_required,
-            code_format=self.code_format,
-            supported_features=self.supported_features,
-        )
-
     @property
-    def state(self) -> dict[str, Any]:
-        """Get the state of the alarm control panel."""
-        response = super().state
-        response["state"] = IAS_ACE_STATE_MAP.get(
+    def alarm_state(self) -> AlarmState:
+        """Return the current alarm state."""
+        return IAS_ACE_STATE_MAP.get(
             self._cluster_handler.armed_state, AlarmState.UNKNOWN
         )
-        return response
 
     @property
     def code_arm_required(self) -> bool:

--- a/zha/application/platforms/alarm_control_panel/__init__.py
+++ b/zha/application/platforms/alarm_control_panel/__init__.py
@@ -76,15 +76,18 @@ class BaseAlarmControlPanel(PlatformEntity, ABC):
     def code_arm_required(self) -> bool:
         """Whether the code is required for arm actions."""
 
-    @property
-    @abstractmethod
-    def code_format(self) -> CodeFormat:
-        """Code format or None if no code is required."""
+    _attr_code_format: CodeFormat
+    _attr_supported_features: int
 
     @property
-    @abstractmethod
+    def code_format(self) -> CodeFormat:
+        """Code format or None if no code is required."""
+        return self._attr_code_format
+
+    @property
     def supported_features(self) -> int:
         """Return the list of supported features."""
+        return self._attr_supported_features
 
     @functools.cached_property
     def info_object(self) -> AlarmControlPanelEntityInfo:
@@ -122,6 +125,13 @@ class AlarmControlPanel(BaseAlarmControlPanel):
     """Entity for ZHA alarm control devices."""
 
     _attr_translation_key: str = "alarm_control_panel"
+    _attr_code_format = CodeFormat.NUMBER
+    _attr_supported_features = (
+        SUPPORT_ALARM_ARM_HOME
+        | SUPPORT_ALARM_ARM_AWAY
+        | SUPPORT_ALARM_ARM_NIGHT
+        | SUPPORT_ALARM_TRIGGER
+    )
 
     _cluster_handler_match = ClusterHandlerMatch(
         client_cluster_handlers=frozenset({CLUSTER_HANDLER_IAS_ACE}),
@@ -181,21 +191,6 @@ class AlarmControlPanel(BaseAlarmControlPanel):
     def code_arm_required(self) -> bool:
         """Whether the code is required for arm actions."""
         return self._cluster_handler.code_required_arm_actions
-
-    @functools.cached_property
-    def code_format(self) -> CodeFormat:
-        """Code format or None if no code is required."""
-        return CodeFormat.NUMBER
-
-    @functools.cached_property
-    def supported_features(self) -> int:
-        """Return the list of supported features."""
-        return (
-            SUPPORT_ALARM_ARM_HOME
-            | SUPPORT_ALARM_ARM_AWAY
-            | SUPPORT_ALARM_ARM_NIGHT
-            | SUPPORT_ALARM_TRIGGER
-        )
 
     def handle_cluster_handler_state_changed(
         self,

--- a/zha/application/platforms/binary_sensor/__init__.py
+++ b/zha/application/platforms/binary_sensor/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass
 import functools
@@ -62,13 +63,30 @@ class BinarySensorEntityInfo(BaseEntityInfo):
     device_class: BinarySensorDeviceClass | None
 
 
-class BinarySensor(PlatformEntity):
+class BaseBinarySensor(PlatformEntity, ABC):
+    """Abstract base class for ZHA binary sensors."""
+
+    PLATFORM: Platform = Platform.BINARY_SENSOR
+
+    @property
+    def state(self) -> dict:
+        """Return the state of the binary sensor."""
+        response = super().state
+        response["state"] = self.is_on
+        return response
+
+    @property
+    @abstractmethod
+    def is_on(self) -> bool:
+        """Return True if the binary sensor is on."""
+
+
+class BinarySensor(BaseBinarySensor):
     """ZHA BinarySensor."""
 
     _attr_device_class: BinarySensorDeviceClass | None
     _attribute_name: str
     _attribute_converter: Callable[[Any], Any] | None = None
-    PLATFORM: Platform = Platform.BINARY_SENSOR
 
     def __init__(
         self,
@@ -114,13 +132,6 @@ class BinarySensor(PlatformEntity):
             **super().info_object.__dict__,
             attribute_name=self._attribute_name,
         )
-
-    @property
-    def state(self) -> dict:
-        """Return the state of the binary sensor."""
-        response = super().state
-        response["state"] = self.is_on
-        return response
 
     @property
     def is_on(self) -> bool:

--- a/zha/application/platforms/button/__init__.py
+++ b/zha/application/platforms/button/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 import functools
 import logging
@@ -36,7 +37,12 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, kw_only=True)
-class CommandButtonEntityInfo(BaseEntityInfo):
+class ButtonEntityInfo(BaseEntityInfo):
+    """Button entity info."""
+
+
+@dataclass(frozen=True, kw_only=True)
+class CommandButtonEntityInfo(ButtonEntityInfo):
     """Command button entity info."""
 
     command: str
@@ -45,17 +51,30 @@ class CommandButtonEntityInfo(BaseEntityInfo):
 
 
 @dataclass(frozen=True, kw_only=True)
-class WriteAttributeButtonEntityInfo(BaseEntityInfo):
+class WriteAttributeButtonEntityInfo(ButtonEntityInfo):
     """Write attribute button entity info."""
 
     attribute_name: str
     attribute_value: Any
 
 
-class Button(PlatformEntity):
-    """Defines a ZHA button."""
+class BaseButton(PlatformEntity, ABC):
+    """Base representation of a ZHA button."""
 
     PLATFORM = Platform.BUTTON
+
+    @functools.cached_property
+    def info_object(self) -> ButtonEntityInfo:
+        """Return a representation of the button."""
+        return ButtonEntityInfo(**super().info_object.__dict__)
+
+    @abstractmethod
+    async def async_press(self) -> None:
+        """Send out a press command."""
+
+
+class Button(BaseButton):
+    """Defines a ZHA button."""
 
     _command_name: str
     _args: list[Any]
@@ -131,10 +150,8 @@ class IdentifyButton(Button):
         return not any(type(entity) is cls for entity in entities)
 
 
-class WriteAttributeButton(PlatformEntity):
+class WriteAttributeButton(BaseButton):
     """Defines a ZHA button, which writes a value to an attribute."""
-
-    PLATFORM = Platform.BUTTON
 
     _attribute_name: str
     _attribute_value: Any = None

--- a/zha/application/platforms/climate/__init__.py
+++ b/zha/application/platforms/climate/__init__.py
@@ -25,16 +25,12 @@ from zha.application.platforms import (
     register_entity,
 )
 from zha.application.platforms.climate.const import (
-    ATTR_HVAC_MODE,
     ATTR_OCCP_COOL_SETPT,
     ATTR_OCCP_HEAT_SETPT,
     ATTR_OCCUPANCY,
     ATTR_PI_COOLING_DEMAND,
     ATTR_PI_HEATING_DEMAND,
     ATTR_SYS_MODE,
-    ATTR_TARGET_TEMP_HIGH,
-    ATTR_TARGET_TEMP_LOW,
-    ATTR_TEMPERATURE,
     ATTR_UNOCCP_COOL_SETPT,
     ATTR_UNOCCP_HEAT_SETPT,
     FAN_AUTO,
@@ -470,45 +466,46 @@ class Thermostat(PlatformEntity):
         self._preset = preset_mode
         self.maybe_emit_state_changed_event()
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_temperature(
+        self,
+        target_temp_low: float | None = None,
+        target_temp_high: float | None = None,
+        temperature: float | None = None,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        low_temp = kwargs.get(ATTR_TARGET_TEMP_LOW)
-        high_temp = kwargs.get(ATTR_TARGET_TEMP_HIGH)
-        temp = kwargs.get(ATTR_TEMPERATURE)
-        hvac_mode = kwargs.get(ATTR_HVAC_MODE)
-
         if hvac_mode is not None:
             await self.async_set_hvac_mode(hvac_mode)
 
         is_away = self.preset_mode == Preset.AWAY
 
         if self.hvac_mode == HVACMode.HEAT_COOL:
-            if low_temp is not None:
+            if target_temp_low is not None:
                 await self._thermostat_cluster_handler.async_set_heating_setpoint(
-                    temperature=int(low_temp * ZCL_TEMP),
+                    temperature=int(target_temp_low * ZCL_TEMP),
                     is_away=is_away,
                 )
-            if high_temp is not None:
+            if target_temp_high is not None:
                 await self._thermostat_cluster_handler.async_set_cooling_setpoint(
-                    temperature=int(high_temp * ZCL_TEMP),
+                    temperature=int(target_temp_high * ZCL_TEMP),
                     is_away=is_away,
                 )
-        elif temp is not None:
+        elif temperature is not None:
             if self.hvac_mode == HVACMode.COOL:
                 await self._thermostat_cluster_handler.async_set_cooling_setpoint(
-                    temperature=int(temp * ZCL_TEMP),
+                    temperature=int(temperature * ZCL_TEMP),
                     is_away=is_away,
                 )
             elif self.hvac_mode == HVACMode.HEAT:
                 await self._thermostat_cluster_handler.async_set_heating_setpoint(
-                    temperature=int(temp * ZCL_TEMP),
+                    temperature=int(temperature * ZCL_TEMP),
                     is_away=is_away,
                 )
             else:
                 self.debug("Not setting temperature for '%s' mode", self.hvac_mode)
                 return
         else:
-            self.debug("incorrect %s setting for '%s' mode", kwargs, self.hvac_mode)
+            self.debug("incorrect temperature setting for '%s' mode", self.hvac_mode)
             return
 
         self.maybe_emit_state_changed_event()

--- a/zha/application/platforms/climate/__init__.py
+++ b/zha/application/platforms/climate/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from asyncio import Task
 from dataclasses import dataclass
 import datetime as dt
@@ -73,11 +74,128 @@ class ThermostatEntityInfo(BaseEntityInfo):
     hvac_modes: list[HVACMode]
 
 
-@register_entity(ThermostatCluster.cluster_id)
-class Thermostat(PlatformEntity):
-    """Representation of a ZHA Thermostat device."""
+class BaseThermostat(PlatformEntity, ABC):
+    """Abstract base class for climate entities."""
 
     PLATFORM = Platform.CLIMATE
+
+    @property
+    def state(self) -> dict[str, Any]:
+        """Get the state of the climate entity."""
+        response = super().state
+        response["current_temperature"] = self.current_temperature
+        response["outdoor_temperature"] = self.outdoor_temperature
+        response["target_temperature"] = self.target_temperature
+        response["target_temperature_high"] = self.target_temperature_high
+        response["target_temperature_low"] = self.target_temperature_low
+        response["hvac_action"] = self.hvac_action
+        response["hvac_mode"] = self.hvac_mode
+        response["preset_mode"] = self.preset_mode
+        response["fan_mode"] = self.fan_mode
+        return response
+
+    @property
+    @abstractmethod
+    def current_temperature(self) -> float | None:
+        """Return the current temperature."""
+
+    @property
+    @abstractmethod
+    def outdoor_temperature(self) -> float | None:
+        """Return the outdoor temperature."""
+
+    @property
+    @abstractmethod
+    def target_temperature(self) -> float | None:
+        """Return the temperature we try to reach."""
+
+    @property
+    @abstractmethod
+    def target_temperature_high(self) -> float | None:
+        """Return the upper bound temperature we try to reach."""
+
+    @property
+    @abstractmethod
+    def target_temperature_low(self) -> float | None:
+        """Return the lower bound temperature we try to reach."""
+
+    @property
+    @abstractmethod
+    def hvac_action(self) -> HVACAction | None:
+        """Return the current HVAC action."""
+
+    @property
+    @abstractmethod
+    def hvac_mode(self) -> HVACMode | None:
+        """Return HVAC operation mode."""
+
+    @property
+    @abstractmethod
+    def hvac_modes(self) -> list[HVACMode]:
+        """Return the list of available HVAC operation modes."""
+
+    @property
+    @abstractmethod
+    def preset_mode(self) -> str | None:
+        """Return current preset mode."""
+
+    @property
+    @abstractmethod
+    def preset_modes(self) -> list[str] | None:
+        """Return supported preset modes."""
+
+    @property
+    @abstractmethod
+    def fan_mode(self) -> str | None:
+        """Return current FAN mode."""
+
+    @property
+    @abstractmethod
+    def fan_modes(self) -> list[str] | None:
+        """Return supported FAN modes."""
+
+    @property
+    @abstractmethod
+    def max_temp(self) -> float:
+        """Return the maximum temperature."""
+
+    @property
+    @abstractmethod
+    def min_temp(self) -> float:
+        """Return the minimum temperature."""
+
+    @property
+    @abstractmethod
+    def supported_features(self) -> ClimateEntityFeature:
+        """Return the list of supported features."""
+
+    @abstractmethod
+    async def async_set_fan_mode(self, fan_mode: str) -> None:
+        """Set fan mode."""
+
+    @abstractmethod
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Set new target operation mode."""
+
+    @abstractmethod
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set new preset mode."""
+
+    @abstractmethod
+    async def async_set_temperature(
+        self,
+        target_temp_low: float | None = None,
+        target_temp_high: float | None = None,
+        temperature: float | None = None,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
+        """Set new target temperature."""
+
+
+@register_entity(ThermostatCluster.cluster_id)
+class Thermostat(BaseThermostat):
+    """Representation of a ZHA Thermostat device."""
+
     DEFAULT_MAX_TEMP = 35
     DEFAULT_MIN_TEMP = 7
 
@@ -182,15 +300,6 @@ class Thermostat(PlatformEntity):
         system_mode = SYSTEM_MODE_2_HVAC.get(thermostat.system_mode, "unknown")
 
         response = super().state
-        response["current_temperature"] = self.current_temperature
-        response["outdoor_temperature"] = self.outdoor_temperature
-        response["target_temperature"] = self.target_temperature
-        response["target_temperature_high"] = self.target_temperature_high
-        response["target_temperature_low"] = self.target_temperature_low
-        response["hvac_action"] = self.hvac_action
-        response["hvac_mode"] = self.hvac_mode
-        response["preset_mode"] = self.preset_mode
-        response["fan_mode"] = self.fan_mode
 
         response[ATTR_SYS_MODE] = (
             f"[{thermostat.system_mode}]/{system_mode}"

--- a/zha/application/platforms/cover/__init__.py
+++ b/zha/application/platforms/cover/__init__.py
@@ -24,8 +24,6 @@ from zha.application.platforms import (
 from zha.application.platforms.cover.const import (
     ATTR_CURRENT_POSITION,
     ATTR_CURRENT_TILT_POSITION,
-    ATTR_POSITION,
-    ATTR_TILT_POSITION,
     POSITION_CLOSED,
     POSITION_OPEN,
     WCT,
@@ -111,19 +109,19 @@ class BaseCover(PlatformEntity, ABC):
         """
 
     @abstractmethod
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
 
     @abstractmethod
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
 
     @abstractmethod
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
 
     @abstractmethod
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
 
 
@@ -578,7 +576,7 @@ class Cover(BaseCover):
         self._tilt_state = None
         self.maybe_emit_state_changed_event()
 
-    async def async_open_cover(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         self._set_lift_transition_target(POSITION_OPEN)
         res = await self._cover_cluster_handler.up_open()
@@ -590,7 +588,7 @@ class Cover(BaseCover):
             self.async_update_state(CoverState.OPENING)
         self._start_lift_transition()
 
-    async def async_open_cover_tilt(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_open_cover_tilt(self) -> None:
         """Open the cover tilt."""
         self._set_tilt_transition_target(POSITION_OPEN)
         res = await self._cover_cluster_handler.go_to_tilt_percentage(
@@ -604,7 +602,7 @@ class Cover(BaseCover):
             self.async_update_state(CoverState.OPENING)
         self._start_tilt_transition()
 
-    async def async_close_cover(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         self._set_lift_transition_target(POSITION_CLOSED)
         res = await self._cover_cluster_handler.down_close()
@@ -616,7 +614,7 @@ class Cover(BaseCover):
             self.async_update_state(CoverState.CLOSING)
         self._start_lift_transition()
 
-    async def async_close_cover_tilt(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_close_cover_tilt(self) -> None:
         """Close the cover tilt."""
         self._set_tilt_transition_target(POSITION_CLOSED)
         res = await self._cover_cluster_handler.go_to_tilt_percentage(
@@ -630,11 +628,10 @@ class Cover(BaseCover):
             self.async_update_state(CoverState.CLOSING)
         self._start_tilt_transition()
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
         assert self.current_cover_position is not None
-        target_position = kwargs[ATTR_POSITION]
-        assert target_position is not None
+        target_position = position
 
         self._set_lift_transition_target(target_position)
         res = await self._cover_cluster_handler.go_to_lift_percentage(
@@ -652,11 +649,10 @@ class Cover(BaseCover):
             )
         self._start_lift_transition()
 
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, tilt_position: int) -> None:
         """Move the cover tilt to a specific position."""
         assert self.current_cover_tilt_position is not None
-        target_position = kwargs[ATTR_TILT_POSITION]
-        assert target_position is not None
+        target_position = tilt_position
 
         self._set_tilt_transition_target(target_position)
         res = await self._cover_cluster_handler.go_to_tilt_percentage(
@@ -674,7 +670,7 @@ class Cover(BaseCover):
             )
         self._start_tilt_transition()
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_stop_cover(self) -> None:
         """Stop the cover.
 
         Upon receipt of this command the cover stops both lift and tilt movement.
@@ -686,12 +682,12 @@ class Cover(BaseCover):
         self._clear_tilt_transition()
         self._determine_cover_state(refresh=True)
 
-    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_stop_cover_tilt(self) -> None:
         """Stop the cover tilt.
 
         This is handled by async_stop_cover because there is no tilt specific command for Zigbee covers.
         """
-        await self.async_stop_cover(**kwargs)
+        await self.async_stop_cover()
 
     @staticmethod
     def _ha_position_to_zcl(position: int) -> int:
@@ -845,7 +841,7 @@ class Shade(BaseCover):
         self._position = self._zcl_level_to_ha_position(event.level)
         self.maybe_emit_state_changed_event()
 
-    async def async_open_cover(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_open_cover(self) -> None:
         """Open the window cover."""
         res = await self._on_off_cluster_handler.on()
         if res[1] != Status.SUCCESS:
@@ -854,7 +850,7 @@ class Shade(BaseCover):
         self._is_open = True
         self.maybe_emit_state_changed_event()
 
-    async def async_close_cover(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_close_cover(self) -> None:
         """Close the window cover."""
         res = await self._on_off_cluster_handler.off()
         if res[1] != Status.SUCCESS:
@@ -863,12 +859,12 @@ class Shade(BaseCover):
         self._is_open = False
         self.maybe_emit_state_changed_event()
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the roller shutter to a specific position."""
         if not self._level_cluster_handler:
             return
 
-        new_pos = kwargs[ATTR_POSITION]
+        new_pos = position
         res = await self._level_cluster_handler.move_to_level_with_on_off(
             self._ha_position_to_zcl_level(new_pos), 1
         )
@@ -879,7 +875,7 @@ class Shade(BaseCover):
         self._position = new_pos
         self.maybe_emit_state_changed_event()
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         if not self._level_cluster_handler:
             return
@@ -915,7 +911,7 @@ class KeenVent(Shade):
         feature_priority=(PlatformFeatureGroup.LIGHT_OR_SWITCH_OR_SHADE, 1),
     )
 
-    async def async_open_cover(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         assert self._level_cluster_handler is not None
 

--- a/zha/application/platforms/cover/__init__.py
+++ b/zha/application/platforms/cover/__init__.py
@@ -71,11 +71,12 @@ class BaseCover(PlatformEntity, ABC):
     PLATFORM = Platform.COVER
 
     _attr_primary_weight = 10
+    _attr_supported_features: CoverEntityFeature
 
     @property
-    @abstractmethod
     def supported_features(self) -> CoverEntityFeature:
         """Return supported features."""
+        return self._attr_supported_features
 
     @property
     @abstractmethod
@@ -265,11 +266,6 @@ class Cover(BaseCover):
                 functools.partial(self._determine_cover_state, refresh=True),
             )
         )
-
-    @property
-    def supported_features(self) -> CoverEntityFeature:
-        """Return supported features."""
-        return self._attr_supported_features
 
     @property
     def state(self) -> dict[str, Any]:
@@ -794,11 +790,6 @@ class Shade(BaseCover):
             }
         )
         return response
-
-    @functools.cached_property
-    def supported_features(self) -> CoverEntityFeature:
-        """Return supported features."""
-        return self._attr_supported_features
 
     @property
     def current_cover_position(self) -> int | None:

--- a/zha/application/platforms/device_tracker.py
+++ b/zha/application/platforms/device_tracker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from enum import StrEnum
 import functools
 import time
@@ -45,11 +46,42 @@ class SourceType(StrEnum):
     BLUETOOTH_LE = "bluetooth_le"
 
 
-@register_entity(PowerConfiguration.cluster_id)
-class DeviceScannerEntity(PlatformEntity):
-    """Represent a tracked device."""
+class BaseDeviceTracker(PlatformEntity, ABC):
+    """Abstract base class for ZHA device tracker entities."""
 
     PLATFORM = Platform.DEVICE_TRACKER
+
+    @property
+    def state(self) -> dict[str, Any]:
+        """Return the state of the device."""
+        response = super().state
+        response.update(
+            {
+                "connected": self.is_connected,
+                "battery_level": self.battery_level,
+            }
+        )
+        return response
+
+    @property
+    @abstractmethod
+    def is_connected(self) -> bool:
+        """Return true if the device is connected to the network."""
+
+    @property
+    @abstractmethod
+    def battery_level(self) -> float | None:
+        """Return the battery level of the device."""
+
+    @property
+    @abstractmethod
+    def source_type(self) -> SourceType:
+        """Return the source type, eg gps or router, of the device."""
+
+
+@register_entity(PowerConfiguration.cluster_id)
+class DeviceScannerEntity(BaseDeviceTracker):
+    """Represent a tracked device."""
 
     _attr_should_poll = True  # BaseZhaEntity defaults to False
     _attr_fallback_name: str = "Device scanner"
@@ -108,18 +140,6 @@ class DeviceScannerEntity(PlatformEntity):
             "started polling with refresh interval of %s",
             getattr(self, "__polling_interval"),
         )
-
-    @property
-    def state(self) -> dict[str, Any]:
-        """Return the state of the device."""
-        response = super().state
-        response.update(
-            {
-                "connected": self._connected,
-                "battery_level": self._battery_level,
-            }
-        )
-        return response
 
     @property
     def is_connected(self):

--- a/zha/application/platforms/fan/__init__.py
+++ b/zha/application/platforms/fan/__init__.py
@@ -183,12 +183,11 @@ class BaseFan(BaseEntity, ABC):
         )
         return response
 
-    async def async_turn_on(  # pylint: disable=unused-argument
+    async def async_turn_on(
         self,
         speed: str | None = None,
         percentage: int | None = None,
         preset_mode: str | None = None,
-        **kwargs: Any,
     ) -> None:
         """Turn the entity on."""
         if preset_mode is not None:
@@ -201,7 +200,7 @@ class BaseFan(BaseEntity, ABC):
             percentage = self.default_on_percentage
             await self.async_set_percentage(percentage)
 
-    async def async_turn_off(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_turn_off(self) -> None:
         """Turn the entity off."""
         await self.async_set_percentage(0)
 
@@ -443,7 +442,6 @@ class IkeaFan(BaseFan, PlatformEntity):
         speed: str | None = None,
         percentage: int | None = None,
         preset_mode: str | None = None,
-        **kwargs: Any,
     ) -> None:
         """Turn the entity on."""
         # Starkvind turns on in auto mode by default.

--- a/zha/application/platforms/fan/__init__.py
+++ b/zha/application/platforms/fan/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 import functools
 import math
@@ -73,7 +73,7 @@ class FanEntityInfo(BaseEntityInfo):
     speed_list: list[str]
 
 
-class BaseFan(BaseEntity):
+class BaseFan(BaseEntity, ABC):
     """Base representation of a ZHA fan."""
 
     PLATFORM = Platform.FAN

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from abc import ABC
+from abc import ABC, abstractmethod
 import asyncio
 from collections import Counter
 import contextlib
@@ -216,6 +216,7 @@ class BaseLight(BaseEntity, ABC):
         """Return the warmest color_temp that this light supports."""
         return self._max_mireds
 
+    @abstractmethod
     async def async_turn_on(
         self,
         *,
@@ -227,11 +228,10 @@ class BaseLight(BaseEntity, ABC):
         xy_color: tuple[int, int] | None = None,
     ) -> None:
         """Turn the entity on."""
-        raise NotImplementedError
 
+    @abstractmethod
     async def async_turn_off(self, *, transition: float | None = None) -> None:
         """Turn the entity off."""
-        raise NotImplementedError
 
     def restore_external_state_attributes(
         self,
@@ -287,9 +287,9 @@ class BaseClusterHandlerLight(BaseLight):
         self._internal_supported_color_modes: set[ColorMode] = set()
 
     @property
+    @abstractmethod
     def _gateway(self) -> Gateway:
         """Return the gateway."""
-        raise NotImplementedError
 
     @property
     def state(self) -> dict[str, Any]:

--- a/zha/application/platforms/lock/__init__.py
+++ b/zha/application/platforms/lock/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 from zigpy.zcl.clusters.closures import DoorLock as DoorLockCluster
@@ -31,11 +32,36 @@ if TYPE_CHECKING:
     from zha.zigbee.endpoint import Endpoint
 
 
-@register_entity(DoorLockCluster.cluster_id)
-class DoorLock(PlatformEntity):
-    """Representation of a ZHA lock."""
+class BaseLock(PlatformEntity, ABC):
+    """Abstract base class for ZHA lock entities."""
 
     PLATFORM = Platform.LOCK
+
+    @property
+    def state(self) -> dict[str, Any]:
+        """Get the state of the lock."""
+        response = super().state
+        response["is_locked"] = self.is_locked
+        return response
+
+    @property
+    @abstractmethod
+    def is_locked(self) -> bool:
+        """Return true if entity is locked."""
+
+    @abstractmethod
+    async def async_lock(self) -> None:
+        """Lock the lock."""
+
+    @abstractmethod
+    async def async_unlock(self) -> None:
+        """Unlock the lock."""
+
+
+@register_entity(DoorLockCluster.cluster_id)
+class DoorLock(BaseLock):
+    """Representation of a ZHA lock."""
+
     _attr_translation_key: str = "door_lock"
     _attr_primary_weight = 5
 
@@ -68,13 +94,6 @@ class DoorLock(PlatformEntity):
                 self.handle_cluster_handler_attribute_updated,
             )
         )
-
-    @property
-    def state(self) -> dict[str, Any]:
-        """Get the state of the lock."""
-        response = super().state
-        response["is_locked"] = self.is_locked
-        return response
 
     @property
     def is_locked(self) -> bool:

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 import functools
 import logging
@@ -63,7 +64,7 @@ class NumberEntityInfo(BaseEntityInfo):
     native_unit_of_measurement: str | None
 
 
-class BaseNumber(PlatformEntity):
+class BaseNumber(PlatformEntity, ABC):
     """Representation of a ZHA Number entity."""
 
     PLATFORM = Platform.NUMBER
@@ -78,9 +79,9 @@ class BaseNumber(PlatformEntity):
     _attr_native_unit_of_measurement: str | None = None
 
     @property
+    @abstractmethod
     def native_value(self) -> float | None:
         """Return the current value."""
-        raise NotImplementedError
 
     @functools.cached_property
     def info_object(self) -> NumberEntityInfo:
@@ -126,9 +127,9 @@ class BaseNumber(PlatformEntity):
         """Return the mode of the entity."""
         return self._attr_mode
 
+    @abstractmethod
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value from HA."""
-        raise NotImplementedError
 
 
 @register_entity(AnalogOutput.cluster_id)

--- a/zha/application/platforms/select.py
+++ b/zha/application/platforms/select.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 import functools
@@ -63,10 +64,36 @@ class EnumSelectInfo(BaseEntityInfo):
     options: list[str]
 
 
-class EnumSelectEntity(PlatformEntity):
-    """Representation of a ZHA select entity."""
+class BaseSelectEntity(PlatformEntity, ABC):
+    """Abstract base class for ZHA select entities."""
 
     PLATFORM = Platform.SELECT
+
+    @property
+    def state(self) -> dict[str, Any]:
+        """Return the state of the select."""
+        response = super().state
+        response["state"] = self.current_option
+        return response
+
+    @property
+    @abstractmethod
+    def options(self) -> list[str]:
+        """Return the list of available options."""
+
+    @property
+    @abstractmethod
+    def current_option(self) -> str | None:
+        """Return the selected entity option to represent the entity state."""
+
+    @abstractmethod
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+
+
+class EnumSelectEntity(BaseSelectEntity):
+    """Representation of a ZHA select entity."""
+
     _attr_entity_category = EntityCategory.CONFIG
     _attribute_name: str
     _enum: type[Enum]
@@ -84,21 +111,19 @@ class EnumSelectEntity(PlatformEntity):
         self._attr_options = [entry.name.replace("_", " ") for entry in self._enum]
         super().__init__(cluster_handlers, endpoint, device, **kwargs)
 
+    @property
+    def options(self) -> list[str]:
+        """Return the list of available options."""
+        return self._attr_options
+
     @functools.cached_property
     def info_object(self) -> EnumSelectInfo:
         """Return a representation of the select."""
         return EnumSelectInfo(
             **super().info_object.__dict__,
             enum=self._enum.__name__,
-            options=self._attr_options,
+            options=self.options,
         )
-
-    @property
-    def state(self) -> dict:
-        """Return the state of the select."""
-        response = super().state
-        response["state"] = self.current_option
-        return response
 
     @property
     def current_option(self) -> str | None:
@@ -186,10 +211,9 @@ class DefaultStrobeSelectEntity(NonZCLSelectEntity):
     )
 
 
-class ZCLEnumSelectEntity(PlatformEntity):
+class ZCLEnumSelectEntity(BaseSelectEntity):
     """Representation of a ZHA ZCL enum select entity."""
 
-    PLATFORM = Platform.SELECT
     _attribute_name: str
     _attr_entity_category = EntityCategory.CONFIG
     _enum: type[Enum]
@@ -239,21 +263,19 @@ class ZCLEnumSelectEntity(PlatformEntity):
         self._attribute_name = entity_metadata.attribute_name
         self._enum = entity_metadata.enum
 
+    @property
+    def options(self) -> list[str]:
+        """Return the list of available options."""
+        return self._attr_options
+
     @functools.cached_property
     def info_object(self) -> EnumSelectInfo:
         """Return a representation of the select."""
         return EnumSelectInfo(
             **super().info_object.__dict__,
             enum=self._enum.__name__,
-            options=self._attr_options,
+            options=self.options,
         )
-
-    @property
-    def state(self) -> dict[str, Any]:
-        """Return the state of the select."""
-        response = super().state
-        response["state"] = self.current_option
-        return response
 
     @property
     def current_option(self) -> str | None:

--- a/zha/application/platforms/select.py
+++ b/zha/application/platforms/select.py
@@ -69,17 +69,19 @@ class BaseSelectEntity(PlatformEntity, ABC):
 
     PLATFORM = Platform.SELECT
 
+    _attr_options: list[str]
+
+    @property
+    def options(self) -> list[str]:
+        """Return the list of available options."""
+        return self._attr_options
+
     @property
     def state(self) -> dict[str, Any]:
         """Return the state of the select."""
         response = super().state
         response["state"] = self.current_option
         return response
-
-    @property
-    @abstractmethod
-    def options(self) -> list[str]:
-        """Return the list of available options."""
 
     @property
     @abstractmethod
@@ -110,11 +112,6 @@ class EnumSelectEntity(BaseSelectEntity):
         self._attribute_name = self._enum.__name__
         self._attr_options = [entry.name.replace("_", " ") for entry in self._enum]
         super().__init__(cluster_handlers, endpoint, device, **kwargs)
-
-    @property
-    def options(self) -> list[str]:
-        """Return the list of available options."""
-        return self._attr_options
 
     @functools.cached_property
     def info_object(self) -> EnumSelectInfo:
@@ -262,11 +259,6 @@ class ZCLEnumSelectEntity(BaseSelectEntity):
         super()._init_from_quirks_metadata(entity_metadata)
         self._attribute_name = entity_metadata.attribute_name
         self._enum = entity_metadata.enum
-
-    @property
-    def options(self) -> list[str]:
-        """Return the list of available options."""
-        return self._attr_options
 
     @functools.cached_property
     def info_object(self) -> EnumSelectInfo:

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from asyncio import Task
 import contextlib
 from dataclasses import dataclass
@@ -187,18 +188,55 @@ class DeviceCounterSensorIdentifiers(BaseIdentifiers):
     device_ieee: str
 
 
-class Sensor(PlatformEntity):
-    """Base ZHA sensor."""
+class BaseSensor(PlatformEntity, ABC):
+    """Abstract base class for ZHA sensor entities."""
 
     PLATFORM = Platform.SENSOR
-    _attribute_name: int | str | None = None
-    _attribute_converter: typing.Callable[[typing.Any], typing.Any] | None = None
-    _divisor: int | float | None = None
-    _multiplier: int | float | None = None
+
     _attr_suggested_display_precision: int | None = None
     _attr_native_unit_of_measurement: str | None = None
     _attr_device_class: SensorDeviceClass | None = None
     _attr_state_class: SensorStateClass | None = None
+
+    @property
+    def suggested_display_precision(self) -> int | None:
+        """Return the suggested display precision."""
+        return self._attr_suggested_display_precision
+
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        """Return the unit of measurement."""
+        return self._attr_native_unit_of_measurement
+
+    @functools.cached_property
+    def info_object(self) -> SensorEntityInfo:
+        """Return a representation of the sensor."""
+        return SensorEntityInfo(
+            **super().info_object.__dict__,
+            suggested_display_precision=self.suggested_display_precision,
+            unit=self.native_unit_of_measurement,
+        )
+
+    @property
+    def state(self) -> dict:
+        """Return the state for this sensor."""
+        response = super().state
+        response["state"] = self.native_value
+        return response
+
+    @property
+    @abstractmethod
+    def native_value(self) -> date | datetime | str | int | float | None:
+        """Return the current sensor value."""
+
+
+class Sensor(BaseSensor):
+    """Base ZHA sensor."""
+
+    _attribute_name: int | str | None = None
+    _attribute_converter: typing.Callable[[typing.Any], typing.Any] | None = None
+    _divisor: int | float | None = None
+    _multiplier: int | float | None = None
     _skip_creation_if_no_attr_cache: bool = False
 
     def __init__(
@@ -292,27 +330,6 @@ class Sensor(PlatformEntity):
             )
         if entity_metadata.unit is not None:
             self._attr_native_unit_of_measurement = entity_metadata.unit
-
-    @functools.cached_property
-    def info_object(self) -> SensorEntityInfo:
-        """Return a representation of the sensor."""
-        return SensorEntityInfo(
-            **super().info_object.__dict__,
-            suggested_display_precision=self._attr_suggested_display_precision,
-            unit=(
-                getattr(self, "entity_description").native_unit_of_measurement
-                if getattr(self, "entity_description", None) is not None
-                else self._attr_native_unit_of_measurement
-            ),
-        )
-
-    @property
-    def state(self) -> dict:
-        """Return the state for this sensor."""
-        response = super().state
-        native_value = self.native_value
-        response["state"] = native_value
-        return response
 
     @property
     def native_value(self) -> date | datetime | str | int | float | None:
@@ -1289,6 +1306,9 @@ class SmartEnergyMetering(PollableSensor):
             self.entity_description = entity_description
             self._attr_device_class = entity_description.device_class
             self._attr_state_class = entity_description.state_class
+            self._attr_native_unit_of_measurement = (
+                entity_description.native_unit_of_measurement
+            )
 
     @property
     def state(self) -> dict[str, Any]:

--- a/zha/application/platforms/siren.py
+++ b/zha/application/platforms/siren.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 import asyncio
 import contextlib
 from dataclasses import dataclass
@@ -66,11 +67,55 @@ class SirenEntityInfo(BaseEntityInfo):
     supported_features: SirenEntityFeature
 
 
-@register_entity(IasWd.cluster_id)
-class Siren(PlatformEntity):
-    """Representation of a ZHA siren."""
+class BaseSiren(PlatformEntity, ABC):
+    """Abstract base class for ZHA siren entities."""
 
     PLATFORM = Platform.SIREN
+
+    @property
+    def state(self) -> dict[str, Any]:
+        """Get the state of the siren."""
+        response = super().state
+        response["state"] = self.is_on
+        return response
+
+    @property
+    @abstractmethod
+    def is_on(self) -> bool:
+        """Return true if the entity is on."""
+
+    @property
+    @abstractmethod
+    def available_tones(self) -> dict[int, str]:
+        """Return available tones."""
+
+    @property
+    @abstractmethod
+    def supported_features(self) -> SirenEntityFeature:
+        """Return supported features."""
+
+    @functools.cached_property
+    def info_object(self) -> SirenEntityInfo:
+        """Return representation of the siren."""
+        return SirenEntityInfo(
+            **super().info_object.__dict__,
+            available_tones=self.available_tones,
+            supported_features=self.supported_features,
+        )
+
+    @abstractmethod
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on siren."""
+
+    @abstractmethod
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off siren."""
+
+
+@register_entity(IasWd.cluster_id)
+class Siren(BaseSiren):
+    """Representation of a ZHA siren."""
+
     _attr_fallback_name: str = "Siren"
     _attr_primary_weight = 4
 
@@ -123,21 +168,10 @@ class Siren(PlatformEntity):
         self._attr_is_on: bool = False
         self._off_listener: asyncio.TimerHandle | None = None
 
-    @functools.cached_property
-    def info_object(self) -> SirenEntityInfo:
-        """Return representation of the siren."""
-        return SirenEntityInfo(
-            **super().info_object.__dict__,
-            available_tones=self._attr_available_tones,
-            supported_features=self._attr_supported_features,
-        )
-
     @property
-    def state(self) -> dict[str, Any]:
-        """Get the state of the siren."""
-        response = super().state
-        response["state"] = self.is_on
-        return response
+    def available_tones(self) -> dict[int, str]:
+        """Return available tones."""
+        return self._attr_available_tones
 
     @property
     def supported_features(self) -> SirenEntityFeature:

--- a/zha/application/platforms/siren.py
+++ b/zha/application/platforms/siren.py
@@ -104,11 +104,16 @@ class BaseSiren(PlatformEntity, ABC):
         )
 
     @abstractmethod
-    async def async_turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(
+        self,
+        duration: int | None = None,
+        tone: int | None = None,
+        volume_level: int | None = None,
+    ) -> None:
         """Turn on siren."""
 
     @abstractmethod
-    async def async_turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self) -> None:
         """Turn off siren."""
 
 
@@ -183,7 +188,12 @@ class Siren(BaseSiren):
         """Return true if the entity is on."""
         return self._attr_is_on
 
-    async def async_turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(
+        self,
+        duration: int | None = None,
+        tone: int | None = None,
+        volume_level: int | None = None,
+    ) -> None:
         """Turn on siren."""
         if self._off_listener:
             self._off_listener.cancel()
@@ -215,12 +225,12 @@ class Siren(BaseSiren):
             if strobe_level_cache is not None
             else WARNING_DEVICE_STROBE_HIGH
         )
-        if (duration := kwargs.get(ATTR_DURATION)) is not None:
+        if duration is not None:
             siren_duration = duration
-        if (tone := kwargs.get(ATTR_TONE)) is not None:
+        if tone is not None:
             siren_tone = tone
-        if (level := kwargs.get(ATTR_VOLUME_LEVEL)) is not None:
-            siren_level = int(level)
+        if volume_level is not None:
+            siren_level = int(volume_level)
         await self._cluster_handler.issue_start_warning(
             mode=siren_tone,
             warning_duration=siren_duration,
@@ -236,7 +246,7 @@ class Siren(BaseSiren):
         self._tracked_handles.append(self._off_listener)
         self.maybe_emit_state_changed_event()
 
-    async def async_turn_off(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_turn_off(self) -> None:
         """Turn off siren."""
         await self._cluster_handler.issue_start_warning(
             mode=WARNING_DEVICE_MODE_STOP, strobe=WARNING_DEVICE_STROBE_NO

--- a/zha/application/platforms/siren.py
+++ b/zha/application/platforms/siren.py
@@ -72,6 +72,10 @@ class BaseSiren(PlatformEntity, ABC):
 
     PLATFORM = Platform.SIREN
 
+    _attr_is_on: bool = False
+    _attr_available_tones: dict[int, str]
+    _attr_supported_features: SirenEntityFeature
+
     @property
     def state(self) -> dict[str, Any]:
         """Get the state of the siren."""
@@ -80,19 +84,19 @@ class BaseSiren(PlatformEntity, ABC):
         return response
 
     @property
-    @abstractmethod
     def is_on(self) -> bool:
         """Return true if the entity is on."""
+        return self._attr_is_on
 
     @property
-    @abstractmethod
     def available_tones(self) -> dict[int, str]:
         """Return available tones."""
+        return self._attr_available_tones
 
     @property
-    @abstractmethod
     def supported_features(self) -> SirenEntityFeature:
         """Return supported features."""
+        return self._attr_supported_features
 
     @functools.cached_property
     def info_object(self) -> SirenEntityInfo:
@@ -170,23 +174,7 @@ class Siren(BaseSiren):
             WARNING_DEVICE_MODE_FIRE_PANIC: "Fire Panic",
             WARNING_DEVICE_MODE_EMERGENCY_PANIC: "Emergency Panic",
         }
-        self._attr_is_on: bool = False
         self._off_listener: asyncio.TimerHandle | None = None
-
-    @property
-    def available_tones(self) -> dict[int, str]:
-        """Return available tones."""
-        return self._attr_available_tones
-
-    @property
-    def supported_features(self) -> SirenEntityFeature:
-        """Return supported features."""
-        return self._attr_supported_features
-
-    @property
-    def is_on(self) -> bool:
-        """Return true if the entity is on."""
-        return self._attr_is_on
 
     async def async_turn_on(
         self,

--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from abc import ABC
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 import functools
 import logging
@@ -73,16 +73,6 @@ class BaseSwitch(BaseEntity, ABC):
     """Common base class for zhawss switches."""
 
     PLATFORM = Platform.SWITCH
-    _attr_primary_weight = 10
-
-    def __init__(
-        self,
-        *args: Any,
-        **kwargs: Any,
-    ):
-        """Initialize the switch."""
-        self._on_off_cluster_handler: OnOffClusterHandler
-        super().__init__(*args, **kwargs)
 
     @property
     def state(self) -> dict[str, Any]:
@@ -92,22 +82,17 @@ class BaseSwitch(BaseEntity, ABC):
         return response
 
     @property
+    @abstractmethod
     def is_on(self) -> bool:
         """Return if the switch is on based on the statemachine."""
-        if self._on_off_cluster_handler.on_off is None:
-            return False
-        return self._on_off_cluster_handler.on_off
 
-    # TODO revert this once group entities use cluster handlers
-    async def async_turn_on(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    @abstractmethod
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
-        await self._on_off_cluster_handler.turn_on()
-        self.maybe_emit_state_changed_event()
 
-    async def async_turn_off(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    @abstractmethod
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
-        await self._on_off_cluster_handler.turn_off()
-        self.maybe_emit_state_changed_event()
 
 
 @register_entity(OnOff.cluster_id)
@@ -165,6 +150,23 @@ class Switch(PlatformEntity, BaseSwitch):
             OnOffClusterHandler, self.cluster_handlers[CLUSTER_HANDLER_ON_OFF]
         )
 
+    @property
+    def is_on(self) -> bool:
+        """Return if the switch is on based on the statemachine."""
+        if self._on_off_cluster_handler.on_off is None:
+            return False
+        return self._on_off_cluster_handler.on_off
+
+    async def async_turn_on(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+        """Turn the entity on."""
+        await self._on_off_cluster_handler.turn_on()
+        self.maybe_emit_state_changed_event()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+        """Turn the entity off."""
+        await self._on_off_cluster_handler.turn_off()
+        self.maybe_emit_state_changed_event()
+
     def on_add(self) -> None:
         """Run when entity is added."""
         super().on_add()
@@ -201,6 +203,7 @@ class Switch(PlatformEntity, BaseSwitch):
 class BinaryOutputSwitch(PlatformEntity, BaseSwitch):
     """BinaryOutputCluster switch."""
 
+    _attr_primary_weight = 10
     _cluster_handler_match = ClusterHandlerMatch(
         cluster_handlers=frozenset({CLUSTER_HANDLER_BINARY_OUTPUT})
     )
@@ -269,6 +272,8 @@ class BinaryOutputSwitch(PlatformEntity, BaseSwitch):
 @register_group_entity
 class SwitchGroup(GroupEntity, BaseSwitch):
     """Representation of a switch group."""
+
+    _attr_primary_weight = 10
 
     def __init__(self, group: Group):
         """Initialize a switch group."""

--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -87,11 +87,11 @@ class BaseSwitch(BaseEntity, ABC):
         """Return if the switch is on based on the statemachine."""
 
     @abstractmethod
-    async def async_turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self) -> None:
         """Turn the entity on."""
 
     @abstractmethod
-    async def async_turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self) -> None:
         """Turn the entity off."""
 
 
@@ -157,12 +157,12 @@ class Switch(PlatformEntity, BaseSwitch):
             return False
         return self._on_off_cluster_handler.on_off
 
-    async def async_turn_on(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_turn_on(self) -> None:
         """Turn the entity on."""
         await self._on_off_cluster_handler.turn_on()
         self.maybe_emit_state_changed_event()
 
-    async def async_turn_off(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_turn_off(self) -> None:
         """Turn the entity off."""
         await self._on_off_cluster_handler.turn_off()
         self.maybe_emit_state_changed_event()
@@ -250,12 +250,12 @@ class BinaryOutputSwitch(PlatformEntity, BaseSwitch):
             return False
         return bool(self._binary_output_cluster_handler.present_value)
 
-    async def async_turn_on(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_turn_on(self) -> None:
         """Turn the entity on."""
         await self._binary_output_cluster_handler.async_set_present_value(True)
         self.maybe_emit_state_changed_event()
 
-    async def async_turn_off(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_turn_off(self) -> None:
         """Turn the entity off."""
         await self._binary_output_cluster_handler.async_set_present_value(False)
         self.maybe_emit_state_changed_event()
@@ -289,7 +289,7 @@ class SwitchGroup(GroupEntity, BaseSwitch):
         """Return if the switch is on based on the statemachine."""
         return bool(self._state)
 
-    async def async_turn_on(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_turn_on(self) -> None:
         """Turn the entity on."""
         result = await self._on_off_cluster_handler.on()
         if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
@@ -297,7 +297,7 @@ class SwitchGroup(GroupEntity, BaseSwitch):
         self._state = True
         self.maybe_emit_state_changed_event()
 
-    async def async_turn_off(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_turn_off(self) -> None:
         """Turn the entity off."""
         result = await self._on_off_cluster_handler.off()
         if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
@@ -461,11 +461,11 @@ class ConfigurableAttributeSwitch(PlatformEntity):
             )
         self.maybe_emit_state_changed_event()
 
-    async def async_turn_on(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_turn_on(self) -> None:
         """Turn the entity on."""
         await self.async_turn_on_off(True)
 
-    async def async_turn_off(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_turn_off(self) -> None:
         """Turn the entity off."""
         await self.async_turn_on_off(False)
 
@@ -919,11 +919,11 @@ class WindowCoveringInversionSwitch(ConfigurableAttributeSwitch):
         )
         return ConfigStatus.Open_up_commands_reversed in config_status
 
-    async def async_turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self) -> None:
         """Turn the entity on."""
         await self._async_on_off(True)
 
-    async def async_turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self) -> None:
         """Turn the entity off."""
         await self._async_on_off(False)
 

--- a/zha/application/platforms/update.py
+++ b/zha/application/platforms/update.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from abc import ABC
 from dataclasses import dataclass
 from enum import IntFlag, StrEnum
 import functools
@@ -70,8 +71,8 @@ class UpdateEntityInfo(BaseEntityInfo):
     device_class: UpdateDeviceClass
 
 
-class BaseFirmwareUpdateEntity(PlatformEntity):
-    """Base representation of a ZHA firmware update entity."""
+class BaseFirmwareUpdateEntity(PlatformEntity, ABC):
+    """Abstract base class for ZHA firmware update entities."""
 
     PLATFORM = Platform.UPDATE
 
@@ -99,7 +100,7 @@ class BaseFirmwareUpdateEntity(PlatformEntity):
         )
 
     @property
-    def state(self):
+    def state(self) -> dict[str, Any]:
         """Get the state for the entity."""
         response = super().state
         if (release_summary := self.release_summary) is not None:


### PR DESCRIPTION
We've already migrated the larger platforms, this migrates the rest. I've also removed `**kwargs` from the `async_` method calls for stronger typing.

This is just a code quality improvement and should have no external effects.