### PR TITLE
[RFC] Merge `state` with `info_object`

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -313,51 +313,51 @@ async def group_entity_availability_test(
 ):
     """Test group entity availability handling."""
 
-    assert entity.state["available"] is True
+    assert entity.state.available is True
 
     device_1.on_network = False
     await asyncio.sleep(0.1)
     await zha_gateway.async_block_till_done()
-    assert entity.state["available"] is True
+    assert entity.state.available is True
 
     device_2.on_network = False
     await asyncio.sleep(0.1)
     await zha_gateway.async_block_till_done()
 
-    assert entity.state["available"] is False
+    assert entity.state.available is False
 
     device_1.on_network = True
     await asyncio.sleep(0.1)
     await zha_gateway.async_block_till_done()
-    assert entity.state["available"] is True
+    assert entity.state.available is True
 
     device_2.on_network = True
     await asyncio.sleep(0.1)
     await zha_gateway.async_block_till_done()
 
-    assert entity.state["available"] is True
+    assert entity.state.available is True
 
     device_1.available = False
     await asyncio.sleep(0.1)
     await zha_gateway.async_block_till_done()
-    assert entity.state["available"] is True
+    assert entity.state.available is True
 
     device_2.available = False
     await asyncio.sleep(0.1)
     await zha_gateway.async_block_till_done()
 
-    assert entity.state["available"] is False
+    assert entity.state.available is False
 
     device_1.available = True
     await asyncio.sleep(0.1)
     await zha_gateway.async_block_till_done()
-    assert entity.state["available"] is True
+    assert entity.state.available is True
 
     device_2.available = True
     await asyncio.sleep(0.1)
     await zha_gateway.async_block_till_done()
 
-    assert entity.state["available"] is True
+    assert entity.state.available is True
 
 
 def zigpy_device_from_device_data(

--- a/tests/common.py
+++ b/tests/common.py
@@ -256,7 +256,7 @@ def get_group_entity(
         if not isinstance(entity, entity_type):
             continue
 
-        if qualifier is not None and qualifier not in entity.info_object.unique_id:
+        if qualifier is not None and qualifier not in entity.state.unique_id:
             continue
 
         return entity
@@ -287,7 +287,7 @@ def get_entity(
         if exact_entity_type is not None and type(entity) is not exact_entity_type:
             continue
 
-        if qualifier is not None and qualifier not in entity.info_object.unique_id:
+        if qualifier is not None and qualifier not in entity.state.unique_id:
             continue
 
         if not qualifier_func(entity):

--- a/tests/test_alarm_control_panel.py
+++ b/tests/test_alarm_control_panel.py
@@ -45,7 +45,7 @@ async def test_alarm_control_panel(
     assert isinstance(alarm_entity, AlarmControlPanel)
 
     # test that the state is STATE_ALARM_DISARMED
-    assert alarm_entity.state["state"] == AlarmState.DISARMED
+    assert alarm_entity.state.state == AlarmState.DISARMED
 
     # arm_away
     cluster.client_command.reset_mock()
@@ -60,7 +60,7 @@ async def test_alarm_control_panel(
         security.IasAce.AudibleNotification.Default_Sound,
         security.IasAce.AlarmStatus.No_Alarm,
     )
-    assert alarm_entity.state["state"] == AlarmState.ARMED_AWAY
+    assert alarm_entity.state.state == AlarmState.ARMED_AWAY  # type: ignore[comparison-overlap]
 
     # disarm
     await reset_alarm_panel(zha_gateway, cluster, alarm_entity)
@@ -69,7 +69,7 @@ async def test_alarm_control_panel(
     cluster.client_command.reset_mock()
     await alarm_entity.async_alarm_arm_away("4321")
     await zha_gateway.async_block_till_done()
-    assert alarm_entity.state["state"] == AlarmState.ARMED_AWAY
+    assert alarm_entity.state.state == AlarmState.ARMED_AWAY
     cluster.client_command.reset_mock()
 
     # now simulate a faulty code entry sequence
@@ -78,7 +78,7 @@ async def test_alarm_control_panel(
     await alarm_entity.async_alarm_disarm("0000")
     await zha_gateway.async_block_till_done()
 
-    assert alarm_entity.state["state"] == AlarmState.TRIGGERED
+    assert alarm_entity.state.state == AlarmState.TRIGGERED
     assert cluster.client_command.call_count == 6
     assert cluster.client_command.await_count == 6
     assert cluster.client_command.call_args == call(
@@ -95,7 +95,7 @@ async def test_alarm_control_panel(
     # arm_home
     await alarm_entity.async_alarm_arm_home("4321")
     await zha_gateway.async_block_till_done()
-    assert alarm_entity.state["state"] == AlarmState.ARMED_HOME
+    assert alarm_entity.state.state == AlarmState.ARMED_HOME
     assert cluster.client_command.call_count == 2
     assert cluster.client_command.await_count == 2
     assert cluster.client_command.call_args == call(
@@ -112,7 +112,7 @@ async def test_alarm_control_panel(
     # arm_night
     await alarm_entity.async_alarm_arm_night("4321")
     await zha_gateway.async_block_till_done()
-    assert alarm_entity.state["state"] == AlarmState.ARMED_NIGHT
+    assert alarm_entity.state.state == AlarmState.ARMED_NIGHT
     assert cluster.client_command.call_count == 2
     assert cluster.client_command.await_count == 2
     assert cluster.client_command.call_args == call(
@@ -131,7 +131,7 @@ async def test_alarm_control_panel(
         "cluster_command", 1, 0, [security.IasAce.ArmMode.Arm_All_Zones, "", 0]
     )
     await zha_gateway.async_block_till_done()
-    assert alarm_entity.state["state"] == AlarmState.ARMED_AWAY
+    assert alarm_entity.state.state == AlarmState.ARMED_AWAY
 
     # reset the panel
     await reset_alarm_panel(zha_gateway, cluster, alarm_entity)
@@ -141,7 +141,7 @@ async def test_alarm_control_panel(
         "cluster_command", 1, 0, [security.IasAce.ArmMode.Arm_Day_Home_Only, "", 0]
     )
     await zha_gateway.async_block_till_done()
-    assert alarm_entity.state["state"] == AlarmState.ARMED_HOME
+    assert alarm_entity.state.state == AlarmState.ARMED_HOME
 
     # reset the panel
     await reset_alarm_panel(zha_gateway, cluster, alarm_entity)
@@ -151,41 +151,41 @@ async def test_alarm_control_panel(
         "cluster_command", 1, 0, [security.IasAce.ArmMode.Arm_Night_Sleep_Only, "", 0]
     )
     await zha_gateway.async_block_till_done()
-    assert alarm_entity.state["state"] == AlarmState.ARMED_NIGHT
+    assert alarm_entity.state.state == AlarmState.ARMED_NIGHT
 
     # disarm from panel with bad code
     cluster.listener_event(
         "cluster_command", 1, 0, [security.IasAce.ArmMode.Disarm, "", 0]
     )
     await zha_gateway.async_block_till_done()
-    assert alarm_entity.state["state"] == AlarmState.ARMED_NIGHT
+    assert alarm_entity.state.state == AlarmState.ARMED_NIGHT
 
     # disarm from panel with bad code for 2nd time still armed
     cluster.listener_event(
         "cluster_command", 1, 0, [security.IasAce.ArmMode.Disarm, "", 0]
     )
     await zha_gateway.async_block_till_done()
-    assert alarm_entity.state["state"] == AlarmState.TRIGGERED
+    assert alarm_entity.state.state == AlarmState.TRIGGERED
 
     # disarm from panel with good code
     cluster.listener_event(
         "cluster_command", 1, 0, [security.IasAce.ArmMode.Disarm, "4321", 0]
     )
     await zha_gateway.async_block_till_done()
-    assert alarm_entity.state["state"] == AlarmState.DISARMED
+    assert alarm_entity.state.state == AlarmState.DISARMED
 
     # disarm when already disarmed
     cluster.listener_event(
         "cluster_command", 1, 0, [security.IasAce.ArmMode.Disarm, "4321", 0]
     )
     await zha_gateway.async_block_till_done()
-    assert alarm_entity.state["state"] == AlarmState.DISARMED
+    assert alarm_entity.state.state == AlarmState.DISARMED
     assert "IAS ACE already disarmed" in caplog.text
 
     # panic from panel
     cluster.listener_event("cluster_command", 1, 4, [])
     await zha_gateway.async_block_till_done()
-    assert alarm_entity.state["state"] == AlarmState.TRIGGERED
+    assert alarm_entity.state.state == AlarmState.TRIGGERED
 
     # reset the panel
     await reset_alarm_panel(zha_gateway, cluster, alarm_entity)
@@ -193,7 +193,7 @@ async def test_alarm_control_panel(
     # fire from panel
     cluster.listener_event("cluster_command", 1, 3, [])
     await zha_gateway.async_block_till_done()
-    assert alarm_entity.state["state"] == AlarmState.TRIGGERED
+    assert alarm_entity.state.state == AlarmState.TRIGGERED
 
     # reset the panel
     await reset_alarm_panel(zha_gateway, cluster, alarm_entity)
@@ -201,24 +201,24 @@ async def test_alarm_control_panel(
     # emergency from panel
     cluster.listener_event("cluster_command", 1, 2, [])
     await zha_gateway.async_block_till_done()
-    assert alarm_entity.state["state"] == AlarmState.TRIGGERED
+    assert alarm_entity.state.state == AlarmState.TRIGGERED
 
     # reset the panel
     await reset_alarm_panel(zha_gateway, cluster, alarm_entity)
-    assert alarm_entity.state["state"] == AlarmState.DISARMED
+    assert alarm_entity.state.state == AlarmState.DISARMED
 
     await alarm_entity.async_alarm_trigger()
     await zha_gateway.async_block_till_done()
-    assert alarm_entity.state["state"] == AlarmState.TRIGGERED
+    assert alarm_entity.state.state == AlarmState.TRIGGERED
 
     # reset the panel
     await reset_alarm_panel(zha_gateway, cluster, alarm_entity)
-    assert alarm_entity.state["state"] == AlarmState.DISARMED
+    assert alarm_entity.state.state == AlarmState.DISARMED
 
     alarm_entity._cluster_handler.code_required_arm_actions = True
     await alarm_entity.async_alarm_arm_away()
     await zha_gateway.async_block_till_done()
-    assert alarm_entity.state["state"] == AlarmState.DISARMED
+    assert alarm_entity.state.state == AlarmState.DISARMED
     assert "Invalid code supplied to IAS ACE" in caplog.text
 
 
@@ -231,7 +231,7 @@ async def reset_alarm_panel(
     cluster.client_command.reset_mock()
     await entity.async_alarm_disarm("4321")
     await zha_gateway.async_block_till_done()
-    assert entity.state["state"] == AlarmState.DISARMED
+    assert entity.state.state == AlarmState.DISARMED
     assert cluster.client_command.call_count == 2
     assert cluster.client_command.await_count == 2
     assert cluster.client_command.call_args == call(

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -316,7 +316,6 @@ async def test_climate_hvac_action_running_state(
     assert entity.state.hvac_action == "off"
     assert sensor_entity.state.state == "off"
 
-
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001E: Thermostat.RunningMode.Off}
     )

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -316,6 +316,7 @@ async def test_climate_hvac_action_running_state(
     assert entity.state.hvac_action == "off"
     assert sensor_entity.state.state == "off"
 
+
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001E: Thermostat.RunningMode.Off}
     )
@@ -1623,9 +1624,9 @@ async def test_thermostat_default_local_temperature_calibration_config(
     ]
     assert local_temperature_calibration_entity
     assert isinstance(local_temperature_calibration_entity, NumberConfigurationEntity)
-    assert local_temperature_calibration_entity.info_object.native_min_value == -2.5
-    assert local_temperature_calibration_entity.info_object.native_max_value == 2.5
-    assert local_temperature_calibration_entity.info_object.native_step == 0.1
+    assert local_temperature_calibration_entity.state.native_min_value == -2.5
+    assert local_temperature_calibration_entity.state.native_max_value == 2.5
+    assert local_temperature_calibration_entity.state.native_step == 0.1
     assert local_temperature_calibration_entity._multiplier == 0.1
 
 
@@ -1667,7 +1668,7 @@ async def test_thermostat_quirkv2_local_temperature_calibration_config_overwrite
     ]
     assert local_temperature_calibration_entity
     assert isinstance(local_temperature_calibration_entity, NumberConfigurationEntity)
-    assert local_temperature_calibration_entity.info_object.native_min_value == -5.0
-    assert local_temperature_calibration_entity.info_object.native_max_value == 5.0
-    assert local_temperature_calibration_entity.info_object.native_step == 0.1
+    assert local_temperature_calibration_entity.state.native_min_value == -5.0
+    assert local_temperature_calibration_entity.state.native_max_value == 5.0
+    assert local_temperature_calibration_entity.state.native_step == 0.1
     assert local_temperature_calibration_entity._multiplier == 0.1

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -269,10 +269,10 @@ async def test_climate_local_temperature(
     entity: ThermostatEntity = get_entity(
         device_climate, platform=Platform.CLIMATE, entity_type=ThermostatEntity
     )
-    assert entity.state["current_temperature"] is None
+    assert entity.state.current_temperature is None
 
     await send_attributes_report(zha_gateway, thrm_cluster, {0: 2100})
-    assert entity.state["current_temperature"] == 21.0
+    assert entity.state.current_temperature == 21.0
 
 
 async def test_climate_outdoor_temperature(
@@ -284,14 +284,14 @@ async def test_climate_outdoor_temperature(
     entity: ThermostatEntity = get_entity(
         device_climate, platform=Platform.CLIMATE, entity_type=ThermostatEntity
     )
-    assert entity.state["outdoor_temperature"] is None
+    assert entity.state.outdoor_temperature is None
 
     await send_attributes_report(
         zha_gateway,
         thrm_cluster,
         {Thermostat.AttributeDefs.outdoor_temperature.id: 2150},
     )
-    assert entity.state["outdoor_temperature"] == 21.5
+    assert entity.state.outdoor_temperature == 21.5
 
 
 async def test_climate_hvac_action_running_state(
@@ -313,55 +313,55 @@ async def test_climate_hvac_action_running_state(
     entity.on_event(STATE_CHANGED, subscriber1)
     sensor_entity.on_event(STATE_CHANGED, subscriber2)
 
-    assert entity.state["hvac_action"] == "off"
-    assert sensor_entity.state["state"] == "off"
+    assert entity.state.hvac_action == "off"
+    assert sensor_entity.state.state == "off"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001E: Thermostat.RunningMode.Off}
     )
     await zha_gateway.async_block_till_done(wait_background_tasks=True)
-    assert entity.state["hvac_action"] == "off"
-    assert sensor_entity.state["state"] == "off"
+    assert entity.state.hvac_action == "off"
+    assert sensor_entity.state.state == "off"
     assert len(subscriber1.mock_calls) == len(subscriber2.mock_calls) == 0
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001C: Thermostat.SystemMode.Auto}
     )
     await zha_gateway.async_block_till_done(wait_background_tasks=True)
-    assert entity.state["hvac_action"] == "idle"
-    assert sensor_entity.state["state"] == "idle"
+    assert entity.state.hvac_action == "idle"
+    assert sensor_entity.state.state == "idle"
     assert len(subscriber1.mock_calls) == len(subscriber2.mock_calls) == 1
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001E: Thermostat.RunningMode.Cool}
     )
     await zha_gateway.async_block_till_done(wait_background_tasks=True)
-    assert entity.state["hvac_action"] == "cooling"
-    assert sensor_entity.state["state"] == "cooling"
+    assert entity.state.hvac_action == "cooling"
+    assert sensor_entity.state.state == "cooling"
     assert len(subscriber1.mock_calls) == len(subscriber2.mock_calls) == 2
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001E: Thermostat.RunningMode.Heat}
     )
     await zha_gateway.async_block_till_done(wait_background_tasks=True)
-    assert entity.state["hvac_action"] == "heating"
-    assert sensor_entity.state["state"] == "heating"
+    assert entity.state.hvac_action == "heating"
+    assert sensor_entity.state.state == "heating"
     assert len(subscriber1.mock_calls) == len(subscriber2.mock_calls) == 3
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001E: Thermostat.RunningMode.Off}
     )
     await zha_gateway.async_block_till_done(wait_background_tasks=True)
-    assert entity.state["hvac_action"] == "idle"
-    assert sensor_entity.state["state"] == "idle"
+    assert entity.state.hvac_action == "idle"
+    assert sensor_entity.state.state == "idle"
     assert len(subscriber1.mock_calls) == len(subscriber2.mock_calls) == 4
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Fan_State_On}
     )
     await zha_gateway.async_block_till_done(wait_background_tasks=True)
-    assert entity.state["hvac_action"] == "fan"
-    assert sensor_entity.state["state"] == "fan"
+    assert entity.state.hvac_action == "fan"
+    assert sensor_entity.state.state == "fan"
     assert len(subscriber1.mock_calls) == len(subscriber2.mock_calls) == 5
 
 
@@ -449,62 +449,62 @@ async def test_climate_hvac_action_running_state_zen(
     )
     assert isinstance(sensor_entity, ThermostatHVACAction)
 
-    assert entity.state["hvac_action"] is None
-    assert sensor_entity.state["state"] is None
+    assert entity.state.hvac_action is None
+    assert sensor_entity.state.state is None
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Cool_2nd_Stage_On}
     )
-    assert entity.state["hvac_action"] == "cooling"
-    assert sensor_entity.state["state"] == "cooling"
+    assert entity.state.hvac_action == "cooling"
+    assert sensor_entity.state.state == "cooling"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Fan_State_On}
     )
-    assert entity.state["hvac_action"] == "fan"
-    assert sensor_entity.state["state"] == "fan"
+    assert entity.state.hvac_action == "fan"
+    assert sensor_entity.state.state == "fan"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Heat_2nd_Stage_On}
     )
-    assert entity.state["hvac_action"] == "heating"
-    assert sensor_entity.state["state"] == "heating"
+    assert entity.state.hvac_action == "heating"
+    assert sensor_entity.state.state == "heating"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Fan_2nd_Stage_On}
     )
-    assert entity.state["hvac_action"] == "fan"
-    assert sensor_entity.state["state"] == "fan"
+    assert entity.state.hvac_action == "fan"
+    assert sensor_entity.state.state == "fan"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Cool_State_On}
     )
-    assert entity.state["hvac_action"] == "cooling"
-    assert sensor_entity.state["state"] == "cooling"
+    assert entity.state.hvac_action == "cooling"
+    assert sensor_entity.state.state == "cooling"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Fan_3rd_Stage_On}
     )
-    assert entity.state["hvac_action"] == "fan"
-    assert sensor_entity.state["state"] == "fan"
+    assert entity.state.hvac_action == "fan"
+    assert sensor_entity.state.state == "fan"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Heat_State_On}
     )
-    assert entity.state["hvac_action"] == "heating"
-    assert sensor_entity.state["state"] == "heating"
+    assert entity.state.hvac_action == "heating"
+    assert sensor_entity.state.state == "heating"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Idle}
     )
-    assert entity.state["hvac_action"] == "off"
-    assert sensor_entity.state["state"] == "off"
+    assert entity.state.hvac_action == "off"
+    assert sensor_entity.state.state == "off"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001C: Thermostat.SystemMode.Heat}
     )
-    assert entity.state["hvac_action"] == "idle"
-    assert sensor_entity.state["state"] == "idle"
+    assert entity.state.hvac_action == "idle"
+    assert sensor_entity.state.state == "idle"
 
 
 async def test_climate_hvac_action_running_state_zehnder(
@@ -521,52 +521,52 @@ async def test_climate_hvac_action_running_state_zehnder(
         device_climate_zehnder, platform=Platform.CLIMATE, entity_type=ThermostatEntity
     )
 
-    assert entity.state["hvac_action"] is None
+    assert entity.state.hvac_action is None
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Cool_2nd_Stage_On}
     )
-    assert entity.state["hvac_action"] == "cooling"
+    assert entity.state.hvac_action == "cooling"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Fan_State_On}
     )
-    assert entity.state["hvac_action"] == "fan"
+    assert entity.state.hvac_action == "fan"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Heat_2nd_Stage_On}
     )
-    assert entity.state["hvac_action"] == "heating"
+    assert entity.state.hvac_action == "heating"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Fan_2nd_Stage_On}
     )
-    assert entity.state["hvac_action"] == "fan"
+    assert entity.state.hvac_action == "fan"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Cool_State_On}
     )
-    assert entity.state["hvac_action"] == "cooling"
+    assert entity.state.hvac_action == "cooling"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Fan_3rd_Stage_On}
     )
-    assert entity.state["hvac_action"] == "fan"
+    assert entity.state.hvac_action == "fan"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Heat_State_On}
     )
-    assert entity.state["hvac_action"] == "heating"
+    assert entity.state.hvac_action == "heating"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x0029: Thermostat.RunningState.Idle}
     )
-    assert entity.state["hvac_action"] == "off"
+    assert entity.state.hvac_action == "off"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001C: Thermostat.SystemMode.Heat}
     )
-    assert entity.state["hvac_action"] == "idle"
+    assert entity.state.hvac_action == "idle"
 
 
 @pytest.mark.parametrize(
@@ -592,27 +592,27 @@ async def test_set_hvac_mode_zehnder(
         device_climate_zehnder, platform=Platform.CLIMATE, entity_type=ZehnderThermostat
     )
 
-    assert entity.state["hvac_mode"] == "off"
+    assert entity.state.hvac_mode == "off"
 
     await entity.async_set_hvac_mode(hvac_mode)
     await zha_gateway.async_block_till_done()
 
     if sys_mode is not None:
-        assert entity.state["hvac_mode"] == hvac_mode
+        assert entity.state.hvac_mode == hvac_mode
         assert thrm_cluster.write_attributes.call_count == 1
         assert thrm_cluster.write_attributes.call_args[0][0] == {
             "system_mode": sys_mode
         }
     else:
         assert thrm_cluster.write_attributes.call_count == 0
-        assert entity.state["hvac_mode"] == "off"
+        assert entity.state.hvac_mode == "off"
 
     # turn off
     thrm_cluster.write_attributes.reset_mock()
     await entity.async_set_hvac_mode("off")
     await zha_gateway.async_block_till_done()
 
-    assert entity.state["hvac_mode"] == "off"
+    assert entity.state.hvac_mode == "off"
     assert thrm_cluster.write_attributes.call_count == 1
     assert thrm_cluster.write_attributes.call_args[0][0] == {
         "system_mode": Thermostat.SystemMode.Off
@@ -629,28 +629,28 @@ async def test_climate_hvac_action_pi_demand(
         device_climate, platform=Platform.CLIMATE, entity_type=ThermostatEntity
     )
 
-    assert entity.state["hvac_action"] is None
+    assert entity.state.hvac_action is None
 
     await send_attributes_report(zha_gateway, thrm_cluster, {0x0007: 10})
-    assert entity.state["hvac_action"] == "cooling"
+    assert entity.state.hvac_action == "cooling"
 
     await send_attributes_report(zha_gateway, thrm_cluster, {0x0008: 20})
-    assert entity.state["hvac_action"] == "heating"
+    assert entity.state.hvac_action == "heating"
 
     await send_attributes_report(zha_gateway, thrm_cluster, {0x0007: 0})
     await send_attributes_report(zha_gateway, thrm_cluster, {0x0008: 0})
 
-    assert entity.state["hvac_action"] == "off"
+    assert entity.state.hvac_action == "off"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001C: Thermostat.SystemMode.Heat}
     )
-    assert entity.state["hvac_action"] == "idle"
+    assert entity.state.hvac_action == "idle"
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001C: Thermostat.SystemMode.Cool}
     )
-    assert entity.state["hvac_action"] == "idle"
+    assert entity.state.hvac_action == "idle"
 
 
 @pytest.mark.parametrize(
@@ -676,18 +676,18 @@ async def test_hvac_mode(
         device_climate, platform=Platform.CLIMATE, entity_type=ThermostatEntity
     )
 
-    assert entity.state["hvac_mode"] == "off"
+    assert entity.state.hvac_mode == "off"
 
     await send_attributes_report(zha_gateway, thrm_cluster, {0x001C: sys_mode})
-    assert entity.state["hvac_mode"] == hvac_mode
+    assert entity.state.hvac_mode == hvac_mode
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {0x001C: Thermostat.SystemMode.Off}
     )
-    assert entity.state["hvac_mode"] == "off"
+    assert entity.state.hvac_mode == "off"
 
     await send_attributes_report(zha_gateway, thrm_cluster, {0x001C: 0xFF})
-    assert entity.state["hvac_mode"] is None
+    assert entity.state.hvac_mode is None
 
 
 @pytest.mark.parametrize(
@@ -755,7 +755,7 @@ async def test_target_temperature(
         await entity.async_set_preset_mode(preset)
         await zha_gateway.async_block_till_done()
 
-    assert entity.state["target_temperature"] == target_temp
+    assert entity.state.target_temperature == target_temp
 
 
 @pytest.mark.parametrize(
@@ -792,7 +792,7 @@ async def test_target_temperature_high(
         await entity.async_set_preset_mode(preset)
         await zha_gateway.async_block_till_done()
 
-    assert entity.state["target_temperature_high"] == target_temp
+    assert entity.state.target_temperature_high == target_temp
 
 
 @pytest.mark.parametrize(
@@ -829,7 +829,7 @@ async def test_target_temperature_low(
         await entity.async_set_preset_mode(preset)
         await zha_gateway.async_block_till_done()
 
-    assert entity.state["target_temperature_low"] == target_temp
+    assert entity.state.target_temperature_low == target_temp
 
 
 @pytest.mark.parametrize(
@@ -856,27 +856,27 @@ async def test_set_hvac_mode(
         device_climate, platform=Platform.CLIMATE, entity_type=ThermostatEntity
     )
 
-    assert entity.state["hvac_mode"] == "off"
+    assert entity.state.hvac_mode == "off"
 
     await entity.async_set_hvac_mode(hvac_mode)
     await zha_gateway.async_block_till_done()
 
     if sys_mode is not None:
-        assert entity.state["hvac_mode"] == hvac_mode
+        assert entity.state.hvac_mode == hvac_mode
         assert thrm_cluster.write_attributes.call_count == 1
         assert thrm_cluster.write_attributes.call_args[0][0] == {
             "system_mode": sys_mode
         }
     else:
         assert thrm_cluster.write_attributes.call_count == 0
-        assert entity.state["hvac_mode"] == "off"
+        assert entity.state.hvac_mode == "off"
 
     # turn off
     thrm_cluster.write_attributes.reset_mock()
     await entity.async_set_hvac_mode("off")
     await zha_gateway.async_block_till_done()
 
-    assert entity.state["hvac_mode"] == "off"
+    assert entity.state.hvac_mode == "off"
     assert thrm_cluster.write_attributes.call_count == 1
     assert thrm_cluster.write_attributes.call_args[0][0] == {
         "system_mode": Thermostat.SystemMode.Off
@@ -893,7 +893,7 @@ async def test_preset_setting(
         dev_climate_sinope, platform=Platform.CLIMATE, entity_type=ThermostatEntity
     )
 
-    assert entity.state["preset_mode"] == "none"
+    assert entity.state.preset_mode == "none"
 
     # unsuccessful occupancy change
     thrm_cluster.write_attributes.return_value = [
@@ -911,7 +911,7 @@ async def test_preset_setting(
         await entity.async_set_preset_mode("away")
         await zha_gateway.async_block_till_done()
 
-    assert entity.state["preset_mode"] == "none"
+    assert entity.state.preset_mode == "none"
     assert thrm_cluster.write_attributes.call_count == 1
     assert thrm_cluster.write_attributes.call_args[0][0] == {"set_occupancy": 0}
 
@@ -923,7 +923,7 @@ async def test_preset_setting(
     await entity.async_set_preset_mode("away")
     await zha_gateway.async_block_till_done()
 
-    assert entity.state["preset_mode"] == "away"
+    assert entity.state.preset_mode == "away"
     assert thrm_cluster.write_attributes.call_count == 1
     assert thrm_cluster.write_attributes.call_args[0][0] == {"set_occupancy": 0}
 
@@ -945,7 +945,7 @@ async def test_preset_setting(
         await entity.async_set_preset_mode("none")
         await zha_gateway.async_block_till_done()
 
-    assert entity.state["preset_mode"] == "away"
+    assert entity.state.preset_mode == "away"
     assert thrm_cluster.write_attributes.call_count == 1
     assert thrm_cluster.write_attributes.call_args[0][0] == {"set_occupancy": 1}
 
@@ -958,7 +958,7 @@ async def test_preset_setting(
     await entity.async_set_preset_mode("none")
     await zha_gateway.async_block_till_done()
 
-    assert entity.state["preset_mode"] == "none"
+    assert entity.state.preset_mode == "none"
     assert thrm_cluster.write_attributes.call_count == 1
     assert thrm_cluster.write_attributes.call_args[0][0] == {"set_occupancy": 1}
 
@@ -973,11 +973,11 @@ async def test_preset_setting_invalid(
         dev_climate_sinope, platform=Platform.CLIMATE, entity_type=ThermostatEntity
     )
 
-    assert entity.state["preset_mode"] == "none"
+    assert entity.state.preset_mode == "none"
     await entity.async_set_preset_mode("invalid_preset")
     await zha_gateway.async_block_till_done()
 
-    assert entity.state["preset_mode"] == "none"
+    assert entity.state.preset_mode == "none"
     assert thrm_cluster.write_attributes.call_count == 0
 
 
@@ -992,11 +992,11 @@ async def test_set_temperature_hvac_mode(
         device_climate, platform=Platform.CLIMATE, entity_type=ThermostatEntity
     )
 
-    assert entity.state["hvac_mode"] == "off"
+    assert entity.state.hvac_mode == "off"
     await entity.async_set_temperature(hvac_mode="heat_cool", temperature=20)
     await zha_gateway.async_block_till_done()
 
-    assert entity.state["hvac_mode"] == "heat_cool"
+    assert entity.state.hvac_mode == "heat_cool"
     assert thrm_cluster.write_attributes.await_count == 1
     assert thrm_cluster.write_attributes.call_args[0][0] == {
         "system_mode": Thermostat.SystemMode.Auto
@@ -1026,20 +1026,20 @@ async def test_set_temperature_heat_cool(
         device_climate, platform=Platform.CLIMATE, entity_type=ThermostatEntity
     )
 
-    assert entity.state["hvac_mode"] == "heat_cool"
+    assert entity.state.hvac_mode == "heat_cool"
 
     await entity.async_set_temperature(temperature=20)
     await zha_gateway.async_block_till_done()
 
-    assert entity.state["target_temperature_low"] == 20.0
-    assert entity.state["target_temperature_high"] == 25.0
+    assert entity.state.target_temperature_low == 20.0
+    assert entity.state.target_temperature_high == 25.0
     assert thrm_cluster.write_attributes.await_count == 0
 
     await entity.async_set_temperature(target_temp_high=26, target_temp_low=19)
     await zha_gateway.async_block_till_done()
 
-    assert entity.state["target_temperature_low"] == 19.0
-    assert entity.state["target_temperature_high"] == 26.0
+    assert entity.state.target_temperature_low == 19.0
+    assert entity.state.target_temperature_high == 26.0
     assert thrm_cluster.write_attributes.await_count == 2
     assert thrm_cluster.write_attributes.call_args_list[0][0][0] == {
         "occupied_heating_setpoint": 1900
@@ -1055,8 +1055,8 @@ async def test_set_temperature_heat_cool(
     await entity.async_set_temperature(target_temp_high=30, target_temp_low=15)
     await zha_gateway.async_block_till_done()
 
-    assert entity.state["target_temperature_low"] == 15.0
-    assert entity.state["target_temperature_high"] == 30.0
+    assert entity.state.target_temperature_low == 15.0
+    assert entity.state.target_temperature_high == 30.0
     assert thrm_cluster.write_attributes.await_count == 2
     assert thrm_cluster.write_attributes.call_args_list[0][0][0] == {
         "unoccupied_heating_setpoint": 1500
@@ -1089,22 +1089,22 @@ async def test_set_temperature_heat(
         device_climate, platform=Platform.CLIMATE, entity_type=ThermostatEntity
     )
 
-    assert entity.state["hvac_mode"] == "heat"
+    assert entity.state.hvac_mode == "heat"
 
     await entity.async_set_temperature(target_temp_high=30, target_temp_low=15)
     await zha_gateway.async_block_till_done()
 
-    assert entity.state["target_temperature_low"] is None
-    assert entity.state["target_temperature_high"] is None
-    assert entity.state["target_temperature"] == 20.0
+    assert entity.state.target_temperature_low is None
+    assert entity.state.target_temperature_high is None
+    assert entity.state.target_temperature == 20.0
     assert thrm_cluster.write_attributes.await_count == 0
 
     await entity.async_set_temperature(temperature=21)
     await zha_gateway.async_block_till_done()
 
-    assert entity.state["target_temperature_low"] is None
-    assert entity.state["target_temperature_high"] is None
-    assert entity.state["target_temperature"] == 21.0
+    assert entity.state.target_temperature_low is None
+    assert entity.state.target_temperature_high is None
+    assert entity.state.target_temperature == 21.0
     assert thrm_cluster.write_attributes.await_count == 1
     assert thrm_cluster.write_attributes.call_args_list[0][0][0] == {
         "occupied_heating_setpoint": 2100
@@ -1117,9 +1117,9 @@ async def test_set_temperature_heat(
     await entity.async_set_temperature(temperature=22)
     await zha_gateway.async_block_till_done()
 
-    assert entity.state["target_temperature_low"] is None
-    assert entity.state["target_temperature_high"] is None
-    assert entity.state["target_temperature"] == 22.0
+    assert entity.state.target_temperature_low is None
+    assert entity.state.target_temperature_high is None
+    assert entity.state.target_temperature == 22.0
     assert thrm_cluster.write_attributes.await_count == 1
     assert thrm_cluster.write_attributes.call_args_list[0][0][0] == {
         "unoccupied_heating_setpoint": 2200
@@ -1149,22 +1149,22 @@ async def test_set_temperature_cool(
         device_climate, platform=Platform.CLIMATE, entity_type=ThermostatEntity
     )
 
-    assert entity.state["hvac_mode"] == "cool"
+    assert entity.state.hvac_mode == "cool"
 
     await entity.async_set_temperature(target_temp_high=30, target_temp_low=15)
     await zha_gateway.async_block_till_done()
 
-    assert entity.state["target_temperature_low"] is None
-    assert entity.state["target_temperature_high"] is None
-    assert entity.state["target_temperature"] == 25.0
+    assert entity.state.target_temperature_low is None
+    assert entity.state.target_temperature_high is None
+    assert entity.state.target_temperature == 25.0
     assert thrm_cluster.write_attributes.await_count == 0
 
     await entity.async_set_temperature(temperature=21)
     await zha_gateway.async_block_till_done()
 
-    assert entity.state["target_temperature_low"] is None
-    assert entity.state["target_temperature_high"] is None
-    assert entity.state["target_temperature"] == 21.0
+    assert entity.state.target_temperature_low is None
+    assert entity.state.target_temperature_high is None
+    assert entity.state.target_temperature == 21.0
     assert thrm_cluster.write_attributes.await_count == 1
     assert thrm_cluster.write_attributes.call_args_list[0][0][0] == {
         "occupied_cooling_setpoint": 2100
@@ -1177,9 +1177,9 @@ async def test_set_temperature_cool(
     await entity.async_set_temperature(temperature=22)
     await zha_gateway.async_block_till_done()
 
-    assert entity.state["target_temperature_low"] is None
-    assert entity.state["target_temperature_high"] is None
-    assert entity.state["target_temperature"] == 22.0
+    assert entity.state.target_temperature_low is None
+    assert entity.state.target_temperature_high is None
+    assert entity.state.target_temperature == 22.0
     assert thrm_cluster.write_attributes.await_count == 1
     assert thrm_cluster.write_attributes.call_args_list[0][0][0] == {
         "unoccupied_cooling_setpoint": 2200
@@ -1213,14 +1213,14 @@ async def test_set_temperature_wrong_mode(
         device_climate, platform=Platform.CLIMATE, entity_type=ThermostatEntity
     )
 
-    assert entity.state["hvac_mode"] == "dry"
+    assert entity.state.hvac_mode == "dry"
 
     await entity.async_set_temperature(temperature=24)
     await zha_gateway.async_block_till_done()
 
-    assert entity.state["target_temperature_low"] is None
-    assert entity.state["target_temperature_high"] is None
-    assert entity.state["target_temperature"] is None
+    assert entity.state.target_temperature_low is None
+    assert entity.state.target_temperature_high is None
+    assert entity.state.target_temperature is None
     assert thrm_cluster.write_attributes.await_count == 0
 
 
@@ -1234,20 +1234,20 @@ async def test_occupancy_reset(
         dev_climate_sinope, platform=Platform.CLIMATE, entity_type=ThermostatEntity
     )
 
-    assert entity.state["preset_mode"] == "none"
+    assert entity.state.preset_mode == "none"
 
     await entity.async_set_preset_mode("away")
     await zha_gateway.async_block_till_done()
     thrm_cluster.write_attributes.reset_mock()
 
-    assert entity.state["preset_mode"] == "away"
+    assert entity.state.preset_mode == "away"
 
     await send_attributes_report(
         zha_gateway,
         thrm_cluster,
         {"occupied_heating_setpoint": zigpy.types.uint16_t(1950)},
     )
-    assert entity.state["preset_mode"] == "none"
+    assert entity.state.preset_mode == "none"
 
 
 async def test_fan_mode(
@@ -1261,26 +1261,26 @@ async def test_fan_mode(
     )
 
     assert set(entity.fan_modes) == {FanState.AUTO, FanState.ON}
-    assert entity.state["fan_mode"] == FanState.AUTO
+    assert entity.state.fan_mode == FanState.AUTO
 
     await send_attributes_report(
         zha_gateway,
         thrm_cluster,
         {"running_state": Thermostat.RunningState.Fan_State_On},
     )
-    assert entity.state["fan_mode"] == FanState.ON
+    assert entity.state.fan_mode == FanState.ON
 
     await send_attributes_report(
         zha_gateway, thrm_cluster, {"running_state": Thermostat.RunningState.Idle}
     )
-    assert entity.state["fan_mode"] == FanState.AUTO
+    assert entity.state.fan_mode == FanState.AUTO
 
     await send_attributes_report(
         zha_gateway,
         thrm_cluster,
         {"running_state": Thermostat.RunningState.Fan_2nd_Stage_On},
     )
-    assert entity.state["fan_mode"] == FanState.ON
+    assert entity.state.fan_mode == FanState.ON
 
 
 async def test_set_fan_mode_not_supported(
@@ -1308,7 +1308,7 @@ async def test_set_fan_mode(
         device_climate_fan, platform=Platform.CLIMATE, entity_type=ThermostatEntity
     )
 
-    assert entity.state["fan_mode"] == FanState.AUTO
+    assert entity.state.fan_mode == FanState.AUTO
 
     await entity.async_set_fan_mode(FanState.ON)
     await zha_gateway.async_block_till_done()
@@ -1337,7 +1337,7 @@ async def test_set_moes_preset(zha_gateway: Gateway):
         device_climate_moes, platform=Platform.CLIMATE, entity_type=ThermostatEntity
     )
 
-    assert entity.state["preset_mode"] == "none"
+    assert entity.state.preset_mode == "none"
 
     await entity.async_set_preset_mode("away")
     await zha_gateway.async_block_till_done()
@@ -1432,31 +1432,31 @@ async def test_set_moes_operation_mode(zha_gateway: Gateway):
 
     await send_attributes_report(zha_gateway, thrm_cluster, {"operation_preset": 0})
 
-    assert entity.state["preset_mode"] == "away"
+    assert entity.state.preset_mode == "away"
 
     await send_attributes_report(zha_gateway, thrm_cluster, {"operation_preset": 1})
 
-    assert entity.state["preset_mode"] == "Schedule"
+    assert entity.state.preset_mode == "Schedule"
 
     await send_attributes_report(zha_gateway, thrm_cluster, {"operation_preset": 2})
 
-    assert entity.state["preset_mode"] == "none"
+    assert entity.state.preset_mode == "none"
 
     await send_attributes_report(zha_gateway, thrm_cluster, {"operation_preset": 3})
 
-    assert entity.state["preset_mode"] == "comfort"
+    assert entity.state.preset_mode == "comfort"
 
     await send_attributes_report(zha_gateway, thrm_cluster, {"operation_preset": 4})
 
-    assert entity.state["preset_mode"] == "eco"
+    assert entity.state.preset_mode == "eco"
 
     await send_attributes_report(zha_gateway, thrm_cluster, {"operation_preset": 5})
 
-    assert entity.state["preset_mode"] == "boost"
+    assert entity.state.preset_mode == "boost"
 
     await send_attributes_report(zha_gateway, thrm_cluster, {"operation_preset": 6})
 
-    assert entity.state["preset_mode"] == "Complex"
+    assert entity.state.preset_mode == "Complex"
 
 
 # Device is running an energy-saving mode
@@ -1496,7 +1496,7 @@ async def test_beca_operation_mode_update(
         zha_gateway, thrm_cluster, {"operation_preset": preset_attr}
     )
 
-    assert entity.state[ATTR_PRESET_MODE] == preset_mode
+    assert entity.state.preset_mode == preset_mode
 
     await entity.async_set_preset_mode(preset_mode)
     await zha_gateway.async_block_till_done()
@@ -1524,7 +1524,7 @@ async def test_set_zonnsmart_preset(zha_gateway: Gateway) -> None:
         entity_type=ThermostatEntity,
     )
 
-    assert entity.state[ATTR_PRESET_MODE] == PRESET_NONE
+    assert entity.state.preset_mode == PRESET_NONE
 
     await entity.async_set_preset_mode(PRESET_SCHEDULE)
     await zha_gateway.async_block_till_done()
@@ -1586,23 +1586,23 @@ async def test_set_zonnsmart_operation_mode(zha_gateway: Gateway) -> None:
 
     await send_attributes_report(zha_gateway, thrm_cluster, {"operation_preset": 0})
 
-    assert entity.state[ATTR_PRESET_MODE] == PRESET_SCHEDULE
+    assert entity.state.preset_mode == PRESET_SCHEDULE
 
     await send_attributes_report(zha_gateway, thrm_cluster, {"operation_preset": 1})
 
-    assert entity.state[ATTR_PRESET_MODE] == PRESET_NONE
+    assert entity.state.preset_mode == PRESET_NONE
 
     await send_attributes_report(zha_gateway, thrm_cluster, {"operation_preset": 2})
 
-    assert entity.state[ATTR_PRESET_MODE] == "holiday"
+    assert entity.state.preset_mode == "holiday"
 
     await send_attributes_report(zha_gateway, thrm_cluster, {"operation_preset": 3})
 
-    assert entity.state[ATTR_PRESET_MODE] == "holiday"
+    assert entity.state.preset_mode == "holiday"
 
     await send_attributes_report(zha_gateway, thrm_cluster, {"operation_preset": 4})
 
-    assert entity.state[ATTR_PRESET_MODE] == "frost protect"
+    assert entity.state.preset_mode == "frost protect"
 
 
 async def test_thermostat_default_local_temperature_calibration_config(

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -31,13 +31,7 @@ from zha.application.platforms.cover import (
     LIFT_MOVEMENT_TIMEOUT_RANGE,
     TILT_MOVEMENT_TIMEOUT_RANGE,
 )
-from zha.application.platforms.cover.const import (
-    ATTR_CURRENT_POSITION,
-    ATTR_CURRENT_TILT_POSITION,
-    WCT,
-    CoverEntityFeature,
-    CoverState,
-)
+from zha.application.platforms.cover.const import WCT, CoverEntityFeature, CoverState
 from zha.exceptions import ZHAException
 from zha.zigbee.device import Device
 
@@ -151,9 +145,9 @@ async def test_cover_non_tilt_initial_state(  # pylint: disable=unused-argument
     )
 
     entity = get_entity(zha_device, platform=Platform.COVER)
-    assert entity.state["state"] == CoverState.OPEN
-    assert entity.state[ATTR_CURRENT_POSITION] == 100
-    assert entity.state[ATTR_CURRENT_TILT_POSITION] is None
+    assert entity.state.state == CoverState.OPEN
+    assert entity.state.current_position == 100
+    assert entity.state.current_tilt_position is None
     assert entity.supported_features == (
         CoverEntityFeature.OPEN
         | CoverEntityFeature.CLOSE
@@ -165,8 +159,8 @@ async def test_cover_non_tilt_initial_state(  # pylint: disable=unused-argument
     await send_attributes_report(
         zha_gateway, cluster, {WCAttrs.current_position_lift_percentage.id: 100}
     )
-    assert entity.state["state"] == CoverState.CLOSED
-    assert entity.state[ATTR_CURRENT_POSITION] == 0
+    assert entity.state.state == CoverState.CLOSED
+    assert entity.state.current_position == 0
 
 
 async def test_cover_non_lift_initial_state(  # pylint: disable=unused-argument
@@ -199,9 +193,9 @@ async def test_cover_non_lift_initial_state(  # pylint: disable=unused-argument
     )
 
     entity = get_entity(zha_device, platform=Platform.COVER)
-    assert entity.state["state"] == CoverState.OPEN
-    assert entity.state[ATTR_CURRENT_POSITION] is None
-    assert entity.state[ATTR_CURRENT_TILT_POSITION] == 100
+    assert entity.state.state == CoverState.OPEN
+    assert entity.state.current_position is None
+    assert entity.state.current_tilt_position == 100
     assert entity.supported_features == (
         CoverEntityFeature.OPEN_TILT
         | CoverEntityFeature.CLOSE_TILT
@@ -213,8 +207,8 @@ async def test_cover_non_lift_initial_state(  # pylint: disable=unused-argument
     await send_attributes_report(
         zha_gateway, cluster, {WCAttrs.current_position_tilt_percentage.id: 100}
     )
-    assert entity.state["state"] == CoverState.CLOSED
-    assert entity.state[ATTR_CURRENT_TILT_POSITION] == 0
+    assert entity.state.state == CoverState.CLOSED
+    assert entity.state.current_tilt_position == 0
 
 
 async def test_cover(
@@ -262,31 +256,31 @@ async def test_cover(
     await send_attributes_report(
         zha_gateway, cluster, {WCAttrs.current_position_lift_percentage.id: 100}
     )
-    assert entity.state["state"] == CoverState.CLOSED
+    assert entity.state.state == CoverState.CLOSED
 
     # test that the state remains after tilting to 100% (closed)
     await send_attributes_report(
         zha_gateway, cluster, {WCAttrs.current_position_tilt_percentage.id: 100}
     )
-    assert entity.state["state"] == CoverState.CLOSED
+    assert entity.state.state == CoverState.CLOSED
 
     # set lift to 0% (open) and test to see if state changes to open
     await send_attributes_report(
         zha_gateway, cluster, {WCAttrs.current_position_lift_percentage.id: 0}
     )
-    assert entity.state["state"] == CoverState.OPEN
+    assert entity.state.state == CoverState.OPEN
 
     # test that the state remains after tilting to 0% (open)
     await send_attributes_report(
         zha_gateway, cluster, {WCAttrs.current_position_tilt_percentage.id: 0}
     )
-    assert entity.state["state"] == CoverState.OPEN
+    assert entity.state.state == CoverState.OPEN
 
     # test to see the state remains after tilting to 100% (closed)
     await send_attributes_report(
         zha_gateway, cluster, {WCAttrs.current_position_tilt_percentage.id: 100}
     )
-    assert entity.state["state"] == CoverState.OPEN
+    assert entity.state.state == CoverState.OPEN
 
     # test entity async_update read of positions from the cluster
     cluster.PLUGGED_ATTR_READS[WCAttrs.current_position_lift_percentage.name] = 0
@@ -294,7 +288,7 @@ async def test_cover(
     update_attribute_cache(cluster)
     await entity.async_update()
     await zha_gateway.async_block_till_done()
-    assert entity.state["state"] == CoverState.OPEN
+    assert entity.state.state == CoverState.OPEN
 
     # close from client
     with patch("zigpy.zcl.Cluster.request", return_value=[0x1, zcl_f.Status.SUCCESS]):
@@ -306,17 +300,17 @@ async def test_cover(
         assert cluster.request.call_args[0][2].command.name == WCCmds.down_close.name
         assert cluster.request.call_args[1]["expect_reply"] is True
 
-        assert entity.state["state"] == CoverState.CLOSING
+        assert entity.state.state == CoverState.CLOSING
 
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_lift_percentage.id: 100}
         )
 
-        assert entity.state["state"] == CoverState.CLOSED
+        assert entity.state.state == CoverState.CLOSED
 
         # verify that a subsequent close command does not change the state to closing
         await entity.async_close_cover()
-        assert entity.state["state"] == CoverState.CLOSED
+        assert entity.state.state == CoverState.CLOSED
 
     # tilt close from client
     with patch("zigpy.zcl.Cluster.request", return_value=[0x1, zcl_f.Status.SUCCESS]):
@@ -324,7 +318,7 @@ async def test_cover(
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_tilt_percentage.id: 0}
         )
-        assert entity.state["state"] == CoverState.CLOSED
+        assert entity.state.state == CoverState.CLOSED
 
         await entity.async_close_cover_tilt()
         await zha_gateway.async_block_till_done()
@@ -338,17 +332,17 @@ async def test_cover(
         assert cluster.request.call_args[0][3] == 100
         assert cluster.request.call_args[1]["expect_reply"] is True
 
-        assert entity.state["state"] == CoverState.CLOSING
+        assert entity.state.state == CoverState.CLOSING
 
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_tilt_percentage.id: 100}
         )
 
-        assert entity.state["state"] == CoverState.CLOSED
+        assert entity.state.state == CoverState.CLOSED
 
         # verify that a subsequent close command does not change the state to closing
         await entity.async_close_cover_tilt()
-        assert entity.state["state"] == CoverState.CLOSED
+        assert entity.state.state == CoverState.CLOSED
 
     # open from client
     with patch("zigpy.zcl.Cluster.request", return_value=[0x0, zcl_f.Status.SUCCESS]):
@@ -360,17 +354,17 @@ async def test_cover(
         assert cluster.request.call_args[0][2].command.name == WCCmds.up_open.name
         assert cluster.request.call_args[1]["expect_reply"] is True
 
-        assert entity.state["state"] == CoverState.OPENING
+        assert entity.state.state == CoverState.OPENING
 
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_lift_percentage.id: 0}
         )
 
-        assert entity.state["state"] == CoverState.OPEN
+        assert entity.state.state == CoverState.OPEN
 
         # verify that a subsequent open command does not change the state to opening
         await entity.async_open_cover()
-        assert entity.state["state"] == CoverState.OPEN
+        assert entity.state.state == CoverState.OPEN
 
     # open tilt from client
     with patch("zigpy.zcl.Cluster.request", return_value=[0x0, zcl_f.Status.SUCCESS]):
@@ -386,21 +380,21 @@ async def test_cover(
         assert cluster.request.call_args[0][3] == 0
         assert cluster.request.call_args[1]["expect_reply"] is True
 
-        assert entity.state["state"] == CoverState.OPENING
+        assert entity.state.state == CoverState.OPENING
 
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_tilt_percentage.id: 0}
         )
 
-        assert entity.state["state"] == CoverState.OPEN
+        assert entity.state.state == CoverState.OPEN
 
         # verify that a subsequent open command does not change the state to opening
         await entity.async_open_cover_tilt()
-        assert entity.state["state"] == CoverState.OPEN
+        assert entity.state.state == CoverState.OPEN
 
     # test set position command, starting at 100 % / 0 ZCL (open) from previous lift test
     with patch("zigpy.zcl.Cluster.request", return_value=[0x5, zcl_f.Status.SUCCESS]):
-        assert entity.state[ATTR_CURRENT_POSITION] == 100
+        assert entity.state.current_position == 100
         await entity.async_set_cover_position(position=47)  # 53 when inverted for ZCL
         await zha_gateway.async_block_till_done()
         assert cluster.request.call_count == 1
@@ -410,33 +404,33 @@ async def test_cover(
         assert cluster.request.call_args[0][3] == 53
         assert cluster.request.call_args[1]["expect_reply"] is True
 
-        assert entity.state["state"] == CoverState.CLOSING
+        assert entity.state.state == CoverState.CLOSING
 
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_lift_percentage.id: 35}
         )
 
-        assert entity.state[ATTR_CURRENT_POSITION] == 65
-        assert entity.state["state"] == CoverState.CLOSING
+        assert entity.state.current_position == 65
+        assert entity.state.state == CoverState.CLOSING
 
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_lift_percentage.id: 53}
         )
 
-        assert entity.state[ATTR_CURRENT_POSITION] == 47
-        assert entity.state["state"] == CoverState.OPEN
+        assert entity.state.current_position == 47
+        assert entity.state.state == CoverState.OPEN
 
         # verify that a subsequent go_to command does not change the state to closing/opening
         await entity.async_set_cover_position(position=47)
-        assert entity.state["state"] == CoverState.OPEN
+        assert entity.state.state == CoverState.OPEN
 
         # wait for transition timeout to clear the target
         await asyncio.sleep(DEFAULT_MOVEMENT_TIMEOUT)
-        assert entity.state["state"] == CoverState.OPEN
+        assert entity.state.state == CoverState.OPEN
 
     # test set tilt position command, starting at 100 % / 0 ZCL (open) from previous tilt test
     with patch("zigpy.zcl.Cluster.request", return_value=[0x5, zcl_f.Status.SUCCESS]):
-        assert entity.state[ATTR_CURRENT_TILT_POSITION] == 100
+        assert entity.state.current_tilt_position == 100
         await entity.async_set_cover_tilt_position(
             tilt_position=47
         )  # 53 when inverted for ZCL
@@ -451,29 +445,29 @@ async def test_cover(
         assert cluster.request.call_args[0][3] == 53
         assert cluster.request.call_args[1]["expect_reply"] is True
 
-        assert entity.state["state"] == CoverState.CLOSING
+        assert entity.state.state == CoverState.CLOSING
 
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_tilt_percentage.id: 35}
         )
 
-        assert entity.state[ATTR_CURRENT_TILT_POSITION] == 65
-        assert entity.state["state"] == CoverState.CLOSING
+        assert entity.state.current_tilt_position == 65
+        assert entity.state.state == CoverState.CLOSING
 
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_tilt_percentage.id: 53}
         )
 
-        assert entity.state[ATTR_CURRENT_TILT_POSITION] == 47
-        assert entity.state["state"] == CoverState.OPEN
+        assert entity.state.current_tilt_position == 47
+        assert entity.state.state == CoverState.OPEN
 
         # verify that a subsequent go_to command does not change the state to closing/opening
         await entity.async_set_cover_tilt_position(tilt_position=47)
-        assert entity.state["state"] == CoverState.OPEN
+        assert entity.state.state == CoverState.OPEN
 
         # wait for transition timeout to clear the target
         await asyncio.sleep(DEFAULT_MOVEMENT_TIMEOUT)
-        assert entity.state["state"] == CoverState.OPEN
+        assert entity.state.state == CoverState.OPEN
 
     # test interrupted movement (e.g. device button press), starting from 47 %
     with patch("zigpy.zcl.Cluster.request", return_value=[0x5, zcl_f.Status.SUCCESS]):
@@ -486,20 +480,20 @@ async def test_cover(
         assert cluster.request.call_args[0][3] == 100
         assert cluster.request.call_args[1]["expect_reply"] is True
 
-        assert entity.state[ATTR_CURRENT_POSITION] == 47
-        assert entity.state["state"] == CoverState.CLOSING
+        assert entity.state.current_position == 47
+        assert entity.state.state == CoverState.CLOSING
 
         # simulate a device position update to set timer to the default duration rather than dynamic
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_lift_percentage.id: 70}
         )
 
-        assert entity.state[ATTR_CURRENT_POSITION] == 30
-        assert entity.state["state"] == CoverState.CLOSING
+        assert entity.state.current_position == 30
+        assert entity.state.state == CoverState.CLOSING
 
         # wait the timer duration
         await asyncio.sleep(DEFAULT_MOVEMENT_TIMEOUT)
-        assert entity.state["state"] == CoverState.OPEN
+        assert entity.state.state == CoverState.OPEN
 
     # test interrupted tilt movement (e.g. device button press), starting from 47 %
     with patch("zigpy.zcl.Cluster.request", return_value=[0x5, zcl_f.Status.SUCCESS]):
@@ -514,57 +508,57 @@ async def test_cover(
         assert cluster.request.call_args[0][3] == 100
         assert cluster.request.call_args[1]["expect_reply"] is True
 
-        assert entity.state[ATTR_CURRENT_TILT_POSITION] == 47
-        assert entity.state["state"] == CoverState.CLOSING
+        assert entity.state.current_tilt_position == 47
+        assert entity.state.state == CoverState.CLOSING
 
         # simulate a device position update to set timer to the default duration rather than dynamic
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_tilt_percentage.id: 70}
         )
 
-        assert entity.state[ATTR_CURRENT_TILT_POSITION] == 30
-        assert entity.state["state"] == CoverState.CLOSING
+        assert entity.state.current_tilt_position == 30
+        assert entity.state.state == CoverState.CLOSING
 
         # wait the timer duration
         await asyncio.sleep(DEFAULT_MOVEMENT_TIMEOUT)
-        assert entity.state["state"] == CoverState.OPEN
+        assert entity.state.state == CoverState.OPEN
 
     # test device instigated movement (e.g. device button press), starting from 30 %
     with patch("zigpy.zcl.Cluster.request", return_value=[0x5, zcl_f.Status.SUCCESS]):
-        assert entity.state[ATTR_CURRENT_POSITION] == 30
-        assert entity.state["state"] == CoverState.OPEN
+        assert entity.state.current_position == 30
+        assert entity.state.state == CoverState.OPEN
 
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_lift_percentage.id: 60}
         )
 
-        assert entity.state[ATTR_CURRENT_POSITION] == 40
-        assert entity.state["state"] == CoverState.OPENING
+        assert entity.state.current_position == 40
+        assert entity.state.state == CoverState.OPENING
 
         # wait the default timer duration
         await asyncio.sleep(DEFAULT_MOVEMENT_TIMEOUT)
-        assert entity.state["state"] == CoverState.OPEN
+        assert entity.state.state == CoverState.OPEN
 
     # test device instigated tilt movement (e.g. device button press), starting from 30 %
     with patch("zigpy.zcl.Cluster.request", return_value=[0x5, zcl_f.Status.SUCCESS]):
-        assert entity.state[ATTR_CURRENT_TILT_POSITION] == 30
-        assert entity.state["state"] == CoverState.OPEN
+        assert entity.state.current_tilt_position == 30
+        assert entity.state.state == CoverState.OPEN
 
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_tilt_percentage.id: 60}
         )
 
-        assert entity.state[ATTR_CURRENT_TILT_POSITION] == 40
-        assert entity.state["state"] == CoverState.OPENING
+        assert entity.state.current_tilt_position == 40
+        assert entity.state.state == CoverState.OPENING
 
         # wait the default timer duration
         await asyncio.sleep(DEFAULT_MOVEMENT_TIMEOUT)
-        assert entity.state["state"] == CoverState.OPEN
+        assert entity.state.state == CoverState.OPEN
 
     # test dynamic movement timeout, starting from 40 % and moving to 90 %
     with patch("zigpy.zcl.Cluster.request", return_value=[0x5, zcl_f.Status.SUCCESS]):
-        assert entity.state[ATTR_CURRENT_POSITION] == 40
-        assert entity.state["state"] == CoverState.OPEN
+        assert entity.state.current_position == 40
+        assert entity.state.state == CoverState.OPEN
 
         await entity.async_set_cover_position(position=90)  # 10 when inverted for ZCL
         await zha_gateway.async_block_till_done()
@@ -575,23 +569,23 @@ async def test_cover(
         assert cluster.request.call_args[0][3] == 10
         assert cluster.request.call_args[1]["expect_reply"] is True
 
-        assert entity.state["state"] == CoverState.OPENING
+        assert entity.state.state == CoverState.OPENING
 
         # wait the default timer duration and verify status is still opening
         await asyncio.sleep(DEFAULT_MOVEMENT_TIMEOUT)
-        assert entity.state["state"] == CoverState.OPENING
+        assert entity.state.state == CoverState.OPENING
 
         # wait the remainder of the dynamic timeout and check if the movement timed out: (50% * 300 seconds) - default
         await asyncio.sleep(
             (50 * 0.01 * LIFT_MOVEMENT_TIMEOUT_RANGE) - DEFAULT_MOVEMENT_TIMEOUT
         )
-        assert entity.state[ATTR_CURRENT_POSITION] == 40
-        assert entity.state["state"] == CoverState.OPEN
+        assert entity.state.current_position == 40
+        assert entity.state.state == CoverState.OPEN
 
     # test dynamic tilt movement timeout, starting from 40 % and moving to 90 %
     with patch("zigpy.zcl.Cluster.request", return_value=[0x5, zcl_f.Status.SUCCESS]):
-        assert entity.state[ATTR_CURRENT_TILT_POSITION] == 40
-        assert entity.state["state"] == CoverState.OPEN
+        assert entity.state.current_tilt_position == 40
+        assert entity.state.state == CoverState.OPEN
 
         await entity.async_set_cover_tilt_position(
             tilt_position=90
@@ -604,23 +598,23 @@ async def test_cover(
         assert cluster.request.call_args[0][3] == 10
         assert cluster.request.call_args[1]["expect_reply"] is True
 
-        assert entity.state["state"] == CoverState.OPENING
+        assert entity.state.state == CoverState.OPENING
 
         # wait the default timer duration and verify status is still opening
         await asyncio.sleep(DEFAULT_MOVEMENT_TIMEOUT)
-        assert entity.state["state"] == CoverState.OPENING
+        assert entity.state.state == CoverState.OPENING
 
         # wait the remainder of the dynamic timeout and check if the movement timed out: (50% * 30 seconds) - default
         await asyncio.sleep(
             (50 * 0.01 * TILT_MOVEMENT_TIMEOUT_RANGE) - DEFAULT_MOVEMENT_TIMEOUT
         )
-        assert entity.state[ATTR_CURRENT_TILT_POSITION] == 40
-        assert entity.state["state"] == CoverState.OPEN
+        assert entity.state.current_tilt_position == 40
+        assert entity.state.state == CoverState.OPEN
 
     # test concurrent movement of both axis, lift and tilt starting at 40 %
     with patch("zigpy.zcl.Cluster.request", return_value=[0x5, zcl_f.Status.SUCCESS]):
-        assert entity.state[ATTR_CURRENT_POSITION] == 40
-        assert entity.state[ATTR_CURRENT_TILT_POSITION] == 40
+        assert entity.state.current_position == 40
+        assert entity.state.current_tilt_position == 40
 
         await entity.async_set_cover_position(position=90)  # 10 when inverted for ZCL
         await zha_gateway.async_block_till_done()
@@ -632,7 +626,7 @@ async def test_cover(
         assert cluster.request.call_args[1]["expect_reply"] is True
 
         # verify the cover is opening due to the lift direction
-        assert entity.state["state"] == CoverState.OPENING
+        assert entity.state.state == CoverState.OPENING
 
         await entity.async_set_cover_tilt_position(
             tilt_position=1
@@ -646,25 +640,25 @@ async def test_cover(
         assert cluster.request.call_args[1]["expect_reply"] is True
 
         # the last action's direction takes state precedence (tilt)
-        assert entity.state["state"] == CoverState.CLOSING
+        assert entity.state.state == CoverState.CLOSING
 
         # report that tilt has reached its target
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_tilt_percentage.id: 99}
         )
-        assert entity.state[ATTR_CURRENT_TILT_POSITION] == 1
+        assert entity.state.current_tilt_position == 1
 
         # state should have reverted to opening because there is still an active lift target transition
-        assert entity.state["state"] == CoverState.OPENING
+        assert entity.state.state == CoverState.OPENING
 
         # report that lift has reached its target
         await send_attributes_report(
             zha_gateway, cluster, {WCAttrs.current_position_lift_percentage.id: 10}
         )
-        assert entity.state[ATTR_CURRENT_POSITION] == 90
+        assert entity.state.current_position == 90
 
         # the state should now be open (static)
-        assert entity.state["state"] == CoverState.OPEN
+        assert entity.state.state == CoverState.OPEN
 
     # stop from client
     with patch("zigpy.zcl.Cluster.request", return_value=[0x2, zcl_f.Status.SUCCESS]):
@@ -706,7 +700,7 @@ async def test_cover_failures(zha_gateway: Gateway) -> None:
         zha_gateway, cluster, {WCAttrs.current_position_lift_percentage.id: 0}
     )
 
-    assert entity.state["state"] == CoverState.OPEN
+    assert entity.state.state == CoverState.OPEN
 
     # close from UI
     with patch(
@@ -724,7 +718,7 @@ async def test_cover_failures(zha_gateway: Gateway) -> None:
             cluster.request.call_args[0][1]
             == closures.WindowCovering.ServerCommandDefs.down_close.id
         )
-        assert entity.state["state"] == CoverState.OPEN
+        assert entity.state.state == CoverState.OPEN
 
     with patch(
         "zigpy.zcl.Cluster.request",
@@ -871,18 +865,18 @@ async def test_shade(
     await send_attributes_report(
         zha_gateway, cluster_on_off, {cluster_on_off.AttributeDefs.on_off.id: 0}
     )
-    assert entity.state["state"] == CoverState.CLOSED
+    assert entity.state.state == CoverState.CLOSED
 
     # test to see if it opens
     await send_attributes_report(
         zha_gateway, cluster_on_off, {cluster_on_off.AttributeDefs.on_off.id: 1}
     )
-    assert entity.state["state"] == CoverState.OPEN
+    assert entity.state.state == CoverState.OPEN
 
     # test entity async_update
     await entity.async_update()
     await zha_gateway.async_block_till_done()
-    assert entity.state["state"] == CoverState.OPEN
+    assert entity.state.state == CoverState.OPEN
 
     # close from client command fails
     with (
@@ -900,7 +894,7 @@ async def test_shade(
         assert cluster_on_off.request.call_count == 1
         assert cluster_on_off.request.call_args[0][0] is False
         assert cluster_on_off.request.call_args[0][1] == 0x0000
-        assert entity.state["state"] == CoverState.OPEN
+        assert entity.state.state == CoverState.OPEN
 
     with patch(
         "zigpy.zcl.Cluster.request", AsyncMock(return_value=[0x1, zcl_f.Status.SUCCESS])
@@ -910,11 +904,11 @@ async def test_shade(
         assert cluster_on_off.request.call_count == 1
         assert cluster_on_off.request.call_args[0][0] is False
         assert cluster_on_off.request.call_args[0][1] == 0x0000
-        assert entity.state["state"] == CoverState.CLOSED
+        assert entity.state.state == CoverState.CLOSED
 
     # open from client command fails
     await send_attributes_report(zha_gateway, cluster_level, {0: 0})
-    assert entity.state["state"] == CoverState.CLOSED
+    assert entity.state.state == CoverState.CLOSED
 
     with (
         patch(
@@ -931,7 +925,7 @@ async def test_shade(
         assert cluster_on_off.request.call_count == 1
         assert cluster_on_off.request.call_args[0][0] is False
         assert cluster_on_off.request.call_args[0][1] == 0x0001
-        assert entity.state["state"] == CoverState.CLOSED
+        assert entity.state.state == CoverState.CLOSED
 
     # open from client succeeds
     with patch(
@@ -942,7 +936,7 @@ async def test_shade(
         assert cluster_on_off.request.call_count == 1
         assert cluster_on_off.request.call_args[0][0] is False
         assert cluster_on_off.request.call_args[0][1] == 0x0001
-        assert entity.state["state"] == CoverState.OPEN
+        assert entity.state.state == CoverState.OPEN
 
     # set position UI command fails
     with (
@@ -961,7 +955,7 @@ async def test_shade(
         assert cluster_level.request.call_args[0][0] is False
         assert cluster_level.request.call_args[0][1] == 0x0004
         assert int(cluster_level.request.call_args[0][3] * 100 / 255) == 47
-        assert entity.state[ATTR_CURRENT_POSITION] == 0
+        assert entity.state.current_position == 0
 
     # set position UI success
     with patch(
@@ -973,11 +967,11 @@ async def test_shade(
         assert cluster_level.request.call_args[0][0] is False
         assert cluster_level.request.call_args[0][1] == 0x0004
         assert int(cluster_level.request.call_args[0][3] * 100 / 255) == 47
-        assert entity.state[ATTR_CURRENT_POSITION] == 47
+        assert entity.state.current_position == 47
 
     # report position change
     await send_attributes_report(zha_gateway, cluster_level, {8: 0, 0: 100, 1: 1})
-    assert entity.state[ATTR_CURRENT_POSITION] == int(100 * 100 / 255)
+    assert entity.state.current_position == int(100 * 100 / 255)
 
     # stop command fails
     with (
@@ -1036,12 +1030,12 @@ async def test_keen_vent(
 
     # test that the state has changed from unavailable to off
     await send_attributes_report(zha_gateway, cluster_on_off, {8: 0, 0: False, 1: 1})
-    assert entity.state["state"] == CoverState.CLOSED
+    assert entity.state.state == CoverState.CLOSED
 
     # test entity async_update
     await entity.async_update()
     await zha_gateway.async_block_till_done()
-    assert entity.state["state"] == CoverState.CLOSED
+    assert entity.state.state == CoverState.CLOSED
 
     # open from client command fails
     p1 = patch.object(cluster_on_off, "request", side_effect=asyncio.TimeoutError)
@@ -1057,7 +1051,7 @@ async def test_keen_vent(
         assert cluster_on_off.request.call_args[0][0] is False
         assert cluster_on_off.request.call_args[0][1] == 0x0001
         assert cluster_level.request.call_count == 1
-        assert entity.state["state"] == CoverState.CLOSED
+        assert entity.state.state == CoverState.CLOSED
 
     # open from client command success
     p1 = patch.object(cluster_on_off, "request", AsyncMock(return_value=[1, 0]))
@@ -1070,8 +1064,8 @@ async def test_keen_vent(
         assert cluster_on_off.request.call_args[0][0] is False
         assert cluster_on_off.request.call_args[0][1] == 0x0001
         assert cluster_level.request.call_count == 1
-        assert entity.state["state"] == CoverState.OPEN
-        assert entity.state[ATTR_CURRENT_POSITION] == 100
+        assert entity.state.state == CoverState.OPEN
+        assert entity.state.current_position == 100
 
 
 async def test_cover_remote(zha_gateway: Gateway) -> None:
@@ -1155,15 +1149,15 @@ async def test_cover_state_restoration(
     )
 
     entity = get_entity(zha_device, platform=Platform.COVER)
-    assert entity.state["state"] == final_state
-    assert entity.state[ATTR_CURRENT_POSITION] == current_position
-    assert entity.state[ATTR_CURRENT_TILT_POSITION] == current_tilt_position
+    assert entity.state.state == final_state
+    assert entity.state.current_position == current_position
+    assert entity.state.current_tilt_position == current_tilt_position
 
     entity.restore_external_state_attributes(state=restore_state)
     if interim_state:
-        assert entity.state["state"] == interim_state
+        assert entity.state.state == interim_state
         await asyncio.sleep(DEFAULT_MOVEMENT_TIMEOUT)
-    assert entity.state["state"] == final_state
+    assert entity.state.state == final_state
 
 
 async def test_cover_lift_timer_cancellation_on_remove(zha_gateway: Gateway) -> None:
@@ -1182,7 +1176,7 @@ async def test_cover_lift_timer_cancellation_on_remove(zha_gateway: Gateway) -> 
     with patch("zigpy.zcl.Cluster.request", return_value=[0x1, zcl_f.Status.SUCCESS]):
         await entity.async_close_cover()
         await zha_gateway.async_block_till_done()
-        assert entity.state["state"] == CoverState.CLOSING
+        assert entity.state.state == CoverState.CLOSING
 
     # remove entity
     await entity.on_remove()
@@ -1204,7 +1198,7 @@ async def test_cover_tilt_timer_cancellation_on_remove(zha_gateway: Gateway) -> 
     with patch("zigpy.zcl.Cluster.request", return_value=[0x1, zcl_f.Status.SUCCESS]):
         await entity.async_close_cover_tilt()
         await zha_gateway.async_block_till_done()
-        assert entity.state["state"] == CoverState.CLOSING
+        assert entity.state.state == CoverState.CLOSING
 
     # remove entity
     await entity.on_remove()
@@ -1226,7 +1220,7 @@ async def test_cover_state_restore_timer_cancellation_on_remove(
     # start state restore timer
     entity = get_entity(zha_device, platform=Platform.COVER)
     entity.restore_external_state_attributes(state=CoverState.CLOSING)
-    assert entity.state["state"] == CoverState.CLOSING
+    assert entity.state.state == CoverState.CLOSING
 
     # remove entity
     await entity.on_remove()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1123,7 +1123,7 @@ async def test_quirks_v2_translation_placeholders(zha_gateway: Gateway) -> None:
 
     assert (
         entity.translation_placeholders
-        == entity.info_object.translation_placeholders
+        == entity.state.translation_placeholders
         == {"sensor_index": "1"}
     )
 

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -50,7 +50,7 @@ async def test_device_tracker(
     cluster = zigpy_device_dt.endpoints.get(1).power
     entity = get_entity(zha_device, platform=Platform.DEVICE_TRACKER)
 
-    assert entity.state["connected"] is False
+    assert entity.state.connected is False
 
     # turn state flip
     await send_attributes_report(
@@ -63,7 +63,7 @@ async def test_device_tracker(
     await zha_gateway.async_block_till_done()
     assert entity.async_update.await_count == 1
 
-    assert entity.state["connected"] is True
+    assert entity.state.connected is True
     assert entity.is_connected is True
     assert entity.source_type == SourceType.ROUTER
     assert entity.battery_level == 100
@@ -72,19 +72,19 @@ async def test_device_tracker(
     zigpy_device_dt.last_seen = time.time() - 90
     await entity.async_update()
     await zha_gateway.async_block_till_done()
-    assert entity.state["connected"] is False
+    assert entity.state.connected is False
     assert entity.is_connected is False
 
     # bring it back
     zigpy_device_dt.last_seen = time.time()
     await entity.async_update()
     await zha_gateway.async_block_till_done()
-    assert entity.state["connected"] is True
+    assert entity.state.connected is True
     assert entity.is_connected is True
 
     # knock it offline by setting last seen None
     zigpy_device_dt.last_seen = None
     await entity.async_update()
     await zha_gateway.async_block_till_done()
-    assert entity.state["connected"] is False
+    assert entity.state.connected is False
     assert entity.is_connected is False

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -390,7 +390,7 @@ async def test_quirks_v2_entity_discovery_e1_curtain(
         qualifier_func=lambda e: e._enum == BasicCluster.PowerSource,
     )
     assert (
-        power_source_entity.state["state"]
+        power_source_entity.state.state
         == BasicCluster.PowerSource.Mains_single_phase.name
     )
 
@@ -400,7 +400,7 @@ async def test_quirks_v2_entity_discovery_e1_curtain(
         exact_entity_type=sensor.EnumSensor,
         qualifier_func=lambda e: e._enum == AqaraE1HookState,
     )
-    assert hook_state_entity.state["state"] == AqaraE1HookState.Unlocked.name
+    assert hook_state_entity.state.state == AqaraE1HookState.Unlocked.name
 
     error_detected_entity = get_entity(
         zha_device,
@@ -408,7 +408,7 @@ async def test_quirks_v2_entity_discovery_e1_curtain(
         exact_entity_type=binary_sensor.BinarySensor,
         qualifier_func=lambda e: e._attribute_name == "error_detected",
     )
-    assert error_detected_entity.state["state"] is False
+    assert error_detected_entity.state.state is False
 
 
 def _get_test_device(

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -299,7 +299,7 @@ async def test_zha_group_fan_entity(
 
     assert entity.group_id == zha_group.group_id
     assert isinstance(entity, GroupEntity)
-    assert entity.info_object.fallback_name == zha_group.name
+    assert entity.state.fallback_name == zha_group.name
 
     group_fan_cluster = zha_group.zigpy_group.endpoint[hvac.Fan.cluster_id]
 

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -32,8 +32,6 @@ from zha.application import Platform
 from zha.application.gateway import Gateway
 from zha.application.platforms import GroupEntity, PlatformEntity
 from zha.application.platforms.fan.const import (
-    ATTR_PERCENTAGE,
-    ATTR_PRESET_MODE,
     PRESET_MODE_AUTO,
     PRESET_MODE_ON,
     PRESET_MODE_SMART,
@@ -145,15 +143,15 @@ async def test_fan(
     cluster = zigpy_device.endpoints.get(1).fan
 
     entity = get_entity(zha_device, platform=Platform.FAN)
-    assert entity.state["is_on"] is False
+    assert entity.state.is_on is False
 
     # turn on at fan
     await send_attributes_report(zha_gateway, cluster, {1: 2, 0: 1, 2: 3})
-    assert entity.state["is_on"] is True
+    assert entity.state.is_on is True
 
     # turn off at fan
     await send_attributes_report(zha_gateway, cluster, {1: 1, 0: 0, 2: 2})
-    assert entity.state["is_on"] is False
+    assert entity.state.is_on is False
 
     # turn on from client
     cluster.write_attributes.reset_mock()
@@ -162,7 +160,7 @@ async def test_fan(
     assert cluster.write_attributes.call_args == call(
         {"fan_mode": 2}, manufacturer=UNDEFINED
     )
-    assert entity.state["is_on"] is True
+    assert entity.state.is_on is True
 
     # turn off from client
     cluster.write_attributes.reset_mock()
@@ -171,7 +169,7 @@ async def test_fan(
     assert cluster.write_attributes.call_args == call(
         {"fan_mode": 0}, manufacturer=UNDEFINED
     )
-    assert entity.state["is_on"] is False
+    assert entity.state.is_on is False
 
     # change speed from client
     cluster.write_attributes.reset_mock()
@@ -180,8 +178,8 @@ async def test_fan(
     assert cluster.write_attributes.call_args == call(
         {"fan_mode": 3}, manufacturer=UNDEFINED
     )
-    assert entity.state["is_on"] is True
-    assert entity.state["speed"] == SPEED_HIGH
+    assert entity.state.is_on is True
+    assert entity.state.speed == SPEED_HIGH
 
     # change preset_mode from client
     cluster.write_attributes.reset_mock()
@@ -190,8 +188,8 @@ async def test_fan(
     assert cluster.write_attributes.call_args == call(
         {"fan_mode": 4}, manufacturer=UNDEFINED
     )
-    assert entity.state["is_on"] is True
-    assert entity.state["preset_mode"] == PRESET_MODE_ON
+    assert entity.state.is_on is True
+    assert entity.state.preset_mode == PRESET_MODE_ON
 
     # test set percentage from client
     cluster.write_attributes.reset_mock()
@@ -202,8 +200,8 @@ async def test_fan(
         {"fan_mode": 2}, manufacturer=UNDEFINED
     )
     # this is converted to a ranged value
-    assert entity.state["percentage"] == 66
-    assert entity.state["is_on"] is True
+    assert entity.state.percentage == 66
+    assert entity.state.is_on is True
 
     # set invalid preset_mode from client
     cluster.write_attributes.reset_mock()
@@ -215,14 +213,14 @@ async def test_fan(
     # test percentage in turn on command
     await entity.async_turn_on(percentage=25)
     await zha_gateway.async_block_till_done()
-    assert entity.state["percentage"] == 33  # this is converted to a ranged value
-    assert entity.state["speed"] == SPEED_LOW
+    assert entity.state.percentage == 33  # this is converted to a ranged value
+    assert entity.state.speed == SPEED_LOW
 
     # test speed in turn on command
     await entity.async_turn_on(speed=SPEED_HIGH)
     await zha_gateway.async_block_till_done()
-    assert entity.state["percentage"] == 100
-    assert entity.state["speed"] == SPEED_HIGH
+    assert entity.state.percentage == 100
+    assert entity.state.speed == SPEED_HIGH
 
 
 async def async_turn_on(
@@ -309,7 +307,7 @@ async def test_zha_group_fan_entity(
     dev2_fan_cluster = device_fan_2.device.endpoints[1].fan
 
     # test that the fan group entity was created and is off
-    assert entity.state["is_on"] is False
+    assert entity.state.is_on is False
 
     # turn on from client
     group_fan_cluster.write_attributes.reset_mock()
@@ -353,32 +351,32 @@ async def test_zha_group_fan_entity(
     await send_attributes_report(zha_gateway, dev2_fan_cluster, {0: 0})
 
     # test that group fan is off
-    assert entity.state["is_on"] is False
+    assert entity.state.is_on is False
 
     await send_attributes_report(zha_gateway, dev2_fan_cluster, {0: 2})
     await zha_gateway.async_block_till_done()
 
     # no update yet because of debouncing
-    assert entity.state["is_on"] is False
+    assert entity.state.is_on is False
 
     # member updates are debounced for .5s
     await asyncio.sleep(1)
     await zha_gateway.async_block_till_done()
 
-    assert entity.state["is_on"] is True
+    assert entity.state.is_on is True
 
     await send_attributes_report(zha_gateway, dev2_fan_cluster, {0: 0})
     await zha_gateway.async_block_till_done()
 
     # no update yet because of debouncing
-    assert entity.state["is_on"] is True
+    assert entity.state.is_on is True
 
     # member updates are debounced for .5s
     await asyncio.sleep(1)
     await zha_gateway.async_block_till_done()
 
     # test that group fan is now off
-    assert entity.state["is_on"] is False
+    assert entity.state.is_on is False
 
     await group_entity_availability_test(
         zha_gateway, device_fan_1, device_fan_2, entity
@@ -420,7 +418,7 @@ async def test_zha_group_fan_entity_failure_state(
     group_fan_cluster = zha_group.zigpy_group.endpoint[hvac.Fan.cluster_id]
 
     # test that the fan group entity was created and is off
-    assert entity.state["is_on"] is False
+    assert entity.state.is_on is False
 
     # turn on from client
     group_fan_cluster.write_attributes.reset_mock()
@@ -458,10 +456,10 @@ async def test_fan_init(
 
     entity = get_entity(zha_device, platform=Platform.FAN)
 
-    assert entity.state["is_on"] == expected_state
-    assert entity.state["speed"] == expected_speed
-    assert entity.state["percentage"] == expected_percentage
-    assert entity.state["preset_mode"] is None
+    assert entity.state.is_on == expected_state
+    assert entity.state.speed == expected_speed
+    assert entity.state.percentage == expected_percentage
+    assert entity.state.preset_mode is None
 
 
 async def test_fan_update_entity(
@@ -476,26 +474,26 @@ async def test_fan_update_entity(
 
     entity = get_entity(zha_device, platform=Platform.FAN)
 
-    assert entity.state["is_on"] is False
-    assert entity.state["speed"] == SPEED_OFF
-    assert entity.state["percentage"] == 0
-    assert entity.state["preset_mode"] is None
+    assert entity.state.is_on is False
+    assert entity.state.speed == SPEED_OFF
+    assert entity.state.percentage == 0
+    assert entity.state.preset_mode is None
     assert entity.percentage_step == 100 / 3
     assert cluster.read_attributes.await_count == 2
 
     await entity.async_update()
     await zha_gateway.async_block_till_done()
-    assert entity.state["is_on"] is False
-    assert entity.state["speed"] == SPEED_OFF
+    assert entity.state.is_on is False
+    assert entity.state.speed == SPEED_OFF
     assert cluster.read_attributes.await_count == 3
 
     cluster.PLUGGED_ATTR_READS = {"fan_mode": 1}
     await entity.async_update()
     await zha_gateway.async_block_till_done()
-    assert entity.state["is_on"] is True
-    assert entity.state["percentage"] == 33
-    assert entity.state["speed"] == SPEED_LOW
-    assert entity.state["preset_mode"] is None
+    assert entity.state.is_on is True
+    assert entity.state.percentage == 33
+    assert entity.state.speed == SPEED_LOW
+    assert entity.state.preset_mode is None
     assert entity.percentage_step == 100 / 3
     assert cluster.read_attributes.await_count == 4
 
@@ -553,15 +551,15 @@ async def test_fan_ikea(
     cluster = zigpy_device_ikea.endpoints.get(1).ikea_airpurifier
     entity = get_entity(zha_device, platform=Platform.FAN)
 
-    assert entity.state["is_on"] is False
+    assert entity.state.is_on is False
 
     # turn on at fan
     await send_attributes_report(zha_gateway, cluster, {6: 1})
-    assert entity.state["is_on"] is True
+    assert entity.state.is_on is True
 
     # turn off at fan
     await send_attributes_report(zha_gateway, cluster, {6: 0})
-    assert entity.state["is_on"] is False
+    assert entity.state.is_on is False
 
     # turn on from HA
     cluster.write_attributes.reset_mock()
@@ -652,9 +650,9 @@ async def test_fan_ikea_init(
 
     zha_device = await join_zigpy_device(zha_gateway, zigpy_device_ikea)
     entity = get_entity(zha_device, platform=Platform.FAN)
-    assert entity.state["is_on"] == ikea_expected_state
-    assert entity.state["percentage"] == ikea_expected_percentage
-    assert entity.state["preset_mode"] == ikea_preset_mode
+    assert entity.state.is_on == ikea_expected_state
+    assert entity.state.percentage == ikea_expected_percentage
+    assert entity.state.preset_mode == ikea_preset_mode
 
 
 async def test_fan_ikea_update_entity(
@@ -668,9 +666,9 @@ async def test_fan_ikea_update_entity(
     zha_device = await join_zigpy_device(zha_gateway, zigpy_device_ikea)
     entity = get_entity(zha_device, platform=Platform.FAN)
 
-    assert entity.state["is_on"] is False
-    assert entity.state[ATTR_PERCENTAGE] == 0
-    assert entity.state[ATTR_PRESET_MODE] is None
+    assert entity.state.is_on is False
+    assert entity.state.percentage == 0
+    assert entity.state.preset_mode is None
     assert entity.percentage_step == 100 / 10
 
     cluster.PLUGGED_ATTR_READS = {"fan_mode": 1, "fan_speed": 6}
@@ -678,9 +676,9 @@ async def test_fan_ikea_update_entity(
     await entity.async_update()
     await zha_gateway.async_block_till_done()
 
-    assert entity.state["is_on"] is True
-    assert entity.state[ATTR_PERCENTAGE] == 60
-    assert entity.state[ATTR_PRESET_MODE] is PRESET_MODE_AUTO
+    assert entity.state.is_on is True
+    assert entity.state.percentage == 60
+    assert entity.state.preset_mode is PRESET_MODE_AUTO
     assert entity.percentage_step == 100 / 10
 
 
@@ -737,15 +735,15 @@ async def test_fan_kof(
     cluster = zigpy_device_kof.endpoints.get(1).fan
     entity = get_entity(zha_device, platform=Platform.FAN)
 
-    assert entity.state["is_on"] is False
+    assert entity.state.is_on is False
 
     # turn on at fan
     await send_attributes_report(zha_gateway, cluster, {1: 2, 0: 1, 2: 3})
-    assert entity.state["is_on"] is True
+    assert entity.state.is_on is True
 
     # turn off at fan
     await send_attributes_report(zha_gateway, cluster, {1: 1, 0: 0, 2: 2})
-    assert entity.state["is_on"] is False
+    assert entity.state.is_on is False
 
     # turn on from HA
     cluster.write_attributes.reset_mock()
@@ -810,9 +808,9 @@ async def test_fan_kof_init(
     zha_device = await join_zigpy_device(zha_gateway, zigpy_device_kof)
     entity = get_entity(zha_device, platform=Platform.FAN)
 
-    assert entity.state["is_on"] is expected_state
-    assert entity.state[ATTR_PERCENTAGE] == expected_percentage
-    assert entity.state[ATTR_PRESET_MODE] == expected_preset
+    assert entity.state.is_on is expected_state
+    assert entity.state.percentage == expected_percentage
+    assert entity.state.preset_mode == expected_preset
 
 
 async def test_fan_kof_update_entity(
@@ -827,9 +825,9 @@ async def test_fan_kof_update_entity(
     zha_device = await join_zigpy_device(zha_gateway, zigpy_device_kof)
     entity = get_entity(zha_device, platform=Platform.FAN)
 
-    assert entity.state["is_on"] is False
-    assert entity.state[ATTR_PERCENTAGE] == 0
-    assert entity.state[ATTR_PRESET_MODE] is None
+    assert entity.state.is_on is False
+    assert entity.state.percentage == 0
+    assert entity.state.preset_mode is None
     assert entity.percentage_step == 100 / 4
 
     cluster.PLUGGED_ATTR_READS = {"fan_mode": 1}
@@ -837,7 +835,7 @@ async def test_fan_kof_update_entity(
     await entity.async_update()
     await zha_gateway.async_block_till_done()
 
-    assert entity.state["is_on"] is True
-    assert entity.state[ATTR_PERCENTAGE] == 25
-    assert entity.state[ATTR_PRESET_MODE] is None
+    assert entity.state.is_on is True
+    assert entity.state.percentage == 25
+    assert entity.state.preset_mode is None
     assert entity.percentage_step == 100 / 4

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -276,7 +276,7 @@ async def test_gateway_group_methods(
     entity: GroupEntity | None = get_group_entity(zha_group, platform=Platform.LIGHT)
     assert entity is not None
 
-    info = entity.info_object
+    info = entity.state
     assert info.class_name == "LightGroup"
     assert info.platform == Platform.LIGHT
     assert info.unique_id == "light_zha_group_0x0002"

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -761,7 +761,7 @@ async def test_zha_group_light_entity(
 
     entity: GroupEntity = get_group_entity(zha_group, platform=Platform.LIGHT)
     assert entity.group_id == zha_group.group_id
-    assert entity.info_object.fallback_name == zha_group.name
+    assert entity.state.fallback_name == zha_group.name
 
     device_1_light_entity = get_entity(device_light_1, platform=Platform.LIGHT)
     device_2_light_entity = get_entity(device_light_2, platform=Platform.LIGHT)

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -283,7 +283,7 @@ async def test_light_refresh(
     zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
 
     entity = get_entity(zha_device, platform=Platform.LIGHT)
-    assert bool(entity.state["on"]) is False
+    assert bool(entity.state.on) is False
 
     on_off_cluster.read_attributes.reset_mock()
 
@@ -292,7 +292,7 @@ async def test_light_refresh(
     await zha_gateway.async_block_till_done()
     assert on_off_cluster.read_attributes.call_count == 0
     assert on_off_cluster.read_attributes.await_count == 0
-    assert bool(entity.state["on"]) is False
+    assert bool(entity.state.on) is False
 
     # 1 interval - at least 1 call
     on_off_cluster.PLUGGED_ATTR_READS = {"on_off": 1}
@@ -300,7 +300,7 @@ async def test_light_refresh(
     await zha_gateway.async_block_till_done()
     assert on_off_cluster.read_attributes.call_count >= 1
     assert on_off_cluster.read_attributes.await_count >= 1
-    assert bool(entity.state["on"]) is True
+    assert bool(entity.state.on) is True
 
     # 2 intervals - at least 2 calls
     on_off_cluster.PLUGGED_ATTR_READS = {"on_off": 0}
@@ -308,7 +308,7 @@ async def test_light_refresh(
     await zha_gateway.async_block_till_done()
     assert on_off_cluster.read_attributes.call_count >= 2
     assert on_off_cluster.read_attributes.await_count >= 2
-    assert bool(entity.state["on"]) is False
+    assert bool(entity.state.on) is False
 
     read_call_count = on_off_cluster.read_attributes.call_count
     read_await_count = on_off_cluster.read_attributes.await_count
@@ -322,7 +322,7 @@ async def test_light_refresh(
     await zha_gateway.async_block_till_done()
     assert on_off_cluster.read_attributes.call_count == read_call_count
     assert on_off_cluster.read_attributes.await_count == read_await_count
-    assert bool(entity.state["on"]) is False
+    assert bool(entity.state.on) is False
 
     entity.enable()
 
@@ -332,7 +332,7 @@ async def test_light_refresh(
     await zha_gateway.async_block_till_done()
     assert on_off_cluster.read_attributes.call_count > read_call_count
     assert on_off_cluster.read_attributes.await_count > read_await_count
-    assert bool(entity.state["on"]) is True
+    assert bool(entity.state.on) is True
 
 
 # TODO reporting is not checked
@@ -391,7 +391,7 @@ async def test_light(
     )
 
     entity = get_entity(zha_device, platform=Platform.LIGHT)
-    assert bool(entity.state["on"]) is False
+    assert bool(entity.state.on) is False
 
     # test turning the lights on and off from the light
     await async_test_on_off_from_light(zha_gateway, cluster_on_off, entity)
@@ -436,14 +436,14 @@ async def test_light(
 
     if cluster_color:
         # test color temperature from the client with transition
-        assert entity.state["brightness"] != 50
-        assert entity.state["color_temp"] != 200
+        assert entity.state.brightness != 50
+        assert entity.state.color_temp != 200
         await entity.async_turn_on(brightness=50, transition=10, color_temp=200)
         await zha_gateway.async_block_till_done()
-        assert entity.state["color_mode"] == ColorMode.COLOR_TEMP
-        assert entity.state["brightness"] == 50
-        assert entity.state["color_temp"] == 200
-        assert bool(entity.state["on"]) is True
+        assert entity.state.color_mode == ColorMode.COLOR_TEMP
+        assert entity.state.brightness == 50
+        assert entity.state.color_temp == 200
+        assert bool(entity.state.on) is True
         assert cluster_color.request.call_count == 1
         assert cluster_color.request.await_count == 1
         assert cluster_color.request.call_args == call(
@@ -458,12 +458,12 @@ async def test_light(
         cluster_color.request.reset_mock()
 
         # test color xy from the client
-        assert entity.state["xy_color"] != [13369, 18087]
+        assert entity.state.xy_color != [13369, 18087]
         await entity.async_turn_on(brightness=50, xy_color=[13369, 18087])
         await zha_gateway.async_block_till_done()
-        assert entity.state["color_mode"] == ColorMode.XY
-        assert entity.state["brightness"] == 50
-        assert entity.state["xy_color"] == [13369, 18087]
+        assert entity.state.color_mode == ColorMode.XY
+        assert entity.state.brightness == 50
+        assert entity.state.xy_color == [13369, 18087]
         assert cluster_color.request.call_count == 1
         assert cluster_color.request.await_count == 1
         assert cluster_color.request.call_args == call(
@@ -492,11 +492,11 @@ async def async_test_on_off_from_light(
 
     # group member updates are debounced
     if isinstance(entity, GroupEntity):
-        assert bool(entity.state["on"]) is False
+        assert bool(entity.state.on) is False
         await asyncio.sleep(0.1)
         await zha_gateway.async_block_till_done()
 
-    assert bool(entity.state["on"]) is True
+    assert bool(entity.state.on) is True
 
     # turn off at light
     await send_attributes_report(zha_gateway, cluster, {1: 1, 0: 0, 2: 3})
@@ -504,11 +504,11 @@ async def async_test_on_off_from_light(
 
     # group member updates are debounced
     if isinstance(entity, GroupEntity):
-        assert bool(entity.state["on"]) is True
+        assert bool(entity.state.on) is True
         await asyncio.sleep(0.1)
         await zha_gateway.async_block_till_done()
 
-    assert bool(entity.state["on"]) is False
+    assert bool(entity.state.on) is False
 
 
 async def async_test_on_from_light(
@@ -525,11 +525,11 @@ async def async_test_on_from_light(
 
     # group member updates are debounced
     if isinstance(entity, GroupEntity):
-        assert bool(entity.state["on"]) is False
+        assert bool(entity.state.on) is False
         await asyncio.sleep(0.1)
         await zha_gateway.async_block_till_done()
 
-    assert bool(entity.state["on"]) is True
+    assert bool(entity.state.on) is True
 
 
 async def async_test_on_off_from_client(
@@ -542,7 +542,7 @@ async def async_test_on_off_from_client(
     cluster.request.reset_mock()
     await entity.async_turn_on()
     await zha_gateway.async_block_till_done()
-    assert bool(entity.state["on"]) is True
+    assert bool(entity.state.on) is True
     assert cluster.request.call_count == 1
     assert cluster.request.await_count == 1
     assert cluster.request.call_args == call(
@@ -567,7 +567,7 @@ async def async_test_off_from_client(
     cluster.request.reset_mock()
     await entity.async_turn_off()
     await zha_gateway.async_block_till_done()
-    assert bool(entity.state["on"]) is False
+    assert bool(entity.state.on) is False
     assert cluster.request.call_count == 1
     assert cluster.request.await_count == 1
     assert cluster.request.call_args == call(
@@ -600,7 +600,7 @@ async def async_test_level_on_off_from_client(
         await zha_gateway.async_block_till_done()
         on_off_cluster.request.reset_mock()
         level_cluster.request.reset_mock()
-        assert bool(entity.state["on"]) is False
+        assert bool(entity.state.on) is False
 
     await _reset_light()
     await _async_shift_time(zha_gateway)
@@ -608,7 +608,7 @@ async def async_test_level_on_off_from_client(
     # turn on via UI
     await entity.async_turn_on()
     await zha_gateway.async_block_till_done()
-    assert bool(entity.state["on"]) is True
+    assert bool(entity.state.on) is True
     assert on_off_cluster.request.call_count == 1
     assert on_off_cluster.request.await_count == 1
     assert level_cluster.request.call_count == 0
@@ -626,7 +626,7 @@ async def async_test_level_on_off_from_client(
 
     await entity.async_turn_on(transition=10)
     await zha_gateway.async_block_till_done()
-    assert bool(entity.state["on"]) is True
+    assert bool(entity.state.on) is True
     assert on_off_cluster.request.call_count == 0
     assert on_off_cluster.request.await_count == 0
     assert level_cluster.request.call_count == 1
@@ -645,7 +645,7 @@ async def async_test_level_on_off_from_client(
 
     await entity.async_turn_on(brightness=10)
     await zha_gateway.async_block_till_done()
-    assert bool(entity.state["on"]) is True
+    assert bool(entity.state.on) is True
     # the onoff cluster is now not used when brightness is present by default
     assert on_off_cluster.request.call_count == 0
     assert on_off_cluster.request.await_count == 0
@@ -679,16 +679,16 @@ async def async_test_dimmer_from_light(
         zha_gateway, cluster, {1: level + 10, 0: level, 2: level - 10 or 22}
     )
     await zha_gateway.async_block_till_done()
-    assert entity.state["on"] == expected_state
+    assert entity.state.on == expected_state
     # hass uses None for brightness of 0 in state attributes
     if level == 0:
-        assert entity.state["brightness"] is None
+        assert entity.state.brightness is None
     else:
         # group member updates are debounced
         if isinstance(entity, GroupEntity):
             await asyncio.sleep(0.1)
             await zha_gateway.async_block_till_done()
-        assert entity.state["brightness"] == level
+        assert entity.state.brightness == level
 
 
 async def async_test_flash_from_client(
@@ -702,7 +702,7 @@ async def async_test_flash_from_client(
     cluster.request.reset_mock()
     await entity.async_turn_on(flash=flash)
     await zha_gateway.async_block_till_done()
-    assert bool(entity.state["on"]) is True
+    assert bool(entity.state.on) is True
     assert cluster.request.call_count == 1
     assert cluster.request.await_count == 1
     assert cluster.request.call_args == call(
@@ -788,7 +788,7 @@ async def test_zha_group_light_entity(
     dev1_cluster_level = device_light_1.device.endpoints[1].level
 
     # test that the lights were created and are off
-    assert bool(entity.state["on"]) is False
+    assert bool(entity.state.on) is False
 
     # Group entities do not support state restoration,
     # except for off_brightness and off_with_transition
@@ -803,9 +803,9 @@ async def test_zha_group_light_entity(
         effect="colorloop",
     )
 
-    assert bool(entity.state["on"]) is False
-    assert bool(entity.state["off_with_transition"]) is False
-    assert entity.state["off_brightness"] == 12
+    assert bool(entity.state.on) is False
+    assert bool(entity.state.off_with_transition) is False
+    assert entity.state.off_brightness == 12
 
     # test turning the lights on and off from the client
     await async_test_on_off_from_client(zha_gateway, group_cluster_on_off, entity)
@@ -849,42 +849,42 @@ async def test_zha_group_light_entity(
     await zha_gateway.async_block_till_done()
 
     # test that group light is on
-    assert device_1_light_entity.state["on"] is True
-    assert device_2_light_entity.state["on"] is True
-    assert bool(entity.state["on"]) is True
+    assert device_1_light_entity.state.on is True
+    assert device_2_light_entity.state.on is True
+    assert bool(entity.state.on) is True
 
     await send_attributes_report(zha_gateway, dev1_cluster_on_off, {0: 0})
     await zha_gateway.async_block_till_done()
 
     # test that group light is still on
-    assert device_1_light_entity.state["on"] is False
-    assert device_2_light_entity.state["on"] is True
-    assert bool(entity.state["on"]) is True
+    assert device_1_light_entity.state.on is False
+    assert device_2_light_entity.state.on is True
+    assert bool(entity.state.on) is True
 
     await send_attributes_report(zha_gateway, dev2_cluster_on_off, {0: 0})
     await zha_gateway.async_block_till_done()
 
     # test that group light is now off
-    assert device_1_light_entity.state["on"] is False
-    assert device_2_light_entity.state["on"] is False
+    assert device_1_light_entity.state.on is False
+    assert device_2_light_entity.state.on is False
 
     # group member updates are debounced
-    assert bool(entity.state["on"]) is True
+    assert bool(entity.state.on) is True
     await asyncio.sleep(0.1)
     await zha_gateway.async_block_till_done()
-    assert bool(entity.state["on"]) is False
+    assert bool(entity.state.on) is False
 
     await send_attributes_report(zha_gateway, dev1_cluster_on_off, {0: 1})
     await zha_gateway.async_block_till_done()
 
     # test that group light is now back on
-    assert device_1_light_entity.state["on"] is True
-    assert device_2_light_entity.state["on"] is False
+    assert device_1_light_entity.state.on is True
+    assert device_2_light_entity.state.on is False
     # group member updates are debounced
-    assert bool(entity.state["on"]) is False
+    assert bool(entity.state.on) is False
     await asyncio.sleep(0.1)
     await zha_gateway.async_block_till_done()
-    assert bool(entity.state["on"]) is True
+    assert bool(entity.state.on) is True
 
     await group_entity_availability_test(
         zha_gateway, device_light_1, device_light_2, entity
@@ -893,13 +893,13 @@ async def test_zha_group_light_entity(
     # turn it off to test a new member add being tracked
     await send_attributes_report(zha_gateway, dev1_cluster_on_off, {0: 0})
     await zha_gateway.async_block_till_done()
-    assert device_1_light_entity.state["on"] is False
-    assert device_2_light_entity.state["on"] is False
+    assert device_1_light_entity.state.on is False
+    assert device_2_light_entity.state.on is False
     # group member updates are debounced
-    assert bool(entity.state["on"]) is True
+    assert bool(entity.state.on) is True
     await asyncio.sleep(0.1)
     await zha_gateway.async_block_till_done()
-    assert bool(entity.state["on"]) is False
+    assert bool(entity.state.on) is False
 
     # add a new member and test that his state is also tracked
     await zha_group.async_add_members(
@@ -913,14 +913,14 @@ async def test_zha_group_light_entity(
     await send_attributes_report(zha_gateway, dev3_cluster_on_off, {0: 1})
     await zha_gateway.async_block_till_done()
 
-    assert device_1_light_entity.state["on"] is False
-    assert device_2_light_entity.state["on"] is False
-    assert device_3_light_entity.state["on"] is True
+    assert device_1_light_entity.state.on is False
+    assert device_2_light_entity.state.on is False
+    assert device_3_light_entity.state.on is True
     # group member updates are debounced
-    assert bool(entity.state["on"]) is False
+    assert bool(entity.state.on) is False
     await asyncio.sleep(0.1)
     await zha_gateway.async_block_till_done()
-    assert bool(entity.state["on"]) is True
+    assert bool(entity.state.on) is True
 
     # make the group have only 1 member and now there should be no entity
     await zha_group.async_remove_members(
@@ -949,7 +949,7 @@ async def test_zha_group_light_entity(
     assert entity is not None
     await send_attributes_report(zha_gateway, dev3_cluster_on_off, {0: 1})
     await zha_gateway.async_block_till_done()
-    assert bool(entity.state["on"]) is True
+    assert bool(entity.state.on) is True
 
     # add a 3rd member and ensure we still have an entity and we track the new member
     # First we turn the lights currently in the group off
@@ -957,10 +957,10 @@ async def test_zha_group_light_entity(
     await send_attributes_report(zha_gateway, dev3_cluster_on_off, {0: 0})
     await zha_gateway.async_block_till_done()
     # group member updates are debounced
-    assert bool(entity.state["on"]) is True
+    assert bool(entity.state.on) is True
     await asyncio.sleep(0.1)
     await zha_gateway.async_block_till_done()
-    assert bool(entity.state["on"]) is False
+    assert bool(entity.state.on) is False
 
     # this will test that _reprobe_group is used correctly
     await zha_group.async_add_members(
@@ -976,10 +976,10 @@ async def test_zha_group_light_entity(
     await send_attributes_report(zha_gateway, dev2_cluster_on_off, {0: 1})
     await zha_gateway.async_block_till_done()
     # group member updates are debounced
-    assert bool(entity.state["on"]) is False
+    assert bool(entity.state.on) is False
     await asyncio.sleep(0.1)
     await zha_gateway.async_block_till_done()
-    assert bool(entity.state["on"]) is True
+    assert bool(entity.state.on) is True
 
     await zha_group.async_remove_members(
         [GroupMemberReference(ieee=coordinator.ieee, endpoint_id=1)]
@@ -987,7 +987,7 @@ async def test_zha_group_light_entity(
     await zha_gateway.async_block_till_done()
     entity = get_group_entity(zha_group, platform=Platform.LIGHT)
     assert entity is not None
-    assert bool(entity.state["on"]) is True
+    assert bool(entity.state.on) is True
     assert len(zha_group.members) == 3
 
     # remove the group and ensure that there is no entity and that the entity registry is cleaned up
@@ -1141,9 +1141,9 @@ async def test_transitions(
     eWeLink_cluster_color = eWeLink_light.device.endpoints[1].light_color
 
     # test that the lights were created and are off
-    assert bool(entity.state["on"]) is False
-    assert bool(device_1_light_entity.state["on"]) is False
-    assert bool(device_2_light_entity.state["on"]) is False
+    assert bool(entity.state.on) is False
+    assert bool(device_1_light_entity.state.on) is False
+    assert bool(device_2_light_entity.state.on) is False
 
     # first test 0 length transition with no color and no brightness provided
     dev1_cluster_on_off.request.reset_mock()
@@ -1166,8 +1166,8 @@ async def test_transitions(
         manufacturer=None,
     )
 
-    assert bool(device_1_light_entity.state["on"]) is True
-    assert device_1_light_entity.state["brightness"] == 254
+    assert bool(device_1_light_entity.state.on) is True
+    assert device_1_light_entity.state.brightness == 254
 
     # test 0 length transition with no color and no brightness provided again, but for "force on" lights
     eWeLink_cluster_on_off.request.reset_mock()
@@ -1198,8 +1198,8 @@ async def test_transitions(
         manufacturer=None,
     )
 
-    assert bool(eWeLink_light_entity.state["on"]) is True
-    assert eWeLink_light_entity.state["brightness"] == 254
+    assert bool(eWeLink_light_entity.state.on) is True
+    assert eWeLink_light_entity.state.brightness == 254
 
     eWeLink_cluster_on_off.request.reset_mock()
     eWeLink_cluster_level.request.reset_mock()
@@ -1225,8 +1225,8 @@ async def test_transitions(
         manufacturer=None,
     )
 
-    assert bool(device_1_light_entity.state["on"]) is True
-    assert device_1_light_entity.state["brightness"] == 50
+    assert bool(device_1_light_entity.state.on) is True
+    assert device_1_light_entity.state.brightness == 50
 
     dev1_cluster_level.request.reset_mock()
 
@@ -1260,10 +1260,10 @@ async def test_transitions(
         manufacturer=None,
     )
 
-    assert bool(device_1_light_entity.state["on"]) is True
-    assert device_1_light_entity.state["brightness"] == 18
-    assert device_1_light_entity.state["color_temp"] == 432
-    assert device_1_light_entity.state["color_mode"] == ColorMode.COLOR_TEMP
+    assert bool(device_1_light_entity.state.on) is True
+    assert device_1_light_entity.state.brightness == 18
+    assert device_1_light_entity.state.color_temp == 432
+    assert device_1_light_entity.state.color_mode == ColorMode.COLOR_TEMP
 
     dev1_cluster_level.request.reset_mock()
     dev1_cluster_color.request.reset_mock()
@@ -1287,7 +1287,7 @@ async def test_transitions(
         manufacturer=None,
     )
 
-    assert bool(device_1_light_entity.state["on"]) is False
+    assert bool(device_1_light_entity.state.on) is False
 
     dev1_cluster_level.request.reset_mock()
 
@@ -1332,10 +1332,10 @@ async def test_transitions(
         manufacturer=None,
     )
 
-    assert bool(device_1_light_entity.state["on"]) is True
-    assert device_1_light_entity.state["brightness"] == 25
-    assert device_1_light_entity.state["color_temp"] == 235
-    assert device_1_light_entity.state["color_mode"] == ColorMode.COLOR_TEMP
+    assert bool(device_1_light_entity.state.on) is True
+    assert device_1_light_entity.state.brightness == 25
+    assert device_1_light_entity.state.color_temp == 235
+    assert device_1_light_entity.state.color_mode == ColorMode.COLOR_TEMP
 
     dev1_cluster_level.request.reset_mock()
     dev1_cluster_color.request.reset_mock()
@@ -1350,7 +1350,7 @@ async def test_transitions(
     assert dev1_cluster_level.request.call_count == 0
     assert dev1_cluster_level.request.await_count == 0
 
-    assert bool(entity.state["on"]) is False
+    assert bool(entity.state.on) is False
 
     dev1_cluster_on_off.request.reset_mock()
     dev1_cluster_color.request.reset_mock()
@@ -1395,10 +1395,10 @@ async def test_transitions(
         manufacturer=None,
     )
 
-    assert bool(device_1_light_entity.state["on"]) is True
-    assert device_1_light_entity.state["brightness"] == 25
-    assert device_1_light_entity.state["color_temp"] == 236
-    assert device_1_light_entity.state["color_mode"] == ColorMode.COLOR_TEMP
+    assert bool(device_1_light_entity.state.on) is True
+    assert device_1_light_entity.state.brightness == 25
+    assert device_1_light_entity.state.color_temp == 236
+    assert device_1_light_entity.state.color_mode == ColorMode.COLOR_TEMP
 
     dev1_cluster_level.request.reset_mock()
     dev1_cluster_color.request.reset_mock()
@@ -1412,7 +1412,7 @@ async def test_transitions(
     assert dev1_cluster_color.request.await_count == 0
     assert dev1_cluster_level.request.call_count == 0
     assert dev1_cluster_level.request.await_count == 0
-    assert bool(entity.state["on"]) is False
+    assert bool(entity.state.on) is False
 
     dev1_cluster_on_off.request.reset_mock()
     dev1_cluster_color.request.reset_mock()
@@ -1446,10 +1446,10 @@ async def test_transitions(
         manufacturer=None,
     )
 
-    assert bool(device_1_light_entity.state["on"]) is True
-    assert device_1_light_entity.state["brightness"] == 25
-    assert device_1_light_entity.state["color_temp"] == 236
-    assert device_1_light_entity.state["color_mode"] == ColorMode.COLOR_TEMP
+    assert bool(device_1_light_entity.state.on) is True
+    assert device_1_light_entity.state.brightness == 25
+    assert device_1_light_entity.state.color_temp == 236
+    assert device_1_light_entity.state.color_mode == ColorMode.COLOR_TEMP
 
     dev1_cluster_on_off.request.reset_mock()
     dev1_cluster_color.request.reset_mock()
@@ -1463,7 +1463,7 @@ async def test_transitions(
     assert dev1_cluster_color.request.await_count == 0
     assert dev1_cluster_level.request.call_count == 0
     assert dev1_cluster_level.request.await_count == 0
-    assert bool(entity.state["on"]) is False
+    assert bool(entity.state.on) is False
 
     dev1_cluster_on_off.request.reset_mock()
     dev1_cluster_color.request.reset_mock()
@@ -1492,8 +1492,8 @@ async def test_transitions(
         manufacturer=None,
     )
 
-    assert bool(device_2_light_entity.state["on"]) is True
-    assert device_2_light_entity.state["brightness"] == 100
+    assert bool(device_2_light_entity.state.on) is True
+    assert device_2_light_entity.state.brightness == 100
 
     dev2_cluster_level.request.reset_mock()
 
@@ -1506,7 +1506,7 @@ async def test_transitions(
     assert dev2_cluster_color.request.await_count == 0
     assert dev2_cluster_level.request.call_count == 0
     assert dev2_cluster_level.request.await_count == 0
-    assert bool(device_2_light_entity.state["on"]) is False
+    assert bool(device_2_light_entity.state.on) is False
 
     dev2_cluster_on_off.request.reset_mock()
 
@@ -1551,10 +1551,10 @@ async def test_transitions(
         manufacturer=None,
     )
 
-    assert bool(device_2_light_entity.state["on"]) is True
-    assert device_2_light_entity.state["brightness"] == 25
-    assert device_2_light_entity.state["color_temp"] == 235
-    assert device_2_light_entity.state["color_mode"] == ColorMode.COLOR_TEMP
+    assert bool(device_2_light_entity.state.on) is True
+    assert device_2_light_entity.state.brightness == 25
+    assert device_2_light_entity.state.color_temp == 235
+    assert device_2_light_entity.state.color_mode == ColorMode.COLOR_TEMP
 
     dev2_cluster_level.request.reset_mock()
     dev2_cluster_color.request.reset_mock()
@@ -1568,7 +1568,7 @@ async def test_transitions(
     assert dev2_cluster_color.request.await_count == 0
     assert dev2_cluster_level.request.call_count == 0
     assert dev2_cluster_level.request.await_count == 0
-    assert bool(device_2_light_entity.state["on"]) is False
+    assert bool(device_2_light_entity.state.on) is False
 
     dev2_cluster_on_off.request.reset_mock()
 
@@ -1606,10 +1606,10 @@ async def test_transitions(
         manufacturer=None,
     )
 
-    assert bool(entity.state["on"]) is True
-    assert entity.state["brightness"] == 25
-    assert entity.state["color_temp"] == 235
-    assert entity.state["color_mode"] == ColorMode.COLOR_TEMP
+    assert bool(entity.state.on) is True
+    assert entity.state.brightness == 25
+    assert entity.state.color_temp == 235
+    assert entity.state.color_mode == ColorMode.COLOR_TEMP
 
     group_on_off_cluster_handler.request.reset_mock()
     group_color_cluster_handler.request.reset_mock()
@@ -1624,7 +1624,7 @@ async def test_transitions(
     assert dev2_cluster_color.request.await_count == 0
     assert dev2_cluster_level.request.call_count == 0
     assert dev2_cluster_level.request.await_count == 0
-    assert bool(device_2_light_entity.state["on"]) is True
+    assert bool(device_2_light_entity.state.on) is True
 
     dev2_cluster_on_off.request.reset_mock()
 
@@ -1647,7 +1647,7 @@ async def test_transitions(
         manufacturer=None,
     )
 
-    assert bool(device_2_light_entity.state["on"]) is False
+    assert bool(device_2_light_entity.state.on) is False
 
     dev2_cluster_level.request.reset_mock()
 
@@ -1670,7 +1670,7 @@ async def test_transitions(
         manufacturer=None,
     )
 
-    assert bool(device_2_light_entity.state["on"]) is True
+    assert bool(device_2_light_entity.state.on) is True
 
     dev2_cluster_level.request.reset_mock()
     eWeLink_cluster_on_off.request.reset_mock()
@@ -1705,9 +1705,9 @@ async def test_transitions(
         manufacturer=None,
     )
 
-    assert bool(eWeLink_light_entity.state["on"]) is True
-    assert eWeLink_light_entity.state["color_temp"] == 235
-    assert eWeLink_light_entity.state["color_mode"] == ColorMode.COLOR_TEMP
+    assert bool(eWeLink_light_entity.state.on) is True
+    assert eWeLink_light_entity.state.color_temp == 235
+    assert eWeLink_light_entity.state.color_mode == ColorMode.COLOR_TEMP
     assert eWeLink_light_entity.min_mireds == 153
     assert eWeLink_light_entity.max_mireds == 500
 
@@ -1770,9 +1770,9 @@ async def test_on_with_off_color(zha_gateway: Gateway) -> None:
         manufacturer=None,
     )
 
-    assert bool(entity.state["on"]) is True
-    assert entity.state["color_temp"] == 235
-    assert entity.state["color_mode"] == ColorMode.COLOR_TEMP
+    assert bool(entity.state.on) is True
+    assert entity.state.color_temp == 235
+    assert entity.state.color_mode == ColorMode.COLOR_TEMP
     assert entity.supported_color_modes == {ColorMode.COLOR_TEMP, ColorMode.XY}
     assert entity._internal_supported_color_modes == {
         ColorMode.COLOR_TEMP,
@@ -1831,10 +1831,10 @@ async def test_on_with_off_color(zha_gateway: Gateway) -> None:
         manufacturer=None,
     )
 
-    assert bool(entity.state["on"]) is True
-    assert entity.state["color_temp"] == 240
-    assert entity.state["brightness"] == 254
-    assert entity.state["color_mode"] == ColorMode.COLOR_TEMP
+    assert bool(entity.state.on) is True
+    assert entity.state.color_temp == 240
+    assert entity.state.brightness == 254
+    assert entity.state.color_mode == ColorMode.COLOR_TEMP
 
 
 @patch(
@@ -1885,7 +1885,7 @@ async def test_group_member_assume_state(zha_gateway: Gateway) -> None:
     group_cluster_on_off = zha_group.endpoint[general.OnOff.cluster_id]
 
     # test that the lights were created and are off
-    assert bool(entity.state["on"]) is False
+    assert bool(entity.state.on) is False
 
     group_cluster_on_off.request.reset_mock()
     await asyncio.sleep(11)
@@ -1896,9 +1896,9 @@ async def test_group_member_assume_state(zha_gateway: Gateway) -> None:
     await asyncio.sleep(1)  # wait for assume debounce
 
     # members also instantly assume STATE_ON
-    assert bool(device_1_light_entity.state["on"]) is True
-    assert bool(device_2_light_entity.state["on"]) is True
-    assert bool(entity.state["on"]) is True
+    assert bool(device_1_light_entity.state.on) is True
+    assert bool(device_2_light_entity.state.on) is True
+    assert bool(entity.state.on) is True
 
     # turn off via UI
     await entity.async_turn_off()
@@ -1906,22 +1906,22 @@ async def test_group_member_assume_state(zha_gateway: Gateway) -> None:
     await asyncio.sleep(1)
 
     # members also instantly assume STATE_OFF
-    assert bool(device_1_light_entity.state["on"]) is False
-    assert bool(device_2_light_entity.state["on"]) is False
-    assert bool(entity.state["on"]) is False
+    assert bool(device_1_light_entity.state.on) is False
+    assert bool(device_2_light_entity.state.on) is False
+    assert bool(entity.state.on) is False
 
     # now test members with different state not being overridden
     # turn on light 1 to brightness 50
     await device_1_light_entity.async_turn_on(brightness=50)
     await zha_gateway.async_block_till_done()
-    assert bool(device_1_light_entity.state["on"]) is True
-    assert device_1_light_entity.state["brightness"] == 50
+    assert bool(device_1_light_entity.state.on) is True
+    assert device_1_light_entity.state.brightness == 50
 
     # turn on light 2 to brightness 100
     await device_2_light_entity.async_turn_on(brightness=100)
     await zha_gateway.async_block_till_done()
-    assert bool(device_2_light_entity.state["on"]) is True
-    assert device_2_light_entity.state["brightness"] == 100
+    assert bool(device_2_light_entity.state.on) is True
+    assert device_2_light_entity.state.brightness == 100
 
     await asyncio.sleep(1)  # wait for assume debounce
 
@@ -1930,11 +1930,11 @@ async def test_group_member_assume_state(zha_gateway: Gateway) -> None:
     await zha_gateway.async_block_till_done()
     await asyncio.sleep(1)
 
-    assert entity.state["brightness"] == 75  # average
+    assert entity.state.brightness == 75  # average
 
     # but members do not change unchanged state
-    assert device_1_light_entity.state["brightness"] == 50
-    assert device_2_light_entity.state["brightness"] == 100
+    assert device_1_light_entity.state.brightness == 50
+    assert device_2_light_entity.state.brightness == 100
 
 
 async def test_light_state_restoration(zha_gateway: Gateway) -> None:
@@ -1952,12 +1952,12 @@ async def test_light_state_restoration(zha_gateway: Gateway) -> None:
         effect="colorloop",
     )
 
-    assert entity.state["on"] is True
-    assert entity.state["brightness"] == 34
-    assert entity.state["color_temp"] == 500
-    assert entity.state["xy_color"] == (1, 2)
-    assert entity.state["color_mode"] == ColorMode.XY
-    assert entity.state["effect"] == "colorloop"
+    assert entity.state.on is True
+    assert entity.state.brightness == 34
+    assert entity.state.color_temp == 500
+    assert entity.state.xy_color == (1, 2)
+    assert entity.state.color_mode == ColorMode.XY
+    assert entity.state.effect == "colorloop"
 
     entity.restore_external_state_attributes(
         state=None,
@@ -1970,9 +1970,9 @@ async def test_light_state_restoration(zha_gateway: Gateway) -> None:
         effect=None,
     )
 
-    assert entity.state["on"] is True
-    assert entity.state["brightness"] == 34
-    assert entity.state["color_temp"] == 500
-    assert entity.state["xy_color"] == (1, 2)
-    assert entity.state["color_mode"] == ColorMode.XY
-    assert entity.state["effect"] == "colorloop"
+    assert entity.state.on is True
+    assert entity.state.brightness == 34
+    assert entity.state.color_temp == 500
+    assert entity.state.xy_color == (1, 2)
+    assert entity.state.color_mode == ColorMode.XY
+    assert entity.state.effect == "colorloop"

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -47,15 +47,15 @@ async def test_lock(zha_gateway: Gateway) -> None:
     cluster = zigpy_device.endpoints[1].door_lock
     entity = get_entity(zha_device, platform=Platform.LOCK)
 
-    assert entity.state["is_locked"] is False
+    assert entity.state.is_locked is False
 
     # set state to locked
     await send_attributes_report(zha_gateway, cluster, {1: 0, 0: 1, 2: 2})
-    assert entity.state["is_locked"] is True
+    assert entity.state.is_locked is True
 
     # set state to unlocked
     await send_attributes_report(zha_gateway, cluster, {1: 0, 0: 2, 2: 3})
-    assert entity.state["is_locked"] is False
+    assert entity.state.is_locked is False
 
     # lock from HA
     await async_lock(zha_gateway, cluster, entity)
@@ -77,13 +77,13 @@ async def test_lock(zha_gateway: Gateway) -> None:
 
     # test updating entity state from client
     cluster.read_attributes.reset_mock()
-    assert entity.state["is_locked"] is False
+    assert entity.state.is_locked is False
     cluster.PLUGGED_ATTR_READS = {"lock_state": 1}
     update_attribute_cache(cluster)
     await entity.async_update()
     await zha_gateway.async_block_till_done()
     assert cluster.read_attributes.call_count == 1
-    assert entity.state["is_locked"] is True
+    assert entity.state.is_locked is True
 
 
 async def async_lock(
@@ -95,7 +95,7 @@ async def async_lock(
     with patch("zigpy.zcl.Cluster.request", return_value=[zcl_f.Status.SUCCESS]):
         await entity.async_lock()
         await zha_gateway.async_block_till_done()
-        assert entity.state["is_locked"] is True
+        assert entity.state.is_locked is True
         assert cluster.request.call_count == 1
         assert cluster.request.call_args[0][0] is False
         assert cluster.request.call_args[0][1] == LOCK_DOOR
@@ -105,7 +105,7 @@ async def async_lock(
     with patch("zigpy.zcl.Cluster.request", return_value=[zcl_f.Status.FAILURE]):
         await entity.async_unlock()
         await zha_gateway.async_block_till_done()
-        assert entity.state["is_locked"] is True
+        assert entity.state.is_locked is True
         assert cluster.request.call_count == 1
         assert cluster.request.call_args[0][0] is False
         assert cluster.request.call_args[0][1] == UNLOCK_DOOR
@@ -121,7 +121,7 @@ async def async_unlock(
     with patch("zigpy.zcl.Cluster.request", return_value=[zcl_f.Status.SUCCESS]):
         await entity.async_unlock()
         await zha_gateway.async_block_till_done()
-        assert entity.state["is_locked"] is False
+        assert entity.state.is_locked is False
         assert cluster.request.call_count == 1
         assert cluster.request.call_args[0][0] is False
         assert cluster.request.call_args[0][1] == UNLOCK_DOOR
@@ -131,7 +131,7 @@ async def async_unlock(
     with patch("zigpy.zcl.Cluster.request", return_value=[zcl_f.Status.FAILURE]):
         await entity.async_lock()
         await zha_gateway.async_block_till_done()
-        assert entity.state["is_locked"] is False
+        assert entity.state.is_locked is False
         assert cluster.request.call_count == 1
         assert cluster.request.call_args[0][0] is False
         assert cluster.request.call_args[0][1] == LOCK_DOOR
@@ -212,10 +212,10 @@ async def test_lock_state_restoration(zha_gateway: Gateway) -> None:
 
     entity = get_entity(zha_device, platform=Platform.LOCK)
 
-    assert entity.state["is_locked"] is False
+    assert entity.state.is_locked is False
 
     entity.restore_external_state_attributes(state=STATE_LOCKED)
-    assert entity.state["is_locked"] is True
+    assert entity.state.is_locked is True
 
     entity.restore_external_state_attributes(state=STATE_UNLOCKED)
-    assert entity.state["is_locked"] is False
+    assert entity.state.is_locked is False

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -124,7 +124,7 @@ async def test_number(
     assert entity.fallback_name == "PWM1"
 
     # test that the state is 15.0
-    assert entity.state["state"] == 15.0
+    assert entity.state.state == 15.0
 
     # test attributes
     assert entity.info_object.native_min_value == 1.0
@@ -142,12 +142,12 @@ async def test_number(
     assert cluster.read_attributes.call_count == 3
     await send_attributes_report(zha_gateway, cluster, {0x0055: 15})
     await zha_gateway.async_block_till_done()
-    assert entity.state["state"] == 15.0
+    assert entity.state.state == 15.0
 
     # update value from device
     await send_attributes_report(zha_gateway, cluster, {0x0055: 20})
     await zha_gateway.async_block_till_done()
-    assert entity.state["state"] == 20.0
+    assert entity.state.state == 20.0
 
     # change value from client
     await entity.async_set_native_value(30.0)
@@ -157,11 +157,11 @@ async def test_number(
     assert cluster.write_attributes.call_args == call(
         {"present_value": 30.0}, manufacturer=UNDEFINED
     )
-    assert entity.state["state"] == 30.0
+    assert entity.state.state == 30.0
 
     # test updating entity state from client
     cluster.read_attributes.reset_mock()
-    assert entity.state["state"] == 30.0
+    assert entity.state.state == 30.0
     cluster.PLUGGED_ATTR_READS = {"present_value": 20}
     await entity.async_update()
     await zha_gateway.async_block_till_done()
@@ -169,7 +169,7 @@ async def test_number(
     assert cluster.read_attributes.await_args == call(
         ["present_value"], allow_cache=False, only_cache=False, manufacturer=UNDEFINED
     )
-    assert entity.state["state"] == 20.0
+    assert entity.state.state == 20.0
 
     await entity.async_set_native_value(30)
     await zha_gateway.async_block_till_done()
@@ -177,7 +177,7 @@ async def test_number(
     assert cluster.write_attributes.call_args == call(
         {"present_value": 30}, manufacturer=UNDEFINED
     )
-    assert entity.state["state"] == 30.0
+    assert entity.state.state == 30.0
 
 
 async def test_number_missing_description_attr(
@@ -266,7 +266,7 @@ async def test_level_control_number(
         ),
     ]
 
-    assert entity.state["state"] == initial_value
+    assert entity.state.state == initial_value
     assert entity._attr_entity_category == EntityCategory.CONFIG
 
     assert entity.icon is None
@@ -282,12 +282,12 @@ async def test_level_control_number(
         call({attr: new_value}, manufacturer=UNDEFINED)
     ]
 
-    assert entity.state["state"] == new_value
+    assert entity.state.state == new_value
 
     level_control_cluster.read_attributes.reset_mock()
     await entity.async_update()
     # the mocking doesn't update the attr cache so this flips back to initial value
-    assert entity.state["state"] == initial_value
+    assert entity.state.state == initial_value
     assert level_control_cluster.read_attributes.mock_calls == [
         call(
             [attr],
@@ -308,11 +308,11 @@ async def test_level_control_number(
         call({attr: new_value}, manufacturer=UNDEFINED),
         call({attr: new_value}, manufacturer=UNDEFINED),
     ]
-    assert entity.state["state"] == initial_value
+    assert entity.state.state == initial_value
 
     # test updating entity state from client
     level_control_cluster.read_attributes.reset_mock()
-    assert entity.state["state"] == initial_value
+    assert entity.state.state == initial_value
     level_control_cluster.PLUGGED_ATTR_READS = {attr: new_value}
     await entity.async_update()
     await zha_gateway.async_block_till_done()
@@ -327,7 +327,7 @@ async def test_level_control_number(
             manufacturer=UNDEFINED,
         ),
     ]
-    assert entity.state["state"] == new_value
+    assert entity.state.state == new_value
 
     # update value from device
     await send_attributes_report(
@@ -336,7 +336,7 @@ async def test_level_control_number(
         {level_control_cluster.attributes_by_name[attr].id: initial_value},
     )
     await zha_gateway.async_block_till_done()
-    assert entity.state["state"] == initial_value
+    assert entity.state.state == initial_value
 
 
 @pytest.mark.parametrize(
@@ -377,7 +377,7 @@ async def test_color_number(
         in color_cluster.read_attributes.call_args_list
     )
 
-    assert entity.state["state"] == initial_value
+    assert entity.state.state == initial_value
     assert entity._attr_entity_category == EntityCategory.CONFIG
 
     await entity.async_set_native_value(new_value)
@@ -386,12 +386,12 @@ async def test_color_number(
         attr: new_value,
     }
 
-    assert entity.state["state"] == new_value
+    assert entity.state.state == new_value
 
     color_cluster.read_attributes.reset_mock()
     await entity.async_update()
     # the mocking doesn't update the attr cache so this flips back to initial value
-    assert entity.state["state"] == initial_value
+    assert entity.state.state == initial_value
     assert color_cluster.read_attributes.call_count == 1
     assert (
         call(
@@ -414,11 +414,11 @@ async def test_color_number(
         call({attr: new_value}, manufacturer=UNDEFINED),
         call({attr: new_value}, manufacturer=UNDEFINED),
     ]
-    assert entity.state["state"] == initial_value
+    assert entity.state.state == initial_value
 
     # test updating entity state from client
     color_cluster.read_attributes.reset_mock()
-    assert entity.state["state"] == initial_value
+    assert entity.state.state == initial_value
     color_cluster.PLUGGED_ATTR_READS = {attr: new_value}
     await entity.async_update()
     await zha_gateway.async_block_till_done()
@@ -433,7 +433,7 @@ async def test_color_number(
             manufacturer=UNDEFINED,
         ),
     ]
-    assert entity.state["state"] == new_value
+    assert entity.state.state == new_value
 
     # update value from device
     await send_attributes_report(
@@ -442,4 +442,4 @@ async def test_color_number(
         {color_cluster.attributes_by_name[attr].id: initial_value},
     )
     await zha_gateway.async_block_till_done()
-    assert entity.state["state"] == initial_value
+    assert entity.state.state == initial_value

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -127,10 +127,10 @@ async def test_number(
     assert entity.state.state == 15.0
 
     # test attributes
-    assert entity.info_object.native_min_value == 1.0
-    assert entity.info_object.native_max_value == 100.0
-    assert entity.info_object.native_step == 1.1
-    assert entity.info_object.mode == NumberMode.AUTO
+    assert entity.state.native_min_value == 1.0
+    assert entity.state.native_max_value == 100.0
+    assert entity.state.native_step == 1.1
+    assert entity.state.mode == NumberMode.AUTO
 
     assert entity.icon == "mdi:percent"
     assert entity.native_unit_of_measurement == "%"

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -55,7 +55,7 @@ async def test_select(zha_gateway: Gateway) -> None:
 
     entity = get_entity(zha_device, platform=Platform.SELECT, qualifier=select_name)
     assert entity.state.state is None  # unknown in HA
-    assert entity.info_object.options == [
+    assert entity.state.options == [
         "Stop",
         "Burglar",
         "Fire",
@@ -191,7 +191,7 @@ async def test_on_off_select_attribute_report_v2(
     entity = get_entity(
         zha_device,
         platform=Platform.SELECT,
-        qualifier_func=lambda e: e.info_object.unique_id.endswith("motion_sensitivity"),
+        qualifier_func=lambda e: e.state.unique_id.endswith("motion_sensitivity"),
     )
 
     # test that the state is in default medium state

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -54,7 +54,7 @@ async def test_select(zha_gateway: Gateway) -> None:
     select_name = security.IasWd.Warning.WarningMode.__name__
 
     entity = get_entity(zha_device, platform=Platform.SELECT, qualifier=select_name)
-    assert entity.state["state"] is None  # unknown in HA
+    assert entity.state.state is None  # unknown in HA
     assert entity.info_object.options == [
         "Stop",
         "Burglar",
@@ -69,7 +69,7 @@ async def test_select(zha_gateway: Gateway) -> None:
     # change value from client
     await entity.async_select_option(security.IasWd.Warning.WarningMode.Burglar.name)
     await zha_gateway.async_block_till_done()
-    assert entity.state["state"] == security.IasWd.Warning.WarningMode.Burglar.name
+    assert entity.state.state == security.IasWd.Warning.WarningMode.Burglar.name
 
 
 class MotionSensitivityQuirk(CustomDevice):
@@ -130,13 +130,13 @@ async def test_on_off_select_attribute_report(zha_gateway: Gateway) -> None:
     cluster = aqara_sensor.device.endpoints.get(1).opple_cluster
 
     entity = get_entity(aqara_sensor, platform=Platform.SELECT)
-    assert entity.state["state"] == AqaraMotionSensitivities.Medium.name
+    assert entity.state.state == AqaraMotionSensitivities.Medium.name
 
     # send attribute report from device
     await send_attributes_report(
         zha_gateway, cluster, {"motion_sensitivity": AqaraMotionSensitivities.Low}
     )
-    assert entity.state["state"] == AqaraMotionSensitivities.Low.name
+    assert entity.state.state == AqaraMotionSensitivities.Low.name
 
 
 (
@@ -195,13 +195,13 @@ async def test_on_off_select_attribute_report_v2(
     )
 
     # test that the state is in default medium state
-    assert entity.state["state"] == AqaraMotionSensitivities.Medium.name
+    assert entity.state.state == AqaraMotionSensitivities.Medium.name
 
     # send attribute report from device
     await send_attributes_report(
         zha_gateway, cluster, {"motion_sensitivity": AqaraMotionSensitivities.Low}
     )
-    assert entity.state["state"] == AqaraMotionSensitivities.Low.name
+    assert entity.state.state == AqaraMotionSensitivities.Low.name
 
     assert entity._attr_entity_category == EntityCategory.CONFIG
     assert entity._attr_entity_registry_enabled_default is True
@@ -227,7 +227,7 @@ async def test_on_off_select_attribute_report_v2(
         await entity.async_select_option(AqaraMotionSensitivities.Medium.name)
 
         await zha_gateway.async_block_till_done()
-        assert entity.state["state"] == AqaraMotionSensitivities.Medium.name
+        assert entity.state.state == AqaraMotionSensitivities.Medium.name
         assert cluster.write_attributes.call_count == 1
         assert cluster.write_attributes.call_args == call(
             {"motion_sensitivity": AqaraMotionSensitivities.Medium},
@@ -253,14 +253,14 @@ async def test_non_zcl_select_state_restoration(zha_gateway: Gateway) -> None:
 
     entity = get_entity(zha_device, platform=Platform.SELECT, qualifier="WarningMode")
 
-    assert entity.state["state"] is None
+    assert entity.state.state is None
 
     entity.restore_external_state_attributes(
         state=security.IasWd.Warning.WarningMode.Burglar.name
     )
-    assert entity.state["state"] == security.IasWd.Warning.WarningMode.Burglar.name
+    assert entity.state.state == security.IasWd.Warning.WarningMode.Burglar.name
 
     entity.restore_external_state_attributes(
         state=security.IasWd.Warning.WarningMode.Fire.name
     )
-    assert entity.state["state"] == security.IasWd.Warning.WarningMode.Fire.name
+    assert entity.state.state == security.IasWd.Warning.WarningMode.Fire.name

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -156,7 +156,7 @@ async def async_test_temperature(
     zha_gateway: Gateway, cluster: Cluster, entity: PlatformEntity
 ) -> None:
     """Test temperature sensor."""
-    assert entity.extra_state_attribute_names is None
+    assert entity.state.extra_state_attribute_names is None
     await send_attributes_report(zha_gateway, cluster, {1: 1, 0: 2900, 2: 100})
     assert_state(entity, 29.0, "°C")
 
@@ -187,7 +187,7 @@ async def async_test_metering(
     zha_gateway: Gateway, cluster: Cluster, entity: PlatformEntity
 ) -> None:
     """Test Smart Energy metering sensor."""
-    assert entity.extra_state_attribute_names == {
+    assert entity.state.extra_state_attribute_names == {
         "status",
         "device_type",
         "zcl_unit_of_measurement",
@@ -241,7 +241,7 @@ async def async_test_smart_energy_summation_delivered(
     zha_gateway: Gateway, cluster, entity
 ):
     """Test SmartEnergy Summation delivered sensor."""
-    assert entity.extra_state_attribute_names == {
+    assert entity.state.extra_state_attribute_names == {
         "status",
         "device_type",
         "zcl_unit_of_measurement",
@@ -310,7 +310,7 @@ async def async_test_electrical_measurement(
     assert_state(entity, 9.9, "W")
 
     await send_attributes_report(zha_gateway, cluster, {0: 1, 0x050D: 88})
-    assert entity.state.active_power_max == 8.8
+    assert entity.state.max_value == 8.8
 
 
 async def async_test_em_apparent_power(
@@ -337,7 +337,7 @@ async def async_test_em_power_factor(
     zha_gateway: Gateway, cluster: Cluster, entity: PlatformEntity
 ):
     """Test electrical measurement Power Factor sensor."""
-    assert entity.extra_state_attribute_names == {"measurement_type"}
+    assert entity.state.extra_state_attribute_names == {"measurement_type"}
 
     # update divisor cached value
     await send_attributes_report(zha_gateway, cluster, {"ac_power_divisor": 1})
@@ -383,7 +383,10 @@ async def async_test_em_rms_voltage(
     zha_gateway: Gateway, cluster: Cluster, entity: PlatformEntity
 ) -> None:
     """Test electrical measurement RMS Voltage sensor."""
-    assert entity.extra_state_attribute_names == {"measurement_type", "rms_voltage_max"}
+    assert entity.state.extra_state_attribute_names == {
+        "measurement_type",
+        "rms_voltage_max",
+    }
 
     await send_attributes_report(zha_gateway, cluster, {0: 1, 0x0505: 1234})
     assert_state(entity, 123.4, "V")
@@ -396,14 +399,14 @@ async def async_test_em_rms_voltage(
     assert_state(entity, 22.36, "V")
 
     await send_attributes_report(zha_gateway, cluster, {0: 1, 0x0507: 888})
-    assert entity.state.rms_voltage_max == 8.88
+    assert entity.state.max_value == 8.88
 
 
 async def async_test_powerconfiguration(
     zha_gateway: Gateway, cluster: Cluster, entity: PlatformEntity
 ) -> None:
     """Test powerconfiguration/battery sensor."""
-    assert entity.extra_state_attribute_names == {
+    assert entity.state.extra_state_attribute_names == {
         "battery_voltage",
         "battery_quantity",
         "battery_size",
@@ -474,7 +477,7 @@ async def async_test_em_dc_voltage(
     zha_gateway: Gateway, cluster: Cluster, entity: PlatformEntity
 ) -> None:
     """Test electrical measurement DC Voltage sensor."""
-    assert entity.extra_state_attribute_names == {"measurement_type"}
+    assert entity.state.extra_state_attribute_names == {"measurement_type"}
 
     await send_attributes_report(zha_gateway, cluster, {0: 1, 0x0100: 1234})
     assert_state(entity, 123.4, "V")
@@ -1818,9 +1821,7 @@ async def test_device_counter_sensors(zha_gateway: Gateway) -> None:
     entity = get_entity(
         coordinator,
         platform=Platform.SENSOR,
-        qualifier_func=lambda e: e.state.unique_id.endswith(
-            "ezsp_counters_counter_1"
-        ),
+        qualifier_func=lambda e: e.state.unique_id.endswith("ezsp_counters_counter_1"),
     )
 
     assert entity.state.state == 1
@@ -1983,9 +1984,9 @@ async def test_danfoss_thermostat_sw_error(zha_gateway: Gateway) -> None:
     )
 
     assert entity.state.state == "something"
-    assert entity.extra_state_attribute_names
-    assert "Top_pcb_sensor_error" in entity.extra_state_attribute_names
-    assert entity.state.Top_pcb_sensor_error
+    assert entity.state.extra_state_attribute_names
+    assert "Top_pcb_sensor_error" in entity.state.extra_state_attribute_names
+    assert entity.state.bit_states["Top_pcb_sensor_error"]
 
 
 async def test_quirks_sensor_attr_converter(zha_gateway: Gateway) -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -196,12 +196,12 @@ async def async_test_metering(
         zha_gateway, cluster, {1025: 1, 1024: 12345, 1026: 100}
     )
     assert_state(entity, 12345.0, None)
-    assert entity.state["status"] == "NO_ALARMS"
-    assert entity.state["device_type"] == "Electric Metering"
+    assert entity.state.status == "NO_ALARMS"
+    assert entity.state.device_type == "Electric Metering"
 
     await send_attributes_report(zha_gateway, cluster, {1024: 12346, "status": 64 + 8})
     assert_state(entity, 12346.0, None)
-    assert entity.state["status"] in (
+    assert entity.state.status in (
         "SERVICE_DISCONNECT|POWER_FAILURE",
         "POWER_FAILURE|SERVICE_DISCONNECT",
     )
@@ -209,7 +209,7 @@ async def async_test_metering(
     await send_attributes_report(
         zha_gateway, cluster, {"status": 64 + 8, "metering_device_type": 1}
     )
-    assert entity.state["status"] in (
+    assert entity.state.status in (
         "SERVICE_DISCONNECT|NOT_DEFINED",
         "NOT_DEFINED|SERVICE_DISCONNECT",
     )
@@ -217,7 +217,7 @@ async def async_test_metering(
     await send_attributes_report(
         zha_gateway, cluster, {"status": 64 + 8, "metering_device_type": 2}
     )
-    assert entity.state["status"] in (
+    assert entity.state.status in (
         "SERVICE_DISCONNECT|PIPE_EMPTY",
         "PIPE_EMPTY|SERVICE_DISCONNECT",
     )
@@ -225,7 +225,7 @@ async def async_test_metering(
     await send_attributes_report(
         zha_gateway, cluster, {"status": 64 + 8, "metering_device_type": 5}
     )
-    assert entity.state["status"] in (
+    assert entity.state.status in (
         "SERVICE_DISCONNECT|TEMPERATURE_SENSOR",
         "TEMPERATURE_SENSOR|SERVICE_DISCONNECT",
     )
@@ -234,7 +234,7 @@ async def async_test_metering(
     await send_attributes_report(
         zha_gateway, cluster, {"status": 32, "metering_device_type": 4}
     )
-    assert entity.state["status"] in ("<bitmap8.32: 32>", "32")
+    assert entity.state.status in ("<bitmap8.32: 32>", "32")
 
 
 async def async_test_smart_energy_summation_delivered(
@@ -250,8 +250,8 @@ async def async_test_smart_energy_summation_delivered(
         zha_gateway, cluster, {1025: 1, "current_summ_delivered": 12321, 1026: 100}
     )
     assert_state(entity, 12.321, UnitOfEnergy.KILO_WATT_HOUR)
-    assert entity.state["status"] == "NO_ALARMS"
-    assert entity.state["device_type"] == "Electric Metering"
+    assert entity.state.status == "NO_ALARMS"
+    assert entity.state.device_type == "Electric Metering"
     assert entity.info_object.device_class == SensorDeviceClass.ENERGY
 
 
@@ -264,8 +264,8 @@ async def async_test_smart_energy_summation_received(
         zha_gateway, cluster, {1025: 1, "current_summ_received": 12321, 1026: 100}
     )
     assert_state(entity, 12.321, UnitOfEnergy.KILO_WATT_HOUR)
-    assert entity.state["status"] == "NO_ALARMS"
-    assert entity.state["device_type"] == "Electric Metering"
+    assert entity.state.status == "NO_ALARMS"
+    assert entity.state.device_type == "Electric Metering"
     assert entity.info_object.device_class == SensorDeviceClass.ENERGY
 
 
@@ -278,8 +278,8 @@ async def async_test_smart_energy_summation(
         zha_gateway, cluster, {1025: 1, "current_summ_delivered": 12321, 1026: 100}
     )
     assert_state(entity, 12.32, "m³")
-    assert entity.state["status"] == "NO_ALARMS"
-    assert entity.state["device_type"] == "Electric Metering"
+    assert entity.state.status == "NO_ALARMS"
+    assert entity.state.device_type == "Electric Metering"
 
 
 async def async_test_electrical_measurement(
@@ -310,7 +310,7 @@ async def async_test_electrical_measurement(
     assert_state(entity, 9.9, "W")
 
     await send_attributes_report(zha_gateway, cluster, {0: 1, 0x050D: 88})
-    assert entity.state["active_power_max"] == 8.8
+    assert entity.state.active_power_max == 8.8
 
 
 async def async_test_em_apparent_power(
@@ -376,7 +376,7 @@ async def async_test_em_rms_current(
     assert_state(entity, 123.6, "A")
 
     await send_attributes_report(zha_gateway, cluster, {0: 1, current_max_attrid: 88})
-    assert entity.state[current_max_attr_name] == 8.8
+    assert entity.state.max_value == 8.8
 
 
 async def async_test_em_rms_voltage(
@@ -396,7 +396,7 @@ async def async_test_em_rms_voltage(
     assert_state(entity, 22.36, "V")
 
     await send_attributes_report(zha_gateway, cluster, {0: 1, 0x0507: 888})
-    assert entity.state["rms_voltage_max"] == 8.88
+    assert entity.state.rms_voltage_max == 8.88
 
 
 async def async_test_powerconfiguration(
@@ -410,11 +410,11 @@ async def async_test_powerconfiguration(
     }
     await send_attributes_report(zha_gateway, cluster, {33: 98})
     assert_state(entity, 49, "%")
-    assert entity.state["battery_voltage"] == 2.9
-    assert entity.state["battery_quantity"] == 3
-    assert entity.state["battery_size"] == "AAA"
+    assert entity.state.battery_voltage == 2.9
+    assert entity.state.battery_quantity == 3
+    assert entity.state.battery_size == "AAA"
     await send_attributes_report(zha_gateway, cluster, {32: 20})
-    assert entity.state["battery_voltage"] == 2.0
+    assert entity.state.battery_voltage == 2.0
 
 
 async def async_test_powerconfiguration2(
@@ -445,7 +445,7 @@ async def async_test_setpoint_change_source(
         cluster,
         {hvac.Thermostat.AttributeDefs.setpoint_change_source.id: 0x01},
     )
-    assert entity.state["state"] == "Schedule"
+    assert entity.state.state == "Schedule"
 
 
 async def async_test_pi_heating_demand(
@@ -467,7 +467,7 @@ async def async_test_change_source_timestamp(
         cluster,
         {hvac.Thermostat.AttributeDefs.setpoint_change_source_timestamp.id: 781355715},
     )
-    assert entity.state["state"] == datetime(2024, 10, 4, 11, 15, 15, tzinfo=UTC)
+    assert entity.state.state == datetime(2024, 10, 4, 11, 15, 15, tzinfo=UTC)
 
 
 async def async_test_em_dc_voltage(
@@ -798,8 +798,8 @@ async def test_analog_input_simple(zha_gateway: Gateway) -> None:
         zha_dev, platform=Platform.SENSOR, exact_entity_type=AnalogInputSensor
     )
 
-    assert entity.state["available"] is True
-    assert entity.state["state"] == 2.1322579383850098
+    assert entity.state.available is True
+    assert entity.state.state == 2.1322579383850098
     assert entity.info_object.fallback_name == "Some description"
     assert entity.info_object.translation_key is None
     assert entity.info_object.unit == UnitOfElectricPotential.VOLT
@@ -873,8 +873,8 @@ async def test_analog_input_complex(zha_gateway: Gateway) -> None:
         zha_dev, platform=Platform.SENSOR, exact_entity_type=AnalogInputSensor
     )
 
-    assert entity.state["available"] is True
-    assert entity.state["state"] == 2.1322579383850098
+    assert entity.state.available is True
+    assert entity.state.state == 2.1322579383850098
     assert entity.info_object.fallback_name == "Some description"
     assert entity.info_object.translation_key is None
     assert entity.info_object.unit is PERCENTAGE  # overridden!
@@ -888,7 +888,7 @@ def assert_state(entity: PlatformEntity, state: Any, unit_of_measurement: str) -
     This is used to ensure that the logic in each sensor class handled the
     attribute report it received correctly.
     """
-    assert entity.state["state"] == state
+    assert entity.state.state == state
     assert entity.info_object.unit == unit_of_measurement
 
 
@@ -925,7 +925,7 @@ async def test_electrical_measurement_init(
         cluster,
         {EMAttrs.active_power.id: 100},
     )
-    assert entity.state["state"] == 100
+    assert entity.state.state == 100
 
     cluster_handler = list(zha_device._endpoints.values())[0].all_cluster_handlers[
         "1:0x0b04"
@@ -941,7 +941,7 @@ async def test_electrical_measurement_init(
     )
     assert cluster_handler.ac_power_divisor == 5
     assert cluster_handler.ac_power_multiplier == 1
-    assert entity.state["state"] == 4.0
+    assert entity.state.state == 4.0
 
     zha_device.on_network = False
 
@@ -961,7 +961,7 @@ async def test_electrical_measurement_init(
     )
     assert cluster_handler.ac_power_divisor == 10
     assert cluster_handler.ac_power_multiplier == 1
-    assert entity.state["state"] == 3.0
+    assert entity.state.state == 3.0
 
     # update power multiplier
     await send_attributes_report(
@@ -971,7 +971,7 @@ async def test_electrical_measurement_init(
     )
     assert cluster_handler.ac_power_divisor == 10
     assert cluster_handler.ac_power_multiplier == 6
-    assert entity.state["state"] == 12.0
+    assert entity.state.state == 12.0
 
     await send_attributes_report(
         zha_gateway,
@@ -980,7 +980,7 @@ async def test_electrical_measurement_init(
     )
     assert cluster_handler.ac_power_divisor == 10
     assert cluster_handler.ac_power_multiplier == 20
-    assert entity.state["state"] == 60.0
+    assert entity.state.state == 60.0
 
     entity._refresh = AsyncMock(wraps=entity._refresh)
 
@@ -1305,7 +1305,7 @@ async def test_elec_measurement_sensor_type(
         platform=Platform.SENSOR,
         entity_type=sensor.ElectricalMeasurementApparentPower,
     )
-    assert entity.state["measurement_type"] == expected_type
+    assert entity.state.measurement_type == expected_type
 
 
 async def test_elec_measurement_sensor_polling(zha_gateway: Gateway) -> None:
@@ -1324,7 +1324,7 @@ async def test_elec_measurement_sensor_polling(zha_gateway: Gateway) -> None:
         platform=Platform.SENSOR,
         exact_entity_type=sensor.PolledElectricalMeasurement,
     )
-    assert entity.state["state"] == 2.0
+    assert entity.state.state == 2.0
 
     # update the value for the power reading
     zigpy_dev.endpoints[1].electrical_measurement.PLUGGED_ATTR_READS["active_power"] = (
@@ -1332,14 +1332,14 @@ async def test_elec_measurement_sensor_polling(zha_gateway: Gateway) -> None:
     )
 
     # ensure the state is still 2.0
-    assert entity.state["state"] == 2.0
+    assert entity.state.state == 2.0
 
     # let the polling happen
     await asyncio.sleep(90)
     await zha_gateway.async_block_till_done(wait_background_tasks=True)
 
     # ensure the state has been updated to 6.0
-    assert entity.state["state"] == 6.0
+    assert entity.state.state == 6.0
 
 
 async def test_metering_sensor_polling(zha_gateway: Gateway) -> None:
@@ -1358,7 +1358,7 @@ async def test_metering_sensor_polling(zha_gateway: Gateway) -> None:
         platform=Platform.SENSOR,
         exact_entity_type=sensor.PolledSmartEnergySummation,
     )
-    assert entity.state["state"] == 2.0
+    assert entity.state.state == 2.0
 
     # update the value for the power reading
     zigpy_dev.endpoints[1].smartenergy_metering.PLUGGED_ATTR_READS[
@@ -1366,14 +1366,14 @@ async def test_metering_sensor_polling(zha_gateway: Gateway) -> None:
     ] = 6000
 
     # ensure the state is still 2.0
-    assert entity.state["state"] == 2.0
+    assert entity.state.state == 2.0
 
     # let the polling happen
     await asyncio.sleep(90)
     await zha_gateway.async_block_till_done(wait_background_tasks=True)
 
     # ensure the state has been updated to 6.0
-    assert entity.state["state"] == 6.0
+    assert entity.state.state == 6.0
 
 
 @pytest.mark.parametrize(
@@ -1547,7 +1547,7 @@ async def test_timestamp_sensor_v2(zha_gateway: Gateway) -> None:
     entity = get_entity(zha_device, platform=Platform.SENSOR, qualifier="start_time")
 
     await send_attributes_report(zha_gateway, cluster, {0xEF65: 781355715})
-    assert entity.state["state"] == datetime(2024, 10, 4, 11, 15, 15, tzinfo=UTC)
+    assert entity.state.state == datetime(2024, 10, 4, 11, 15, 15, tzinfo=UTC)
 
 
 class OppleCluster(CustomCluster, ManufacturerSpecificCluster):
@@ -1823,7 +1823,7 @@ async def test_device_counter_sensors(zha_gateway: Gateway) -> None:
         ),
     )
 
-    assert entity.state["state"] == 1
+    assert entity.state.state == 1
 
     # simulate counter increment on application
     coordinator.device.application.state.counters["ezsp_counters"][
@@ -1833,7 +1833,7 @@ async def test_device_counter_sensors(zha_gateway: Gateway) -> None:
     await asyncio.sleep(zha_gateway.global_updater.__polling_interval + 2)
     await zha_gateway.async_block_till_done(wait_background_tasks=True)
 
-    assert entity.state["state"] == 2
+    assert entity.state.state == 2
 
     # test disabling the entity disables it and removes it from the updater
     assert len(zha_gateway.global_updater._update_listeners) == 3
@@ -1874,14 +1874,14 @@ async def test_device_unavailable_or_disabled_skips_entity_polling(
         exact_entity_type=sensor.RSSISensor,
     )
 
-    assert entity.state["state"] is None
+    assert entity.state.state is None
 
     elec_measurement_zha_dev.device.rssi = 60
 
     await asyncio.sleep(zha_gateway.global_updater.__polling_interval + 2)
     await zha_gateway.async_block_till_done(wait_background_tasks=True)
 
-    assert entity.state["state"] == 60
+    assert entity.state.state == 60
     assert entity.enabled is True
     assert len(zha_gateway.global_updater._update_listeners) == 5
 
@@ -1982,10 +1982,10 @@ async def test_danfoss_thermostat_sw_error(zha_gateway: Gateway) -> None:
         },
     )
 
-    assert entity.state["state"] == "something"
+    assert entity.state.state == "something"
     assert entity.extra_state_attribute_names
     assert "Top_pcb_sensor_error" in entity.extra_state_attribute_names
-    assert entity.state["Top_pcb_sensor_error"]
+    assert entity.state.Top_pcb_sensor_error
 
 
 async def test_quirks_sensor_attr_converter(zha_gateway: Gateway) -> None:
@@ -2031,10 +2031,10 @@ async def test_quirks_sensor_attr_converter(zha_gateway: Gateway) -> None:
 
     # send updated value, check if the value is converted
     await send_attributes_report(zha_gateway, cluster, {"present_value": 100})
-    assert entity.state["state"] == 200.0
+    assert entity.state.state == 200.0
 
     await send_attributes_report(zha_gateway, cluster, {"present_value": 0})
-    assert entity.state["state"] == 100.0
+    assert entity.state.state == 100.0
 
 
 async def test_ignore_non_value(zha_gateway: Gateway) -> None:
@@ -2049,7 +2049,7 @@ async def test_ignore_non_value(zha_gateway: Gateway) -> None:
     cluster = zha_device.device.endpoints[1].temperature
     entity = get_entity(zha_device, platform=Platform.SENSOR, entity_type=Temperature)
 
-    assert entity.state["state"] == 22.3
+    assert entity.state.state == 22.3
 
     # Normal attribute report
     await send_attributes_report(
@@ -2057,7 +2057,7 @@ async def test_ignore_non_value(zha_gateway: Gateway) -> None:
         cluster,
         {measurement.TemperatureMeasurement.AttributeDefs.measured_value.id: 3000},
     )
-    assert entity.state["state"] == 30.0
+    assert entity.state.state == 30.0
 
     # Invalid attribute value, ignored
     await send_attributes_report(
@@ -2065,7 +2065,7 @@ async def test_ignore_non_value(zha_gateway: Gateway) -> None:
         cluster,
         {measurement.TemperatureMeasurement.AttributeDefs.measured_value.id: -0x8000},
     )
-    assert entity.state["state"] is None
+    assert entity.state.state is None
 
 
 @pytest.mark.parametrize(
@@ -2143,14 +2143,14 @@ async def test_enum_sensor(zha_gateway: Gateway) -> None:
     zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
     entity = get_entity(zha_device, platform=Platform.SENSOR, qualifier="battery_size")
 
-    assert entity.state["state"] == "AAA"
+    assert entity.state.state == "AAA"
 
     zigpy_dev.endpoints[1].power.update_attribute(
         PowerConfiguration.AttributeDefs.battery_size.id,
         0xAB,  # unknown
     )
 
-    assert entity.state["state"] == "undefined_0xab"  # TODO: should this be `None`?
+    assert entity.state.state == "undefined_0xab"  # TODO: should this be `None`?
 
 
 async def test_ubisys_polled_em_keeps_polling_when_disabled(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -252,7 +252,7 @@ async def async_test_smart_energy_summation_delivered(
     assert_state(entity, 12.321, UnitOfEnergy.KILO_WATT_HOUR)
     assert entity.state.status == "NO_ALARMS"
     assert entity.state.device_type == "Electric Metering"
-    assert entity.info_object.device_class == SensorDeviceClass.ENERGY
+    assert entity.state.device_class == SensorDeviceClass.ENERGY
 
 
 async def async_test_smart_energy_summation_received(
@@ -266,7 +266,7 @@ async def async_test_smart_energy_summation_received(
     assert_state(entity, 12.321, UnitOfEnergy.KILO_WATT_HOUR)
     assert entity.state.status == "NO_ALARMS"
     assert entity.state.device_type == "Electric Metering"
-    assert entity.info_object.device_class == SensorDeviceClass.ENERGY
+    assert entity.state.device_class == SensorDeviceClass.ENERGY
 
 
 async def async_test_smart_energy_summation(
@@ -800,11 +800,11 @@ async def test_analog_input_simple(zha_gateway: Gateway) -> None:
 
     assert entity.state.available is True
     assert entity.state.state == 2.1322579383850098
-    assert entity.info_object.fallback_name == "Some description"
-    assert entity.info_object.translation_key is None
-    assert entity.info_object.unit == UnitOfElectricPotential.VOLT
-    assert entity.info_object.device_class is None
-    assert entity.info_object.suggested_display_precision is None
+    assert entity.state.fallback_name == "Some description"
+    assert entity.state.translation_key is None
+    assert entity.state.unit == UnitOfElectricPotential.VOLT
+    assert entity.state.device_class is None
+    assert entity.state.suggested_display_precision is None
 
 
 async def test_analog_input_ignored(zha_gateway: Gateway) -> None:
@@ -875,11 +875,11 @@ async def test_analog_input_complex(zha_gateway: Gateway) -> None:
 
     assert entity.state.available is True
     assert entity.state.state == 2.1322579383850098
-    assert entity.info_object.fallback_name == "Some description"
-    assert entity.info_object.translation_key is None
-    assert entity.info_object.unit is PERCENTAGE  # overridden!
-    assert entity.info_object.device_class is SensorDeviceClass.HUMIDITY  # overridden!
-    assert entity.info_object.suggested_display_precision == 2
+    assert entity.state.fallback_name == "Some description"
+    assert entity.state.translation_key is None
+    assert entity.state.unit is PERCENTAGE  # overridden!
+    assert entity.state.device_class is SensorDeviceClass.HUMIDITY  # overridden!
+    assert entity.state.suggested_display_precision == 2
 
 
 def assert_state(entity: PlatformEntity, state: Any, unit_of_measurement: str) -> None:
@@ -889,7 +889,7 @@ def assert_state(entity: PlatformEntity, state: Any, unit_of_measurement: str) -
     attribute report it received correctly.
     """
     assert entity.state.state == state
-    assert entity.info_object.unit == unit_of_measurement
+    assert entity.state.unit == unit_of_measurement
 
 
 async def test_electrical_measurement_init(
@@ -1667,12 +1667,12 @@ async def test_state_class(
     power_entity = get_entity(
         zha_device,
         platform=Platform.SENSOR,
-        qualifier_func=lambda e: e.info_object.unique_id.endswith("power"),
+        qualifier_func=lambda e: e.state.unique_id.endswith("power"),
     )
     energy_entity = get_entity(
         zha_device,
         platform=Platform.SENSOR,
-        qualifier_func=lambda e: e.info_object.unique_id.endswith("energy"),
+        qualifier_func=lambda e: e.state.unique_id.endswith("energy"),
     )
     energy_delivered_entity = get_entity(
         zha_device, platform=Platform.SENSOR, qualifier="energy_delivered"
@@ -1818,7 +1818,7 @@ async def test_device_counter_sensors(zha_gateway: Gateway) -> None:
     entity = get_entity(
         coordinator,
         platform=Platform.SENSOR,
-        qualifier_func=lambda e: e.info_object.unique_id.endswith(
+        qualifier_func=lambda e: e.state.unique_id.endswith(
             "ezsp_counters_counter_1"
         ),
     )

--- a/tests/test_siren.py
+++ b/tests/test_siren.py
@@ -59,7 +59,7 @@ async def test_siren(zha_gateway: Gateway) -> None:
         | SirenEntityFeature.DURATION
     )
 
-    assert entity.state["state"] is False
+    assert entity.state.state is False
 
     # turn on from client
     with patch(
@@ -78,7 +78,7 @@ async def test_siren(zha_gateway: Gateway) -> None:
         cluster.request.reset_mock()
 
     # test that the state has changed to on
-    assert entity.state["state"] is True
+    assert entity.state.state is True
 
     # turn off from client
     with patch(
@@ -97,7 +97,7 @@ async def test_siren(zha_gateway: Gateway) -> None:
         cluster.request.reset_mock()
 
     # test that the state has changed to off
-    assert entity.state["state"] is False
+    assert entity.state.state is False
 
     # turn on from client with options
     with patch(
@@ -116,7 +116,7 @@ async def test_siren(zha_gateway: Gateway) -> None:
         cluster.request.reset_mock()
 
     # test that the state has changed to on
-    assert entity.state["state"] is True
+    assert entity.state.state is True
 
 
 async def test_siren_timed_off(zha_gateway: Gateway) -> None:
@@ -126,7 +126,7 @@ async def test_siren_timed_off(zha_gateway: Gateway) -> None:
 
     entity = get_entity(zha_device, platform=Platform.SIREN)
 
-    assert entity.state["state"] is False
+    assert entity.state.state is False
 
     # turn on from client
     with patch(
@@ -145,9 +145,9 @@ async def test_siren_timed_off(zha_gateway: Gateway) -> None:
         cluster.request.reset_mock()
 
     # test that the state has changed to on
-    assert entity.state["state"] is True
+    assert entity.state.state is True
 
     await asyncio.sleep(6)
 
     # test that the state has changed to off from the timer
-    assert entity.state["state"] is False
+    assert entity.state.state is False

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -242,7 +242,7 @@ async def test_zha_group_switch_entity(zha_gateway: Gateway) -> None:
 
     entity: GroupEntity = get_group_entity(zha_group, platform=Platform.SWITCH)
     assert entity.group_id == zha_group.group_id
-    assert entity.info_object.fallback_name == zha_group.name
+    assert entity.state.fallback_name == zha_group.name
 
     group_cluster_on_off = zha_group.zigpy_group.endpoint[general.OnOff.cluster_id]
     dev1_cluster_on_off = device_switch_1.device.endpoints[1].on_off
@@ -864,7 +864,7 @@ async def test_binary_output_cluster(zha_gateway: Gateway) -> None:
     # Clear out the attribute first, to test handling of the missing state
     cluster.update_attribute(BinaryOutput.AttributeDefs.present_value.id, None)
 
-    assert switch_entity.info_object.fallback_name == "Entity Description"
+    assert switch_entity.state.fallback_name == "Entity Description"
     assert switch_entity.state.state is False
 
     # Turn it on

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -122,15 +122,15 @@ async def test_switch(zha_gateway: Gateway) -> None:
     cluster = zigpy_device.endpoints.get(1).on_off
     entity: PlatformEntity = get_entity(zha_device, Platform.SWITCH)
 
-    assert bool(bool(entity.state["state"])) is False
+    assert bool(bool(entity.state.state)) is False
 
     # turn on at switch
     await send_attributes_report(zha_gateway, cluster, {1: 0, 0: 1, 2: 2})
-    assert bool(entity.state["state"]) is True
+    assert bool(entity.state.state) is True
 
     # turn off at switch
     await send_attributes_report(zha_gateway, cluster, {1: 1, 0: 0, 2: 2})
-    assert bool(entity.state["state"]) is False
+    assert bool(entity.state.state) is False
 
     # turn on from client
     with patch(
@@ -139,7 +139,7 @@ async def test_switch(zha_gateway: Gateway) -> None:
     ):
         await entity.async_turn_on()
         await zha_gateway.async_block_till_done()
-        assert bool(entity.state["state"]) is True
+        assert bool(entity.state.state) is True
         assert len(cluster.request.mock_calls) == 1
         assert cluster.request.call_args == call(
             False,
@@ -159,7 +159,7 @@ async def test_switch(zha_gateway: Gateway) -> None:
     ):
         await entity.async_turn_off()
         await zha_gateway.async_block_till_done()
-        assert bool(entity.state["state"]) is True
+        assert bool(entity.state.state) is True
         assert len(cluster.request.mock_calls) == 1
         assert cluster.request.call_args == call(
             False,
@@ -176,7 +176,7 @@ async def test_switch(zha_gateway: Gateway) -> None:
     ):
         await entity.async_turn_off()
         await zha_gateway.async_block_till_done()
-        assert bool(entity.state["state"]) is False
+        assert bool(entity.state.state) is False
         assert len(cluster.request.mock_calls) == 1
         assert cluster.request.call_args == call(
             False,
@@ -196,7 +196,7 @@ async def test_switch(zha_gateway: Gateway) -> None:
     ):
         await entity.async_turn_on()
         await zha_gateway.async_block_till_done()
-        assert bool(entity.state["state"]) is False
+        assert bool(entity.state.state) is False
         assert len(cluster.request.mock_calls) == 1
         assert cluster.request.call_args == call(
             False,
@@ -208,7 +208,7 @@ async def test_switch(zha_gateway: Gateway) -> None:
 
     # test updating entity state from client
     cluster.read_attributes.reset_mock()
-    assert bool(entity.state["state"]) is False
+    assert bool(entity.state.state) is False
     cluster.PLUGGED_ATTR_READS = {"on_off": True}
     await entity.async_update()
     await zha_gateway.async_block_till_done()
@@ -216,7 +216,7 @@ async def test_switch(zha_gateway: Gateway) -> None:
     assert cluster.read_attributes.await_args == call(
         ["on_off"], allow_cache=False, only_cache=False, manufacturer=UNDEFINED
     )
-    assert bool(entity.state["state"]) is True
+    assert bool(entity.state.state) is True
 
 
 async def test_zha_group_switch_entity(zha_gateway: Gateway) -> None:
@@ -249,7 +249,7 @@ async def test_zha_group_switch_entity(zha_gateway: Gateway) -> None:
     dev2_cluster_on_off = device_switch_2.device.endpoints[1].on_off
 
     # test that the lights were created and are off
-    assert bool(entity.state["state"]) is False
+    assert bool(entity.state.state) is False
 
     # turn on from HA
     with patch(
@@ -267,7 +267,7 @@ async def test_zha_group_switch_entity(zha_gateway: Gateway) -> None:
             expect_reply=True,
             manufacturer=None,
         )
-    assert bool(entity.state["state"]) is True
+    assert bool(entity.state.state) is True
 
     # turn off from HA
     with patch(
@@ -285,7 +285,7 @@ async def test_zha_group_switch_entity(zha_gateway: Gateway) -> None:
             expect_reply=True,
             manufacturer=None,
         )
-    assert bool(entity.state["state"]) is False
+    assert bool(entity.state.state) is False
 
     # test some of the group logic to make sure we key off states correctly
     await send_attributes_report(zha_gateway, dev1_cluster_on_off, {0: 1})
@@ -293,40 +293,40 @@ async def test_zha_group_switch_entity(zha_gateway: Gateway) -> None:
     await zha_gateway.async_block_till_done()
 
     # group member updates are debounced
-    assert bool(entity.state["state"]) is False
+    assert bool(entity.state.state) is False
     await asyncio.sleep(1)
     await zha_gateway.async_block_till_done()
 
     # test that group light is on
-    assert bool(entity.state["state"]) is True
+    assert bool(entity.state.state) is True
 
     await send_attributes_report(zha_gateway, dev1_cluster_on_off, {0: 0})
     await zha_gateway.async_block_till_done()
 
     # test that group light is still on
-    assert bool(entity.state["state"]) is True
+    assert bool(entity.state.state) is True
 
     await send_attributes_report(zha_gateway, dev2_cluster_on_off, {0: 0})
     await zha_gateway.async_block_till_done()
 
     # group member updates are debounced
-    assert bool(entity.state["state"]) is True
+    assert bool(entity.state.state) is True
     await asyncio.sleep(1)
     await zha_gateway.async_block_till_done()
 
     # test that group light is now off
-    assert bool(entity.state["state"]) is False
+    assert bool(entity.state.state) is False
 
     await send_attributes_report(zha_gateway, dev1_cluster_on_off, {0: 1})
     await zha_gateway.async_block_till_done()
 
     # group member updates are debounced
-    assert bool(entity.state["state"]) is False
+    assert bool(entity.state.state) is False
     await asyncio.sleep(1)
     await zha_gateway.async_block_till_done()
 
     # test that group light is now back on
-    assert bool(entity.state["state"]) is True
+    assert bool(entity.state.state) is True
 
     await group_entity_availability_test(
         zha_gateway, device_switch_1, device_switch_2, entity
@@ -390,19 +390,19 @@ async def test_switch_configurable(
     entity = get_entity(zha_device, platform=Platform.SWITCH)
 
     # test that the state has changed from unavailable to off
-    assert bool(entity.state["state"]) is False
+    assert bool(entity.state.state) is False
 
     # turn on at switch
     await send_attributes_report(
         zha_gateway, cluster, {"window_detection_function": True}
     )
-    assert bool(entity.state["state"]) is True
+    assert bool(entity.state.state) is True
 
     # turn off at switch
     await send_attributes_report(
         zha_gateway, cluster, {"window_detection_function": False}
     )
-    assert bool(entity.state["state"]) is False
+    assert bool(entity.state.state) is False
 
     # turn on from HA
     with patch(
@@ -522,15 +522,15 @@ async def test_switch_configurable_custom_on_off_values(zha_gateway: Gateway) ->
 
     entity = get_entity(zha_device, platform=Platform.SWITCH)
 
-    assert bool(entity.state["state"]) is False
+    assert bool(entity.state.state) is False
 
     # turn on at switch
     await send_attributes_report(zha_gateway, cluster, {"window_detection_function": 3})
-    assert bool(entity.state["state"]) is True
+    assert bool(entity.state.state) is True
 
     # turn off at switch
     await send_attributes_report(zha_gateway, cluster, {"window_detection_function": 5})
-    assert bool(entity.state["state"]) is False
+    assert bool(entity.state.state) is False
 
     # turn on from HA
     with patch(
@@ -603,15 +603,15 @@ async def test_switch_configurable_custom_on_off_values_force_inverted(
 
     entity = get_entity(zha_device, platform=Platform.SWITCH)
 
-    assert bool(entity.state["state"]) is True
+    assert bool(entity.state.state) is True
 
     # turn on at switch
     await send_attributes_report(zha_gateway, cluster, {"window_detection_function": 3})
-    assert bool(entity.state["state"]) is False
+    assert bool(entity.state.state) is False
 
     # turn off at switch
     await send_attributes_report(zha_gateway, cluster, {"window_detection_function": 5})
-    assert bool(entity.state["state"]) is True
+    assert bool(entity.state.state) is True
 
     # turn on from HA
     with patch(
@@ -687,15 +687,15 @@ async def test_switch_configurable_custom_on_off_values_inverter_attribute(
 
     entity = get_entity(zha_device, platform=Platform.SWITCH)
 
-    assert bool(entity.state["state"]) is True
+    assert bool(entity.state.state) is True
 
     # turn on at switch
     await send_attributes_report(zha_gateway, cluster, {"window_detection_function": 3})
-    assert bool(entity.state["state"]) is False
+    assert bool(entity.state.state) is False
 
     # turn off at switch
     await send_attributes_report(zha_gateway, cluster, {"window_detection_function": 5})
-    assert bool(entity.state["state"]) is True
+    assert bool(entity.state.state) is True
 
     # turn on from HA
     with patch(
@@ -766,13 +766,13 @@ async def test_cover_inversion_switch(zha_gateway: Gateway) -> None:
     await entity.async_update()
     await zha_gateway.async_block_till_done()
     assert cluster.read_attributes.call_count == prev_call_count + 1
-    assert bool(entity.state["state"]) is False
+    assert bool(entity.state.state) is False
 
     # test to see the state remains after tilting to 0%
     await send_attributes_report(
         zha_gateway, cluster, {WCAttrs.current_position_tilt_percentage.id: 0}
     )
-    assert bool(entity.state["state"]) is False
+    assert bool(entity.state.state) is False
 
     with patch(
         "zigpy.zcl.Cluster.write_attributes", return_value=[0x1, zcl_f.Status.SUCCESS]
@@ -793,7 +793,7 @@ async def test_cover_inversion_switch(zha_gateway: Gateway) -> None:
             manufacturer=UNDEFINED,
         )
 
-        assert bool(entity.state["state"]) is True
+        assert bool(entity.state.state) is True
 
         cluster.write_attributes.reset_mock()
 
@@ -809,7 +809,7 @@ async def test_cover_inversion_switch(zha_gateway: Gateway) -> None:
             manufacturer=UNDEFINED,
         )
 
-        assert bool(entity.state["state"]) is False
+        assert bool(entity.state.state) is False
 
         cluster.write_attributes.reset_mock()
 
@@ -818,7 +818,7 @@ async def test_cover_inversion_switch(zha_gateway: Gateway) -> None:
         await zha_gateway.async_block_till_done()
         assert cluster.write_attributes.call_count == 0
 
-        assert bool(entity.state["state"]) is False
+        assert bool(entity.state.state) is False
 
 
 async def test_cover_inversion_switch_not_created(zha_gateway: Gateway) -> None:
@@ -865,7 +865,7 @@ async def test_binary_output_cluster(zha_gateway: Gateway) -> None:
     cluster.update_attribute(BinaryOutput.AttributeDefs.present_value.id, None)
 
     assert switch_entity.info_object.fallback_name == "Entity Description"
-    assert switch_entity.state["state"] is False
+    assert switch_entity.state.state is False
 
     # Turn it on
     cluster.write_attributes.reset_mock()
@@ -873,7 +873,7 @@ async def test_binary_output_cluster(zha_gateway: Gateway) -> None:
     assert cluster.write_attributes.mock_calls == [
         call({"present_value": True}, manufacturer=UNDEFINED)
     ]
-    assert switch_entity.state["state"] is True
+    assert switch_entity.state.state is True
 
     # Turn it off
     cluster.write_attributes.reset_mock()
@@ -881,7 +881,7 @@ async def test_binary_output_cluster(zha_gateway: Gateway) -> None:
     assert cluster.write_attributes.mock_calls == [
         call({"present_value": False}, manufacturer=UNDEFINED)
     ]
-    assert switch_entity.state["state"] is False
+    assert switch_entity.state.state is False
 
     # Report an attribute change
     await send_attributes_report(
@@ -889,14 +889,14 @@ async def test_binary_output_cluster(zha_gateway: Gateway) -> None:
         cluster,
         {BinaryOutput.AttributeDefs.present_value.id: t.Bool(False)},
     )
-    assert switch_entity.state["state"] is False
+    assert switch_entity.state.state is False
 
     # Force an update
     cluster.read_attributes.reset_mock()
     cluster.PLUGGED_ATTR_READS = {BinaryOutput.AttributeDefs.present_value.name: True}
 
     await switch_entity.async_update()
-    assert switch_entity.state["state"] is True
+    assert switch_entity.state.state is True
 
     assert cluster.read_attributes.mock_calls == [
         call(

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -26,15 +26,6 @@ from tests.common import (
 )
 from zha.application import Platform
 from zha.application.gateway import Gateway
-from zha.application.platforms.update import (
-    ATTR_IN_PROGRESS,
-    ATTR_INSTALLED_VERSION,
-    ATTR_LATEST_VERSION,
-    ATTR_RELEASE_NOTES,
-    ATTR_RELEASE_SUMMARY,
-    ATTR_RELEASE_URL,
-    ATTR_UPDATE_PERCENTAGE,
-)
 from zha.exceptions import ZHAException
 
 
@@ -175,8 +166,8 @@ async def test_firmware_update_notification_from_zigpy(zha_gateway: Gateway) -> 
     )
 
     entity = get_entity(zha_device, platform=Platform.UPDATE)
-    assert entity.state["installed_version"] == f"0x{installed_fw_version:08x}"
-    assert entity.state["latest_version"] is None
+    assert entity.state.installed_version == f"0x{installed_fw_version:08x}"
+    assert entity.state.latest_version is None
 
     # simulate an image available notification
     await ota_cluster._handle_query_next_image(
@@ -193,11 +184,10 @@ async def test_firmware_update_notification_from_zigpy(zha_gateway: Gateway) -> 
     )
 
     await zha_gateway.async_block_till_done()
-    assert entity.state[ATTR_INSTALLED_VERSION] == f"0x{installed_fw_version:08x}"
-    assert entity.state[ATTR_IN_PROGRESS] is False
+    assert entity.state.installed_version == f"0x{installed_fw_version:08x}"
+    assert entity.state.in_progress is False
     assert (
-        entity.state[ATTR_LATEST_VERSION]
-        == f"0x{fw_image.firmware.header.file_version:08x}"
+        entity.state.latest_version == f"0x{fw_image.firmware.header.file_version:08x}"
     )
 
 
@@ -227,11 +217,10 @@ async def test_firmware_update_success(zha_gateway: Gateway) -> None:
     )
 
     await zha_gateway.async_block_till_done()
-    assert entity.state[ATTR_INSTALLED_VERSION] == f"0x{installed_fw_version:08x}"
-    assert entity.state[ATTR_IN_PROGRESS] is False
+    assert entity.state.installed_version == f"0x{installed_fw_version:08x}"
+    assert entity.state.in_progress is False
     assert (
-        entity.state[ATTR_LATEST_VERSION]
-        == f"0x{fw_image.firmware.header.file_version:08x}"
+        entity.state.latest_version == f"0x{fw_image.firmware.header.file_version:08x}"
     )
 
     async def endpoint_reply(cluster, sequence, data, **kwargs):
@@ -313,15 +302,15 @@ async def test_firmware_update_success(zha_gateway: Gateway) -> None:
                     # make sure the state machine gets progress reports
 
                     assert (
-                        entity.state[ATTR_INSTALLED_VERSION]
+                        entity.state.installed_version
                         == f"0x{installed_fw_version:08x}"
                     )
-                    assert entity.state[ATTR_IN_PROGRESS] is True
-                    assert entity.state[ATTR_UPDATE_PERCENTAGE] == pytest.approx(
+                    assert entity.state.in_progress is True
+                    assert entity.state.update_percentage == pytest.approx(
                         100 * (40 / 70)
                     )
                     assert (
-                        entity.state[ATTR_LATEST_VERSION]
+                        entity.state.latest_version
                         == f"0x{fw_image.firmware.header.file_version:08x}"
                     )
 
@@ -367,16 +356,16 @@ async def test_firmware_update_success(zha_gateway: Gateway) -> None:
     await zha_gateway.async_block_till_done()
 
     assert (
-        entity.state[ATTR_INSTALLED_VERSION]
+        entity.state.installed_version
         == f"0x{fw_image.firmware.header.file_version:08x}"
     )
-    assert not entity.state[ATTR_IN_PROGRESS]
-    assert entity.state[ATTR_LATEST_VERSION] == entity.state[ATTR_INSTALLED_VERSION]
+    assert not entity.state.in_progress
+    assert entity.state.latest_version == entity.state.installed_version
 
     # If we send a progress notification incorrectly, it won't be handled
     entity._update_progress(50, 100, 0.50)
 
-    assert not entity.state[ATTR_IN_PROGRESS]
+    assert not entity.state.in_progress
 
 
 async def test_firmware_update_raises(zha_gateway: Gateway) -> None:
@@ -403,11 +392,10 @@ async def test_firmware_update_raises(zha_gateway: Gateway) -> None:
     )
 
     await zha_gateway.async_block_till_done()
-    assert entity.state[ATTR_INSTALLED_VERSION] == f"0x{installed_fw_version:08x}"
-    assert not entity.state[ATTR_IN_PROGRESS]
+    assert entity.state.installed_version == f"0x{installed_fw_version:08x}"
+    assert not entity.state.in_progress
     assert (
-        entity.state[ATTR_LATEST_VERSION]
-        == f"0x{fw_image.firmware.header.file_version:08x}"
+        entity.state.latest_version == f"0x{fw_image.firmware.header.file_version:08x}"
     )
 
     async def endpoint_reply(cluster, sequence, data, **kwargs):
@@ -489,11 +477,10 @@ async def test_firmware_update_downgrade(zha_gateway: Gateway) -> None:
     )
 
     await zha_gateway.async_block_till_done()
-    assert entity.state[ATTR_INSTALLED_VERSION] == f"0x{installed_fw_version:08x}"
-    assert not entity.state[ATTR_IN_PROGRESS]
+    assert entity.state.installed_version == f"0x{installed_fw_version:08x}"
+    assert not entity.state.in_progress
     assert (
-        entity.state[ATTR_LATEST_VERSION]
-        == f"0x{fw_image.firmware.header.file_version:08x}"
+        entity.state.latest_version == f"0x{fw_image.firmware.header.file_version:08x}"
     )
 
     with patch.object(
@@ -521,13 +508,12 @@ async def test_firmware_update_downgrade(zha_gateway: Gateway) -> None:
     ]
 
     assert (
-        entity.state[ATTR_INSTALLED_VERSION]
+        entity.state.installed_version
         == f"0x{fw_image_downgrade.firmware.header.file_version:08x}"
     )
-    assert not entity.state[ATTR_IN_PROGRESS]
+    assert not entity.state.in_progress
     assert (
-        entity.state[ATTR_LATEST_VERSION]
-        == f"0x{fw_image.firmware.header.file_version:08x}"
+        entity.state.latest_version == f"0x{fw_image.firmware.header.file_version:08x}"
     )
 
 
@@ -562,16 +548,16 @@ async def test_firmware_update_no_image(zha_gateway: Gateway) -> None:
     )
 
     await zha_gateway.async_block_till_done()
-    assert entity.state[ATTR_INSTALLED_VERSION] == f"0x{installed_fw_version:08x}"
-    assert not entity.state[ATTR_IN_PROGRESS]
-    assert entity.state[ATTR_LATEST_VERSION] is None
+    assert entity.state.installed_version == f"0x{installed_fw_version:08x}"
+    assert not entity.state.in_progress
+    assert entity.state.latest_version is None
 
     with pytest.raises(ZHAException):
         await entity.async_install(version=None)
 
-    assert entity.state[ATTR_INSTALLED_VERSION] == f"0x{installed_fw_version:08x}"
-    assert not entity.state[ATTR_IN_PROGRESS]
-    assert entity.state[ATTR_LATEST_VERSION] is None
+    assert entity.state.installed_version == f"0x{installed_fw_version:08x}"
+    assert not entity.state.in_progress
+    assert entity.state.latest_version is None
 
 
 async def test_firmware_update_latest_version_even_if_downgrade(
@@ -609,10 +595,10 @@ async def test_firmware_update_latest_version_even_if_downgrade(
     )
 
     await zha_gateway.async_block_till_done()
-    assert entity.state[ATTR_INSTALLED_VERSION] == f"0x{installed_fw_version:08x}"
-    assert not entity.state[ATTR_IN_PROGRESS]
+    assert entity.state.installed_version == f"0x{installed_fw_version:08x}"
+    assert not entity.state.in_progress
     assert (
-        entity.state[ATTR_LATEST_VERSION]
+        entity.state.latest_version
         == f"0x{fw_image_downgrade.firmware.header.file_version:08x}"
     )
 
@@ -642,9 +628,9 @@ async def test_firmware_update_metadata(zha_gateway: Gateway) -> None:
     entity = get_entity(zha_device, platform=Platform.UPDATE)
 
     # metadata should be None before notification
-    assert entity.state[ATTR_RELEASE_SUMMARY] is None
-    assert entity.state[ATTR_RELEASE_NOTES] is None
-    assert entity.state[ATTR_RELEASE_URL] is None
+    assert entity.state.release_summary is None
+    assert entity.state.release_notes is None
+    assert entity.state.release_url is None
 
     # simulate an image available notification
     await ota_cluster._handle_query_next_image(
@@ -663,16 +649,15 @@ async def test_firmware_update_metadata(zha_gateway: Gateway) -> None:
     await zha_gateway.async_block_till_done()
 
     # verify metadata is exposed in entity state now
-    assert entity.state[ATTR_INSTALLED_VERSION] == f"0x{installed_fw_version:08x}"
+    assert entity.state.installed_version == f"0x{installed_fw_version:08x}"
     assert (
-        entity.state[ATTR_LATEST_VERSION]
-        == f"0x{fw_image.firmware.header.file_version:08x}"
+        entity.state.latest_version == f"0x{fw_image.firmware.header.file_version:08x}"
     )
-    assert entity.state[ATTR_RELEASE_URL] == "https://example.com/releases/v1.0"
-    assert entity.state[ATTR_RELEASE_SUMMARY] == "This is a test changelog!"
+    assert entity.state.release_url == "https://example.com/releases/v1.0"
+    assert entity.state.release_summary == "This is a test changelog!"
 
     # release notes include version header
-    assert entity.state[ATTR_RELEASE_NOTES] == (
+    assert entity.state.release_notes == (
         f"## 0x{fw_image.firmware.header.file_version:08x}\n"
         "These are the full release notes."
     )
@@ -731,12 +716,12 @@ async def test_firmware_update_multiple_upgrades_combined_release_notes(
 
     # Verify latest version is the newest firmware
     assert (
-        entity.state[ATTR_LATEST_VERSION]
+        entity.state.latest_version
         == f"0x{fw_image_v3.firmware.header.file_version:08x}"
     )
     # Only latest firmware provides URL and release summary
-    assert entity.state[ATTR_RELEASE_URL] == "https://example.com/releases/v3"
-    assert entity.state[ATTR_RELEASE_SUMMARY] == "Latest changelog"
+    assert entity.state.release_url == "https://example.com/releases/v3"
+    assert entity.state.release_summary == "Latest changelog"
 
     # Release notes should be combined with version headers
     # fw_image_v2 is skipped because it has no release notes
@@ -746,4 +731,4 @@ async def test_firmware_update_multiple_upgrades_combined_release_notes(
         f"## 0x{fw_image_v1.firmware.header.file_version:08x}\n"
         "Release notes for v1."
     )
-    assert entity.state[ATTR_RELEASE_NOTES] == expected_release_notes
+    assert entity.state.release_notes == expected_release_notes

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -509,7 +509,7 @@ class Gateway(AsyncUtilMixin, EventBase):
                 gateway_message_type,
                 GroupEvent(
                     event=gateway_message_type,
-                    group_info=zha_group.info_object,
+                    group_info=zha_group.state,
                 ),
             )
 

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -150,6 +150,8 @@ class BaseEntityState:
     enabled: bool = True
     primary: bool
 
+    extra_state_attribute_names: frozenset[str] | None
+
     # For platform entities
     device_ieee: EUI64 | None
     endpoint_id: int | None
@@ -209,6 +211,7 @@ class BaseEntity(LogMixin, EventBase):
     _attr_device_class: str | None = None
     _attr_state_class: str | None = None
     _attr_enabled: bool = True
+    _attr_extra_state_attribute_names: set[str] | None = None
     _attr_always_supported: bool = False
     _attr_primary: bool | None = None
 
@@ -356,6 +359,11 @@ class BaseEntity(LogMixin, EventBase):
             entity_registry_enabled_default=self.entity_registry_enabled_default,
             enabled=self.enabled,
             primary=self.primary,
+            extra_state_attribute_names=(
+                frozenset(self._attr_extra_state_attribute_names)
+                if self._attr_extra_state_attribute_names is not None
+                else None
+            ),
             # Set by platform entities
             device_ieee=None,
             endpoint_id=None,

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -24,7 +24,6 @@ from zha.const import STATE_CHANGED
 from zha.debounce import Debouncer
 from zha.event import EventBase
 from zha.mixins import LogMixin
-from zha.zigbee.cluster_handlers import ClusterHandlerInfo
 
 if TYPE_CHECKING:
     from zha.zigbee.cluster_handlers import ClusterHandler
@@ -152,7 +151,6 @@ class BaseEntityState:
     primary: bool
 
     # For platform entities
-    cluster_handlers: list[ClusterHandlerInfo]
     device_ieee: EUI64 | None
     endpoint_id: int | None
     available: bool | None
@@ -359,7 +357,6 @@ class BaseEntity(LogMixin, EventBase):
             enabled=self.enabled,
             primary=self.primary,
             # Set by platform entities
-            cluster_handlers=[],
             device_ieee=None,
             endpoint_id=None,
             available=None,
@@ -535,7 +532,6 @@ class PlatformEntity(BaseEntity):
         """Return the state of this entity."""
         return dataclasses.replace(
             super().state,
-            cluster_handlers=[ch.info_object for ch in self._cluster_handlers],
             device_ieee=self._device.ieee,
             endpoint_id=self._endpoint.id,
             available=self.available,

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -134,8 +134,8 @@ class EntityCategory(StrEnum):
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class BaseEntityInfo:
-    """Information about a base entity."""
+class BaseEntityState:
+    """State for the base entity."""
 
     fallback_name: str
     unique_id: str
@@ -341,11 +341,10 @@ class BaseEntity(LogMixin, EventBase):
             platform=self.PLATFORM,
         )
 
-    @cached_property
-    def info_object(self) -> BaseEntityInfo:
-        """Return a representation of the platform entity."""
-
-        return BaseEntityInfo(
+    @property
+    def state(self) -> BaseEntityState:
+        """Return the state of this entity."""
+        return BaseEntityState(
             unique_id=self.unique_id,
             migrate_unique_ids=self.migrate_unique_ids,
             platform=self.PLATFORM,
@@ -367,24 +366,6 @@ class BaseEntity(LogMixin, EventBase):
             # Set by group entities
             group_id=None,
         )
-
-    @property
-    def state(self) -> dict[str, Any]:
-        """Return the arguments to use in the command."""
-        return {
-            "class_name": self.__class__.__name__,
-        }
-
-    @cached_property
-    def extra_state_attribute_names(self) -> set[str] | None:
-        """Return entity specific state attribute names.
-
-        Implemented by platform classes. Convention for attribute names
-        is lowercase snake_case.
-        """
-        if hasattr(self, "_attr_extra_state_attribute_names"):
-            return self._attr_extra_state_attribute_names
-        return None
 
     def enable(self) -> None:
         """Enable the entity."""
@@ -529,17 +510,6 @@ class PlatformEntity(BaseEntity):
             endpoint_id=self.endpoint.id,
         )
 
-    @cached_property
-    def info_object(self) -> BaseEntityInfo:
-        """Return a representation of the platform entity."""
-        return dataclasses.replace(
-            super().info_object,
-            cluster_handlers=[ch.info_object for ch in self._cluster_handlers],
-            device_ieee=self._device.ieee,
-            endpoint_id=self._endpoint.id,
-            available=self.available,
-        )
-
     @property
     def device(self) -> Device:
         """Return the device."""
@@ -561,11 +531,15 @@ class PlatformEntity(BaseEntity):
         return self.device.available
 
     @property
-    def state(self) -> dict[str, Any]:
-        """Return the arguments to use in the command."""
-        state = super().state
-        state["available"] = self.available
-        return state
+    def state(self) -> BaseEntityState:
+        """Return the state of this entity."""
+        return dataclasses.replace(
+            super().state,
+            cluster_handlers=[ch.info_object for ch in self._cluster_handlers],
+            device_ieee=self._device.ieee,
+            endpoint_id=self._endpoint.id,
+            available=self.available,
+        )
 
     async def async_update(self) -> None:
         """Retrieve latest state."""
@@ -609,20 +583,14 @@ class GroupEntity(BaseEntity):
             group_id=self.group_id,
         )
 
-    @cached_property
-    def info_object(self) -> BaseEntityInfo:
-        """Return a representation of the group."""
+    @property
+    def state(self) -> BaseEntityState:
+        """Return the state of this entity."""
         return dataclasses.replace(
-            super().info_object,
+            super().state,
+            available=self.available,
             group_id=self.group_id,
         )
-
-    @property
-    def state(self) -> dict[str, Any]:
-        """Return the arguments to use in the command."""
-        state = super().state
-        state["available"] = self.available
-        return state
 
     @property
     def available(self) -> bool:

--- a/zha/application/platforms/alarm_control_panel/__init__.py
+++ b/zha/application/platforms/alarm_control_panel/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 import functools
 import logging
@@ -53,12 +54,74 @@ class AlarmControlPanelEntityInfo(BaseEntityInfo):
     translation_key: str
 
 
+class BaseAlarmControlPanel(PlatformEntity, ABC):
+    """Abstract base class for ZHA alarm control panel entities."""
+
+    PLATFORM = Platform.ALARM_CONTROL_PANEL
+
+    @property
+    def state(self) -> dict[str, Any]:
+        """Get the state of the alarm control panel."""
+        response = super().state
+        response["state"] = self.alarm_state
+        return response
+
+    @property
+    @abstractmethod
+    def alarm_state(self) -> AlarmState:
+        """Return the current alarm state."""
+
+    @property
+    @abstractmethod
+    def code_arm_required(self) -> bool:
+        """Whether the code is required for arm actions."""
+
+    @property
+    @abstractmethod
+    def code_format(self) -> CodeFormat:
+        """Code format or None if no code is required."""
+
+    @property
+    @abstractmethod
+    def supported_features(self) -> int:
+        """Return the list of supported features."""
+
+    @functools.cached_property
+    def info_object(self) -> AlarmControlPanelEntityInfo:
+        """Return a representation of the alarm control panel."""
+        return AlarmControlPanelEntityInfo(
+            **super().info_object.__dict__,
+            code_arm_required=self.code_arm_required,
+            code_format=self.code_format,
+            supported_features=self.supported_features,
+        )
+
+    @abstractmethod
+    async def async_alarm_disarm(self, code: str | None = None) -> None:
+        """Send disarm command."""
+
+    @abstractmethod
+    async def async_alarm_arm_home(self, code: str | None = None) -> None:
+        """Send arm home command."""
+
+    @abstractmethod
+    async def async_alarm_arm_away(self, code: str | None = None) -> None:
+        """Send arm away command."""
+
+    @abstractmethod
+    async def async_alarm_arm_night(self, code: str | None = None) -> None:
+        """Send arm night command."""
+
+    @abstractmethod
+    async def async_alarm_trigger(self, code: str | None = None) -> None:
+        """Send alarm trigger command."""
+
+
 @register_entity(IasAce.cluster_id)
-class AlarmControlPanel(PlatformEntity):
+class AlarmControlPanel(BaseAlarmControlPanel):
     """Entity for ZHA alarm control devices."""
 
     _attr_translation_key: str = "alarm_control_panel"
-    PLATFORM = Platform.ALARM_CONTROL_PANEL
 
     _cluster_handler_match = ClusterHandlerMatch(
         client_cluster_handlers=frozenset({CLUSTER_HANDLER_IAS_ACE}),
@@ -107,24 +170,12 @@ class AlarmControlPanel(PlatformEntity):
             )
         )
 
-    @functools.cached_property
-    def info_object(self) -> AlarmControlPanelEntityInfo:
-        """Return a representation of the alarm control panel."""
-        return AlarmControlPanelEntityInfo(
-            **super().info_object.__dict__,
-            code_arm_required=self.code_arm_required,
-            code_format=self.code_format,
-            supported_features=self.supported_features,
-        )
-
     @property
-    def state(self) -> dict[str, Any]:
-        """Get the state of the alarm control panel."""
-        response = super().state
-        response["state"] = IAS_ACE_STATE_MAP.get(
+    def alarm_state(self) -> AlarmState:
+        """Return the current alarm state."""
+        return IAS_ACE_STATE_MAP.get(
             self._cluster_handler.armed_state, AlarmState.UNKNOWN
         )
-        return response
 
     @property
     def code_arm_required(self) -> bool:

--- a/zha/application/platforms/alarm_control_panel/__init__.py
+++ b/zha/application/platforms/alarm_control_panel/__init__.py
@@ -76,15 +76,18 @@ class BaseAlarmControlPanel(PlatformEntity, ABC):
     def code_arm_required(self) -> bool:
         """Whether the code is required for arm actions."""
 
-    @property
-    @abstractmethod
-    def code_format(self) -> CodeFormat:
-        """Code format or None if no code is required."""
+    _attr_code_format: CodeFormat
+    _attr_supported_features: int
 
     @property
-    @abstractmethod
+    def code_format(self) -> CodeFormat:
+        """Code format or None if no code is required."""
+        return self._attr_code_format
+
+    @property
     def supported_features(self) -> int:
         """Return the list of supported features."""
+        return self._attr_supported_features
 
     @functools.cached_property
     def info_object(self) -> AlarmControlPanelEntityInfo:
@@ -122,6 +125,13 @@ class AlarmControlPanel(BaseAlarmControlPanel):
     """Entity for ZHA alarm control devices."""
 
     _attr_translation_key: str = "alarm_control_panel"
+    _attr_code_format = CodeFormat.NUMBER
+    _attr_supported_features = (
+        SUPPORT_ALARM_ARM_HOME
+        | SUPPORT_ALARM_ARM_AWAY
+        | SUPPORT_ALARM_ARM_NIGHT
+        | SUPPORT_ALARM_TRIGGER
+    )
 
     _cluster_handler_match = ClusterHandlerMatch(
         client_cluster_handlers=frozenset({CLUSTER_HANDLER_IAS_ACE}),
@@ -181,21 +191,6 @@ class AlarmControlPanel(BaseAlarmControlPanel):
     def code_arm_required(self) -> bool:
         """Whether the code is required for arm actions."""
         return self._cluster_handler.code_required_arm_actions
-
-    @functools.cached_property
-    def code_format(self) -> CodeFormat:
-        """Code format or None if no code is required."""
-        return CodeFormat.NUMBER
-
-    @functools.cached_property
-    def supported_features(self) -> int:
-        """Return the list of supported features."""
-        return (
-            SUPPORT_ALARM_ARM_HOME
-            | SUPPORT_ALARM_ARM_AWAY
-            | SUPPORT_ALARM_ARM_NIGHT
-            | SUPPORT_ALARM_TRIGGER
-        )
 
     def handle_cluster_handler_state_changed(
         self,

--- a/zha/application/platforms/alarm_control_panel/__init__.py
+++ b/zha/application/platforms/alarm_control_panel/__init__.py
@@ -3,17 +3,16 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-import functools
+import dataclasses
 import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, cast
 
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.security import IasAce
 
 from zha.application import Platform
 from zha.application.platforms import (
-    BaseEntityInfo,
+    BaseEntityState,
     ClusterHandlerMatch,
     PlatformEntity,
     register_entity,
@@ -44,14 +43,14 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True, kw_only=True)
-class AlarmControlPanelEntityInfo(BaseEntityInfo):
-    """Alarm control panel entity info."""
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class AlarmControlPanelState(BaseEntityState):
+    """State for alarm control panel entities."""
 
+    state: AlarmState
     code_arm_required: bool
     code_format: CodeFormat
     supported_features: int
-    translation_key: str
 
 
 class BaseAlarmControlPanel(PlatformEntity, ABC):
@@ -60,11 +59,15 @@ class BaseAlarmControlPanel(PlatformEntity, ABC):
     PLATFORM = Platform.ALARM_CONTROL_PANEL
 
     @property
-    def state(self) -> dict[str, Any]:
+    def state(self) -> AlarmControlPanelState:
         """Get the state of the alarm control panel."""
-        response = super().state
-        response["state"] = self.alarm_state
-        return response
+        return AlarmControlPanelState(
+            **super().state.__dict__,
+            state=self.alarm_state,
+            code_arm_required=self.code_arm_required,
+            code_format=self.code_format,
+            supported_features=self.supported_features,
+        )
 
     @property
     @abstractmethod
@@ -88,16 +91,6 @@ class BaseAlarmControlPanel(PlatformEntity, ABC):
     def supported_features(self) -> int:
         """Return the list of supported features."""
         return self._attr_supported_features
-
-    @functools.cached_property
-    def info_object(self) -> AlarmControlPanelEntityInfo:
-        """Return a representation of the alarm control panel."""
-        return AlarmControlPanelEntityInfo(
-            **super().info_object.__dict__,
-            code_arm_required=self.code_arm_required,
-            code_format=self.code_format,
-            supported_features=self.supported_features,
-        )
 
     @abstractmethod
     async def async_alarm_disarm(self, code: str | None = None) -> None:

--- a/zha/application/platforms/binary_sensor/__init__.py
+++ b/zha/application/platforms/binary_sensor/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass
 import functools
@@ -62,13 +63,30 @@ class BinarySensorEntityInfo(BaseEntityInfo):
     device_class: BinarySensorDeviceClass | None
 
 
-class BinarySensor(PlatformEntity):
+class BaseBinarySensor(PlatformEntity, ABC):
+    """Abstract base class for ZHA binary sensors."""
+
+    PLATFORM: Platform = Platform.BINARY_SENSOR
+
+    @property
+    def state(self) -> dict:
+        """Return the state of the binary sensor."""
+        response = super().state
+        response["state"] = self.is_on
+        return response
+
+    @property
+    @abstractmethod
+    def is_on(self) -> bool:
+        """Return True if the binary sensor is on."""
+
+
+class BinarySensor(BaseBinarySensor):
     """ZHA BinarySensor."""
 
     _attr_device_class: BinarySensorDeviceClass | None
     _attribute_name: str
     _attribute_converter: Callable[[Any], Any] | None = None
-    PLATFORM: Platform = Platform.BINARY_SENSOR
 
     def __init__(
         self,
@@ -114,13 +132,6 @@ class BinarySensor(PlatformEntity):
             **super().info_object.__dict__,
             attribute_name=self._attribute_name,
         )
-
-    @property
-    def state(self) -> dict:
-        """Return the state of the binary sensor."""
-        response = super().state
-        response["state"] = self.is_on
-        return response
 
     @property
     def is_on(self) -> bool:

--- a/zha/application/platforms/binary_sensor/__init__.py
+++ b/zha/application/platforms/binary_sensor/__init__.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from dataclasses import dataclass
-import functools
+import dataclasses
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -19,7 +18,7 @@ from zigpy.zcl.clusters.security import IasZone
 
 from zha.application import Platform
 from zha.application.platforms import (
-    BaseEntityInfo,
+    BaseEntityState,
     ClusterHandlerMatch,
     EntityCategory,
     PlatformEntity,
@@ -55,25 +54,18 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True, kw_only=True)
-class BinarySensorEntityInfo(BaseEntityInfo):
-    """Binary sensor entity info."""
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class BinarySensorState(BaseEntityState):
+    """State for binary sensor entities."""
 
+    state: bool
     attribute_name: str
-    device_class: BinarySensorDeviceClass | None
 
 
 class BaseBinarySensor(PlatformEntity, ABC):
     """Abstract base class for ZHA binary sensors."""
 
     PLATFORM: Platform = Platform.BINARY_SENSOR
-
-    @property
-    def state(self) -> dict:
-        """Return the state of the binary sensor."""
-        response = super().state
-        response["state"] = self.is_on
-        return response
 
     @property
     @abstractmethod
@@ -87,6 +79,15 @@ class BinarySensor(BaseBinarySensor):
     _attr_device_class: BinarySensorDeviceClass | None
     _attribute_name: str
     _attribute_converter: Callable[[Any], Any] | None = None
+
+    @property
+    def state(self) -> BinarySensorState:
+        """Return the state of the binary sensor."""
+        return BinarySensorState(
+            **super().state.__dict__,
+            state=self.is_on,
+            attribute_name=self._attribute_name,
+        )
 
     def __init__(
         self,
@@ -124,14 +125,6 @@ class BinarySensor(BaseBinarySensor):
                 Platform.BINARY_SENSOR.value,
                 _LOGGER,
             )
-
-    @functools.cached_property
-    def info_object(self) -> BinarySensorEntityInfo:
-        """Return a representation of the binary sensor."""
-        return BinarySensorEntityInfo(
-            **super().info_object.__dict__,
-            attribute_name=self._attribute_name,
-        )
 
     @property
     def is_on(self) -> bool:

--- a/zha/application/platforms/button/__init__.py
+++ b/zha/application/platforms/button/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 import functools
 import logging
@@ -36,7 +37,12 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, kw_only=True)
-class CommandButtonEntityInfo(BaseEntityInfo):
+class ButtonEntityInfo(BaseEntityInfo):
+    """Button entity info."""
+
+
+@dataclass(frozen=True, kw_only=True)
+class CommandButtonEntityInfo(ButtonEntityInfo):
     """Command button entity info."""
 
     command: str
@@ -45,17 +51,30 @@ class CommandButtonEntityInfo(BaseEntityInfo):
 
 
 @dataclass(frozen=True, kw_only=True)
-class WriteAttributeButtonEntityInfo(BaseEntityInfo):
+class WriteAttributeButtonEntityInfo(ButtonEntityInfo):
     """Write attribute button entity info."""
 
     attribute_name: str
     attribute_value: Any
 
 
-class Button(PlatformEntity):
-    """Defines a ZHA button."""
+class BaseButton(PlatformEntity, ABC):
+    """Base representation of a ZHA button."""
 
     PLATFORM = Platform.BUTTON
+
+    @functools.cached_property
+    def info_object(self) -> ButtonEntityInfo:
+        """Return a representation of the button."""
+        return ButtonEntityInfo(**super().info_object.__dict__)
+
+    @abstractmethod
+    async def async_press(self) -> None:
+        """Send out a press command."""
+
+
+class Button(BaseButton):
+    """Defines a ZHA button."""
 
     _command_name: str
     _args: list[Any]
@@ -131,10 +150,8 @@ class IdentifyButton(Button):
         return not any(type(entity) is cls for entity in entities)
 
 
-class WriteAttributeButton(PlatformEntity):
+class WriteAttributeButton(BaseButton):
     """Defines a ZHA button, which writes a value to an attribute."""
-
-    PLATFORM = Platform.BUTTON
 
     _attribute_name: str
     _attribute_value: Any = None

--- a/zha/application/platforms/button/__init__.py
+++ b/zha/application/platforms/button/__init__.py
@@ -15,7 +15,7 @@ from zha.application import Platform
 from zha.application.const import ENTITY_METADATA
 from zha.application.platforms import (
     BaseEntity,
-    BaseEntityInfo,
+    BaseEntityState,
     ClusterHandlerMatch,
     EntityCategory,
     PlatformEntity,
@@ -37,13 +37,15 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, kw_only=True)
-class ButtonEntityInfo(BaseEntityInfo):
-    """Button entity info."""
+class ButtonState(BaseEntityState):
+    """State for button entities."""
+
+    pass
 
 
 @dataclass(frozen=True, kw_only=True)
-class CommandButtonEntityInfo(ButtonEntityInfo):
-    """Command button entity info."""
+class CommandButtonState(ButtonState):
+    """State for command button entities."""
 
     command: str
     args: list[Any]
@@ -51,8 +53,8 @@ class CommandButtonEntityInfo(ButtonEntityInfo):
 
 
 @dataclass(frozen=True, kw_only=True)
-class WriteAttributeButtonEntityInfo(ButtonEntityInfo):
-    """Write attribute button entity info."""
+class WriteAttributeButtonState(ButtonState):
+    """State for write attribute button entities."""
 
     attribute_name: str
     attribute_value: Any
@@ -63,10 +65,10 @@ class BaseButton(PlatformEntity, ABC):
 
     PLATFORM = Platform.BUTTON
 
-    @functools.cached_property
-    def info_object(self) -> ButtonEntityInfo:
-        """Return a representation of the button."""
-        return ButtonEntityInfo(**super().info_object.__dict__)
+    @property
+    def state(self) -> ButtonState:
+        """Return the state of the button."""
+        return ButtonState(**super().state.__dict__)
 
     @abstractmethod
     async def async_press(self) -> None:
@@ -102,11 +104,11 @@ class Button(BaseButton):
         self._args = entity_metadata.args
         self._kwargs = entity_metadata.kwargs
 
-    @functools.cached_property
-    def info_object(self) -> CommandButtonEntityInfo:
-        """Return a representation of the button."""
-        return CommandButtonEntityInfo(
-            **super().info_object.__dict__,
+    @property
+    def state(self) -> CommandButtonState:
+        """Return the state of the button."""
+        return CommandButtonState(
+            **super().state.__dict__,
             command=self._command_name,
             args=self._args,
             kwargs=self._kwargs,
@@ -178,11 +180,11 @@ class WriteAttributeButton(BaseButton):
         self._attribute_name = entity_metadata.attribute_name
         self._attribute_value = entity_metadata.attribute_value
 
-    @functools.cached_property
-    def info_object(self) -> WriteAttributeButtonEntityInfo:
-        """Return a representation of the button."""
-        return WriteAttributeButtonEntityInfo(
-            **super().info_object.__dict__,
+    @property
+    def state(self) -> WriteAttributeButtonState:
+        """Return the state of the button."""
+        return WriteAttributeButtonState(
+            **super().state.__dict__,
             attribute_name=self._attribute_name,
             attribute_value=self._attribute_value,
         )

--- a/zha/application/platforms/climate/__init__.py
+++ b/zha/application/platforms/climate/__init__.py
@@ -7,7 +7,7 @@ from asyncio import Task
 from dataclasses import dataclass
 import datetime as dt
 import functools
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, cast
 
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.hvac import (
@@ -19,7 +19,7 @@ from zigpy.zcl.clusters.hvac import (
 
 from zha.application import Platform
 from zha.application.platforms import (
-    BaseEntityInfo,
+    BaseEntityState,
     ClusterHandlerMatch,
     PlatformEntity,
     PlatformFeatureGroup,
@@ -28,12 +28,6 @@ from zha.application.platforms import (
 from zha.application.platforms.climate.const import (
     ATTR_OCCP_COOL_SETPT,
     ATTR_OCCP_HEAT_SETPT,
-    ATTR_OCCUPANCY,
-    ATTR_PI_COOLING_DEMAND,
-    ATTR_PI_HEATING_DEMAND,
-    ATTR_SYS_MODE,
-    ATTR_UNOCCP_COOL_SETPT,
-    ATTR_UNOCCP_HEAT_SETPT,
     FAN_AUTO,
     FAN_ON,
     HVAC_MODE_2_SYSTEM,
@@ -63,9 +57,18 @@ if TYPE_CHECKING:
 
 
 @dataclass(frozen=True, kw_only=True)
-class ThermostatEntityInfo(BaseEntityInfo):
-    """Thermostat entity info."""
+class ClimateState(BaseEntityState):
+    """State for climate entities."""
 
+    current_temperature: float | None
+    outdoor_temperature: float | None
+    target_temperature: float | None
+    target_temperature_high: float | None
+    target_temperature_low: float | None
+    hvac_action: HVACAction | None
+    hvac_mode: HVACMode | None
+    preset_mode: str | None
+    fan_mode: str | None
     max_temp: float
     min_temp: float
     supported_features: ClimateEntityFeature
@@ -74,25 +77,46 @@ class ThermostatEntityInfo(BaseEntityInfo):
     hvac_modes: list[HVACMode]
 
 
+@dataclass(frozen=True, kw_only=True)
+class ThermostatState(ClimateState):
+    """State for thermostat entities with extra attributes."""
+
+    sys_mode: str | None = None
+    occupancy: int | None = None
+    occupied_cooling_setpoint: int | None = None
+    occupied_heating_setpoint: int | None = None
+    pi_heating_demand: int | None = None
+    pi_cooling_demand: int | None = None
+    unoccupied_cooling_setpoint: int | None = None
+    unoccupied_heating_setpoint: int | None = None
+
+
 class BaseThermostat(PlatformEntity, ABC):
     """Abstract base class for climate entities."""
 
     PLATFORM = Platform.CLIMATE
 
     @property
-    def state(self) -> dict[str, Any]:
+    def state(self) -> ClimateState:
         """Get the state of the climate entity."""
-        response = super().state
-        response["current_temperature"] = self.current_temperature
-        response["outdoor_temperature"] = self.outdoor_temperature
-        response["target_temperature"] = self.target_temperature
-        response["target_temperature_high"] = self.target_temperature_high
-        response["target_temperature_low"] = self.target_temperature_low
-        response["hvac_action"] = self.hvac_action
-        response["hvac_mode"] = self.hvac_mode
-        response["preset_mode"] = self.preset_mode
-        response["fan_mode"] = self.fan_mode
-        return response
+        return ClimateState(
+            **super().state.__dict__,
+            current_temperature=self.current_temperature,
+            outdoor_temperature=self.outdoor_temperature,
+            target_temperature=self.target_temperature,
+            target_temperature_high=self.target_temperature_high,
+            target_temperature_low=self.target_temperature_low,
+            hvac_action=self.hvac_action,
+            hvac_mode=self.hvac_mode,
+            preset_mode=self.preset_mode,
+            fan_mode=self.fan_mode,
+            max_temp=self.max_temp,
+            min_temp=self.min_temp,
+            supported_features=self.supported_features,
+            fan_modes=self.fan_modes,
+            preset_modes=self.preset_modes,
+            hvac_modes=self.hvac_modes,
+        )
 
     @property
     @abstractmethod
@@ -204,17 +228,6 @@ class Thermostat(BaseThermostat):
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_translation_key: str = "thermostat"
     _enable_turn_on_off_backwards_compatibility = False
-    _attr_extra_state_attribute_names: set[str] = {
-        ATTR_SYS_MODE,
-        ATTR_OCCUPANCY,
-        ATTR_OCCP_COOL_SETPT,
-        ATTR_OCCP_HEAT_SETPT,
-        ATTR_PI_HEATING_DEMAND,
-        ATTR_PI_COOLING_DEMAND,
-        ATTR_UNOCCP_COOL_SETPT,
-        ATTR_UNOCCP_HEAT_SETPT,
-    }
-
     _cluster_handler_match = ClusterHandlerMatch(
         cluster_handlers=frozenset({CLUSTER_HANDLER_THERMOSTAT}),
         optional_cluster_handlers=frozenset({CLUSTER_HANDLER_FAN}),
@@ -280,40 +293,26 @@ class Thermostat(BaseThermostat):
             )
         )
 
-    @functools.cached_property
-    def info_object(self) -> ThermostatEntityInfo:
-        """Return a representation of the thermostat."""
-        return ThermostatEntityInfo(
-            **super().info_object.__dict__,
-            max_temp=self.max_temp,
-            min_temp=self.min_temp,
-            supported_features=self.supported_features,
-            fan_modes=self.fan_modes,
-            preset_modes=self.preset_modes,
-            hvac_modes=self.hvac_modes,
-        )
-
     @property
-    def state(self) -> dict[str, Any]:
+    def state(self) -> ThermostatState:
         """Get the state of the thermostat."""
         thermostat = self._thermostat_cluster_handler
         system_mode = SYSTEM_MODE_2_HVAC.get(thermostat.system_mode, "unknown")
-
-        response = super().state
-
-        response[ATTR_SYS_MODE] = (
-            f"[{thermostat.system_mode}]/{system_mode}"
-            if self.hvac_mode is not None
-            else None
+        return ThermostatState(
+            **super().state.__dict__,
+            sys_mode=(
+                f"[{thermostat.system_mode}]/{system_mode}"
+                if self.hvac_mode is not None
+                else None
+            ),
+            occupancy=thermostat.occupancy,
+            occupied_cooling_setpoint=thermostat.occupied_cooling_setpoint,
+            occupied_heating_setpoint=thermostat.occupied_heating_setpoint,
+            pi_heating_demand=thermostat.pi_heating_demand,
+            pi_cooling_demand=thermostat.pi_cooling_demand,
+            unoccupied_cooling_setpoint=thermostat.unoccupied_cooling_setpoint,
+            unoccupied_heating_setpoint=thermostat.unoccupied_heating_setpoint,
         )
-        response[ATTR_OCCUPANCY] = thermostat.occupancy
-        response[ATTR_OCCP_COOL_SETPT] = thermostat.occupied_cooling_setpoint
-        response[ATTR_OCCP_HEAT_SETPT] = thermostat.occupied_heating_setpoint
-        response[ATTR_PI_HEATING_DEMAND] = thermostat.pi_heating_demand
-        response[ATTR_PI_COOLING_DEMAND] = thermostat.pi_cooling_demand
-        response[ATTR_UNOCCP_COOL_SETPT] = thermostat.unoccupied_cooling_setpoint
-        response[ATTR_UNOCCP_HEAT_SETPT] = thermostat.unoccupied_heating_setpoint
-        return response
 
     @property
     def current_temperature(self):
@@ -793,22 +792,20 @@ class ZehnderThermostat(Thermostat):
         return None
 
     @property
-    def state(self) -> dict[str, Any]:
-        """Get the state of the lock."""
+    def state(self) -> ThermostatState:
+        """Get the state of the thermostat."""
         thermostat = self._thermostat_cluster_handler
         system_mode = ZehnderThermostat.ZEHNDER_SYSTEM_MODE_2_HVAC.get(
             thermostat.system_mode, "unknown"
         )
-
-        response = super().state
-
-        response[ATTR_SYS_MODE] = (
-            f"[{thermostat.system_mode}]/{system_mode}"
-            if self.hvac_mode is not None
-            else None
+        return ThermostatState(
+            **super().state.__dict__,
+            sys_mode=(
+                f"[{thermostat.system_mode}]/{system_mode}"
+                if self.hvac_mode is not None
+                else None
+            ),
         )
-
-        return response
 
     @property
     def hvac_mode(self) -> HVACMode | None:

--- a/zha/application/platforms/climate/__init__.py
+++ b/zha/application/platforms/climate/__init__.py
@@ -25,16 +25,12 @@ from zha.application.platforms import (
     register_entity,
 )
 from zha.application.platforms.climate.const import (
-    ATTR_HVAC_MODE,
     ATTR_OCCP_COOL_SETPT,
     ATTR_OCCP_HEAT_SETPT,
     ATTR_OCCUPANCY,
     ATTR_PI_COOLING_DEMAND,
     ATTR_PI_HEATING_DEMAND,
     ATTR_SYS_MODE,
-    ATTR_TARGET_TEMP_HIGH,
-    ATTR_TARGET_TEMP_LOW,
-    ATTR_TEMPERATURE,
     ATTR_UNOCCP_COOL_SETPT,
     ATTR_UNOCCP_HEAT_SETPT,
     FAN_AUTO,
@@ -470,45 +466,46 @@ class Thermostat(PlatformEntity):
         self._preset = preset_mode
         self.maybe_emit_state_changed_event()
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_temperature(
+        self,
+        target_temp_low: float | None = None,
+        target_temp_high: float | None = None,
+        temperature: float | None = None,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        low_temp = kwargs.get(ATTR_TARGET_TEMP_LOW)
-        high_temp = kwargs.get(ATTR_TARGET_TEMP_HIGH)
-        temp = kwargs.get(ATTR_TEMPERATURE)
-        hvac_mode = kwargs.get(ATTR_HVAC_MODE)
-
         if hvac_mode is not None:
             await self.async_set_hvac_mode(hvac_mode)
 
         is_away = self.preset_mode == Preset.AWAY
 
         if self.hvac_mode == HVACMode.HEAT_COOL:
-            if low_temp is not None:
+            if target_temp_low is not None:
                 await self._thermostat_cluster_handler.async_set_heating_setpoint(
-                    temperature=int(low_temp * ZCL_TEMP),
+                    temperature=int(target_temp_low * ZCL_TEMP),
                     is_away=is_away,
                 )
-            if high_temp is not None:
+            if target_temp_high is not None:
                 await self._thermostat_cluster_handler.async_set_cooling_setpoint(
-                    temperature=int(high_temp * ZCL_TEMP),
+                    temperature=int(target_temp_high * ZCL_TEMP),
                     is_away=is_away,
                 )
-        elif temp is not None:
+        elif temperature is not None:
             if self.hvac_mode == HVACMode.COOL:
                 await self._thermostat_cluster_handler.async_set_cooling_setpoint(
-                    temperature=int(temp * ZCL_TEMP),
+                    temperature=int(temperature * ZCL_TEMP),
                     is_away=is_away,
                 )
             elif self.hvac_mode == HVACMode.HEAT:
                 await self._thermostat_cluster_handler.async_set_heating_setpoint(
-                    temperature=int(temp * ZCL_TEMP),
+                    temperature=int(temperature * ZCL_TEMP),
                     is_away=is_away,
                 )
             else:
                 self.debug("Not setting temperature for '%s' mode", self.hvac_mode)
                 return
         else:
-            self.debug("incorrect %s setting for '%s' mode", kwargs, self.hvac_mode)
+            self.debug("incorrect temperature setting for '%s' mode", self.hvac_mode)
             return
 
         self.maybe_emit_state_changed_event()

--- a/zha/application/platforms/climate/__init__.py
+++ b/zha/application/platforms/climate/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from asyncio import Task
 from dataclasses import dataclass
 import datetime as dt
@@ -73,11 +74,128 @@ class ThermostatEntityInfo(BaseEntityInfo):
     hvac_modes: list[HVACMode]
 
 
-@register_entity(ThermostatCluster.cluster_id)
-class Thermostat(PlatformEntity):
-    """Representation of a ZHA Thermostat device."""
+class BaseThermostat(PlatformEntity, ABC):
+    """Abstract base class for climate entities."""
 
     PLATFORM = Platform.CLIMATE
+
+    @property
+    def state(self) -> dict[str, Any]:
+        """Get the state of the climate entity."""
+        response = super().state
+        response["current_temperature"] = self.current_temperature
+        response["outdoor_temperature"] = self.outdoor_temperature
+        response["target_temperature"] = self.target_temperature
+        response["target_temperature_high"] = self.target_temperature_high
+        response["target_temperature_low"] = self.target_temperature_low
+        response["hvac_action"] = self.hvac_action
+        response["hvac_mode"] = self.hvac_mode
+        response["preset_mode"] = self.preset_mode
+        response["fan_mode"] = self.fan_mode
+        return response
+
+    @property
+    @abstractmethod
+    def current_temperature(self) -> float | None:
+        """Return the current temperature."""
+
+    @property
+    @abstractmethod
+    def outdoor_temperature(self) -> float | None:
+        """Return the outdoor temperature."""
+
+    @property
+    @abstractmethod
+    def target_temperature(self) -> float | None:
+        """Return the temperature we try to reach."""
+
+    @property
+    @abstractmethod
+    def target_temperature_high(self) -> float | None:
+        """Return the upper bound temperature we try to reach."""
+
+    @property
+    @abstractmethod
+    def target_temperature_low(self) -> float | None:
+        """Return the lower bound temperature we try to reach."""
+
+    @property
+    @abstractmethod
+    def hvac_action(self) -> HVACAction | None:
+        """Return the current HVAC action."""
+
+    @property
+    @abstractmethod
+    def hvac_mode(self) -> HVACMode | None:
+        """Return HVAC operation mode."""
+
+    @property
+    @abstractmethod
+    def hvac_modes(self) -> list[HVACMode]:
+        """Return the list of available HVAC operation modes."""
+
+    @property
+    @abstractmethod
+    def preset_mode(self) -> str | None:
+        """Return current preset mode."""
+
+    @property
+    @abstractmethod
+    def preset_modes(self) -> list[str] | None:
+        """Return supported preset modes."""
+
+    @property
+    @abstractmethod
+    def fan_mode(self) -> str | None:
+        """Return current FAN mode."""
+
+    @property
+    @abstractmethod
+    def fan_modes(self) -> list[str] | None:
+        """Return supported FAN modes."""
+
+    @property
+    @abstractmethod
+    def max_temp(self) -> float:
+        """Return the maximum temperature."""
+
+    @property
+    @abstractmethod
+    def min_temp(self) -> float:
+        """Return the minimum temperature."""
+
+    @property
+    @abstractmethod
+    def supported_features(self) -> ClimateEntityFeature:
+        """Return the list of supported features."""
+
+    @abstractmethod
+    async def async_set_fan_mode(self, fan_mode: str) -> None:
+        """Set fan mode."""
+
+    @abstractmethod
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Set new target operation mode."""
+
+    @abstractmethod
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set new preset mode."""
+
+    @abstractmethod
+    async def async_set_temperature(
+        self,
+        target_temp_low: float | None = None,
+        target_temp_high: float | None = None,
+        temperature: float | None = None,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
+        """Set new target temperature."""
+
+
+@register_entity(ThermostatCluster.cluster_id)
+class Thermostat(BaseThermostat):
+    """Representation of a ZHA Thermostat device."""
+
     DEFAULT_MAX_TEMP = 35
     DEFAULT_MIN_TEMP = 7
 
@@ -182,15 +300,6 @@ class Thermostat(PlatformEntity):
         system_mode = SYSTEM_MODE_2_HVAC.get(thermostat.system_mode, "unknown")
 
         response = super().state
-        response["current_temperature"] = self.current_temperature
-        response["outdoor_temperature"] = self.outdoor_temperature
-        response["target_temperature"] = self.target_temperature
-        response["target_temperature_high"] = self.target_temperature_high
-        response["target_temperature_low"] = self.target_temperature_low
-        response["hvac_action"] = self.hvac_action
-        response["hvac_mode"] = self.hvac_mode
-        response["preset_mode"] = self.preset_mode
-        response["fan_mode"] = self.fan_mode
 
         response[ATTR_SYS_MODE] = (
             f"[{thermostat.system_mode}]/{system_mode}"

--- a/zha/application/platforms/climate/__init__.py
+++ b/zha/application/platforms/climate/__init__.py
@@ -294,17 +294,21 @@ class Thermostat(BaseThermostat):
         )
 
     @property
+    def system_mode_string(self) -> str | None:
+        """Return a formatted system mode string."""
+        if self.hvac_mode is None:
+            return None
+        thermostat = self._thermostat_cluster_handler
+        system_mode = SYSTEM_MODE_2_HVAC.get(thermostat.system_mode, "unknown")
+        return f"[{thermostat.system_mode}]/{system_mode}"
+
+    @property
     def state(self) -> ThermostatState:
         """Get the state of the thermostat."""
         thermostat = self._thermostat_cluster_handler
-        system_mode = SYSTEM_MODE_2_HVAC.get(thermostat.system_mode, "unknown")
         return ThermostatState(
             **super().state.__dict__,
-            sys_mode=(
-                f"[{thermostat.system_mode}]/{system_mode}"
-                if self.hvac_mode is not None
-                else None
-            ),
+            sys_mode=self.system_mode_string,
             occupancy=thermostat.occupancy,
             occupied_cooling_setpoint=thermostat.occupied_cooling_setpoint,
             occupied_heating_setpoint=thermostat.occupied_heating_setpoint,
@@ -792,20 +796,15 @@ class ZehnderThermostat(Thermostat):
         return None
 
     @property
-    def state(self) -> ThermostatState:
-        """Get the state of the thermostat."""
+    def system_mode_string(self) -> str | None:
+        """Return a formatted system mode string."""
+        if self.hvac_mode is None:
+            return None
         thermostat = self._thermostat_cluster_handler
         system_mode = ZehnderThermostat.ZEHNDER_SYSTEM_MODE_2_HVAC.get(
             thermostat.system_mode, "unknown"
         )
-        return ThermostatState(
-            **super().state.__dict__,
-            sys_mode=(
-                f"[{thermostat.system_mode}]/{system_mode}"
-                if self.hvac_mode is not None
-                else None
-            ),
-        )
+        return f"[{thermostat.system_mode}]/{system_mode}"
 
     @property
     def hvac_mode(self) -> HVACMode | None:

--- a/zha/application/platforms/cover/__init__.py
+++ b/zha/application/platforms/cover/__init__.py
@@ -24,8 +24,6 @@ from zha.application.platforms import (
 from zha.application.platforms.cover.const import (
     ATTR_CURRENT_POSITION,
     ATTR_CURRENT_TILT_POSITION,
-    ATTR_POSITION,
-    ATTR_TILT_POSITION,
     POSITION_CLOSED,
     POSITION_OPEN,
     WCT,
@@ -111,19 +109,19 @@ class BaseCover(PlatformEntity, ABC):
         """
 
     @abstractmethod
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
 
     @abstractmethod
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
 
     @abstractmethod
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
 
     @abstractmethod
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
 
 
@@ -578,7 +576,7 @@ class Cover(BaseCover):
         self._tilt_state = None
         self.maybe_emit_state_changed_event()
 
-    async def async_open_cover(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         self._set_lift_transition_target(POSITION_OPEN)
         res = await self._cover_cluster_handler.up_open()
@@ -590,7 +588,7 @@ class Cover(BaseCover):
             self.async_update_state(CoverState.OPENING)
         self._start_lift_transition()
 
-    async def async_open_cover_tilt(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_open_cover_tilt(self) -> None:
         """Open the cover tilt."""
         self._set_tilt_transition_target(POSITION_OPEN)
         res = await self._cover_cluster_handler.go_to_tilt_percentage(
@@ -604,7 +602,7 @@ class Cover(BaseCover):
             self.async_update_state(CoverState.OPENING)
         self._start_tilt_transition()
 
-    async def async_close_cover(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         self._set_lift_transition_target(POSITION_CLOSED)
         res = await self._cover_cluster_handler.down_close()
@@ -616,7 +614,7 @@ class Cover(BaseCover):
             self.async_update_state(CoverState.CLOSING)
         self._start_lift_transition()
 
-    async def async_close_cover_tilt(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_close_cover_tilt(self) -> None:
         """Close the cover tilt."""
         self._set_tilt_transition_target(POSITION_CLOSED)
         res = await self._cover_cluster_handler.go_to_tilt_percentage(
@@ -630,11 +628,10 @@ class Cover(BaseCover):
             self.async_update_state(CoverState.CLOSING)
         self._start_tilt_transition()
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
         assert self.current_cover_position is not None
-        target_position = kwargs[ATTR_POSITION]
-        assert target_position is not None
+        target_position = position
 
         self._set_lift_transition_target(target_position)
         res = await self._cover_cluster_handler.go_to_lift_percentage(
@@ -652,11 +649,10 @@ class Cover(BaseCover):
             )
         self._start_lift_transition()
 
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, tilt_position: int) -> None:
         """Move the cover tilt to a specific position."""
         assert self.current_cover_tilt_position is not None
-        target_position = kwargs[ATTR_TILT_POSITION]
-        assert target_position is not None
+        target_position = tilt_position
 
         self._set_tilt_transition_target(target_position)
         res = await self._cover_cluster_handler.go_to_tilt_percentage(
@@ -674,7 +670,7 @@ class Cover(BaseCover):
             )
         self._start_tilt_transition()
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_stop_cover(self) -> None:
         """Stop the cover.
 
         Upon receipt of this command the cover stops both lift and tilt movement.
@@ -686,12 +682,12 @@ class Cover(BaseCover):
         self._clear_tilt_transition()
         self._determine_cover_state(refresh=True)
 
-    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_stop_cover_tilt(self) -> None:
         """Stop the cover tilt.
 
         This is handled by async_stop_cover because there is no tilt specific command for Zigbee covers.
         """
-        await self.async_stop_cover(**kwargs)
+        await self.async_stop_cover()
 
     @staticmethod
     def _ha_position_to_zcl(position: int) -> int:
@@ -845,7 +841,7 @@ class Shade(BaseCover):
         self._position = self._zcl_level_to_ha_position(event.level)
         self.maybe_emit_state_changed_event()
 
-    async def async_open_cover(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_open_cover(self) -> None:
         """Open the window cover."""
         res = await self._on_off_cluster_handler.on()
         if res[1] != Status.SUCCESS:
@@ -854,7 +850,7 @@ class Shade(BaseCover):
         self._is_open = True
         self.maybe_emit_state_changed_event()
 
-    async def async_close_cover(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_close_cover(self) -> None:
         """Close the window cover."""
         res = await self._on_off_cluster_handler.off()
         if res[1] != Status.SUCCESS:
@@ -863,12 +859,12 @@ class Shade(BaseCover):
         self._is_open = False
         self.maybe_emit_state_changed_event()
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the roller shutter to a specific position."""
         if not self._level_cluster_handler:
             return
 
-        new_pos = kwargs[ATTR_POSITION]
+        new_pos = position
         res = await self._level_cluster_handler.move_to_level_with_on_off(
             self._ha_position_to_zcl_level(new_pos), 1
         )
@@ -879,7 +875,7 @@ class Shade(BaseCover):
         self._position = new_pos
         self.maybe_emit_state_changed_event()
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         if not self._level_cluster_handler:
             return
@@ -915,7 +911,7 @@ class KeenVent(Shade):
         feature_priority=(PlatformFeatureGroup.LIGHT_OR_SWITCH_OR_SHADE, 1),
     )
 
-    async def async_open_cover(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         assert self._level_cluster_handler is not None
 

--- a/zha/application/platforms/cover/__init__.py
+++ b/zha/application/platforms/cover/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 import asyncio
 from collections import deque
+import dataclasses
 import functools
 import logging
 from typing import TYPE_CHECKING, Any, cast
@@ -16,14 +17,13 @@ from zigpy.zcl.foundation import Status
 
 from zha.application import Platform
 from zha.application.platforms import (
+    BaseEntityState,
     ClusterHandlerMatch,
     PlatformEntity,
     PlatformFeatureGroup,
     register_entity,
 )
 from zha.application.platforms.cover.const import (
-    ATTR_CURRENT_POSITION,
-    ATTR_CURRENT_TILT_POSITION,
     POSITION_CLOSED,
     POSITION_OPEN,
     WCT,
@@ -63,6 +63,18 @@ DEFAULT_MOVEMENT_TIMEOUT: float = 5
 # Upper limit for dynamic timeout
 LIFT_MOVEMENT_TIMEOUT_RANGE: float = 300
 TILT_MOVEMENT_TIMEOUT_RANGE: float = 30
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class CoverEntityState(BaseEntityState):
+    """State for cover entities."""
+
+    current_position: int | None
+    current_tilt_position: int | None
+    state: CoverState | None
+    is_opening: bool | None
+    is_closing: bool | None
+    is_closed: bool | None
 
 
 class BaseCover(PlatformEntity, ABC):
@@ -268,20 +280,17 @@ class Cover(BaseCover):
         )
 
     @property
-    def state(self) -> dict[str, Any]:
+    def state(self) -> CoverEntityState:
         """Get the state of the cover."""
-        response = super().state
-        response.update(
-            {
-                ATTR_CURRENT_POSITION: self.current_cover_position,
-                ATTR_CURRENT_TILT_POSITION: self.current_cover_tilt_position,
-                "state": self._state,
-                "is_opening": self.is_opening,
-                "is_closing": self.is_closing,
-                "is_closed": self.is_closed,
-            }
+        return CoverEntityState(
+            **super().state.__dict__,
+            current_position=self.current_cover_position,
+            current_tilt_position=self.current_cover_tilt_position,
+            state=self._state,
+            is_opening=self.is_opening,
+            is_closing=self.is_closing,
+            is_closed=self.is_closed,
         )
-        return response
 
     @property
     def is_closed(self) -> bool | None:
@@ -775,21 +784,21 @@ class Shade(BaseCover):
             )
 
     @property
-    def state(self) -> dict[str, Any]:
+    def state(self) -> CoverEntityState:
         """Get the state of the cover."""
         if (closed := self.is_closed) is None:
             state = None
         else:
             state = CoverState.CLOSED if closed else CoverState.OPEN
-        response = super().state
-        response.update(
-            {
-                ATTR_CURRENT_POSITION: self.current_cover_position,
-                "is_closed": self.is_closed,
-                "state": state,
-            }
+        return CoverEntityState(
+            **super().state.__dict__,
+            current_position=self.current_cover_position,
+            current_tilt_position=self.current_cover_tilt_position,
+            state=state,
+            is_opening=self.is_opening,
+            is_closing=self.is_closing,
+            is_closed=self.is_closed,
         )
-        return response
 
     @property
     def current_cover_position(self) -> int | None:

--- a/zha/application/platforms/cover/__init__.py
+++ b/zha/application/platforms/cover/__init__.py
@@ -71,11 +71,12 @@ class BaseCover(PlatformEntity, ABC):
     PLATFORM = Platform.COVER
 
     _attr_primary_weight = 10
+    _attr_supported_features: CoverEntityFeature
 
     @property
-    @abstractmethod
     def supported_features(self) -> CoverEntityFeature:
         """Return supported features."""
+        return self._attr_supported_features
 
     @property
     @abstractmethod
@@ -265,11 +266,6 @@ class Cover(BaseCover):
                 functools.partial(self._determine_cover_state, refresh=True),
             )
         )
-
-    @property
-    def supported_features(self) -> CoverEntityFeature:
-        """Return supported features."""
-        return self._attr_supported_features
 
     @property
     def state(self) -> dict[str, Any]:
@@ -794,11 +790,6 @@ class Shade(BaseCover):
             }
         )
         return response
-
-    @functools.cached_property
-    def supported_features(self) -> CoverEntityFeature:
-        """Return supported features."""
-        return self._attr_supported_features
 
     @property
     def current_cover_position(self) -> int | None:

--- a/zha/application/platforms/device_tracker.py
+++ b/zha/application/platforms/device_tracker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from enum import StrEnum
 import functools
 import time
@@ -45,11 +46,42 @@ class SourceType(StrEnum):
     BLUETOOTH_LE = "bluetooth_le"
 
 
-@register_entity(PowerConfiguration.cluster_id)
-class DeviceScannerEntity(PlatformEntity):
-    """Represent a tracked device."""
+class BaseDeviceTracker(PlatformEntity, ABC):
+    """Abstract base class for ZHA device tracker entities."""
 
     PLATFORM = Platform.DEVICE_TRACKER
+
+    @property
+    def state(self) -> dict[str, Any]:
+        """Return the state of the device."""
+        response = super().state
+        response.update(
+            {
+                "connected": self.is_connected,
+                "battery_level": self.battery_level,
+            }
+        )
+        return response
+
+    @property
+    @abstractmethod
+    def is_connected(self) -> bool:
+        """Return true if the device is connected to the network."""
+
+    @property
+    @abstractmethod
+    def battery_level(self) -> float | None:
+        """Return the battery level of the device."""
+
+    @property
+    @abstractmethod
+    def source_type(self) -> SourceType:
+        """Return the source type, eg gps or router, of the device."""
+
+
+@register_entity(PowerConfiguration.cluster_id)
+class DeviceScannerEntity(BaseDeviceTracker):
+    """Represent a tracked device."""
 
     _attr_should_poll = True  # BaseZhaEntity defaults to False
     _attr_fallback_name: str = "Device scanner"
@@ -108,18 +140,6 @@ class DeviceScannerEntity(PlatformEntity):
             "started polling with refresh interval of %s",
             getattr(self, "__polling_interval"),
         )
-
-    @property
-    def state(self) -> dict[str, Any]:
-        """Return the state of the device."""
-        response = super().state
-        response.update(
-            {
-                "connected": self._connected,
-                "battery_level": self._battery_level,
-            }
-        )
-        return response
 
     @property
     def is_connected(self):

--- a/zha/application/platforms/device_tracker.py
+++ b/zha/application/platforms/device_tracker.py
@@ -3,16 +3,18 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+import dataclasses
 from enum import StrEnum
 import functools
 import time
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, cast
 
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import PowerConfiguration
 
 from zha.application import Platform
 from zha.application.platforms import (
+    BaseEntityState,
     ClusterHandlerMatch,
     PlatformEntity,
     register_entity,
@@ -46,22 +48,27 @@ class SourceType(StrEnum):
     BLUETOOTH_LE = "bluetooth_le"
 
 
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class DeviceTrackerState(BaseEntityState):
+    """State for device tracker entities."""
+
+    connected: bool
+    battery_level: float | None
+
+
 class BaseDeviceTracker(PlatformEntity, ABC):
     """Abstract base class for ZHA device tracker entities."""
 
     PLATFORM = Platform.DEVICE_TRACKER
 
     @property
-    def state(self) -> dict[str, Any]:
+    def state(self) -> DeviceTrackerState:
         """Return the state of the device."""
-        response = super().state
-        response.update(
-            {
-                "connected": self.is_connected,
-                "battery_level": self.battery_level,
-            }
+        return DeviceTrackerState(
+            **super().state.__dict__,
+            connected=self.is_connected,
+            battery_level=self.battery_level,
         )
-        return response
 
     @property
     @abstractmethod

--- a/zha/application/platforms/fan/__init__.py
+++ b/zha/application/platforms/fan/__init__.py
@@ -183,12 +183,11 @@ class BaseFan(BaseEntity, ABC):
         )
         return response
 
-    async def async_turn_on(  # pylint: disable=unused-argument
+    async def async_turn_on(
         self,
         speed: str | None = None,
         percentage: int | None = None,
         preset_mode: str | None = None,
-        **kwargs: Any,
     ) -> None:
         """Turn the entity on."""
         if preset_mode is not None:
@@ -201,7 +200,7 @@ class BaseFan(BaseEntity, ABC):
             percentage = self.default_on_percentage
             await self.async_set_percentage(percentage)
 
-    async def async_turn_off(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_turn_off(self) -> None:
         """Turn the entity off."""
         await self.async_set_percentage(0)
 
@@ -443,7 +442,6 @@ class IkeaFan(BaseFan, PlatformEntity):
         speed: str | None = None,
         percentage: int | None = None,
         preset_mode: str | None = None,
-        **kwargs: Any,
     ) -> None:
         """Turn the entity on."""
         # Starkvind turns on in auto mode by default.

--- a/zha/application/platforms/fan/__init__.py
+++ b/zha/application/platforms/fan/__init__.py
@@ -13,7 +13,7 @@ from zigpy.zcl.clusters import hvac
 from zha.application import Platform
 from zha.application.platforms import (
     BaseEntity,
-    BaseEntityInfo,
+    BaseEntityState,
     ClusterHandlerMatch,
     GroupEntity,
     PlatformEntity,
@@ -22,8 +22,6 @@ from zha.application.platforms import (
     register_group_entity,
 )
 from zha.application.platforms.fan.const import (
-    ATTR_PERCENTAGE,
-    ATTR_PRESET_MODE,
     DEFAULT_ON_PERCENTAGE,
     LEGACY_SPEED_LIST,
     OFF_SPEED_VALUES,
@@ -64,9 +62,13 @@ if TYPE_CHECKING:
 
 
 @dataclass(frozen=True, kw_only=True)
-class FanEntityInfo(BaseEntityInfo):
-    """Fan entity info."""
+class FanState(BaseEntityState):
+    """State for fan entities."""
 
+    preset_mode: str | None
+    percentage: int | None
+    is_on: bool
+    speed: str | None
     preset_modes: list[str]
     supported_features: FanEntityFeature
     speed_count: int
@@ -158,30 +160,20 @@ class BaseFan(BaseEntity, ABC):
             return None
         return self.percentage_to_speed(percentage)
 
-    @functools.cached_property
-    def info_object(self) -> FanEntityInfo:
-        """Return a representation of the binary sensor."""
-        return FanEntityInfo(
-            **super().info_object.__dict__,
+    @property
+    def state(self) -> FanState:
+        """Return the state of the fan."""
+        return FanState(
+            **super().state.__dict__,
+            preset_mode=self.preset_mode,
+            percentage=self.percentage,
+            is_on=self.is_on,
+            speed=self.speed,
             preset_modes=self.preset_modes,
             supported_features=self.supported_features,
             speed_count=self.speed_count,
             speed_list=self.speed_list,
         )
-
-    @property
-    def state(self) -> dict[str, Any]:
-        """Return the state of the fan."""
-        response = super().state
-        response.update(
-            {
-                "preset_mode": self.preset_mode,
-                "percentage": self.percentage,
-                "is_on": self.is_on,
-                "speed": self.speed,
-            }
-        )
-        return response
 
     async def async_turn_on(
         self,
@@ -314,10 +306,8 @@ class FanGroup(BaseFan, GroupEntity):
             FanClusterHandler, group.endpoint[hvac.Fan.cluster_id]
         )
         super().__init__(group)
-        self._percentage = None
-        self._preset_mode = None
-        if hasattr(self, "info_object"):
-            delattr(self, "info_object")
+        self._percentage: int | None = None
+        self._preset_mode: str | None = None
         self.update()
 
     @property
@@ -342,23 +332,19 @@ class FanGroup(BaseFan, GroupEntity):
         """Query all members and determine the fan group state."""
         self.debug("Updating fan group entity state")
         platform_entities = self._group.get_platform_entities(self.PLATFORM)
-        all_states = [entity.state for entity in platform_entities]
+        all_states = [cast(FanState, entity.state) for entity in platform_entities]
         self.debug(
             "All platform entity states for group entity members: %s", all_states
         )
 
-        percentage_states: list[dict] = [
-            state for state in all_states if state.get(ATTR_PERCENTAGE)
-        ]
-        preset_mode_states: list[dict] = [
-            state for state in all_states if state.get(ATTR_PRESET_MODE)
-        ]
+        percentage_states = [state for state in all_states if state.percentage]
+        preset_mode_states = [state for state in all_states if state.preset_mode]
 
         if percentage_states:
-            self._percentage = percentage_states[0][ATTR_PERCENTAGE]
+            self._percentage = percentage_states[0].percentage
             self._preset_mode = None
         elif preset_mode_states:
-            self._preset_mode = preset_mode_states[0][ATTR_PRESET_MODE]
+            self._preset_mode = preset_mode_states[0].preset_mode
             self._percentage = None
         else:
             self._percentage = None

--- a/zha/application/platforms/fan/__init__.py
+++ b/zha/application/platforms/fan/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 import functools
 import math
@@ -73,7 +73,7 @@ class FanEntityInfo(BaseEntityInfo):
     speed_list: list[str]
 
 
-class BaseFan(BaseEntity):
+class BaseFan(BaseEntity, ABC):
     """Base representation of a ZHA fan."""
 
     PLATFORM = Platform.FAN

--- a/zha/application/platforms/helpers.py
+++ b/zha/application/platforms/helpers.py
@@ -7,16 +7,18 @@ import enum
 import logging
 from typing import TYPE_CHECKING, Any, overload
 
+from zha.application.platforms import BaseEntityState
+
 if TYPE_CHECKING:
     from zha.application.platforms.binary_sensor.const import BinarySensorDeviceClass
     from zha.application.platforms.number.const import NumberDeviceClass
     from zha.application.platforms.sensor.const import SensorDeviceClass
 
 
-def find_state_attributes(states: list[dict], key: str) -> Iterator[Any]:
+def find_state_attributes(states: list[BaseEntityState], key: str) -> Iterator[Any]:
     """Find attributes with matching key from states."""
     for state in states:
-        if (value := state.get(key)) is not None:
+        if (value := getattr(state, key, None)) is not None:
             yield value
 
 
@@ -31,7 +33,7 @@ def mean_tuple(*args: Any) -> tuple:
 
 
 def reduce_attribute(
-    states: list[dict],
+    states: list[BaseEntityState],
     key: str,
     default: Any | None = None,
     reduce: Callable[..., Any] = mean_int,

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from abc import ABC
+from abc import ABC, abstractmethod
 import asyncio
 from collections import Counter
 import contextlib
@@ -216,6 +216,7 @@ class BaseLight(BaseEntity, ABC):
         """Return the warmest color_temp that this light supports."""
         return self._max_mireds
 
+    @abstractmethod
     async def async_turn_on(
         self,
         *,
@@ -227,11 +228,10 @@ class BaseLight(BaseEntity, ABC):
         xy_color: tuple[int, int] | None = None,
     ) -> None:
         """Turn the entity on."""
-        raise NotImplementedError
 
+    @abstractmethod
     async def async_turn_off(self, *, transition: float | None = None) -> None:
         """Turn the entity off."""
-        raise NotImplementedError
 
     def restore_external_state_attributes(
         self,
@@ -287,9 +287,9 @@ class BaseClusterHandlerLight(BaseLight):
         self._internal_supported_color_modes: set[ColorMode] = set()
 
     @property
+    @abstractmethod
     def _gateway(self) -> Gateway:
         """Return the gateway."""
-        raise NotImplementedError
 
     @property
     def state(self) -> dict[str, Any]:

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -9,8 +9,6 @@ import asyncio
 from collections import Counter
 import contextlib
 import dataclasses
-from dataclasses import dataclass
-import functools
 import itertools
 import logging
 from typing import TYPE_CHECKING, Any, cast
@@ -23,7 +21,7 @@ from zha.application import Platform
 from zha.application.platforms import (
     DEFAULT_UPDATE_GROUP_FROM_CHILD_DELAY,
     BaseEntity,
-    BaseEntityInfo,
+    BaseEntityState,
     ClusterHandlerMatch,
     GroupEntity,
     PlatformEntity,
@@ -94,24 +92,29 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True, kw_only=True)
-class LightEntityInfo(BaseEntityInfo):
-    """Light entity info."""
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class LightState(BaseEntityState):
+    """State for light entities."""
 
-    effect_list: list[str] | None = dataclasses.field(default=None)
+    on: bool | None
+    brightness: int | None
+    xy_color: tuple[float, float] | None
+    color_temp: int | None
+    effect_list: list[str] | None
+    effect: str
     supported_features: LightEntityFeature
-    min_mireds: int
-    max_mireds: int
+    color_mode: ColorMode | None
+    supported_color_modes: set[ColorMode]
+    off_with_transition: bool
+    off_brightness: int | None
+    min_mireds: int | None
+    max_mireds: int | None
 
 
 class BaseLight(BaseEntity, ABC):
     """Operations common to all light entities."""
 
     PLATFORM = Platform.LIGHT
-    _attr_extra_state_attribute_names: set[str] = {
-        "off_with_transition",
-        "off_brightness",
-    }
     _attr_primary_weight = 10
 
     def __init__(self, *args, **kwargs):
@@ -132,29 +135,21 @@ class BaseLight(BaseEntity, ABC):
         self._supported_color_modes: set[ColorMode] = set()
 
     @property
-    def state(self) -> dict[str, Any]:
+    def state(self) -> LightState:
         """Return the state of the light."""
-        response = super().state
-        response["on"] = self.is_on
-        response["brightness"] = self.brightness
-        response["xy_color"] = self.xy_color
-        response["color_temp"] = self.color_temp
-        response["effect_list"] = self.effect_list
-        response["effect"] = self.effect
-        response["supported_features"] = self.supported_features
-        response["color_mode"] = self.color_mode
-        response["supported_color_modes"] = self.supported_color_modes
-        response["off_with_transition"] = self._off_with_transition
-        response["off_brightness"] = self._off_brightness
-        return response
-
-    @functools.cached_property
-    def info_object(self) -> LightEntityInfo:
-        """Return a representation of the select."""
-        return LightEntityInfo(
-            **super().info_object.__dict__,
+        return LightState(
+            **super().state.__dict__,
+            on=self.is_on,
+            brightness=self.brightness,
+            xy_color=self.xy_color,
+            color_temp=self.color_temp,
             effect_list=self.effect_list,
+            effect=self.effect,
             supported_features=self.supported_features,
+            color_mode=self.color_mode,
+            supported_color_modes=self.supported_color_modes,
+            off_with_transition=self._off_with_transition,
+            off_brightness=self._off_brightness,
             min_mireds=self.min_mireds,
             max_mireds=self.max_mireds,
         )
@@ -292,12 +287,12 @@ class BaseClusterHandlerLight(BaseLight):
         """Return the gateway."""
 
     @property
-    def state(self) -> dict[str, Any]:
+    def state(self) -> LightState:
         """Return the state of the light."""
-        response = super().state
-        # XXX: for backwards compatibility
-        response["supported_color_modes"] = self._internal_supported_color_modes
-        return response
+        return dataclasses.replace(
+            super().state,
+            supported_color_modes=self._internal_supported_color_modes,
+        )
 
     def recompute_capabilities(self) -> None:
         """Recompute supported features and color modes."""
@@ -1184,8 +1179,6 @@ class LightGroup(BaseClusterHandlerLight, GroupEntity):
         self._color_mode = ColorMode.UNKNOWN
         self._internal_supported_color_modes = {ColorMode.ONOFF}
 
-        if hasattr(self, "info_object"):
-            delattr(self, "info_object")
         self.update()
 
     async def on_remove(self) -> None:
@@ -1229,7 +1222,7 @@ class LightGroup(BaseClusterHandlerLight, GroupEntity):
         self.debug(
             "All platform entity states for group entity members: %s", all_states
         )
-        on_states = [state for state in states if state["on"]]
+        on_states = [state for state in states if state.on]
 
         self._state = len(on_states) > 0
 

--- a/zha/application/platforms/lock/__init__.py
+++ b/zha/application/platforms/lock/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 from zigpy.zcl.clusters.closures import DoorLock as DoorLockCluster
@@ -31,11 +32,36 @@ if TYPE_CHECKING:
     from zha.zigbee.endpoint import Endpoint
 
 
-@register_entity(DoorLockCluster.cluster_id)
-class DoorLock(PlatformEntity):
-    """Representation of a ZHA lock."""
+class BaseLock(PlatformEntity, ABC):
+    """Abstract base class for ZHA lock entities."""
 
     PLATFORM = Platform.LOCK
+
+    @property
+    def state(self) -> dict[str, Any]:
+        """Get the state of the lock."""
+        response = super().state
+        response["is_locked"] = self.is_locked
+        return response
+
+    @property
+    @abstractmethod
+    def is_locked(self) -> bool:
+        """Return true if entity is locked."""
+
+    @abstractmethod
+    async def async_lock(self) -> None:
+        """Lock the lock."""
+
+    @abstractmethod
+    async def async_unlock(self) -> None:
+        """Unlock the lock."""
+
+
+@register_entity(DoorLockCluster.cluster_id)
+class DoorLock(BaseLock):
+    """Representation of a ZHA lock."""
+
     _attr_translation_key: str = "door_lock"
     _attr_primary_weight = 5
 
@@ -68,13 +94,6 @@ class DoorLock(PlatformEntity):
                 self.handle_cluster_handler_attribute_updated,
             )
         )
-
-    @property
-    def state(self) -> dict[str, Any]:
-        """Get the state of the lock."""
-        response = super().state
-        response["is_locked"] = self.is_locked
-        return response
 
     @property
     def is_locked(self) -> bool:

--- a/zha/application/platforms/lock/__init__.py
+++ b/zha/application/platforms/lock/__init__.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Literal, cast
+import dataclasses
+from typing import TYPE_CHECKING, Literal, cast
 
 from zigpy.zcl.clusters.closures import DoorLock as DoorLockCluster
 from zigpy.zcl.foundation import Status
 
 from zha.application import Platform
 from zha.application.platforms import (
+    BaseEntityState,
     ClusterHandlerMatch,
     PlatformEntity,
     register_entity,
@@ -32,17 +34,25 @@ if TYPE_CHECKING:
     from zha.zigbee.endpoint import Endpoint
 
 
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class LockState(BaseEntityState):
+    """State for lock entities."""
+
+    is_locked: bool
+
+
 class BaseLock(PlatformEntity, ABC):
     """Abstract base class for ZHA lock entities."""
 
     PLATFORM = Platform.LOCK
 
     @property
-    def state(self) -> dict[str, Any]:
+    def state(self) -> LockState:
         """Get the state of the lock."""
-        response = super().state
-        response["is_locked"] = self.is_locked
-        return response
+        return LockState(
+            **super().state.__dict__,
+            is_locked=self.is_locked,
+        )
 
     @property
     @abstractmethod

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 import functools
 import logging
@@ -63,7 +64,7 @@ class NumberEntityInfo(BaseEntityInfo):
     native_unit_of_measurement: str | None
 
 
-class BaseNumber(PlatformEntity):
+class BaseNumber(PlatformEntity, ABC):
     """Representation of a ZHA Number entity."""
 
     PLATFORM = Platform.NUMBER
@@ -78,9 +79,9 @@ class BaseNumber(PlatformEntity):
     _attr_native_unit_of_measurement: str | None = None
 
     @property
+    @abstractmethod
     def native_value(self) -> float | None:
         """Return the current value."""
-        raise NotImplementedError
 
     @functools.cached_property
     def info_object(self) -> NumberEntityInfo:
@@ -126,9 +127,9 @@ class BaseNumber(PlatformEntity):
         """Return the mode of the entity."""
         return self._attr_mode
 
+    @abstractmethod
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value from HA."""
-        raise NotImplementedError
 
 
 @register_entity(AnalogOutput.cluster_id)

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -17,7 +17,7 @@ from zigpy.zcl.clusters.measurement import OccupancySensing
 
 from zha.application import Platform
 from zha.application.platforms import (
-    BaseEntityInfo,
+    BaseEntityState,
     ClusterHandlerMatch,
     EntityCategory,
     PlatformEntity,
@@ -54,9 +54,10 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, kw_only=True)
-class NumberEntityInfo(BaseEntityInfo):
-    """Number entity info."""
+class NumberState(BaseEntityState):
+    """State for number entities."""
 
+    state: float | None
     mode: NumberMode
     native_max_value: float
     native_min_value: float
@@ -83,24 +84,18 @@ class BaseNumber(PlatformEntity, ABC):
     def native_value(self) -> float | None:
         """Return the current value."""
 
-    @functools.cached_property
-    def info_object(self) -> NumberEntityInfo:
-        """Return a representation of the number entity."""
-        return NumberEntityInfo(
-            **super().info_object.__dict__,
+    @property
+    def state(self) -> NumberState:
+        """Return the state of the entity."""
+        return NumberState(
+            **super().state.__dict__,
+            state=self.native_value,
             mode=self.mode,
             native_max_value=self.native_max_value,
             native_min_value=self.native_min_value,
             native_step=self.native_step,
             native_unit_of_measurement=self.native_unit_of_measurement,
         )
-
-    @property
-    def state(self) -> dict[str, Any]:
-        """Return the state of the entity."""
-        response = super().state
-        response["state"] = self.native_value
-        return response
 
     @property
     def native_min_value(self) -> float:
@@ -276,13 +271,6 @@ class NumberConfigurationEntity(BaseNumber):
             self._attr_native_unit_of_measurement = entity_metadata.unit
         if entity_metadata.mode in NumberMode:
             self._attr_mode = NumberMode(entity_metadata.mode)
-
-    @property
-    def state(self) -> dict[str, Any]:
-        """Return the state of the entity."""
-        response = super().state
-        response["state"] = self.native_value
-        return response
 
     @property
     def native_value(self) -> float | None:

--- a/zha/application/platforms/select.py
+++ b/zha/application/platforms/select.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-import functools
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -27,7 +26,7 @@ from zigpy.zcl.clusters.security import IasWd
 from zha.application import Platform
 from zha.application.const import Strobe
 from zha.application.platforms import (
-    BaseEntityInfo,
+    BaseEntityState,
     ClusterHandlerMatch,
     EntityCategory,
     PlatformEntity,
@@ -57,8 +56,15 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, kw_only=True)
-class EnumSelectInfo(BaseEntityInfo):
-    """Enum select entity info."""
+class SelectState(BaseEntityState):
+    """State for select entities."""
+
+    state: str | None
+
+
+@dataclass(frozen=True, kw_only=True)
+class EnumSelectState(SelectState):
+    """State for enum select entities."""
 
     enum: str
     options: list[str]
@@ -77,11 +83,12 @@ class BaseSelectEntity(PlatformEntity, ABC):
         return self._attr_options
 
     @property
-    def state(self) -> dict[str, Any]:
+    def state(self) -> SelectState:
         """Return the state of the select."""
-        response = super().state
-        response["state"] = self.current_option
-        return response
+        return SelectState(
+            **super().state.__dict__,
+            state=self.current_option,
+        )
 
     @property
     @abstractmethod
@@ -113,11 +120,11 @@ class EnumSelectEntity(BaseSelectEntity):
         self._attr_options = [entry.name.replace("_", " ") for entry in self._enum]
         super().__init__(cluster_handlers, endpoint, device, **kwargs)
 
-    @functools.cached_property
-    def info_object(self) -> EnumSelectInfo:
-        """Return a representation of the select."""
-        return EnumSelectInfo(
-            **super().info_object.__dict__,
+    @property
+    def state(self) -> EnumSelectState:
+        """Return the state of the select."""
+        return EnumSelectState(
+            **super().state.__dict__,
             enum=self._enum.__name__,
             options=self.options,
         )
@@ -260,11 +267,11 @@ class ZCLEnumSelectEntity(BaseSelectEntity):
         self._attribute_name = entity_metadata.attribute_name
         self._enum = entity_metadata.enum
 
-    @functools.cached_property
-    def info_object(self) -> EnumSelectInfo:
-        """Return a representation of the select."""
-        return EnumSelectInfo(
-            **super().info_object.__dict__,
+    @property
+    def state(self) -> EnumSelectState:
+        """Return the state of the select."""
+        return EnumSelectState(
+            **super().state.__dict__,
             enum=self._enum.__name__,
             options=self.options,
         )

--- a/zha/application/platforms/select.py
+++ b/zha/application/platforms/select.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 import functools
@@ -63,10 +64,36 @@ class EnumSelectInfo(BaseEntityInfo):
     options: list[str]
 
 
-class EnumSelectEntity(PlatformEntity):
-    """Representation of a ZHA select entity."""
+class BaseSelectEntity(PlatformEntity, ABC):
+    """Abstract base class for ZHA select entities."""
 
     PLATFORM = Platform.SELECT
+
+    @property
+    def state(self) -> dict[str, Any]:
+        """Return the state of the select."""
+        response = super().state
+        response["state"] = self.current_option
+        return response
+
+    @property
+    @abstractmethod
+    def options(self) -> list[str]:
+        """Return the list of available options."""
+
+    @property
+    @abstractmethod
+    def current_option(self) -> str | None:
+        """Return the selected entity option to represent the entity state."""
+
+    @abstractmethod
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+
+
+class EnumSelectEntity(BaseSelectEntity):
+    """Representation of a ZHA select entity."""
+
     _attr_entity_category = EntityCategory.CONFIG
     _attribute_name: str
     _enum: type[Enum]
@@ -84,21 +111,19 @@ class EnumSelectEntity(PlatformEntity):
         self._attr_options = [entry.name.replace("_", " ") for entry in self._enum]
         super().__init__(cluster_handlers, endpoint, device, **kwargs)
 
+    @property
+    def options(self) -> list[str]:
+        """Return the list of available options."""
+        return self._attr_options
+
     @functools.cached_property
     def info_object(self) -> EnumSelectInfo:
         """Return a representation of the select."""
         return EnumSelectInfo(
             **super().info_object.__dict__,
             enum=self._enum.__name__,
-            options=self._attr_options,
+            options=self.options,
         )
-
-    @property
-    def state(self) -> dict:
-        """Return the state of the select."""
-        response = super().state
-        response["state"] = self.current_option
-        return response
 
     @property
     def current_option(self) -> str | None:
@@ -186,10 +211,9 @@ class DefaultStrobeSelectEntity(NonZCLSelectEntity):
     )
 
 
-class ZCLEnumSelectEntity(PlatformEntity):
+class ZCLEnumSelectEntity(BaseSelectEntity):
     """Representation of a ZHA ZCL enum select entity."""
 
-    PLATFORM = Platform.SELECT
     _attribute_name: str
     _attr_entity_category = EntityCategory.CONFIG
     _enum: type[Enum]
@@ -239,21 +263,19 @@ class ZCLEnumSelectEntity(PlatformEntity):
         self._attribute_name = entity_metadata.attribute_name
         self._enum = entity_metadata.enum
 
+    @property
+    def options(self) -> list[str]:
+        """Return the list of available options."""
+        return self._attr_options
+
     @functools.cached_property
     def info_object(self) -> EnumSelectInfo:
         """Return a representation of the select."""
         return EnumSelectInfo(
             **super().info_object.__dict__,
             enum=self._enum.__name__,
-            options=self._attr_options,
+            options=self.options,
         )
-
-    @property
-    def state(self) -> dict[str, Any]:
-        """Return the state of the select."""
-        response = super().state
-        response["state"] = self.current_option
-        return response
 
     @property
     def current_option(self) -> str | None:

--- a/zha/application/platforms/select.py
+++ b/zha/application/platforms/select.py
@@ -69,17 +69,19 @@ class BaseSelectEntity(PlatformEntity, ABC):
 
     PLATFORM = Platform.SELECT
 
+    _attr_options: list[str]
+
+    @property
+    def options(self) -> list[str]:
+        """Return the list of available options."""
+        return self._attr_options
+
     @property
     def state(self) -> dict[str, Any]:
         """Return the state of the select."""
         response = super().state
         response["state"] = self.current_option
         return response
-
-    @property
-    @abstractmethod
-    def options(self) -> list[str]:
-        """Return the list of available options."""
 
     @property
     @abstractmethod
@@ -110,11 +112,6 @@ class EnumSelectEntity(BaseSelectEntity):
         self._attribute_name = self._enum.__name__
         self._attr_options = [entry.name.replace("_", " ") for entry in self._enum]
         super().__init__(cluster_handlers, endpoint, device, **kwargs)
-
-    @property
-    def options(self) -> list[str]:
-        """Return the list of available options."""
-        return self._attr_options
 
     @functools.cached_property
     def info_object(self) -> EnumSelectInfo:
@@ -262,11 +259,6 @@ class ZCLEnumSelectEntity(BaseSelectEntity):
         super()._init_from_quirks_metadata(entity_metadata)
         self._attribute_name = entity_metadata.attribute_name
         self._enum = entity_metadata.enum
-
-    @property
-    def options(self) -> list[str]:
-        """Return the list of available options."""
-        return self._attr_options
 
     @functools.cached_property
     def info_object(self) -> EnumSelectInfo:

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from asyncio import Task
 import contextlib
 from dataclasses import dataclass
@@ -187,18 +188,55 @@ class DeviceCounterSensorIdentifiers(BaseIdentifiers):
     device_ieee: str
 
 
-class Sensor(PlatformEntity):
-    """Base ZHA sensor."""
+class BaseSensor(PlatformEntity, ABC):
+    """Abstract base class for ZHA sensor entities."""
 
     PLATFORM = Platform.SENSOR
-    _attribute_name: int | str | None = None
-    _attribute_converter: typing.Callable[[typing.Any], typing.Any] | None = None
-    _divisor: int | float | None = None
-    _multiplier: int | float | None = None
+
     _attr_suggested_display_precision: int | None = None
     _attr_native_unit_of_measurement: str | None = None
     _attr_device_class: SensorDeviceClass | None = None
     _attr_state_class: SensorStateClass | None = None
+
+    @property
+    def suggested_display_precision(self) -> int | None:
+        """Return the suggested display precision."""
+        return self._attr_suggested_display_precision
+
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        """Return the unit of measurement."""
+        return self._attr_native_unit_of_measurement
+
+    @functools.cached_property
+    def info_object(self) -> SensorEntityInfo:
+        """Return a representation of the sensor."""
+        return SensorEntityInfo(
+            **super().info_object.__dict__,
+            suggested_display_precision=self.suggested_display_precision,
+            unit=self.native_unit_of_measurement,
+        )
+
+    @property
+    def state(self) -> dict:
+        """Return the state for this sensor."""
+        response = super().state
+        response["state"] = self.native_value
+        return response
+
+    @property
+    @abstractmethod
+    def native_value(self) -> date | datetime | str | int | float | None:
+        """Return the current sensor value."""
+
+
+class Sensor(BaseSensor):
+    """Base ZHA sensor."""
+
+    _attribute_name: int | str | None = None
+    _attribute_converter: typing.Callable[[typing.Any], typing.Any] | None = None
+    _divisor: int | float | None = None
+    _multiplier: int | float | None = None
     _skip_creation_if_no_attr_cache: bool = False
 
     def __init__(
@@ -292,27 +330,6 @@ class Sensor(PlatformEntity):
             )
         if entity_metadata.unit is not None:
             self._attr_native_unit_of_measurement = entity_metadata.unit
-
-    @functools.cached_property
-    def info_object(self) -> SensorEntityInfo:
-        """Return a representation of the sensor."""
-        return SensorEntityInfo(
-            **super().info_object.__dict__,
-            suggested_display_precision=self._attr_suggested_display_precision,
-            unit=(
-                getattr(self, "entity_description").native_unit_of_measurement
-                if getattr(self, "entity_description", None) is not None
-                else self._attr_native_unit_of_measurement
-            ),
-        )
-
-    @property
-    def state(self) -> dict:
-        """Return the state for this sensor."""
-        response = super().state
-        native_value = self.native_value
-        response["state"] = native_value
-        return response
 
     @property
     def native_value(self) -> date | datetime | str | int | float | None:
@@ -1289,6 +1306,9 @@ class SmartEnergyMetering(PollableSensor):
             self.entity_description = entity_description
             self._attr_device_class = entity_description.device_class
             self._attr_state_class = entity_description.state_class
+            self._attr_native_unit_of_measurement = (
+                entity_description.native_unit_of_measurement
+            )
 
     @property
     def state(self) -> dict[str, Any]:

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -53,7 +53,7 @@ from zigpy.zcl.clusters.smartenergy import (
 from zha.application import Platform
 from zha.application.platforms import (
     BaseEntity,
-    BaseEntityInfo,
+    BaseEntityState,
     BaseIdentifiers,
     ClusterHandlerMatch,
     EntityCategory,
@@ -159,22 +159,20 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, kw_only=True)
-class SensorEntityInfo(BaseEntityInfo):
-    """Sensor entity info."""
+class SensorState(BaseEntityState):
+    """State for sensor entities."""
 
+    state: date | datetime | str | int | float | None
     suggested_display_precision: int | None = None
     unit: str | None = None
-    device_class: SensorDeviceClass | None = None
-    state_class: SensorStateClass | None = None
 
 
 @dataclass(frozen=True, kw_only=True)
-class DeviceCounterEntityInfo(BaseEntityInfo):
-    """Device counter entity info."""
+class DeviceCounterSensorState(BaseEntityState):
+    """State for device counter sensor entities."""
 
-    device_ieee: str
+    state: int | None
     suggested_display_precision: int
-    available: bool
     counter: str
     counter_value: int
     counter_groups: str
@@ -208,21 +206,15 @@ class BaseSensor(PlatformEntity, ABC):
         """Return the unit of measurement."""
         return self._attr_native_unit_of_measurement
 
-    @functools.cached_property
-    def info_object(self) -> SensorEntityInfo:
-        """Return a representation of the sensor."""
-        return SensorEntityInfo(
-            **super().info_object.__dict__,
+    @property
+    def state(self) -> SensorState:
+        """Return the state for this sensor."""
+        return SensorState(
+            **super().state.__dict__,
+            state=self.native_value,
             suggested_display_precision=self.suggested_display_precision,
             unit=self.native_unit_of_measurement,
         )
-
-    @property
-    def state(self) -> dict:
-        """Return the state for this sensor."""
-        response = super().state
-        response["state"] = self.native_value
-        return response
 
     @property
     @abstractmethod
@@ -516,24 +508,19 @@ class DeviceCounterSensor(BaseEntity):
             **super().identifiers.__dict__, device_ieee=str(self._device.ieee)
         )
 
-    @functools.cached_property
-    def info_object(self) -> DeviceCounterEntityInfo:
-        """Return a representation of the platform entity."""
-        return DeviceCounterEntityInfo(
-            **super().info_object.__dict__,
+    @property
+    def state(self) -> DeviceCounterSensorState:
+        """Return the state for this sensor."""
+        return DeviceCounterSensorState(
+            **super().state.__dict__,
+            state=self._zigpy_counter.value,
             suggested_display_precision=self._attr_suggested_display_precision,
+            device_ieee=self._device.ieee,
             counter=self._zigpy_counter.name,
             counter_value=self._zigpy_counter.value,
             counter_groups=self._zigpy_counter_groups,
             counter_group=self._zigpy_counter_group,
         )
-
-    @property
-    def state(self) -> dict[str, Any]:
-        """Return the state for this sensor."""
-        response = super().state
-        response["state"] = self._zigpy_counter.value
-        return response
 
     @property
     def native_value(self) -> int | None:
@@ -673,6 +660,15 @@ class AnalogInputSensor(Sensor):
         return super()._is_supported()
 
 
+@dataclass(frozen=True, kw_only=True)
+class BatterySensorState(SensorState):
+    """State for battery sensor entities."""
+
+    battery_size: str | None = None
+    battery_quantity: int | None = None
+    battery_voltage: float | None = None
+
+
 @register_entity(PowerConfiguration.cluster_id)
 class Battery(Sensor):
     """Battery sensor of power configuration cluster."""
@@ -706,19 +702,35 @@ class Battery(Sensor):
         return value / 2
 
     @property
-    def state(self) -> dict[str, Any]:
+    def state(self) -> BatterySensorState:
         """Return the state for battery sensors."""
-        response = super().state
-        battery_size = self._cluster_handler.cluster.get("battery_size")
-        if battery_size is not None:
-            response["battery_size"] = BATTERY_SIZES.get(battery_size, "Unknown")
+        battery_size_raw = self._cluster_handler.cluster.get("battery_size")
+        battery_size = (
+            BATTERY_SIZES.get(battery_size_raw, "Unknown")
+            if battery_size_raw is not None
+            else None
+        )
         battery_quantity = self._cluster_handler.cluster.get("battery_quantity")
-        if battery_quantity is not None:
-            response["battery_quantity"] = battery_quantity
-        battery_voltage = self._cluster_handler.cluster.get("battery_voltage")
-        if battery_voltage is not None:
-            response["battery_voltage"] = round(battery_voltage / 10, 2)
-        return response
+        battery_voltage_raw = self._cluster_handler.cluster.get("battery_voltage")
+        battery_voltage = (
+            round(battery_voltage_raw / 10, 2)
+            if battery_voltage_raw is not None
+            else None
+        )
+        return BatterySensorState(
+            **super().state.__dict__,
+            battery_size=battery_size,
+            battery_quantity=battery_quantity,
+            battery_voltage=battery_voltage,
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class ElectricalMeasurementState(SensorState):
+    """State for electrical measurement sensor entities."""
+
+    measurement_type: str | None = None
+    max_value: float | int | None = None
 
 
 class BaseElectricalMeasurement(PollableSensor):
@@ -745,19 +757,21 @@ class BaseElectricalMeasurement(PollableSensor):
             self._attr_extra_state_attribute_names.add(self._attr_max_attribute_name)
 
     @property
-    def state(self) -> dict[str, Any]:
+    def state(self) -> ElectricalMeasurementState:
         """Return the state for this sensor."""
-        response = super().state
-        if self._cluster_handler.measurement_type is not None:
-            response["measurement_type"] = self._cluster_handler.measurement_type
-
-        if (max_attr_name := self._attr_max_attribute_name) is None:
-            return response
-
-        if (max_v := self._cluster_handler.cluster.get(max_attr_name)) is not None:
-            response[max_attr_name] = self.formatter(max_v)
-
-        return response
+        measurement_type = self._cluster_handler.measurement_type
+        max_value = None
+        if (max_attr_name := self._attr_max_attribute_name) is not None:
+            max_v = self._cluster_handler.cluster.get(max_attr_name)
+            if max_v is not None:
+                max_value = self.formatter(max_v)
+        return ElectricalMeasurementState(
+            **super().state.__dict__,
+            measurement_type=str(measurement_type)
+            if measurement_type is not None
+            else None,
+            max_value=max_value,
+        )
 
     @property
     def _multiplier(self) -> int | float | None:
@@ -1213,6 +1227,15 @@ class SmartEnergyMeteringEntityDescription:
     device_class: SensorDeviceClass | None = None
 
 
+@dataclass(frozen=True, kw_only=True)
+class SmartEnergySensorState(SensorState):
+    """State for smart energy metering sensor entities."""
+
+    device_type: int | None = None
+    status: str | None = None
+    zcl_unit_of_measurement: int | None = None
+
+
 @register_entity(Metering.cluster_id)
 class SmartEnergyMetering(PollableSensor):
     """Metering sensor."""
@@ -1311,20 +1334,22 @@ class SmartEnergyMetering(PollableSensor):
             )
 
     @property
-    def state(self) -> dict[str, Any]:
+    def state(self) -> SmartEnergySensorState:
         """Return state for this sensor."""
-        response = super().state
-        if self._cluster_handler.device_type is not None:
-            response["device_type"] = self._cluster_handler.device_type
-        if (status := self._cluster_handler.metering_status) is not None:
-            if isinstance(status, enum.IntFlag):
-                response["status"] = str(
-                    status.name if status.name is not None else status.value
+        status = None
+        if (raw_status := self._cluster_handler.metering_status) is not None:
+            if isinstance(raw_status, enum.IntFlag):
+                status = str(
+                    raw_status.name if raw_status.name is not None else raw_status.value
                 )
             else:
-                response["status"] = str(status)[len(status.__class__.__name__) + 1 :]
-        response["zcl_unit_of_measurement"] = self._cluster_handler.unit_of_measurement
-        return response
+                status = str(raw_status)[len(raw_status.__class__.__name__) + 1 :]
+        return SmartEnergySensorState(
+            **super().state.__dict__,
+            device_type=self._cluster_handler.device_type,
+            status=status,
+            zcl_unit_of_measurement=self._cluster_handler.unit_of_measurement,
+        )
 
     @property
     def _multiplier(self) -> int | float | None:
@@ -1853,19 +1878,6 @@ class ThermostatHVACAction(Sensor):
         return PlatformEntity._is_supported(self)
 
     @property
-    def state(self) -> dict:
-        """Return the current HVAC action."""
-        response = super().state
-        if (
-            self._cluster_handler.pi_heating_demand is None
-            and self._cluster_handler.pi_cooling_demand is None
-        ):
-            response["state"] = self._rm_rs_action
-        else:
-            response["state"] = self._pi_demand_action
-        return response
-
-    @property
     def native_value(self) -> str | None:
         """Return the current HVAC action."""
         if (
@@ -2011,13 +2023,6 @@ class RSSISensor(Sensor):
         return not any(type(entity) is cls for entity in entities)
 
     @property
-    def state(self) -> dict:
-        """Return the state of the sensor."""
-        response = super().state
-        response["state"] = self.device.device.rssi
-        return response
-
-    @property
     def native_value(self) -> str | int | float | None:
         """Return the state of the entity."""
         return self._device.device.rssi
@@ -2058,13 +2063,6 @@ class LQISensor(RSSISensor):
     _cluster_handler_match = ClusterHandlerMatch(
         cluster_handlers=frozenset({CLUSTER_HANDLER_BASIC}),
     )
-
-    @property
-    def state(self) -> dict:
-        """Return the state of the sensor."""
-        response = super().state
-        response["state"] = self.device.device.lqi
-        return response
 
     @property
     def native_value(self) -> str | int | float | None:
@@ -2351,6 +2349,13 @@ class AqaraCurtainHookStateSensor(EnumSensor):
     )
 
 
+@dataclass(frozen=True, kw_only=True)
+class BitmapSensorState(SensorState):
+    """State for bitmap sensor entities."""
+
+    bit_states: dict[str, bool]
+
+
 class BitMapSensor(Sensor):
     """A sensor with only state attributes.
 
@@ -2373,17 +2378,19 @@ class BitMapSensor(Sensor):
         }
 
     @property
-    def state(self) -> dict[str, Any]:
+    def state(self) -> BitmapSensorState:
         """Return the state for this sensor."""
-        response = super().state
-        response["state"] = self.native_value
         value = self._cluster_handler.cluster.get(self._attribute_name)
+        bit_states = {}
         for bit in list(self._bitmap):
             if value is None:
-                response[bit.name] = False
+                bit_states[bit.name] = False
             else:
-                response[bit.name] = bit in self._bitmap(value)
-        return response
+                bit_states[bit.name] = bit in self._bitmap(value)
+        return BitmapSensorState(
+            **super().state.__dict__,
+            bit_states=bit_states,
+        )
 
     def formatter(self, _value: int) -> str:
         """Summary of all attributes."""

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from asyncio import Task
 import contextlib
+import dataclasses
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 import enum
@@ -515,7 +516,6 @@ class DeviceCounterSensor(BaseEntity):
             **super().state.__dict__,
             state=self._zigpy_counter.value,
             suggested_display_precision=self._attr_suggested_display_precision,
-            device_ieee=self._device.ieee,
             counter=self._zigpy_counter.name,
             counter_value=self._zigpy_counter.value,
             counter_groups=self._zigpy_counter_groups,

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from asyncio import Task
 import contextlib
-import dataclasses
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 import enum
@@ -345,9 +344,8 @@ class Sensor(BaseSensor):
         if (
             event.attribute_name == self._attribute_name
             or (
-                hasattr(self, "_attr_extra_state_attribute_names")
-                and event.attribute_name
-                in getattr(self, "_attr_extra_state_attribute_names")
+                self._attr_extra_state_attribute_names is not None
+                and event.attribute_name in self._attr_extra_state_attribute_names
             )
             or self._attribute_name is None
         ):

--- a/zha/application/platforms/siren.py
+++ b/zha/application/platforms/siren.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 import asyncio
 import contextlib
 from dataclasses import dataclass
@@ -66,11 +67,55 @@ class SirenEntityInfo(BaseEntityInfo):
     supported_features: SirenEntityFeature
 
 
-@register_entity(IasWd.cluster_id)
-class Siren(PlatformEntity):
-    """Representation of a ZHA siren."""
+class BaseSiren(PlatformEntity, ABC):
+    """Abstract base class for ZHA siren entities."""
 
     PLATFORM = Platform.SIREN
+
+    @property
+    def state(self) -> dict[str, Any]:
+        """Get the state of the siren."""
+        response = super().state
+        response["state"] = self.is_on
+        return response
+
+    @property
+    @abstractmethod
+    def is_on(self) -> bool:
+        """Return true if the entity is on."""
+
+    @property
+    @abstractmethod
+    def available_tones(self) -> dict[int, str]:
+        """Return available tones."""
+
+    @property
+    @abstractmethod
+    def supported_features(self) -> SirenEntityFeature:
+        """Return supported features."""
+
+    @functools.cached_property
+    def info_object(self) -> SirenEntityInfo:
+        """Return representation of the siren."""
+        return SirenEntityInfo(
+            **super().info_object.__dict__,
+            available_tones=self.available_tones,
+            supported_features=self.supported_features,
+        )
+
+    @abstractmethod
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on siren."""
+
+    @abstractmethod
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off siren."""
+
+
+@register_entity(IasWd.cluster_id)
+class Siren(BaseSiren):
+    """Representation of a ZHA siren."""
+
     _attr_fallback_name: str = "Siren"
     _attr_primary_weight = 4
 
@@ -123,21 +168,10 @@ class Siren(PlatformEntity):
         self._attr_is_on: bool = False
         self._off_listener: asyncio.TimerHandle | None = None
 
-    @functools.cached_property
-    def info_object(self) -> SirenEntityInfo:
-        """Return representation of the siren."""
-        return SirenEntityInfo(
-            **super().info_object.__dict__,
-            available_tones=self._attr_available_tones,
-            supported_features=self._attr_supported_features,
-        )
-
     @property
-    def state(self) -> dict[str, Any]:
-        """Get the state of the siren."""
-        response = super().state
-        response["state"] = self.is_on
-        return response
+    def available_tones(self) -> dict[int, str]:
+        """Return available tones."""
+        return self._attr_available_tones
 
     @property
     def supported_features(self) -> SirenEntityFeature:

--- a/zha/application/platforms/siren.py
+++ b/zha/application/platforms/siren.py
@@ -104,11 +104,16 @@ class BaseSiren(PlatformEntity, ABC):
         )
 
     @abstractmethod
-    async def async_turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(
+        self,
+        duration: int | None = None,
+        tone: int | None = None,
+        volume_level: int | None = None,
+    ) -> None:
         """Turn on siren."""
 
     @abstractmethod
-    async def async_turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self) -> None:
         """Turn off siren."""
 
 
@@ -183,7 +188,12 @@ class Siren(BaseSiren):
         """Return true if the entity is on."""
         return self._attr_is_on
 
-    async def async_turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(
+        self,
+        duration: int | None = None,
+        tone: int | None = None,
+        volume_level: int | None = None,
+    ) -> None:
         """Turn on siren."""
         if self._off_listener:
             self._off_listener.cancel()
@@ -215,12 +225,12 @@ class Siren(BaseSiren):
             if strobe_level_cache is not None
             else WARNING_DEVICE_STROBE_HIGH
         )
-        if (duration := kwargs.get(ATTR_DURATION)) is not None:
+        if duration is not None:
             siren_duration = duration
-        if (tone := kwargs.get(ATTR_TONE)) is not None:
+        if tone is not None:
             siren_tone = tone
-        if (level := kwargs.get(ATTR_VOLUME_LEVEL)) is not None:
-            siren_level = int(level)
+        if volume_level is not None:
+            siren_level = int(volume_level)
         await self._cluster_handler.issue_start_warning(
             mode=siren_tone,
             warning_duration=siren_duration,
@@ -236,7 +246,7 @@ class Siren(BaseSiren):
         self._tracked_handles.append(self._off_listener)
         self.maybe_emit_state_changed_event()
 
-    async def async_turn_off(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_turn_off(self) -> None:
         """Turn off siren."""
         await self._cluster_handler.issue_start_warning(
             mode=WARNING_DEVICE_MODE_STOP, strobe=WARNING_DEVICE_STROBE_NO

--- a/zha/application/platforms/siren.py
+++ b/zha/application/platforms/siren.py
@@ -7,7 +7,6 @@ import asyncio
 import contextlib
 from dataclasses import dataclass
 from enum import IntFlag
-import functools
 from typing import TYPE_CHECKING, Any, Final, cast
 
 from zigpy.profiles import zha
@@ -28,7 +27,7 @@ from zha.application.const import (
     Strobe,
 )
 from zha.application.platforms import (
-    BaseEntityInfo,
+    BaseEntityState,
     ClusterHandlerMatch,
     PlatformEntity,
     register_entity,
@@ -60,9 +59,10 @@ class SirenEntityFeature(IntFlag):
 
 
 @dataclass(frozen=True, kw_only=True)
-class SirenEntityInfo(BaseEntityInfo):
-    """Siren entity info."""
+class SirenState(BaseEntityState):
+    """State for siren entities."""
 
+    state: bool
     available_tones: dict[int, str]
     supported_features: SirenEntityFeature
 
@@ -77,11 +77,14 @@ class BaseSiren(PlatformEntity, ABC):
     _attr_supported_features: SirenEntityFeature
 
     @property
-    def state(self) -> dict[str, Any]:
+    def state(self) -> SirenState:
         """Get the state of the siren."""
-        response = super().state
-        response["state"] = self.is_on
-        return response
+        return SirenState(
+            **super().state.__dict__,
+            state=self.is_on,
+            available_tones=self.available_tones,
+            supported_features=self.supported_features,
+        )
 
     @property
     def is_on(self) -> bool:
@@ -97,15 +100,6 @@ class BaseSiren(PlatformEntity, ABC):
     def supported_features(self) -> SirenEntityFeature:
         """Return supported features."""
         return self._attr_supported_features
-
-    @functools.cached_property
-    def info_object(self) -> SirenEntityInfo:
-        """Return representation of the siren."""
-        return SirenEntityInfo(
-            **super().info_object.__dict__,
-            available_tones=self.available_tones,
-            supported_features=self.supported_features,
-        )
 
     @abstractmethod
     async def async_turn_on(

--- a/zha/application/platforms/siren.py
+++ b/zha/application/platforms/siren.py
@@ -72,6 +72,10 @@ class BaseSiren(PlatformEntity, ABC):
 
     PLATFORM = Platform.SIREN
 
+    _attr_is_on: bool = False
+    _attr_available_tones: dict[int, str]
+    _attr_supported_features: SirenEntityFeature
+
     @property
     def state(self) -> dict[str, Any]:
         """Get the state of the siren."""
@@ -80,19 +84,19 @@ class BaseSiren(PlatformEntity, ABC):
         return response
 
     @property
-    @abstractmethod
     def is_on(self) -> bool:
         """Return true if the entity is on."""
+        return self._attr_is_on
 
     @property
-    @abstractmethod
     def available_tones(self) -> dict[int, str]:
         """Return available tones."""
+        return self._attr_available_tones
 
     @property
-    @abstractmethod
     def supported_features(self) -> SirenEntityFeature:
         """Return supported features."""
+        return self._attr_supported_features
 
     @functools.cached_property
     def info_object(self) -> SirenEntityInfo:
@@ -170,23 +174,7 @@ class Siren(BaseSiren):
             WARNING_DEVICE_MODE_FIRE_PANIC: "Fire Panic",
             WARNING_DEVICE_MODE_EMERGENCY_PANIC: "Emergency Panic",
         }
-        self._attr_is_on: bool = False
         self._off_listener: asyncio.TimerHandle | None = None
-
-    @property
-    def available_tones(self) -> dict[int, str]:
-        """Return available tones."""
-        return self._attr_available_tones
-
-    @property
-    def supported_features(self) -> SirenEntityFeature:
-        """Return supported features."""
-        return self._attr_supported_features
-
-    @property
-    def is_on(self) -> bool:
-        """Return true if the entity is on."""
-        return self._attr_is_on
 
     async def async_turn_on(
         self,

--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-import functools
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
@@ -19,7 +18,7 @@ from zigpy.zcl.foundation import Status
 from zha.application import Platform
 from zha.application.platforms import (
     BaseEntity,
-    BaseEntityInfo,
+    BaseEntityState,
     ClusterHandlerMatch,
     EntityCategory,
     GroupEntity,
@@ -59,9 +58,17 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, kw_only=True)
-class ConfigurableAttributeSwitchInfo(BaseEntityInfo):
-    """Switch configuration entity info."""
+class SwitchState(BaseEntityState):
+    """State for switch entities."""
 
+    state: bool
+
+
+@dataclass(frozen=True, kw_only=True)
+class ConfigurableAttributeSwitchState(SwitchState):
+    """State for configurable attribute switch entities."""
+
+    inverted: bool
     attribute_name: str
     invert_attribute_name: str | None
     force_inverted: bool
@@ -75,11 +82,12 @@ class BaseSwitch(BaseEntity, ABC):
     PLATFORM = Platform.SWITCH
 
     @property
-    def state(self) -> dict[str, Any]:
+    def state(self) -> SwitchState:
         """Return the state of the switch."""
-        response = super().state
-        response["state"] = self.is_on
-        return response
+        return SwitchState(
+            **super().state.__dict__,
+            state=self.is_on,
+        )
 
     @property
     @abstractmethod
@@ -96,7 +104,7 @@ class BaseSwitch(BaseEntity, ABC):
 
 
 @register_entity(OnOff.cluster_id)
-class Switch(PlatformEntity, BaseSwitch):
+class Switch(PlatformEntity, BaseSwitch):  # type: ignore[misc]
     """ZHA switch."""
 
     _attr_translation_key = "switch"
@@ -200,7 +208,7 @@ class Switch(PlatformEntity, BaseSwitch):
 
 
 @register_entity(BinaryOutput.cluster_id)
-class BinaryOutputSwitch(PlatformEntity, BaseSwitch):
+class BinaryOutputSwitch(PlatformEntity, BaseSwitch):  # type: ignore[misc]
     """BinaryOutputCluster switch."""
 
     _attr_primary_weight = 10
@@ -270,7 +278,7 @@ class BinaryOutputSwitch(PlatformEntity, BaseSwitch):
 
 
 @register_group_entity
-class SwitchGroup(GroupEntity, BaseSwitch):
+class SwitchGroup(GroupEntity, BaseSwitch):  # type: ignore[misc]
     """Representation of a switch group."""
 
     _attr_primary_weight = 10
@@ -280,8 +288,6 @@ class SwitchGroup(GroupEntity, BaseSwitch):
         super().__init__(group)
         self._state: bool
         self._on_off_cluster_handler = group.zigpy_group.endpoint[OnOff.cluster_id]
-        if hasattr(self, "info_object"):
-            delattr(self, "info_object")
         self.update()
 
     @property
@@ -309,11 +315,11 @@ class SwitchGroup(GroupEntity, BaseSwitch):
         """Query all members and determine the light group state."""
         self.debug("Updating switch group entity state")
         platform_entities = self._group.get_platform_entities(self.PLATFORM)
-        all_states = [entity.state for entity in platform_entities]
+        all_states = [cast(SwitchState, entity.state) for entity in platform_entities]
         self.debug(
             "All platform entity states for group entity members: %s", all_states
         )
-        on_states = [state for state in all_states if state["state"]]
+        on_states = [state for state in all_states if state.state]
 
         self._state = len(on_states) > 0
 
@@ -400,25 +406,18 @@ class ConfigurableAttributeSwitch(PlatformEntity):
 
         return super()._is_supported()
 
-    @functools.cached_property
-    def info_object(self) -> ConfigurableAttributeSwitchInfo:
-        """Return representation of the switch configuration entity."""
-        return ConfigurableAttributeSwitchInfo(
-            **super().info_object.__dict__,
+    @property
+    def state(self) -> ConfigurableAttributeSwitchState:
+        """Return the state of the switch."""
+        return ConfigurableAttributeSwitchState(
+            **super().state.__dict__,
+            inverted=self.inverted,
             attribute_name=self._attribute_name,
             invert_attribute_name=self._inverter_attribute_name,
             force_inverted=self._force_inverted,
             off_value=self._off_value,
             on_value=self._on_value,
         )
-
-    @property
-    def state(self) -> dict[str, Any]:
-        """Return the state of the switch."""
-        response = super().state
-        response["state"] = self.is_on
-        response["inverted"] = self.inverted
-        return response
 
     @property
     def inverted(self) -> bool:

--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from abc import ABC
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 import functools
 import logging
@@ -73,16 +73,6 @@ class BaseSwitch(BaseEntity, ABC):
     """Common base class for zhawss switches."""
 
     PLATFORM = Platform.SWITCH
-    _attr_primary_weight = 10
-
-    def __init__(
-        self,
-        *args: Any,
-        **kwargs: Any,
-    ):
-        """Initialize the switch."""
-        self._on_off_cluster_handler: OnOffClusterHandler
-        super().__init__(*args, **kwargs)
 
     @property
     def state(self) -> dict[str, Any]:
@@ -92,22 +82,17 @@ class BaseSwitch(BaseEntity, ABC):
         return response
 
     @property
+    @abstractmethod
     def is_on(self) -> bool:
         """Return if the switch is on based on the statemachine."""
-        if self._on_off_cluster_handler.on_off is None:
-            return False
-        return self._on_off_cluster_handler.on_off
 
-    # TODO revert this once group entities use cluster handlers
-    async def async_turn_on(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    @abstractmethod
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
-        await self._on_off_cluster_handler.turn_on()
-        self.maybe_emit_state_changed_event()
 
-    async def async_turn_off(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    @abstractmethod
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
-        await self._on_off_cluster_handler.turn_off()
-        self.maybe_emit_state_changed_event()
 
 
 @register_entity(OnOff.cluster_id)
@@ -165,6 +150,23 @@ class Switch(PlatformEntity, BaseSwitch):
             OnOffClusterHandler, self.cluster_handlers[CLUSTER_HANDLER_ON_OFF]
         )
 
+    @property
+    def is_on(self) -> bool:
+        """Return if the switch is on based on the statemachine."""
+        if self._on_off_cluster_handler.on_off is None:
+            return False
+        return self._on_off_cluster_handler.on_off
+
+    async def async_turn_on(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+        """Turn the entity on."""
+        await self._on_off_cluster_handler.turn_on()
+        self.maybe_emit_state_changed_event()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+        """Turn the entity off."""
+        await self._on_off_cluster_handler.turn_off()
+        self.maybe_emit_state_changed_event()
+
     def on_add(self) -> None:
         """Run when entity is added."""
         super().on_add()
@@ -201,6 +203,7 @@ class Switch(PlatformEntity, BaseSwitch):
 class BinaryOutputSwitch(PlatformEntity, BaseSwitch):
     """BinaryOutputCluster switch."""
 
+    _attr_primary_weight = 10
     _cluster_handler_match = ClusterHandlerMatch(
         cluster_handlers=frozenset({CLUSTER_HANDLER_BINARY_OUTPUT})
     )
@@ -269,6 +272,8 @@ class BinaryOutputSwitch(PlatformEntity, BaseSwitch):
 @register_group_entity
 class SwitchGroup(GroupEntity, BaseSwitch):
     """Representation of a switch group."""
+
+    _attr_primary_weight = 10
 
     def __init__(self, group: Group):
         """Initialize a switch group."""

--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -87,11 +87,11 @@ class BaseSwitch(BaseEntity, ABC):
         """Return if the switch is on based on the statemachine."""
 
     @abstractmethod
-    async def async_turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self) -> None:
         """Turn the entity on."""
 
     @abstractmethod
-    async def async_turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self) -> None:
         """Turn the entity off."""
 
 
@@ -157,12 +157,12 @@ class Switch(PlatformEntity, BaseSwitch):
             return False
         return self._on_off_cluster_handler.on_off
 
-    async def async_turn_on(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_turn_on(self) -> None:
         """Turn the entity on."""
         await self._on_off_cluster_handler.turn_on()
         self.maybe_emit_state_changed_event()
 
-    async def async_turn_off(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_turn_off(self) -> None:
         """Turn the entity off."""
         await self._on_off_cluster_handler.turn_off()
         self.maybe_emit_state_changed_event()
@@ -250,12 +250,12 @@ class BinaryOutputSwitch(PlatformEntity, BaseSwitch):
             return False
         return bool(self._binary_output_cluster_handler.present_value)
 
-    async def async_turn_on(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_turn_on(self) -> None:
         """Turn the entity on."""
         await self._binary_output_cluster_handler.async_set_present_value(True)
         self.maybe_emit_state_changed_event()
 
-    async def async_turn_off(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_turn_off(self) -> None:
         """Turn the entity off."""
         await self._binary_output_cluster_handler.async_set_present_value(False)
         self.maybe_emit_state_changed_event()
@@ -289,7 +289,7 @@ class SwitchGroup(GroupEntity, BaseSwitch):
         """Return if the switch is on based on the statemachine."""
         return bool(self._state)
 
-    async def async_turn_on(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_turn_on(self) -> None:
         """Turn the entity on."""
         result = await self._on_off_cluster_handler.on()
         if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
@@ -297,7 +297,7 @@ class SwitchGroup(GroupEntity, BaseSwitch):
         self._state = True
         self.maybe_emit_state_changed_event()
 
-    async def async_turn_off(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_turn_off(self) -> None:
         """Turn the entity off."""
         result = await self._on_off_cluster_handler.off()
         if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
@@ -461,11 +461,11 @@ class ConfigurableAttributeSwitch(PlatformEntity):
             )
         self.maybe_emit_state_changed_event()
 
-    async def async_turn_on(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_turn_on(self) -> None:
         """Turn the entity on."""
         await self.async_turn_on_off(True)
 
-    async def async_turn_off(self, **kwargs: Any) -> None:  # pylint: disable=unused-argument
+    async def async_turn_off(self) -> None:
         """Turn the entity off."""
         await self.async_turn_on_off(False)
 
@@ -919,11 +919,11 @@ class WindowCoveringInversionSwitch(ConfigurableAttributeSwitch):
         )
         return ConfigStatus.Open_up_commands_reversed in config_status
 
-    async def async_turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self) -> None:
         """Turn the entity on."""
         await self._async_on_off(True)
 
-    async def async_turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self) -> None:
         """Turn the entity off."""
         await self._async_on_off(False)
 

--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -411,6 +411,7 @@ class ConfigurableAttributeSwitch(PlatformEntity):
         """Return the state of the switch."""
         return ConfigurableAttributeSwitchState(
             **super().state.__dict__,
+            state=self.is_on,
             inverted=self.inverted,
             attribute_name=self._attribute_name,
             invert_attribute_name=self._inverter_attribute_name,

--- a/zha/application/platforms/update.py
+++ b/zha/application/platforms/update.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from abc import ABC
 from dataclasses import dataclass
 from enum import IntFlag, StrEnum
 import functools
@@ -70,8 +71,8 @@ class UpdateEntityInfo(BaseEntityInfo):
     device_class: UpdateDeviceClass
 
 
-class BaseFirmwareUpdateEntity(PlatformEntity):
-    """Base representation of a ZHA firmware update entity."""
+class BaseFirmwareUpdateEntity(PlatformEntity, ABC):
+    """Abstract base class for ZHA firmware update entities."""
 
     PLATFORM = Platform.UPDATE
 
@@ -99,7 +100,7 @@ class BaseFirmwareUpdateEntity(PlatformEntity):
         )
 
     @property
-    def state(self):
+    def state(self) -> dict[str, Any]:
         """Get the state for the entity."""
         response = super().state
         if (release_summary := self.release_summary) is not None:

--- a/zha/application/platforms/update.py
+++ b/zha/application/platforms/update.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from abc import ABC
 from dataclasses import dataclass
 from enum import IntFlag, StrEnum
-import functools
 import itertools
 import logging
 from typing import TYPE_CHECKING, Any, Final
@@ -16,7 +15,7 @@ from zigpy.zcl.foundation import Status
 
 from zha.application import Platform
 from zha.application.platforms import (
-    BaseEntityInfo,
+    BaseEntityState,
     ClusterHandlerMatch,
     EntityCategory,
     PlatformEntity,
@@ -64,11 +63,17 @@ ATTR_VERSION: Final = "version"
 
 
 @dataclass(frozen=True, kw_only=True)
-class UpdateEntityInfo(BaseEntityInfo):
-    """Update entity info."""
+class UpdateState(BaseEntityState):
+    """State for update entities."""
 
+    installed_version: str | None
+    in_progress: bool | int
+    update_percentage: int | None
+    latest_version: str | None
+    release_summary: str | None
+    release_notes: str | None
+    release_url: str | None
     supported_features: UpdateEntityFeature
-    device_class: UpdateDeviceClass
 
 
 class BaseFirmwareUpdateEntity(PlatformEntity, ABC):
@@ -91,29 +96,24 @@ class BaseFirmwareUpdateEntity(PlatformEntity, ABC):
     _attr_release_notes: str | None = None
     _attr_release_url: str | None = None
 
-    @functools.cached_property
-    def info_object(self) -> UpdateEntityInfo:
-        """Return a representation of the entity."""
-        return UpdateEntityInfo(
-            **super().info_object.__dict__,
-            supported_features=self.supported_features,
-        )
-
     @property
-    def state(self) -> dict[str, Any]:
+    def state(self) -> UpdateState:
         """Get the state for the entity."""
-        response = super().state
-        if (release_summary := self.release_summary) is not None:
+        release_summary = self.release_summary
+        if release_summary is not None:
             release_summary = release_summary[:255]
 
-        response[ATTR_INSTALLED_VERSION] = self.installed_version
-        response[ATTR_IN_PROGRESS] = self.in_progress
-        response[ATTR_UPDATE_PERCENTAGE] = self.update_percentage
-        response[ATTR_LATEST_VERSION] = self.latest_version
-        response[ATTR_RELEASE_SUMMARY] = release_summary
-        response[ATTR_RELEASE_NOTES] = self.release_notes
-        response[ATTR_RELEASE_URL] = self.release_url
-        return response
+        return UpdateState(
+            **super().state.__dict__,
+            installed_version=self.installed_version,
+            in_progress=self.in_progress,
+            update_percentage=self.update_percentage,
+            latest_version=self.latest_version,
+            release_summary=release_summary,
+            release_notes=self.release_notes,
+            release_url=self.release_url,
+            supported_features=self.supported_features,
+        )
 
     @property
     def installed_version(self) -> str | None:

--- a/zha/event.py
+++ b/zha/event.py
@@ -3,13 +3,28 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import Callable, Generator
+import contextlib
+from contextvars import ContextVar
 import dataclasses
 import inspect
 import logging
 from typing import Any
 
 _LOGGER = logging.getLogger(__package__)
+
+_suppress_events: ContextVar[bool] = ContextVar("suppress_events", default=False)
+
+
+@contextlib.contextmanager
+def suppress_events() -> Generator[None, None, None]:
+    """Context manager to suppress event emission."""
+    token = _suppress_events.set(True)
+
+    try:
+        yield
+    finally:
+        _suppress_events.reset(token)
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -86,6 +101,9 @@ class EventBase:
 
     def emit(self, event_name: str, data=None) -> None:
         """Run all callbacks for an event."""
+        if _suppress_events.get():
+            return
+
         listeners = [*self._listeners.get(event_name, []), *self._global_listeners]
         _LOGGER.debug(
             "Emitting event %s with data %r (%d listeners)",

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -80,7 +80,7 @@ from zha.application.platforms import (
 )
 from zha.application.platforms.update import BaseFirmwareUpdateEntity
 from zha.const import STATE_CHANGED
-from zha.event import EventBase
+from zha.event import EventBase, suppress_events
 from zha.exceptions import ZHAException
 from zha.mixins import LogMixin
 from zha.zigbee.cluster_handlers import ClusterHandler, ZDOClusterHandler
@@ -1021,8 +1021,12 @@ class Device(LogMixin, EventBase):
             _LOGGER.debug("Discovered new entities %r", new_entities)
             self._platform_entities.update(new_entities)
 
-        # At this point we can compute a primary entity
-        self._compute_primary_entity()
+        # Compute primary entity within suppress_events so that the change to
+        # `primary` is absorbed into __previous_state without emitting events.
+        with suppress_events():
+            self._compute_primary_entity()
+            for entity in self._platform_entities.values():
+                entity.maybe_emit_state_changed_event()
 
         # Sync the device's firmware version with the first platform entity
         for (platform, _unique_id), entity in self.platform_entities.items():
@@ -1545,15 +1549,18 @@ class Device(LogMixin, EventBase):
             self.platform_entities.items()
         ):
             state_dict = dataclasses.asdict(platform_entity.state)
-            state_dict["cluster_handlers"].sort(key=lambda i: i["unique_id"])
             state_dict["migrate_unique_ids"] = list(state_dict["migrate_unique_ids"])
             state_dict["device_ieee"] = str(state_dict["device_ieee"])
 
-            for cluster_handler_info in state_dict["cluster_handlers"]:
-                cluster_info = cluster_handler_info["cluster"]
-
-                if cluster_info is not None:
-                    cluster_info.pop("commands", None)
+            ch_dicts = [
+                dataclasses.asdict(ch.info_object)
+                for ch in platform_entity._cluster_handlers
+            ]
+            ch_dicts.sort(key=lambda i: i["unique_id"])
+            for ch_dict in ch_dicts:
+                if ch_dict["cluster"] is not None:
+                    ch_dict["cluster"].pop("commands", None)
+            state_dict["cluster_handlers"] = ch_dicts
 
             info["zha_lib_entities"][platform].append(state_dict)
 

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -1551,6 +1551,10 @@ class Device(LogMixin, EventBase):
             state_dict = dataclasses.asdict(platform_entity.state)
             state_dict["migrate_unique_ids"] = list(state_dict["migrate_unique_ids"])
             state_dict["device_ieee"] = str(state_dict["device_ieee"])
+            if state_dict["extra_state_attribute_names"] is not None:
+                state_dict["extra_state_attribute_names"] = sorted(
+                    state_dict["extra_state_attribute_names"]
+                )
 
             ch_dicts = [
                 dataclasses.asdict(ch.info_object)

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -74,7 +74,7 @@ from zha.application.const import (
 from zha.application.helpers import convert_to_zcl_values, convert_zcl_value
 from zha.application.platforms import (
     BaseEntity,
-    BaseEntityInfo,
+    BaseEntityState,
     EntityStateChangedEvent,
     PlatformEntity,
 )
@@ -244,7 +244,7 @@ class ExtendedDeviceInfo(DeviceInfo):
     """Describes a ZHA device."""
 
     active_coordinator: bool
-    entities: dict[str, BaseEntityInfo]
+    entities: dict[str, BaseEntityState]
     neighbors: list[NeighborInfo]
     routes: list[RouteInfo]
     endpoint_names: list[EndpointNameInfo]
@@ -794,7 +794,7 @@ class Device(LogMixin, EventBase):
             **self.device_info.__dict__,
             active_coordinator=self.is_active_coordinator,
             entities={
-                platform_entity.unique_id: platform_entity.info_object
+                platform_entity.unique_id: platform_entity.state
                 for platform_entity in self.platform_entities.values()
             },
             neighbors=[
@@ -1406,7 +1406,7 @@ class Device(LogMixin, EventBase):
         candidates = [
             e
             for e in self._platform_entities.values()
-            if e.enabled and hasattr(e, "info_object") and e._attr_primary is not False
+            if e.enabled and e._attr_primary is not False
         ]
         candidates.sort(reverse=True, key=lambda e: e.primary_weight)
 
@@ -1419,11 +1419,9 @@ class Device(LogMixin, EventBase):
         # We have a clear winner
         if not others or winner.primary_weight > others[0].primary_weight:
             winner.primary = True
-            del winner.info_object
 
             for entity in others:
                 entity.primary = False
-                del entity.info_object
 
             return
 
@@ -1433,7 +1431,6 @@ class Device(LogMixin, EventBase):
 
         for entity in candidates:
             entity.primary = False
-            del entity.info_object
 
     def get_diagnostics_json(self):
         """Get ZHA device information."""
@@ -1547,28 +1544,18 @@ class Device(LogMixin, EventBase):
         for (platform, _unique_id), platform_entity in sorted(
             self.platform_entities.items()
         ):
-            info_object = dataclasses.asdict(platform_entity.info_object)
-            info_object["cluster_handlers"].sort(key=lambda i: i["unique_id"])
-            info_object["migrate_unique_ids"] = list(info_object["migrate_unique_ids"])
-            info_object["device_ieee"] = str(info_object["device_ieee"])
+            state_dict = dataclasses.asdict(platform_entity.state)
+            state_dict["cluster_handlers"].sort(key=lambda i: i["unique_id"])
+            state_dict["migrate_unique_ids"] = list(state_dict["migrate_unique_ids"])
+            state_dict["device_ieee"] = str(state_dict["device_ieee"])
 
-            for cluster_handler_info in info_object["cluster_handlers"]:
+            for cluster_handler_info in state_dict["cluster_handlers"]:
                 cluster_info = cluster_handler_info["cluster"]
 
                 if cluster_info is not None:
                     cluster_info.pop("commands", None)
 
-            obj: dict[str, Any] = {
-                "info_object": info_object,
-                "state": platform_entity.state,
-            }
-
-            if platform_entity.extra_state_attribute_names is not None:
-                obj["extra_state_attributes"] = sorted(
-                    platform_entity.extra_state_attribute_names
-                )
-
-            info["zha_lib_entities"][platform].append(obj)
+            info["zha_lib_entities"][platform].append(state_dict)
 
         topology = self.gateway.application_controller.topology
         info["neighbors"] = [

--- a/zha/zigbee/group.py
+++ b/zha/zigbee/group.py
@@ -198,7 +198,7 @@ class Group(LogMixin):
         ]
 
     @cached_property
-    def info_object(self) -> GroupInfo:
+    def state(self) -> GroupInfo:
         """Get ZHA group info."""
         return GroupInfo(
             group_id=self.group_id,
@@ -254,8 +254,8 @@ class Group(LogMixin):
         """Clear cached properties."""
         if hasattr(self, "all_member_entity_unique_ids"):
             delattr(self, "all_member_entity_unique_ids")
-        if hasattr(self, "info_object"):
-            delattr(self, "info_object")
+        if hasattr(self, "state"):
+            delattr(self, "state")
         if hasattr(self, "members"):
             delattr(self, "members")
 

--- a/zha/zigbee/group.py
+++ b/zha/zigbee/group.py
@@ -13,7 +13,7 @@ import zigpy.exceptions
 from zigpy.types.named import EUI64
 
 from zha.application.platforms import (
-    BaseEntityInfo,
+    BaseEntityState,
     EntityStateChangedEvent,
     PlatformEntity,
 )
@@ -55,7 +55,7 @@ class GroupMemberInfo:
     ieee: EUI64
     endpoint_id: int
     device_info: ExtendedDeviceInfo
-    entities: dict[str, BaseEntityInfo]
+    entities: dict[str, BaseEntityState]
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -65,7 +65,7 @@ class GroupInfo:
     group_id: int
     name: str
     members: list[GroupMemberInfo]
-    entities: dict[str, BaseEntityInfo]
+    entities: dict[str, BaseEntityState]
 
 
 class GroupMember(LogMixin):
@@ -105,8 +105,7 @@ class GroupMember(LogMixin):
             endpoint_id=self.endpoint_id,
             device_info=self.device.extended_device_info,
             entities={
-                entity.unique_id: entity.info_object
-                for entity in self.associated_entities
+                entity.unique_id: entity.state for entity in self.associated_entities
             },
         )
 
@@ -206,7 +205,7 @@ class Group(LogMixin):
             name=self.name,
             members=[member.member_info for member in self.members],
             entities={
-                unique_id: entity.info_object
+                unique_id: entity.state
                 for unique_id, entity in self._group_entities.items()
             },
         )


### PR DESCRIPTION
This PR builds off of https://github.com/zigpy/zha/pull/662 and replaces the `state` dict with a strongly typed dataclass that absorbs `info_object`.

For stronger typing and to support the client/server architecture split in the future, we benefit from having more centralized state for entities. This will allow us to send batched state updates to the client instead of the client being notified of a general "update" and then reaching for the `state` dict of the ZHA entity.

One consequence of this change is that practically all entity descriptors are part of the `state`, including availability, the device class, and so on. This in theory will give us the ability to react to changes to these fundamental descriptors on the Home Assistant side.

This is part of / a requirement for:
- https://github.com/OpenHomeFoundation/roadmap/issues/93