### PR TITLE
Add `OccupancySensing` PIR delay entities

### DIFF
--- a/tests/data/devices/ikea-of-sweden-vallhorn-wireless-motion-sensor.json
+++ b/tests/data/devices/ikea-of-sweden-vallhorn-wireless-motion-sensor.json
@@ -551,6 +551,100 @@
           "available": true,
           "state": null
         }
+      },
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "8c:6f:b9:ff:fe:26:3b:4a-2-1030-pir_o_to_u_delay",
+          "migrate_unique_ids": [],
+          "platform": "number",
+          "class_name": "PIROccupiedToUnoccupiedDelayConfigurationEntity",
+          "translation_key": "pir_o_to_u_delay",
+          "translation_placeholders": null,
+          "device_class": "duration",
+          "state_class": null,
+          "entity_category": "config",
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "OccupancySensingClusterHandler",
+              "generic_id": "cluster_handler_0x0406",
+              "endpoint_id": 2,
+              "cluster": {
+                "id": 1030,
+                "name": "Occupancy Sensing",
+                "type": "server"
+              },
+              "id": "2:0x0406",
+              "unique_id": "8c:6f:b9:ff:fe:26:3b:4a:2:0x0406",
+              "status": "INITIALIZED",
+              "value_attribute": "occupancy"
+            }
+          ],
+          "device_ieee": "8c:6f:b9:ff:fe:26:3b:4a",
+          "endpoint_id": 2,
+          "available": true,
+          "group_id": null,
+          "mode": "auto",
+          "native_max_value": 65535,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": "s"
+        },
+        "state": {
+          "class_name": "PIROccupiedToUnoccupiedDelayConfigurationEntity",
+          "available": true,
+          "state": 5
+        }
+      },
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "8c:6f:b9:ff:fe:26:3b:4a-2-1030-pir_u_to_o_delay",
+          "migrate_unique_ids": [],
+          "platform": "number",
+          "class_name": "PIRUnoccupiedToOccupiedDelayConfigurationEntity",
+          "translation_key": "pir_u_to_o_delay",
+          "translation_placeholders": null,
+          "device_class": "duration",
+          "state_class": null,
+          "entity_category": "config",
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "OccupancySensingClusterHandler",
+              "generic_id": "cluster_handler_0x0406",
+              "endpoint_id": 2,
+              "cluster": {
+                "id": 1030,
+                "name": "Occupancy Sensing",
+                "type": "server"
+              },
+              "id": "2:0x0406",
+              "unique_id": "8c:6f:b9:ff:fe:26:3b:4a:2:0x0406",
+              "status": "INITIALIZED",
+              "value_attribute": "occupancy"
+            }
+          ],
+          "device_ieee": "8c:6f:b9:ff:fe:26:3b:4a",
+          "endpoint_id": 2,
+          "available": true,
+          "group_id": null,
+          "mode": "auto",
+          "native_max_value": 65535,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": "s"
+        },
+        "state": {
+          "class_name": "PIRUnoccupiedToOccupiedDelayConfigurationEntity",
+          "available": true,
+          "state": 0
+        }
       }
     ],
     "sensor": [

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -1226,3 +1226,37 @@ class SinopeLightLEDOffIntensityConfigurationEntity(NumberConfigurationEntity):
             }
         ),
     )
+
+
+@register_entity(OccupancySensing.cluster_id)
+class PIROccupiedToUnoccupiedDelayConfigurationEntity(NumberConfigurationEntity):
+    """Representation of a ZHA PIR occupied to unoccupied delay configuration entity."""
+
+    _unique_id_suffix = "pir_o_to_u_delay"
+    _attr_native_min_value: float = 0x0000
+    _attr_native_max_value: float = 0xFFFF
+    _attr_device_class = NumberDeviceClass.DURATION
+    _attr_native_unit_of_measurement: str = UnitOfTime.SECONDS
+    _attribute_name = "pir_o_to_u_delay"
+    _attr_translation_key: str = "pir_o_to_u_delay"
+
+    _cluster_handler_match = ClusterHandlerMatch(
+        cluster_handlers=frozenset({CLUSTER_HANDLER_OCCUPANCY})
+    )
+
+
+@register_entity(OccupancySensing.cluster_id)
+class PIRUnoccupiedToOccupiedDelayConfigurationEntity(NumberConfigurationEntity):
+    """Representation of a ZHA PIR unoccupied to occupied delay configuration entity."""
+
+    _unique_id_suffix = "pir_u_to_o_delay"
+    _attr_native_min_value: float = 0x0000
+    _attr_native_max_value: float = 0xFFFF
+    _attr_device_class = NumberDeviceClass.DURATION
+    _attr_native_unit_of_measurement: str = UnitOfTime.SECONDS
+    _attribute_name = "pir_u_to_o_delay"
+    _attr_translation_key: str = "pir_u_to_o_delay"
+
+    _cluster_handler_match = ClusterHandlerMatch(
+        cluster_handlers=frozenset({CLUSTER_HANDLER_OCCUPANCY})
+    )

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -445,6 +445,59 @@ class StartUpColorTemperatureConfigurationEntity(NumberConfigurationEntity):
         self._attr_native_max_value = self._cluster_handler.max_mireds
 
 
+@register_entity(OccupancySensing.cluster_id)
+class PIROccupiedToUnoccupiedDelayConfigurationEntity(NumberConfigurationEntity):
+    """Representation of a ZHA PIR occupied to unoccupied delay configuration entity."""
+
+    _unique_id_suffix = "pir_o_to_u_delay"
+    _attr_native_min_value: float = 0x0000
+    _attr_native_max_value: float = 0xFFFF
+    _attr_device_class = NumberDeviceClass.DURATION
+    _attr_native_unit_of_measurement: str = UnitOfTime.SECONDS
+    _attribute_name = "pir_o_to_u_delay"
+    _attr_translation_key: str = "pir_o_to_u_delay"
+
+    _cluster_handler_match = ClusterHandlerMatch(
+        cluster_handlers=frozenset({CLUSTER_HANDLER_OCCUPANCY})
+    )
+
+
+@register_entity(OccupancySensing.cluster_id)
+class PIRUnoccupiedToOccupiedDelayConfigurationEntity(NumberConfigurationEntity):
+    """Representation of a ZHA PIR unoccupied to occupied delay configuration entity."""
+
+    _unique_id_suffix = "pir_u_to_o_delay"
+    _attr_native_min_value: float = 0x0000
+    _attr_native_max_value: float = 0xFFFF
+    _attr_device_class = NumberDeviceClass.DURATION
+    _attr_native_unit_of_measurement: str = UnitOfTime.SECONDS
+    _attribute_name = "pir_u_to_o_delay"
+    _attr_translation_key: str = "pir_u_to_o_delay"
+
+    _cluster_handler_match = ClusterHandlerMatch(
+        cluster_handlers=frozenset({CLUSTER_HANDLER_OCCUPANCY})
+    )
+
+
+@register_entity(OccupancySensing.cluster_id)
+class SonoffPresenceSenorTimeout(NumberConfigurationEntity):
+    """Configuration of Sonoff sensor presence detection timeout."""
+
+    _unique_id_suffix = "presence_detection_timeout"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_native_min_value: int = 15
+    _attr_native_max_value: int = 60
+    _attribute_name = "ultrasonic_o_to_u_delay"
+    _attr_translation_key: str = "presence_detection_timeout"
+
+    _attr_mode: NumberMode = NumberMode.BOX
+
+    _cluster_handler_match = ClusterHandlerMatch(
+        cluster_handlers=frozenset({CLUSTER_HANDLER_OCCUPANCY}),
+        models=frozenset({"SNZB-06P", "SNZB-03P"}),
+    )
+
+
 @register_entity(TUYA_MANUFACTURER_CLUSTER)
 class TimerDurationMinutes(NumberConfigurationEntity):
     """Representation of a ZHA timer duration configuration entity."""
@@ -984,25 +1037,6 @@ class BoschThermostatLocalTempCalibration(ThermostatLocalTempCalibration):
     )
 
 
-@register_entity(OccupancySensing.cluster_id)
-class SonoffPresenceSenorTimeout(NumberConfigurationEntity):
-    """Configuration of Sonoff sensor presence detection timeout."""
-
-    _unique_id_suffix = "presence_detection_timeout"
-    _attr_entity_category = EntityCategory.CONFIG
-    _attr_native_min_value: int = 15
-    _attr_native_max_value: int = 60
-    _attribute_name = "ultrasonic_o_to_u_delay"
-    _attr_translation_key: str = "presence_detection_timeout"
-
-    _attr_mode: NumberMode = NumberMode.BOX
-
-    _cluster_handler_match = ClusterHandlerMatch(
-        cluster_handlers=frozenset({CLUSTER_HANDLER_OCCUPANCY}),
-        models=frozenset({"SNZB-06P", "SNZB-03P"}),
-    )
-
-
 class ZCLTemperatureEntity(NumberConfigurationEntity):
     """Common entity class for ZCL temperature input."""
 
@@ -1225,38 +1259,4 @@ class SinopeLightLEDOffIntensityConfigurationEntity(NumberConfigurationEntity):
                 "SW2500ZB-G2",
             }
         ),
-    )
-
-
-@register_entity(OccupancySensing.cluster_id)
-class PIROccupiedToUnoccupiedDelayConfigurationEntity(NumberConfigurationEntity):
-    """Representation of a ZHA PIR occupied to unoccupied delay configuration entity."""
-
-    _unique_id_suffix = "pir_o_to_u_delay"
-    _attr_native_min_value: float = 0x0000
-    _attr_native_max_value: float = 0xFFFF
-    _attr_device_class = NumberDeviceClass.DURATION
-    _attr_native_unit_of_measurement: str = UnitOfTime.SECONDS
-    _attribute_name = "pir_o_to_u_delay"
-    _attr_translation_key: str = "pir_o_to_u_delay"
-
-    _cluster_handler_match = ClusterHandlerMatch(
-        cluster_handlers=frozenset({CLUSTER_HANDLER_OCCUPANCY})
-    )
-
-
-@register_entity(OccupancySensing.cluster_id)
-class PIRUnoccupiedToOccupiedDelayConfigurationEntity(NumberConfigurationEntity):
-    """Representation of a ZHA PIR unoccupied to occupied delay configuration entity."""
-
-    _unique_id_suffix = "pir_u_to_o_delay"
-    _attr_native_min_value: float = 0x0000
-    _attr_native_max_value: float = 0xFFFF
-    _attr_device_class = NumberDeviceClass.DURATION
-    _attr_native_unit_of_measurement: str = UnitOfTime.SECONDS
-    _attribute_name = "pir_u_to_o_delay"
-    _attr_translation_key: str = "pir_u_to_o_delay"
-
-    _cluster_handler_match = ClusterHandlerMatch(
-        cluster_handlers=frozenset({CLUSTER_HANDLER_OCCUPANCY})
     )

--- a/zha/zigbee/cluster_handlers/measurement.py
+++ b/zha/zigbee/cluster_handlers/measurement.py
@@ -85,6 +85,10 @@ class OccupancySensingClusterHandler(ClusterHandler):
             config=REPORT_CONFIG_IMMEDIATE,
         ),
     )
+    ZCL_INIT_ATTRS = {
+        "pir_o_to_u_delay": True,
+        "pir_u_to_o_delay": True,
+    }
 
     def __init__(self, cluster: zigpy.zcl.Cluster, endpoint: Endpoint) -> None:
         """Initialize Occupancy cluster handler."""


### PR DESCRIPTION
TODO: Translations in HA!

## Proposed change

This adds config number entities for the `OccupancySensing` `pir_o_to_u_delay` and `pir_u_to_o_delay` attributes. 
The entity class for the Sonoff sensors (`ultrasonic_o_to_u_delay`) is also moved to be near below the PIR delay classes.


## Additional information

This would avoid introducing quirks v2 entities, e.g. for the Hue sensors or the Frient sensor below:
- https://github.com/zigpy/zha-device-handlers/pull/4427

IIRC there was an issue with Hue sensors returning this attribute was unsupported during pairing, but maybe that was only an issue because of the manufacturer code stuff we had going on. I'll need to recheck that.

### Sonoff specific entity – `ultrasonic_o_to_u_delay`

In the future, we may wanna look at exposing that entity for all devices, just with the limits removed.
All these entities will end up using the `BOX` `NumberMode` in HA anyway (where you can even enter numbers outside min/max IIRC), so these limits are more artificial.

TODO: Also look at attributes in `SonoffPresenceSenorTimeout` (device class + unit of measurement + unnecessary attributes). This can be done in a separate PR.