### PR TITLE
Buffer brightness attribute reports during light transitions

### DIFF
--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -2009,6 +2009,65 @@ async def test_transition_brightness_buffering(zha_gateway: Gateway) -> None:
     assert entity.state["brightness"] == 150  # target preserved
 
 
+@patch(
+    "zigpy.zcl.clusters.general.LevelControl.request",
+    new=AsyncMock(return_value=[sentinel.data, zcl_f.Status.SUCCESS]),
+)
+@patch(
+    "zigpy.zcl.clusters.general.OnOff.request",
+    new=AsyncMock(return_value=[sentinel.data, zcl_f.Status.SUCCESS]),
+)
+async def test_turn_on_during_off_transition(zha_gateway: Gateway) -> None:
+    """Test turning a light on while it is mid-way through an off transition.
+
+    Some devices refuse to turn on while a transition to off is still running,
+    even though they return Status.SUCCESS for the on command. The device then
+    correctly reports on_off=false. That report must be buffered and applied
+    when the transition window ends, so HA reflects the actual off state.
+    """
+    device_light_1 = await device_light_1_mock(zha_gateway)
+    dev1_cluster_on_off = device_light_1.device.endpoints[1].on_off
+    entity = get_entity(device_light_1, platform=Platform.LIGHT)
+
+    # Start with the light on.
+    await entity.async_turn_on(brightness=200)
+    await zha_gateway.async_block_till_done()
+    assert bool(entity.state["on"]) is True
+
+    # Turn it off with a transition (timer runs for 1 + 0.5s = 1.5s).
+    await entity.async_turn_off(transition=1)
+    await zha_gateway.async_block_till_done()
+    assert bool(entity.state["on"]) is False
+    assert entity.is_transitioning
+
+    # Before the off-transition timer fires, turn the light back on.
+    # The device accepts the command (returns SUCCESS) but refuses to execute it.
+    await entity.async_turn_on(brightness=150)
+    await zha_gateway.async_block_till_done()
+    # Optimistically, HA now thinks it's on.
+    assert bool(entity.state["on"]) is True
+    assert entity.state["brightness"] == 150
+    assert entity.is_transitioning
+
+    # The device correctly reports it is still off (it refused the on command).
+    # This must be buffered, not ignored.
+    await send_attributes_report(
+        zha_gateway,
+        dev1_cluster_on_off,
+        {general.OnOff.AttributeDefs.on_off.id: 0},
+    )
+    await zha_gateway.async_block_till_done()
+
+    # During the transition window the state is still optimistically on.
+    assert bool(entity.state["on"]) is True
+
+    # Once the transition timer fires, the buffered off report is applied.
+    await asyncio.sleep(0.8)
+    await zha_gateway.async_block_till_done()
+    assert not entity.is_transitioning
+    assert bool(entity.state["on"]) is False
+
+
 async def test_light_state_restoration(zha_gateway: Gateway) -> None:
     """Test the light state restoration function."""
     device_light_3 = await device_light_3_mock(zha_gateway)

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -1937,6 +1937,78 @@ async def test_group_member_assume_state(zha_gateway: Gateway) -> None:
     assert device_2_light_entity.state["brightness"] == 100
 
 
+@patch(
+    "zigpy.zcl.clusters.general.LevelControl.request",
+    new=AsyncMock(return_value=[sentinel.data, zcl_f.Status.SUCCESS]),
+)
+@patch(
+    "zigpy.zcl.clusters.general.OnOff.request",
+    new=AsyncMock(return_value=[sentinel.data, zcl_f.Status.SUCCESS]),
+)
+async def test_transition_brightness_buffering(zha_gateway: Gateway) -> None:
+    """Test that brightness reports during a transition are buffered.
+
+    The last received report is applied when the transition completes, which
+    handles lights that claim SUCCESS but fail to reach the target brightness.
+    """
+    device_light_1 = await device_light_1_mock(zha_gateway)
+    dev1_cluster_level = device_light_1.device.endpoints[1].level
+    entity = get_entity(device_light_1, platform=Platform.LIGHT)
+
+    assert bool(entity.state["on"]) is False
+
+    # Turn on with a short transition and a target brightness of 200.
+    await entity.async_turn_on(transition=0.1, brightness=200)
+    await zha_gateway.async_block_till_done()
+
+    # The state is optimistically set to the target brightness immediately.
+    assert bool(entity.state["on"]) is True
+    assert entity.state["brightness"] == 200
+    assert entity.is_transitioning
+
+    # Simulate intermediate brightness reports during the transition (light slowly ramping up).
+    # These should be buffered, not immediately applied to HA state.
+    await send_attributes_report(
+        zha_gateway,
+        dev1_cluster_level,
+        {general.LevelControl.AttributeDefs.current_level.id: 50},
+    )
+    await zha_gateway.async_block_till_done()
+    assert entity.state["brightness"] == 200  # still the optimistic value
+
+    # The light only goes to brightness 120 (for some reason), not the requested 200.
+    await send_attributes_report(
+        zha_gateway,
+        dev1_cluster_level,
+        {general.LevelControl.AttributeDefs.current_level.id: 120},
+    )
+    await zha_gateway.async_block_till_done()
+    assert entity.state["brightness"] == 200  # still buffered, not yet applied
+
+    # Wait for the transition timer to fire (0.1 + 0.5s delay = 0.6s).
+    await asyncio.sleep(0.8)
+    await zha_gateway.async_block_till_done()
+
+    # After the transition, the last buffered report (120) is applied instead of the target (200).
+    assert not entity.is_transitioning
+    assert entity.state["brightness"] == 120
+
+    # Now verify that if no brightness reports arrive during a transition, the
+    # optimistically set target brightness is preserved unchanged.
+    await entity.async_turn_on(transition=0.1, brightness=150)
+    await zha_gateway.async_block_till_done()
+
+    assert entity.state["brightness"] == 150
+    assert entity.is_transitioning
+
+    # No level reports during this transition.
+    await asyncio.sleep(0.8)
+    await zha_gateway.async_block_till_done()
+
+    assert not entity.is_transitioning
+    assert entity.state["brightness"] == 150  # target preserved
+
+
 async def test_light_state_restoration(zha_gateway: Gateway) -> None:
     """Test the light state restoration function."""
     device_light_3 = await device_light_3_mock(zha_gateway)

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -283,6 +283,7 @@ class BaseClusterHandlerLight(BaseLight):
         self._transitioning_individual: bool = False
         self._transitioning_group: bool = False
         self._transition_listener: asyncio.TimerHandle | None = None
+        self._transition_brightness_buffer: int | None = None
 
         self._internal_supported_color_modes: set[ColorMode] = set()
 
@@ -686,6 +687,7 @@ class BaseClusterHandlerLight(BaseLight):
         self.debug("setting transitioning flag to True")
         self._transitioning_individual = True
         self._transitioning_group = False
+        self._transition_brightness_buffer = None
         if isinstance(self, LightGroup):
             for platform_entity in self.group.get_platform_entities(Light.PLATFORM):
                 assert isinstance(platform_entity, Light)
@@ -724,6 +726,13 @@ class BaseClusterHandlerLight(BaseLight):
         self.debug("transition complete - future attribute reports will write HA state")
         self._transitioning_individual = False
         self._async_unsub_transition_listener()
+        if self._transition_brightness_buffer is not None:
+            self.debug(
+                "applying buffered brightness %s from transition",
+                self._transition_brightness_buffer,
+            )
+            self._brightness = self._transition_brightness_buffer
+            self._transition_brightness_buffer = None
         self.maybe_emit_state_changed_event()
         if isinstance(self, LightGroup):
             for platform_entity in self.group.get_platform_entities(Light.PLATFORM):
@@ -880,13 +889,14 @@ class Light(BaseClusterHandlerLight, PlatformEntity):
         on at `on_level` Zigbee attribute value, regardless of the last set
         level
         """
+        value = max(0, min(254, event.level))
         if self.is_transitioning:
             self.debug(
-                "received level change event %s while transitioning - skipping update",
+                "received level change event %s while transitioning - buffering",
                 event,
             )
+            self._transition_brightness_buffer = value
             return
-        value = max(0, min(254, event.level))
         self._brightness = value
         self.maybe_emit_state_changed_event()
 

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -284,6 +284,7 @@ class BaseClusterHandlerLight(BaseLight):
         self._transitioning_group: bool = False
         self._transition_listener: asyncio.TimerHandle | None = None
         self._transition_brightness_buffer: int | None = None
+        self._transition_on_off_buffer: bool | None = None
 
         self._internal_supported_color_modes: set[ColorMode] = set()
 
@@ -688,6 +689,7 @@ class BaseClusterHandlerLight(BaseLight):
         self._transitioning_individual = True
         self._transitioning_group = False
         self._transition_brightness_buffer = None
+        self._transition_on_off_buffer = None
         if isinstance(self, LightGroup):
             for platform_entity in self.group.get_platform_entities(Light.PLATFORM):
                 assert isinstance(platform_entity, Light)
@@ -733,6 +735,16 @@ class BaseClusterHandlerLight(BaseLight):
             )
             self._brightness = self._transition_brightness_buffer
             self._transition_brightness_buffer = None
+        if self._transition_on_off_buffer is not None:
+            self.debug(
+                "applying buffered on/off %s from transition",
+                self._transition_on_off_buffer,
+            )
+            self._state = self._transition_on_off_buffer
+            if self._transition_on_off_buffer:
+                self._off_with_transition = False
+                self._off_brightness = None
+            self._transition_on_off_buffer = None
         self.maybe_emit_state_changed_event()
         if isinstance(self, LightGroup):
             for platform_entity in self.group.get_platform_entities(Light.PLATFORM):
@@ -953,9 +965,10 @@ class Light(BaseClusterHandlerLight, PlatformEntity):
             return
         if self.is_transitioning:
             self.debug(
-                "received onoff %s while transitioning - skipping update",
+                "received onoff %s while transitioning - buffering",
                 event.attribute_value,
             )
+            self._transition_on_off_buffer = bool(event.attribute_value)
             return
         self._state = bool(event.attribute_value)
         if event.attribute_value:

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -284,7 +284,6 @@ class BaseClusterHandlerLight(BaseLight):
         self._transitioning_group: bool = False
         self._transition_listener: asyncio.TimerHandle | None = None
         self._transition_brightness_buffer: int | None = None
-        self._transition_on_off_buffer: bool | None = None
 
         self._internal_supported_color_modes: set[ColorMode] = set()
 
@@ -689,7 +688,6 @@ class BaseClusterHandlerLight(BaseLight):
         self._transitioning_individual = True
         self._transitioning_group = False
         self._transition_brightness_buffer = None
-        self._transition_on_off_buffer = None
         if isinstance(self, LightGroup):
             for platform_entity in self.group.get_platform_entities(Light.PLATFORM):
                 assert isinstance(platform_entity, Light)
@@ -733,18 +731,12 @@ class BaseClusterHandlerLight(BaseLight):
                 "applying buffered brightness %s from transition",
                 self._transition_brightness_buffer,
             )
-            self._brightness = self._transition_brightness_buffer
+            if self._transition_brightness_buffer == 0:
+                # The device is actually off; override the optimistic on-state.
+                self._state = False
+            else:
+                self._brightness = self._transition_brightness_buffer
             self._transition_brightness_buffer = None
-        if self._transition_on_off_buffer is not None:
-            self.debug(
-                "applying buffered on/off %s from transition",
-                self._transition_on_off_buffer,
-            )
-            self._state = self._transition_on_off_buffer
-            if self._transition_on_off_buffer:
-                self._off_with_transition = False
-                self._off_brightness = None
-            self._transition_on_off_buffer = None
         self.maybe_emit_state_changed_event()
         if isinstance(self, LightGroup):
             for platform_entity in self.group.get_platform_entities(Light.PLATFORM):
@@ -968,7 +960,8 @@ class Light(BaseClusterHandlerLight, PlatformEntity):
                 "received onoff %s while transitioning - buffering",
                 event.attribute_value,
             )
-            self._transition_on_off_buffer = bool(event.attribute_value)
+            if not event.attribute_value:
+                self._transition_brightness_buffer = 0
             return
         self._state = bool(event.attribute_value)
         if event.attribute_value:

--- a/zha/application/platforms/light/const.py
+++ b/zha/application/platforms/light/const.py
@@ -7,7 +7,7 @@ from zigpy.profiles import zha, zll
 from zigpy.zcl.clusters.general import Identify
 
 DEFAULT_ON_OFF_TRANSITION = 1  # most bulbs default to a 1-second turn on/off transition
-DEFAULT_EXTRA_TRANSITION_DELAY_SHORT = 0.25
+DEFAULT_EXTRA_TRANSITION_DELAY_SHORT = 0.5
 DEFAULT_EXTRA_TRANSITION_DELAY_LONG = 2.0
 DEFAULT_LONG_TRANSITION_TIME = 10
 DEFAULT_MIN_BRIGHTNESS = 2


### PR DESCRIPTION
## Proposed change

Instead of ignoring brightness attribute reports during a light transition, we buffer them and apply the last received value when the transition completes.

## Additional information

Currently, we ignore all brightness attribute reports during a light transition. If a user were to use a remote directly bound to the light during a transition, we'd currently have an incorrect state at the end.

Also, there are some lights (or dimmers to be exact) which acknowledge an `on` command during an already ongoing transition to off-state, but then immediately send an attribute report from the `OnOff` cluster that they're off. We expect them to be on, as that's what the user last sent.

This seems to be some kind of firmware bug unique to these dimmers, but we should still handle this better in ZHA.
But it seems like the device does support `move_to_level_with_on_off` commands during an off-transition to turn back on, just not pure `on` commands.....

## Side-note/future issue

There's likely also an issue where a HA `restart` mode automation cancels the ongoing `turn_on` task during the Zigbee `on` call, so we end up with a flag that is never reset, as the timer has not started.
Maybe we can just catch `CancelledError` and reset the flag (+ initiate a poll and/or emit updated state, as the light can be in some kind of in-between state)? Or actually, we can just use `finally:` to complete the timer?

## AI summary

## Problem

- When turning on a Zigbee light, many bulbs apply a default 1-second transition. During this time the bulb sends attribute reports with a slowly increasing brightness level. Previously, these intermediate reports were completely ignored while `is_transitioning` was `True`, and we showed the optimistically-set target brightness, until another attribute report came in AFTER the transition.
  - This worked well for well-behaved lights, but if a light refuses to turn on while still returning `Status.SUCCESS` for the turn-on command, we'd always show the (never-reached) target brightness, not updating it to the actual brightness afterwards, even if it sent a "correct" `on_off=false` attribute report during the supposed transition.
  - A related issue occurs when turning a light **on** while it is mid-way through an **off** transition: the device may refuse the on command (returning SUCCESS anyway) and report `on_off=false` to correctly reflect that it is still off. Previously this report was silently dropped, causing HA to show the light as on indefinitely.
  - If a user used a remote directly bound to a light during a ZHA-initiated transition, we'd also end up with wrong state in HA.
- A secondary issue was that `DEFAULT_EXTRA_TRANSITION_DELAY_SHORT` (previously 0.25 s) was short enough that a late-arriving attribute report could slip through *after* the flag cleared and be applied directly to state, briefly showing a stale intermediate brightness.
  - Note: This wasn't a real issue until now, as we just ignored all attribute reports during a transition, so if the final one arrived after (rare, but happened), it would be the same as the target brightness we had already set. Now, the brightness would assume the last 

## Solution

Instead of discarding attribute reports during a transition, the last received value is now buffered in `_transition_brightness_buffer`. When `async_transition_complete` fires at the end of the transition window, the buffer is applied before emitting state:

- A non-zero buffered brightness is used as the final `_brightness` (reflecting what the device actually reached).
- A buffered value of `0` — written when an `on_off=false` report arrives — overrides `_state` to `False`, correctly reflecting a device that refused to turn on.
- `on_off=true` reports during a transition are still skipped (the optimistic state is already correct).

Reports during transition are still not shown in Home Assistant (no intermediate state flicker). The buffer is cleared when a new transition starts so stale values can never bleed through.

`DEFAULT_EXTRA_TRANSITION_DELAY_SHORT` is increased from 0.25 s to 0.5 s to ensure any report that arrives slightly after the physical transition ends is still captured in the buffer rather than applied to state directly.

## Changes

- `zha/application/platforms/light/const.py` — `DEFAULT_EXTRA_TRANSITION_DELAY_SHORT`: 0.25 → 0.5
- `zha/application/platforms/light/__init__.py`
  - Add `_transition_brightness_buffer` field to `BaseClusterHandlerLight`
  - Clear buffer at the start of each transition (`async_transition_set_flag`)
  - Buffer the last brightness report in `handle_cluster_handler_set_level` instead of silently ignoring it
  - Buffer `on_off=false` as brightness `0` in `handle_cluster_handler_attribute_updated`
  - Apply the buffer in `async_transition_complete`: non-zero → update `_brightness`; zero → set `_state = False`
- `tests/test_light.py`
  - `test_transition_brightness_buffering`: verifies intermediate reports are buffered and the last value is applied on completion; also verifies that when no reports arrive the optimistic target is preserved
  - `test_turn_on_during_off_transition`: verifies that a device which refuses to turn on during an off-transition correctly ends up shown as off in HA once the transition window closes