### PR TITLE
Remove request `isinstance` `Exception` checks from switch

### DIFF
--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -292,7 +292,7 @@ class SwitchGroup(GroupEntity, BaseSwitch):
     async def async_turn_on(self) -> None:
         """Turn the entity on."""
         result = await self._on_off_cluster_handler.on()
-        if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
+        if result[1] is not Status.SUCCESS:
             return
         self._state = True
         self.maybe_emit_state_changed_event()
@@ -300,7 +300,7 @@ class SwitchGroup(GroupEntity, BaseSwitch):
     async def async_turn_off(self) -> None:
         """Turn the entity off."""
         result = await self._on_off_cluster_handler.off()
-        if isinstance(result, Exception) or result[1] is not Status.SUCCESS:
+        if result[1] is not Status.SUCCESS:
             return
         self._state = False
         self.maybe_emit_state_changed_event()


### PR DESCRIPTION
This removes two dead `isinstance` check in the switch platform. Zigpy cannot return an exception as the result here. It'll always raise instead.

Another PR will remove all `Status.SUCCESS` checks for the result. We'll have to be slightly more careful with that change because ZCL errors like `UNSUPP_CLUSTER_COMMAND` don't raise(?) But they should also never occur, really.

Related discussion in:
- https://github.com/zigpy/zha/pull/672#discussion_r2850410343