### PR TITLE
Use attribute names for `send_attributes_report` in tests

### DIFF
--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -556,11 +556,11 @@ async def test_fan_ikea(
     assert entity.state["is_on"] is False
 
     # turn on at fan
-    await send_attributes_report(zha_gateway, cluster, {6: 1})
+    await send_attributes_report(zha_gateway, cluster, {"fan_mode": 1})
     assert entity.state["is_on"] is True
 
     # turn off at fan
-    await send_attributes_report(zha_gateway, cluster, {6: 0})
+    await send_attributes_report(zha_gateway, cluster, {"fan_mode": 0})
     assert entity.state["is_on"] is False
 
     # turn on from HA

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1546,7 +1546,7 @@ async def test_timestamp_sensor_v2(zha_gateway: Gateway) -> None:
     assert isinstance(zha_device.device, CustomDeviceV2)
     entity = get_entity(zha_device, platform=Platform.SENSOR, qualifier="start_time")
 
-    await send_attributes_report(zha_gateway, cluster, {0xEF65: 781355715})
+    await send_attributes_report(zha_gateway, cluster, {"start_time": 781355715})
     assert entity.state["state"] == datetime(2024, 10, 4, 11, 15, 15, tzinfo=UTC)
 
 
@@ -1650,10 +1650,10 @@ async def test_last_feeding_size_sensor_v2(zha_gateway: Gateway) -> None:
         zha_device, platform=Platform.SENSOR, qualifier="last_feeding_size"
     )
 
-    await send_attributes_report(zha_gateway, cluster, {0x010C: 1})
+    await send_attributes_report(zha_gateway, cluster, {"last_feeding_size": 1})
     assert_state(entity, 1.0, "g")
 
-    await send_attributes_report(zha_gateway, cluster, {0x010C: 5})
+    await send_attributes_report(zha_gateway, cluster, {"last_feeding_size": 5})
     assert_state(entity, 5.0, "g")
 
 
@@ -1978,7 +1978,7 @@ async def test_danfoss_thermostat_sw_error(zha_gateway: Gateway) -> None:
         zha_gateway,
         cluster,
         {
-            danfoss_thermostat.DanfossDiagnosticCluster.AttributeDefs.sw_error_code.id: 0x0001
+            danfoss_thermostat.DanfossDiagnosticCluster.AttributeDefs.sw_error_code.name: 0x0001
         },
     )
 


### PR DESCRIPTION
## Proposed change

In preparation for bumping zigpy to 1.0.0 with https://github.com/zigpy/zha/pull/679, we need to adapt our tests to send attribute reports with the correct manufacturer code due to https://github.com/zigpy/zigpy/pull/1775. With https://github.com/zigpy/zha/pull/637, some tests were already updated to provide the attribute name (instead of ID) to `send_attributes_report`. This updates the tests that also require this for the new zigpy version.

## Additional information

We may want to revisit `send_attributes_report`, since using `None` manufacturer code when providing an ID is not fully correct: https://github.com/zigpy/zha/blob/c5a3171597848515b5a90bb6ed13b12972f75415/tests/common.py#L141-L143

`find_attribute` could be used and determine the `ZCLAttributeDef` if there's only matching definition by ID.
We could also simply prevent allowing providing attribute IDs to this. It's better if all tests provided attribute names or `ZCLAttributeDef` references directly.
... or we just leave it like this and accept that it should basically never be used.