### PR TITLE
Disable device availability checker during diagnostics regeneration

### DIFF
--- a/tools/regenerate_diagnostics.py
+++ b/tools/regenerate_diagnostics.py
@@ -38,6 +38,12 @@ async def main(files: list[str] | None = None) -> None:
         paths = [pathlib.Path(f) for f in files]
 
     async with create_zha_gateway() as zha_gateway:
+        # Regeneration should be deterministic: disable background tasks that can
+        # asynchronously mutate device availability while fixtures are being written.
+        zha_gateway.global_updater.stop()
+        zha_gateway._device_availability_checker.stop()  # noqa: SLF001
+        zha_gateway.config.allow_polling = False
+
         for device_json in paths:
             _LOGGER.info("Migrating %s", device_json)
             zigpy_device = await zigpy_device_from_json(


### PR DESCRIPTION
## Proposed change

This disable device availability checker during diagnostics regeneration.
At the moment, there's a rare issue where you can manage to regenerate diagnostics with `available` being set to `false` everywhere, as the checker starts after 30 to 45 seconds of running diagnostics regeneration.

It's possible that the implementation can be cleaned up. Just wanted to put it into a PR for now.