### PR TITLE
Log unique ID conflicts

### DIFF
--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -976,6 +976,51 @@ class Device(LogMixin, EventBase):
             entity.on_add()
             self._pending_entities.append(entity)
 
+    @staticmethod
+    def _entity_class_path(entity: BaseEntity) -> tuple[str, str]:
+        """Return module and class name for an entity."""
+        return (entity.__class__.__module__, entity.__class__.__name__)
+
+    @staticmethod
+    def _entity_endpoint_id(entity: BaseEntity) -> int | None:
+        """Return endpoint id if this is a platform entity."""
+        if not isinstance(entity, PlatformEntity):
+            return None
+        return entity.endpoint.id
+
+    @staticmethod
+    def _entity_cluster_handler_names(entity: BaseEntity) -> list[str]:
+        """Return cluster handler names if this is a platform entity."""
+        if not isinstance(entity, PlatformEntity):
+            return []
+        return sorted(entity.cluster_handlers.keys())
+
+    def _log_entity_unique_id_conflict(
+        self,
+        key: tuple[Platform, str],
+        existing_entity: BaseEntity,
+        duplicate_entity: BaseEntity,
+    ) -> None:
+        """Log duplicate unique_id collisions when classes differ."""
+        existing_class = self._entity_class_path(existing_entity)
+        duplicate_class = self._entity_class_path(duplicate_entity)
+        if existing_class == duplicate_class:
+            return
+
+        _LOGGER.warning(
+            "Entity unique_id conflict on device %s for %s: keeping %s "
+            "(endpoint=%s, cluster_handlers=%s), dropping %s "
+            "(endpoint=%s, cluster_handlers=%s)",
+            self.ieee,
+            key,
+            ".".join(existing_class),
+            self._entity_endpoint_id(existing_entity),
+            self._entity_cluster_handler_names(existing_entity),
+            ".".join(duplicate_class),
+            self._entity_endpoint_id(duplicate_entity),
+            self._entity_cluster_handler_names(duplicate_entity),
+        )
+
     async def async_initialize(self, from_cache: bool = False) -> None:
         """Initialize cluster handlers."""
         self.debug("started initialization")
@@ -1012,43 +1057,7 @@ class Device(LogMixin, EventBase):
 
             # Ignore entities that already exist
             if key in new_entities:
-                existing_entity = new_entities[key]
-                existing_class = (
-                    existing_entity.__class__.__module__,
-                    existing_entity.__class__.__name__,
-                )
-                duplicate_class = (
-                    entity.__class__.__module__,
-                    entity.__class__.__name__,
-                )
-
-                if existing_class != duplicate_class:
-                    existing_endpoint_id = getattr(
-                        getattr(existing_entity, "endpoint", None), "id", None
-                    )
-                    duplicate_endpoint_id = getattr(
-                        getattr(entity, "endpoint", None), "id", None
-                    )
-                    existing_handlers = sorted(
-                        getattr(existing_entity, "cluster_handlers", {}).keys()
-                    )
-                    duplicate_handlers = sorted(
-                        getattr(entity, "cluster_handlers", {}).keys()
-                    )
-                    _LOGGER.warning(
-                        "Entity unique_id conflict on device %s for %s: keeping %s "
-                        "(endpoint=%s, cluster_handlers=%s), dropping %s "
-                        "(endpoint=%s, cluster_handlers=%s)",
-                        self.ieee,
-                        key,
-                        ".".join(existing_class),
-                        existing_endpoint_id,
-                        existing_handlers,
-                        ".".join(duplicate_class),
-                        duplicate_endpoint_id,
-                        duplicate_handlers,
-                    )
-
+                self._log_entity_unique_id_conflict(key, new_entities[key], entity)
                 await entity.on_remove()
                 continue
 

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -1012,6 +1012,43 @@ class Device(LogMixin, EventBase):
 
             # Ignore entities that already exist
             if key in new_entities:
+                existing_entity = new_entities[key]
+                existing_class = (
+                    existing_entity.__class__.__module__,
+                    existing_entity.__class__.__name__,
+                )
+                duplicate_class = (
+                    entity.__class__.__module__,
+                    entity.__class__.__name__,
+                )
+
+                if existing_class != duplicate_class:
+                    existing_endpoint_id = getattr(
+                        getattr(existing_entity, "endpoint", None), "id", None
+                    )
+                    duplicate_endpoint_id = getattr(
+                        getattr(entity, "endpoint", None), "id", None
+                    )
+                    existing_handlers = sorted(
+                        getattr(existing_entity, "cluster_handlers", {}).keys()
+                    )
+                    duplicate_handlers = sorted(
+                        getattr(entity, "cluster_handlers", {}).keys()
+                    )
+                    _LOGGER.warning(
+                        "Entity unique_id conflict on device %s for %s: keeping %s "
+                        "(endpoint=%s, cluster_handlers=%s), dropping %s "
+                        "(endpoint=%s, cluster_handlers=%s)",
+                        self.ieee,
+                        key,
+                        ".".join(existing_class),
+                        existing_endpoint_id,
+                        existing_handlers,
+                        ".".join(duplicate_class),
+                        duplicate_endpoint_id,
+                        duplicate_handlers,
+                    )
+
                 await entity.on_remove()
                 continue
 


### PR DESCRIPTION
This is experimental. It prints all unique ID conflicts (four times...)

These are existing ones:
```python
zha.zigbee.device[69476] WARNING Entity unique_id conflict on device ab:cd:ef:12:63:c6:80:fe for (<Platform.UPDATE: 'update'>, 'ab:cd:ef:12:63:c6:80:fe-1-25-firmware_update'): keeping zha.application.platforms.update.FirmwareUpdateEntity (endpoint=1, cluster_handlers=['ota']), dropping zha.application.platforms.update.FirmwareUpdateServerEntity (endpoint=1, cluster_handlers=['ota'])
zha.zigbee.device[69476] WARNING Entity unique_id conflict on device 00:15:8d:00:02:af:97:27 for (<Platform.UPDATE: 'update'>, '00:15:8d:00:02:af:97:27-1-25-firmware_update'): keeping zha.application.platforms.update.FirmwareUpdateEntity (endpoint=1, cluster_handlers=['ota']), dropping zha.application.platforms.update.FirmwareUpdateServerEntity (endpoint=1, cluster_handlers=['ota'])
zha.zigbee.device[69476] WARNING Entity unique_id conflict on device 54:ef:44:10:00:14:f3:e7 for (<Platform.UPDATE: 'update'>, '54:ef:44:10:00:14:f3:e7-1-25-firmware_update'): keeping zha.application.platforms.update.FirmwareUpdateEntity (endpoint=1, cluster_handlers=['ota']), dropping zha.application.platforms.update.FirmwareUpdateServerEntity (endpoint=1, cluster_handlers=['ota'])
zha.zigbee.device[69476] WARNING Entity unique_id conflict on device 00:15:8d:00:02:54:cb:fa for (<Platform.UPDATE: 'update'>, '00:15:8d:00:02:54:cb:fa-1-25-firmware_update'): keeping zha.application.platforms.update.FirmwareUpdateEntity (endpoint=1, cluster_handlers=['ota']), dropping zha.application.platforms.update.FirmwareUpdateServerEntity (endpoint=1, cluster_handlers=['ota'])
zha.zigbee.device[69476] WARNING Entity unique_id conflict on device ab:cd:ef:12:7b:7c:3f:a7 for (<Platform.UPDATE: 'update'>, 'ab:cd:ef:12:7b:7c:3f:a7-232-25-firmware_update'): keeping zha.application.platforms.update.FirmwareUpdateEntity (endpoint=232, cluster_handlers=['ota']), dropping zha.application.platforms.update.FirmwareUpdateServerEntity (endpoint=232, cluster_handlers=['ota'])
zha.zigbee.device[69476] WARNING Entity unique_id conflict on device ab:cd:ef:12:c1:6d:31:24 for (<Platform.UPDATE: 'update'>, 'ab:cd:ef:12:c1:6d:31:24-1-25-firmware_update'): keeping zha.application.platforms.update.FirmwareUpdateEntity (endpoint=1, cluster_handlers=['ota']), dropping zha.application.platforms.update.FirmwareUpdateServerEntity (endpoint=1, cluster_handlers=['ota'])
zha.zigbee.device[69476] WARNING Entity unique_id conflict on device ab:cd:ef:12:35:1a:bf:9e for (<Platform.UPDATE: 'update'>, 'ab:cd:ef:12:35:1a:bf:9e-1-25-firmware_update'): keeping zha.application.platforms.update.FirmwareUpdateEntity (endpoint=1, cluster_handlers=['ota']), dropping zha.application.platforms.update.FirmwareUpdateServerEntity (endpoint=1, cluster_handlers=['ota'])
```