### PR TITLE
Use `feature_priority` for update entities

### DIFF
--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -72,6 +72,9 @@ class PlatformFeatureGroup(StrEnum):
     # Model-specific overrides for local temperature calibration
     LOCAL_TEMPERATURE_CALIBRATION = "local_temperature_calibration"
 
+    # Prefer OTA client update entities over OTA server update entities
+    OTA_UPDATE = "ota_update"
+
 
 @dataclasses.dataclass(frozen=True)
 class ClusterHandlerMatch:

--- a/zha/application/platforms/update.py
+++ b/zha/application/platforms/update.py
@@ -20,6 +20,7 @@ from zha.application.platforms import (
     ClusterHandlerMatch,
     EntityCategory,
     PlatformEntity,
+    PlatformFeatureGroup,
     register_entity,
 )
 from zha.exceptions import ZHAException
@@ -285,7 +286,8 @@ class FirmwareUpdateEntity(BaseFirmwareUpdateEntity):
     _unique_id_suffix = "firmware_update"
 
     _cluster_handler_match = ClusterHandlerMatch(
-        client_cluster_handlers=frozenset({CLUSTER_HANDLER_OTA})
+        client_cluster_handlers=frozenset({CLUSTER_HANDLER_OTA}),
+        feature_priority=(PlatformFeatureGroup.OTA_UPDATE, 1),
     )
 
     def __init__(
@@ -335,7 +337,8 @@ class FirmwareUpdateServerEntity(BaseFirmwareUpdateEntity):
 
     _unique_id_suffix = "firmware_update"
     _cluster_handler_match = ClusterHandlerMatch(
-        cluster_handlers=frozenset({CLUSTER_HANDLER_OTA})
+        cluster_handlers=frozenset({CLUSTER_HANDLER_OTA}),
+        feature_priority=(PlatformFeatureGroup.OTA_UPDATE, 0),
     )
 
     def __init__(


### PR DESCRIPTION
## Proposed change

This introduces `feature_priority` for update entities.

Currently, there's an issue where both the update entity for the client OTA cluster and the one for the server OTA cluster are discovered. If there's both an `in` and  `out` OTA cluster present on a device (endpoint), the `unique_id` will conflict, with no warnings logged. The client OTA entity class indirectly takes precedence due to definition order.

This PR changes that to have only one entity be truly discovered, making the priority more explicit: client, then server.
For all affected devices in our diagnostics, see: https://github.com/zigpy/zha/pull/683

## Additional information

Note: We can also prefer the server OTA entity if that's better, without causing breaking changes in HA. The  `unique_id` stays the same after all. But I don't know which one actually works on these devices. Client is generally the way to do it.