### PR TITLE
Recompute cover capabilities on `window_covering_type` change

### DIFF
--- a/tests/data/devices/aeotec-zga004.json
+++ b/tests/data/devices/aeotec-zga004.json
@@ -643,7 +643,8 @@
           "state": "closed",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": true
+          "is_closed": true,
+          "supported_features": 15
         }
       },
       {
@@ -690,7 +691,8 @@
           "state": "closed",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": true
+          "is_closed": true,
+          "supported_features": 240
         }
       }
     ],

--- a/tests/data/devices/aqara-lumi-curtain-acn04.json
+++ b/tests/data/devices/aqara-lumi-curtain-acn04.json
@@ -249,7 +249,8 @@
           "state": "open",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": false
+          "is_closed": false,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/aqara-lumi-switch-aeu003.json
+++ b/tests/data/devices/aqara-lumi-switch-aeu003.json
@@ -797,7 +797,8 @@
           "state": "open",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": false
+          "is_closed": false,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/bosch-rbsh-mms-zb-eu.json
+++ b/tests/data/devices/bosch-rbsh-mms-zb-eu.json
@@ -738,7 +738,8 @@
           "state": "open",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": false
+          "is_closed": false,
+          "supported_features": 255
         }
       }
     ],

--- a/tests/data/devices/ikea-of-sweden-fyrtur-block-out-roller-blind.json
+++ b/tests/data/devices/ikea-of-sweden-fyrtur-block-out-roller-blind.json
@@ -354,7 +354,8 @@
           "state": "closed",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": true
+          "is_closed": true,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/ikea-of-sweden-praktlysing-cellular-blind.json
+++ b/tests/data/devices/ikea-of-sweden-praktlysing-cellular-blind.json
@@ -361,7 +361,8 @@
           "state": "closed",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": true
+          "is_closed": true,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/lumi-lumi-curtain-acn002.json
+++ b/tests/data/devices/lumi-lumi-curtain-acn002.json
@@ -567,7 +567,8 @@
           "state": "closed",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": true
+          "is_closed": true,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/lumi-lumi-curtain-acn003.json
+++ b/tests/data/devices/lumi-lumi-curtain-acn003.json
@@ -280,7 +280,8 @@
           "state": "closed",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": true
+          "is_closed": true,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/lumi-lumi-curtain-agl001.json
+++ b/tests/data/devices/lumi-lumi-curtain-agl001.json
@@ -448,7 +448,8 @@
           "state": "open",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": false
+          "is_closed": false,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/lumi-lumi-curtain-hagl04.json
+++ b/tests/data/devices/lumi-lumi-curtain-hagl04.json
@@ -354,7 +354,8 @@
           "state": null,
           "is_opening": null,
           "is_closing": null,
-          "is_closed": null
+          "is_closed": null,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/niko-nv-connectable-motor-control-3a.json
+++ b/tests/data/devices/niko-nv-connectable-motor-control-3a.json
@@ -485,7 +485,8 @@
           "state": "closed",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": true
+          "is_closed": true,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/nodon-sin-4-rs-20.json
+++ b/tests/data/devices/nodon-sin-4-rs-20.json
@@ -384,7 +384,8 @@
           "state": "closed",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": true
+          "is_closed": true,
+          "supported_features": 255
         }
       }
     ],

--- a/tests/data/devices/schneider-electric-puck-shutter-1.json
+++ b/tests/data/devices/schneider-electric-puck-shutter-1.json
@@ -502,7 +502,8 @@
           "state": "open",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": false
+          "is_closed": false,
+          "supported_features": 255
         }
       }
     ],

--- a/tests/data/devices/shelly-2pm.json
+++ b/tests/data/devices/shelly-2pm.json
@@ -335,7 +335,8 @@
           "state": null,
           "is_opening": null,
           "is_closing": null,
-          "is_closed": null
+          "is_closed": null,
+          "supported_features": 240
         }
       }
     ],

--- a/tests/data/devices/smartwings-wm25-l-z.json
+++ b/tests/data/devices/smartwings-wm25-l-z.json
@@ -391,7 +391,8 @@
           "state": "closed",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": true
+          "is_closed": true,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/somfy-sonesse-28-wf-li-ion-roller.json
+++ b/tests/data/devices/somfy-sonesse-28-wf-li-ion-roller.json
@@ -378,7 +378,8 @@
           "state": "open",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": false
+          "is_closed": false,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/sonoff-mini-zbrbs.json
+++ b/tests/data/devices/sonoff-mini-zbrbs.json
@@ -371,7 +371,8 @@
           "state": "open",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": false
+          "is_closed": false,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/third-reality-inc-3rsb015bz.json
+++ b/tests/data/devices/third-reality-inc-3rsb015bz.json
@@ -395,7 +395,8 @@
           "state": "open",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": false
+          "is_closed": false,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/tz3000-1dd0d5yi-ts130f.json
+++ b/tests/data/devices/tz3000-1dd0d5yi-ts130f.json
@@ -433,7 +433,8 @@
           "state": "closed",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": true
+          "is_closed": true,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/tz3000-j1xl73iw-ts130f.json
+++ b/tests/data/devices/tz3000-j1xl73iw-ts130f.json
@@ -462,7 +462,8 @@
           "state": "closed",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": true
+          "is_closed": true,
+          "supported_features": 15
         }
       },
       {
@@ -509,7 +510,8 @@
           "state": "closed",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": true
+          "is_closed": true,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/tz3000-kmsbwdol-ts130f.json
+++ b/tests/data/devices/tz3000-kmsbwdol-ts130f.json
@@ -384,7 +384,8 @@
           "state": "open",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": false
+          "is_closed": false,
+          "supported_features": 15
         }
       },
       {
@@ -431,7 +432,8 @@
           "state": "closed",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": true
+          "is_closed": true,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/tz3000-ltiqubue-ts130f.json
+++ b/tests/data/devices/tz3000-ltiqubue-ts130f.json
@@ -244,7 +244,8 @@
           "state": "open",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": false
+          "is_closed": false,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/tz3000-qa8s8vca-ts130f.json
+++ b/tests/data/devices/tz3000-qa8s8vca-ts130f.json
@@ -237,7 +237,8 @@
           "state": "open",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": false
+          "is_closed": false,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/tz3000-qqdbccb3-ts130f.json
+++ b/tests/data/devices/tz3000-qqdbccb3-ts130f.json
@@ -231,7 +231,8 @@
           "state": "open",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": false
+          "is_closed": false,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/tz3000-vw8pawxa-ts130f.json
+++ b/tests/data/devices/tz3000-vw8pawxa-ts130f.json
@@ -323,7 +323,8 @@
           "state": "open",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": false
+          "is_closed": false,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/tz3210-dwytrmda-ts130f.json
+++ b/tests/data/devices/tz3210-dwytrmda-ts130f.json
@@ -369,7 +369,8 @@
           "state": "open",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": false
+          "is_closed": false,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/tze200-68nvbio9-ts0601.json
+++ b/tests/data/devices/tze200-68nvbio9-ts0601.json
@@ -334,7 +334,8 @@
           "state": "closed",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": true
+          "is_closed": true,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/tze200-9caxna4s-ts0301.json
+++ b/tests/data/devices/tze200-9caxna4s-ts0301.json
@@ -323,7 +323,8 @@
           "state": "open",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": false
+          "is_closed": false,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/tze200-cpbo62rn-ts0601.json
+++ b/tests/data/devices/tze200-cpbo62rn-ts0601.json
@@ -189,7 +189,8 @@
           "state": "open",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": false
+          "is_closed": false,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/tze200-gaj531w3-ts0601.json
+++ b/tests/data/devices/tze200-gaj531w3-ts0601.json
@@ -236,7 +236,8 @@
           "state": null,
           "is_opening": null,
           "is_closing": null,
-          "is_closed": null
+          "is_closed": null,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/tze200-gubdgai2-ts0601.json
+++ b/tests/data/devices/tze200-gubdgai2-ts0601.json
@@ -201,7 +201,8 @@
           "state": "open",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": false
+          "is_closed": false,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/tze200-icka1clh-ts0601.json
+++ b/tests/data/devices/tze200-icka1clh-ts0601.json
@@ -236,7 +236,8 @@
           "state": null,
           "is_opening": null,
           "is_closing": null,
-          "is_closed": null
+          "is_closed": null,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/tze200-pw7mji0l-ts0601.json
+++ b/tests/data/devices/tze200-pw7mji0l-ts0601.json
@@ -189,7 +189,8 @@
           "state": "open",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": false
+          "is_closed": false,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/tze200-vdiuwbkq-ts0601.json
+++ b/tests/data/devices/tze200-vdiuwbkq-ts0601.json
@@ -237,7 +237,8 @@
           "state": null,
           "is_opening": null,
           "is_closing": null,
-          "is_closed": null
+          "is_closed": null,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/tze204-1fuxihti-ts0601.json
+++ b/tests/data/devices/tze204-1fuxihti-ts0601.json
@@ -218,7 +218,8 @@
           "state": null,
           "is_opening": null,
           "is_closing": null,
-          "is_closed": null
+          "is_closed": null,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/tze204-guvc7pdy-ts0601.json
+++ b/tests/data/devices/tze204-guvc7pdy-ts0601.json
@@ -267,7 +267,8 @@
           "state": null,
           "is_opening": null,
           "is_closing": null,
-          "is_closed": null
+          "is_closed": null,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/tze284-3mzb0sdz-ts0601.json
+++ b/tests/data/devices/tze284-3mzb0sdz-ts0601.json
@@ -435,7 +435,8 @@
           "state": null,
           "is_opening": null,
           "is_closing": null,
-          "is_closed": null
+          "is_closed": null,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/uiot-uiot-windowcovring2-0402.json
+++ b/tests/data/devices/uiot-uiot-windowcovring2-0402.json
@@ -560,7 +560,8 @@
           "state": "open",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": false
+          "is_closed": false,
+          "supported_features": 15
         }
       },
       {
@@ -607,7 +608,8 @@
           "state": "open",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": false
+          "is_closed": false,
+          "supported_features": 15
         }
       },
       {
@@ -654,7 +656,8 @@
           "state": "open",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": false
+          "is_closed": false,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/data/devices/yooksmart-d10110.json
+++ b/tests/data/devices/yooksmart-d10110.json
@@ -330,7 +330,8 @@
           "state": "open",
           "is_opening": false,
           "is_closing": false,
-          "is_closed": false
+          "is_closed": false,
+          "supported_features": 15
         }
       }
     ],

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -687,6 +687,39 @@ async def test_cover(
         assert cluster.request.call_args[1]["expect_reply"] is True
 
 
+async def test_cover_recompute_capabilities_on_type_update(
+    zha_gateway: Gateway,
+) -> None:
+    """Test supported features update when window covering type changes."""
+    zha_device, zigpy_cover_device = await device_cover_mock(
+        zha_gateway,
+        current_position_lift_percentage=0,
+        current_position_tilt_percentage=0,
+        window_covering_type=WCT.Drapery,
+    )
+    cluster = zigpy_cover_device.endpoints[1].window_covering
+    entity = get_entity(zha_device, platform=Platform.COVER)
+
+    assert entity.supported_features == (
+        CoverEntityFeature.OPEN
+        | CoverEntityFeature.CLOSE
+        | CoverEntityFeature.STOP
+        | CoverEntityFeature.SET_POSITION
+    )
+
+    await send_attributes_report(
+        zha_gateway,
+        cluster,
+        {WCAttrs.window_covering_type: WCT.Tilt_blind_tilt_only},
+    )
+    assert entity.supported_features == (
+        CoverEntityFeature.OPEN_TILT
+        | CoverEntityFeature.CLOSE_TILT
+        | CoverEntityFeature.STOP_TILT
+        | CoverEntityFeature.SET_TILT_POSITION
+    )
+
+
 async def test_cover_failures(zha_gateway: Gateway) -> None:
     """Test ZHA cover platform failure cases."""
 

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -38,6 +38,7 @@ from zha.application.platforms.cover.const import (
     CoverEntityFeature,
     CoverState,
 )
+from zha.const import STATE_CHANGED
 from zha.exceptions import ZHAException
 from zha.zigbee.device import Device
 
@@ -693,12 +694,14 @@ async def test_cover_recompute_capabilities_on_type_update(
     """Test supported features update when window covering type changes."""
     zha_device, zigpy_cover_device = await device_cover_mock(
         zha_gateway,
-        current_position_lift_percentage=0,
-        current_position_tilt_percentage=0,
+        current_position_lift_percentage=None,
+        current_position_tilt_percentage=None,
         window_covering_type=WCT.Drapery,
     )
     cluster = zigpy_cover_device.endpoints[1].window_covering
     entity = get_entity(zha_device, platform=Platform.COVER)
+    subscriber = MagicMock()
+    entity.on_event(STATE_CHANGED, subscriber)
 
     assert entity.supported_features == (
         CoverEntityFeature.OPEN
@@ -706,6 +709,7 @@ async def test_cover_recompute_capabilities_on_type_update(
         | CoverEntityFeature.STOP
         | CoverEntityFeature.SET_POSITION
     )
+    assert len(subscriber.mock_calls) == 0
 
     await send_attributes_report(
         zha_gateway,
@@ -718,6 +722,7 @@ async def test_cover_recompute_capabilities_on_type_update(
         | CoverEntityFeature.STOP_TILT
         | CoverEntityFeature.SET_TILT_POSITION
     )
+    assert len(subscriber.mock_calls) == 1
 
 
 async def test_cover_failures(zha_gateway: Gateway) -> None:

--- a/zha/application/platforms/cover/__init__.py
+++ b/zha/application/platforms/cover/__init__.py
@@ -279,6 +279,7 @@ class Cover(BaseCover):
                 "is_opening": self.is_opening,
                 "is_closing": self.is_closing,
                 "is_closed": self.is_closed,
+                "supported_features": self.supported_features,
             }
         )
         return response
@@ -565,6 +566,7 @@ class Cover(BaseCover):
             self._determine_cover_state(is_tilt_update=True)
         elif event.attribute_id == WCAttrs.window_covering_type.id:
             self.recompute_capabilities()
+            self.maybe_emit_state_changed_event()
 
     def async_update_state(self, state):
         """Handle state update from HA operations below."""

--- a/zha/application/platforms/cover/__init__.py
+++ b/zha/application/platforms/cover/__init__.py
@@ -563,6 +563,8 @@ class Cover(BaseCover):
         elif event.attribute_id == WCAttrs.current_position_tilt_percentage.id:
             self._tilt_position_history.append(self.current_cover_tilt_position)
             self._determine_cover_state(is_tilt_update=True)
+        elif event.attribute_id == WCAttrs.window_covering_type.id:
+            self.recompute_capabilities()
 
     def async_update_state(self, state):
         """Handle state update from HA operations below."""


### PR DESCRIPTION
## Proposed change

This recomputes cover capabilities when the `WindowCovering`'s `window_covering_type` attribute values changes.

## Additional information

This is relevant for the Ubisys J1 shutter control, as it has a quirks v2 entity that allows writing of this attribute (via a manufacturer-specific attribute).

The ZHA integration in HA will also need a small patch: https://github.com/home-assistant/core/compare/dev...TheJulianJES:tjj/zha_recompute_cover_cap

With both changes, the entity works properly now.