### PR TITLE
Bump pytest-asyncio to 1.4.0

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,7 +6,7 @@ pre-commit
 pytest-cov
 pytest-sugar
 pytest-timeout
-pytest-asyncio<1.0
+pytest-asyncio>=1.3.0
 pytest-xdist
 pytest
 python-slugify

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 """Test configuration for the ZHA component."""
 
 import asyncio
-from collections.abc import Callable, Generator
+from collections.abc import AsyncGenerator, Callable, Generator
 from contextlib import contextmanager
 import logging
 import os
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import looptime
 import pytest
+import pytest_asyncio
 import zigpy
 from zigpy.application import ControllerApplication
 import zigpy.config
@@ -151,18 +152,18 @@ def expected_lingering_timers() -> bool:
     return False
 
 
-@pytest.fixture(autouse=True)
-def verify_cleanup(
-    event_loop: asyncio.AbstractEventLoop,
+@pytest_asyncio.fixture(autouse=True)
+async def verify_cleanup(
     expected_lingering_tasks: bool,  # pylint: disable=redefined-outer-name
     expected_lingering_timers: bool,  # pylint: disable=redefined-outer-name
-) -> Generator[None, None, None]:
+) -> AsyncGenerator[None, None]:
     """Verify that the test has cleaned up resources correctly."""
+    event_loop = asyncio.get_running_loop()
     threads_before = frozenset(threading.enumerate())
     tasks_before = asyncio.all_tasks(event_loop)
     yield
 
-    event_loop.run_until_complete(event_loop.shutdown_default_executor())
+    await event_loop.shutdown_default_executor()
 
     if len(INSTANCES) >= 2:
         count = len(INSTANCES)
@@ -172,7 +173,12 @@ def verify_cleanup(
 
     # Warn and clean-up lingering tasks and timers
     # before moving on to the next test.
-    tasks = asyncio.all_tasks(event_loop) - tasks_before
+    current_task = asyncio.current_task()
+    tasks = {
+        task
+        for task in asyncio.all_tasks(event_loop) - tasks_before
+        if task is not current_task
+    }
     for task in tasks:
         if expected_lingering_tasks:
             _LOGGER.warning("Lingering task after test %r", task)
@@ -180,7 +186,7 @@ def verify_cleanup(
             pytest.fail(f"Lingering task after test {task!r}")
         task.cancel()
     if tasks:
-        event_loop.run_until_complete(asyncio.wait(tasks))
+        await asyncio.wait(tasks)
 
     for handle in event_loop._scheduled:
         if not handle.cancelled():

--- a/zha/async_.py
+++ b/zha/async_.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 import enum
 import functools
 from functools import cached_property
+import inspect
 import logging
 import time
 from typing import (
@@ -133,7 +134,7 @@ def get_zhajob_callable_job_type(target: Callable[..., Any]) -> ZHAJobType:
     while isinstance(target, functools.partial):
         target = target.func
 
-    if asyncio.iscoroutinefunction(target):
+    if inspect.iscoroutinefunction(target):
         return ZHAJobType.Coroutinefunction
     else:
         return ZHAJobType.Callback


### PR DESCRIPTION
This bumps the minimum required `pytest-asyncio` version to 1.4.0, though as low as 1.0.0 is probably fine as well.
It's just a test dependency though, so pinned it to what I tested with.

Multiple changes were made to make it work, since the `event_loop` fixture was finally dropped (long deprecated before). 