### PR TITLE
Suppress expected warnings in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,11 @@ COUNTER_NAMES = ["counter_1", "counter_2", "counter_3"]
 INSTANCES: list[Gateway] = []
 _LOGGER = logging.getLogger(__name__)
 
+EXPECTED_WARNING_FILTERS = (
+    r"ignore:Attribute '.*' has `is_manufacturer_specific` without an explicit `manufacturer_code`\. Please set `manufacturer_code=0x[0-9A-Fa-f]+`\.:DeprecationWarning",
+    r"ignore:Unique IDs are unique only with platform prefix.*:UserWarning",
+)
+
 
 class _FakeApp(ControllerApplication):
     async def add_endpoint(self, descriptor: zdo_t.SimpleDescriptor):
@@ -388,7 +393,9 @@ def cluster_handler() -> Callable:
 
 
 def pytest_collection_modifyitems(config, items):
-    """Add the looptime marker to all tests except the test_async.py file."""
+    """Add shared markers to tests."""
     for item in items:
         if "test_async_.py" not in item.nodeid:
             item.add_marker(pytest.mark.looptime)
+        for warning_filter in EXPECTED_WARNING_FILTERS:
+            item.add_marker(pytest.mark.filterwarnings(warning_filter))


### PR DESCRIPTION
This filters expected warnings triggered by various tests.
Alternatively, we can also add this to our `pyproject.toml`. Adding it to the individual tests or modules doesn't really work here, except if we want to add it to basically all.