### PR TITLE
Show update release URL for installed version

### DIFF
--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -577,13 +577,15 @@ async def test_firmware_update_no_image(zha_gateway: Gateway) -> None:
 async def test_firmware_update_latest_version_even_if_downgrade(
     zha_gateway: Gateway,
 ) -> None:
-    """Test ZHA update platform - `latest_version` always reflects the latest."""
+    """Test ZHA update platform - latest downgrade sets version and release URL."""
     zigpy_device = zigpy_device_mock(zha_gateway)
     zha_device, ota_cluster, fw_image, installed_fw_version = await setup_test_data(
         zha_gateway, zigpy_device
     )
 
-    fw_image_downgrade = create_fw_image(installed_fw_version - 10)
+    fw_image_downgrade = create_fw_image(
+        installed_fw_version - 10, release_url="https://example.com/releases/v0.1"
+    )
 
     zigpy_device.application.ota.get_ota_images = AsyncMock(
         return_value=OtaImagesResult(
@@ -615,6 +617,7 @@ async def test_firmware_update_latest_version_even_if_downgrade(
         entity.state[ATTR_LATEST_VERSION]
         == f"0x{fw_image_downgrade.firmware.header.file_version:08x}"
     )
+    assert entity.state[ATTR_RELEASE_URL] == "https://example.com/releases/v0.1"
 
 
 async def test_firmware_update_metadata(zha_gateway: Gateway) -> None:

--- a/zha/application/platforms/update.py
+++ b/zha/application/platforms/update.py
@@ -215,8 +215,20 @@ class BaseFirmwareUpdateEntity(PlatformEntity, ABC):
             )
         elif images_result.downgrades:
             # If not, note the version of the most recent firmware
-            latest_firmware = None
-            self._attr_latest_version = f"0x{images_result.downgrades[0].version:08x}"
+            # latest_firmware = images_result.downgrades[0]
+            # self._attr_latest_version = f"0x{latest_firmware.version:08x}"
+            # self._attr_release_notes = latest_firmware.metadata.release_notes or None
+            # self._attr_release_url = latest_firmware.metadata.release_url or None
+            latest_firmware = images_result.downgrades[0]
+            self._attr_latest_version = f"0x{latest_firmware.version:08x}"
+            self._attr_release_url = latest_firmware.metadata.release_url or None
+            if latest_firmware.metadata.release_notes:
+                self._attr_release_notes = (
+                    f"## 0x{latest_firmware.version:08x}\n"
+                    f"{latest_firmware.metadata.release_notes}"
+                )
+            else:
+                self._attr_release_notes = None
 
         self.maybe_emit_state_changed_event()
 

--- a/zha/application/platforms/update.py
+++ b/zha/application/platforms/update.py
@@ -214,21 +214,10 @@ class BaseFirmwareUpdateEntity(PlatformEntity, ABC):
                 "\n\n".join(release_notes_parts) if release_notes_parts else None
             )
         elif images_result.downgrades:
-            # If not, note the version of the most recent firmware
-            # latest_firmware = images_result.downgrades[0]
-            # self._attr_latest_version = f"0x{latest_firmware.version:08x}"
-            # self._attr_release_notes = latest_firmware.metadata.release_notes or None
-            # self._attr_release_url = latest_firmware.metadata.release_url or None
+            # If not, note the version of the most recent firmware and show its link
             latest_firmware = images_result.downgrades[0]
             self._attr_latest_version = f"0x{latest_firmware.version:08x}"
             self._attr_release_url = latest_firmware.metadata.release_url or None
-            if latest_firmware.metadata.release_notes:
-                self._attr_release_notes = (
-                    f"## 0x{latest_firmware.version:08x}\n"
-                    f"{latest_firmware.metadata.release_notes}"
-                )
-            else:
-                self._attr_release_notes = None
 
         self.maybe_emit_state_changed_event()
 


### PR DESCRIPTION
## Proposed change

This changes ZHA update entities to show the `release_url` of the latest firmware (provided as `.downgrades[0]`).


## Additional information

For zigpy-ota provided updates, the `release_url` is generally a link to the pull request where that update was submitted. The pull request also shows more context for the update, potentially with additional release notes in the comments. This also allows us to have an easy place to collect feedback for these updates and for HA users to find that, even after they already installed the update.

We can also consider showing the latest (markdown) release notes if that update is already installed. If so, should only the latest version's release notes be shown, the last 5, or all of them?

Related:
- https://github.com/zigpy/zha/pull/625

### Newer version installed than latest in OTA repo?

Right now, we'll show the release URL for the latest version in zigpy-ota. If a user has newer firmware installed than in the zigpy-ota repo, should we not show that link then?
This sometimes happens when manufacturers install new firmware in the factory but consider it to be unimportant to upgrade existing devices with.

### Apps

ESPHome / HA apps do not use HA's `release_url` but instead provide the "release announcement link" in the release notes themselves. This may also be useful for us, since we combine multiple upgrade release notes with the PR linked above, but only ever show the link for the latest release.

<img width="550" height="291" alt="More info dialog for ESPHome update entity showing release announcement link in the release notes itself, instead of using HA's dedicated release link position at the top" src="https://github.com/user-attachments/assets/2fd55164-9d7e-41e4-9472-6351bc4fb43f" />

It's also a little easier to spot there IMO, as it's [currently a bit hidden](https://github.com/user-attachments/assets/f77632e6-610d-4136-a935-fa729b573831) at the top. The general update note is only shown below, which Matter might do the other way around even(?)