### PR TITLE
Fix light polling trusting unsupported `color_mode`

### DIFF
--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -2149,7 +2149,7 @@ async def test_light_state_restoration_unsupported_color_mode(
 async def test_color_temp_only_light_ignores_incorrect_color_mode(
     zha_gateway: Gateway,
 ) -> None:
-    """Test that a color_temp-only light ignores incorrect color_mode reports from the device."""
+    """Test color_temp-only light ignores incorrect color_mode reads when polling."""
     zigpy_device = create_mock_zigpy_device(zha_gateway, LIGHT_COLOR)
     color_cluster = zigpy_device.endpoints[1].light_color
     color_cluster.PLUGGED_ATTR_READS = {
@@ -2199,6 +2199,53 @@ async def test_color_temp_only_light_ignores_incorrect_color_mode(
     assert entity.state["color_mode"] == ColorMode.COLOR_TEMP
     assert entity.state["color_temp"] == 400
     assert entity.state["xy_color"] is None
+
+
+async def test_poll_updates_color_mode_on_dual_mode_light(
+    zha_gateway: Gateway,
+) -> None:
+    """Test polling XY + COLOR_TEMP light updates color_mode and attribute values."""
+    device = await device_light_1_mock(zha_gateway)
+    entity = get_entity(device, platform=Platform.LIGHT)
+    color_cluster = device.device.endpoints[1].light_color
+
+    assert entity.supported_color_modes == {ColorMode.COLOR_TEMP, ColorMode.XY}
+
+    # Poll with color_temp mode
+    color_cluster.PLUGGED_ATTR_READS = {
+        "color_capabilities": (
+            lighting.Color.ColorCapabilities.Color_temperature
+            | lighting.Color.ColorCapabilities.XY_attributes
+        ),
+        "color_mode": lighting.Color.ColorMode.Color_temperature,
+        "color_temperature": 350,
+        "current_x": 20000,
+        "current_y": 20000,
+    }
+    update_attribute_cache(color_cluster)
+    await entity.async_update()
+
+    assert entity.state["color_mode"] == ColorMode.COLOR_TEMP
+    assert entity.state["color_temp"] == 350
+    assert entity.state["xy_color"] is None
+
+    # Poll with XY mode
+    color_cluster.PLUGGED_ATTR_READS = {
+        "color_capabilities": (
+            lighting.Color.ColorCapabilities.Color_temperature
+            | lighting.Color.ColorCapabilities.XY_attributes
+        ),
+        "color_mode": lighting.Color.ColorMode.X_and_Y,
+        "color_temperature": 350,
+        "current_x": 30000,
+        "current_y": 25000,
+    }
+    update_attribute_cache(color_cluster)
+    await entity.async_update()
+
+    assert entity.state["color_mode"] == ColorMode.XY
+    assert entity.state["xy_color"] == (30000 / 65535, 25000 / 65535)
+    assert entity.state["color_temp"] is None
 
 
 async def test_turn_on_cancellation_cleans_up_transition_flag(

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -2110,6 +2110,97 @@ async def test_light_state_restoration(zha_gateway: Gateway) -> None:
     assert entity.state["effect"] == "colorloop"
 
 
+async def test_light_state_restoration_unsupported_color_mode(
+    zha_gateway: Gateway,
+) -> None:
+    """Test that restoring an unsupported color_mode is ignored."""
+    zigpy_device = create_mock_zigpy_device(zha_gateway, LIGHT_COLOR)
+    color_cluster = zigpy_device.endpoints[1].light_color
+    color_cluster.PLUGGED_ATTR_READS = {
+        "color_capabilities": lighting.Color.ColorCapabilities.Color_temperature,
+        "color_temperature": 250,
+        "color_temp_physical_min": 153,
+        "color_temp_physical_max": 500,
+    }
+    update_attribute_cache(color_cluster)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
+    entity = get_entity(zha_device, platform=Platform.LIGHT)
+
+    assert entity.supported_color_modes == {ColorMode.COLOR_TEMP}
+    assert entity.state["color_mode"] == ColorMode.COLOR_TEMP
+
+    # Attempt to restore XY color_mode on a color_temp-only light
+    entity.restore_external_state_attributes(
+        state=True,
+        off_with_transition=False,
+        off_brightness=None,
+        brightness=100,
+        color_temp=300,
+        xy_color=None,
+        color_mode=ColorMode.XY,
+        effect=None,
+    )
+
+    # color_mode should remain COLOR_TEMP since XY is not supported
+    assert entity.state["color_mode"] == ColorMode.COLOR_TEMP
+    assert entity.state["color_temp"] == 300
+
+
+async def test_color_temp_only_light_ignores_incorrect_color_mode(
+    zha_gateway: Gateway,
+) -> None:
+    """Test that a color_temp-only light ignores incorrect color_mode reports from the device."""
+    zigpy_device = create_mock_zigpy_device(zha_gateway, LIGHT_COLOR)
+    color_cluster = zigpy_device.endpoints[1].light_color
+    color_cluster.PLUGGED_ATTR_READS = {
+        "color_capabilities": lighting.Color.ColorCapabilities.Color_temperature,
+        "color_temperature": 250,
+        "color_temp_physical_min": 153,
+        "color_temp_physical_max": 500,
+    }
+    update_attribute_cache(color_cluster)
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
+    entity = get_entity(zha_device, platform=Platform.LIGHT)
+
+    assert entity.supported_color_modes == {ColorMode.COLOR_TEMP}
+    assert entity.state["color_mode"] == ColorMode.COLOR_TEMP
+    assert entity.state["color_temp"] == 250
+
+    # Simulate the device incorrectly reporting XY color mode during a poll
+    color_cluster.PLUGGED_ATTR_READS = {
+        "color_capabilities": lighting.Color.ColorCapabilities.Color_temperature,
+        "color_mode": lighting.Color.ColorMode.X_and_Y,
+        "color_temperature": 300,
+        "color_temp_physical_min": 153,
+        "color_temp_physical_max": 500,
+    }
+    update_attribute_cache(color_cluster)
+
+    # Trigger a poll
+    await entity.async_update()
+
+    # color_mode should remain COLOR_TEMP and color_temp should be updated
+    assert entity.state["color_mode"] == ColorMode.COLOR_TEMP
+    assert entity.state["color_temp"] == 300
+    assert entity.state["xy_color"] is None
+
+    # Same test with Hue_and_saturation mode
+    color_cluster.PLUGGED_ATTR_READS = {
+        "color_capabilities": lighting.Color.ColorCapabilities.Color_temperature,
+        "color_mode": lighting.Color.ColorMode.Hue_and_saturation,
+        "color_temperature": 400,
+        "color_temp_physical_min": 153,
+        "color_temp_physical_max": 500,
+    }
+    update_attribute_cache(color_cluster)
+
+    await entity.async_update()
+
+    assert entity.state["color_mode"] == ColorMode.COLOR_TEMP
+    assert entity.state["color_temp"] == 400
+    assert entity.state["xy_color"] is None
+
+
 async def test_turn_on_cancellation_cleans_up_transition_flag(
     zha_gateway: Gateway,
 ) -> None:

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -258,6 +258,7 @@ class BaseLight(BaseEntity, ABC):
             self._color_temp = color_temp
         if xy_color is not None:
             self._xy_color = xy_color
+        # Older persisted states may contain a color_mode not in supported modes
         if color_mode is not None and color_mode in self._supported_color_modes:
             self._color_mode = color_mode
         if effect is not None:

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -1088,13 +1088,12 @@ class Light(BaseClusterHandlerLight, PlatformEntity):
                 if color_mode == Color.ColorMode.Color_temperature:
                     if ColorMode.COLOR_TEMP in self._supported_color_modes:
                         self._color_mode = ColorMode.COLOR_TEMP
-                    color_temp = results.get("color_temperature")
-                    if color_temp is not None and color_mode:
-                        self._color_temp = color_temp
-                        self._xy_color = None
-                else:
-                    if ColorMode.XY in self._supported_color_modes:
-                        self._color_mode = ColorMode.XY
+                        color_temp = results.get("color_temperature")
+                        if color_temp is not None and color_mode:
+                            self._color_temp = color_temp
+                            self._xy_color = None
+                elif ColorMode.XY in self._supported_color_modes:
+                    self._color_mode = ColorMode.XY
                     color_x = results.get("current_x")
                     color_y = results.get("current_y")
                     if color_x is not None and color_y is not None:

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -1085,29 +1085,22 @@ class Light(BaseClusterHandlerLight, PlatformEntity):
                 return  # type: ignore[unreachable]
 
             if (color_mode := results.get("color_mode")) is not None:
+                # Determine the effective color mode: if only one mode is
+                # supported, use it regardless of what the device reports
                 if len(self._supported_color_modes) == 1:
-                    # Only one color mode supported, use it regardless of
-                    # what the device reports
-                    supported_mode = next(iter(self._supported_color_modes))
-                    if supported_mode == ColorMode.COLOR_TEMP:
-                        color_temp = results.get("color_temperature")
-                        if color_temp is not None:
-                            self._color_temp = color_temp
-                            self._xy_color = None
-                    elif supported_mode == ColorMode.XY:
-                        color_x = results.get("current_x")
-                        color_y = results.get("current_y")
-                        if color_x is not None and color_y is not None:
-                            self._xy_color = (color_x / 65535, color_y / 65535)
-                            self._color_temp = None
+                    effective_mode = next(iter(self._supported_color_modes))
                 elif color_mode == Color.ColorMode.Color_temperature:
-                    self._color_mode = ColorMode.COLOR_TEMP
+                    effective_mode = ColorMode.COLOR_TEMP
+                else:
+                    effective_mode = ColorMode.XY
+                self._color_mode = effective_mode
+
+                if effective_mode == ColorMode.COLOR_TEMP:
                     color_temp = results.get("color_temperature")
                     if color_temp is not None:
                         self._color_temp = color_temp
                         self._xy_color = None
-                else:
-                    self._color_mode = ColorMode.XY
+                elif effective_mode == ColorMode.XY:
                     color_x = results.get("current_x")
                     color_y = results.get("current_y")
                     if color_x is not None and color_y is not None:

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -258,7 +258,7 @@ class BaseLight(BaseEntity, ABC):
             self._color_temp = color_temp
         if xy_color is not None:
             self._xy_color = xy_color
-        if color_mode is not None:
+        if color_mode is not None and color_mode in self._supported_color_modes:
             self._color_mode = color_mode
         if effect is not None:
             self._effect = effect
@@ -1086,13 +1086,15 @@ class Light(BaseClusterHandlerLight, PlatformEntity):
 
             if (color_mode := results.get("color_mode")) is not None:
                 if color_mode == Color.ColorMode.Color_temperature:
-                    self._color_mode = ColorMode.COLOR_TEMP
+                    if ColorMode.COLOR_TEMP in self._supported_color_modes:
+                        self._color_mode = ColorMode.COLOR_TEMP
                     color_temp = results.get("color_temperature")
                     if color_temp is not None and color_mode:
                         self._color_temp = color_temp
                         self._xy_color = None
                 else:
-                    self._color_mode = ColorMode.XY
+                    if ColorMode.XY in self._supported_color_modes:
+                        self._color_mode = ColorMode.XY
                     color_x = results.get("current_x")
                     color_y = results.get("current_y")
                     if color_x is not None and color_y is not None:

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -1085,22 +1085,34 @@ class Light(BaseClusterHandlerLight, PlatformEntity):
                 return  # type: ignore[unreachable]
 
             if (color_mode := results.get("color_mode")) is not None:
-                if (
-                    color_mode != Color.ColorMode.Color_temperature
-                    and ColorMode.XY in self._supported_color_modes
-                ):
+                if len(self._supported_color_modes) == 1:
+                    # Only one color mode supported, use it regardless of
+                    # what the device reports
+                    supported_mode = next(iter(self._supported_color_modes))
+                    if supported_mode == ColorMode.COLOR_TEMP:
+                        color_temp = results.get("color_temperature")
+                        if color_temp is not None:
+                            self._color_temp = color_temp
+                            self._xy_color = None
+                    elif supported_mode == ColorMode.XY:
+                        color_x = results.get("current_x")
+                        color_y = results.get("current_y")
+                        if color_x is not None and color_y is not None:
+                            self._xy_color = (color_x / 65535, color_y / 65535)
+                            self._color_temp = None
+                elif color_mode == Color.ColorMode.Color_temperature:
+                    self._color_mode = ColorMode.COLOR_TEMP
+                    color_temp = results.get("color_temperature")
+                    if color_temp is not None:
+                        self._color_temp = color_temp
+                        self._xy_color = None
+                else:
                     self._color_mode = ColorMode.XY
                     color_x = results.get("current_x")
                     color_y = results.get("current_y")
                     if color_x is not None and color_y is not None:
                         self._xy_color = (color_x / 65535, color_y / 65535)
                         self._color_temp = None
-                elif ColorMode.COLOR_TEMP in self._supported_color_modes:
-                    self._color_mode = ColorMode.COLOR_TEMP
-                    color_temp = results.get("color_temperature")
-                    if color_temp is not None:
-                        self._color_temp = color_temp
-                        self._xy_color = None
 
             color_loop_active = results.get("color_loop_active")
             if color_loop_active is not None:

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -1085,20 +1085,22 @@ class Light(BaseClusterHandlerLight, PlatformEntity):
                 return  # type: ignore[unreachable]
 
             if (color_mode := results.get("color_mode")) is not None:
-                if color_mode == Color.ColorMode.Color_temperature:
-                    if ColorMode.COLOR_TEMP in self._supported_color_modes:
-                        self._color_mode = ColorMode.COLOR_TEMP
-                        color_temp = results.get("color_temperature")
-                        if color_temp is not None and color_mode:
-                            self._color_temp = color_temp
-                            self._xy_color = None
-                elif ColorMode.XY in self._supported_color_modes:
+                if (
+                    color_mode != Color.ColorMode.Color_temperature
+                    and ColorMode.XY in self._supported_color_modes
+                ):
                     self._color_mode = ColorMode.XY
                     color_x = results.get("current_x")
                     color_y = results.get("current_y")
                     if color_x is not None and color_y is not None:
                         self._xy_color = (color_x / 65535, color_y / 65535)
                         self._color_temp = None
+                elif ColorMode.COLOR_TEMP in self._supported_color_modes:
+                    self._color_mode = ColorMode.COLOR_TEMP
+                    color_temp = results.get("color_temperature")
+                    if color_temp is not None:
+                        self._color_temp = color_temp
+                        self._xy_color = None
 
             color_loop_active = results.get("color_loop_active")
             if color_loop_active is not None:


### PR DESCRIPTION
## Proposed change

This works around an issue in lights that report `color_mode=XY` during polling, even though they only support color temperature. This PR effectively clones the logic used to determine the color mode in `recompute_capabilities`:
https://github.com/zigpy/zha/blob/c51efa5aaedbcbe270e4bb35f69667e5b7015030/zha/application/platforms/light/__init__.py#L928-L938

This has the advantage that even if a color temperature light reports `color_mode=XY`, we still update the color temp values during polling, as `_supported_color_modes` only contains `COLOR_TEMP`.

We can also consider polling out that logic into a `_determine_color_mode` method, for example.


## Additional information

HA Core recently introduced stricter validation of the set `color_mode`, which seems to have exposed this issue. See:
- https://github.com/home-assistant/core/issues/164598


### Related PR

- https://github.com/zigpy/zha/pull/703

A bigger change is tried in the PR linked above, where the endpoint's `device_type` is used and trusted to determine the color capabilities of a light. However, it seems like we already have one device that doesn't follow those rules either...

There's also a difference in how that PR handles `color_mode` when polling: If the device responds with an incorrect `color_mode` (e.g. `XY`), even though we know from `_supported_color_modes` that it only supports `COLOR_TEMP`, that PR ignores the updates it got from polling. With this PR, we update color temper values, even if the light reports `color_mode=XY` when our `_supported_color_modes` only include `COLOR_TEMP`.

### Future

We do need to have a more robust solution for this in the future. For a patch release, I think this is the easiest solution that should fix the issue and not introduce new ones. 

Notes for me later (for a proper long-term solution):
- Should we also check if `current_x` and `current_y` are unsupported?
- Fallback logic to supporting color temperature if it just has a value, but not in color capabilities.
  - Min/max mireds sometime set to `0` then, causing log warnings, as device shouldn't show color temp in first place