### PR TITLE
Fix reporting status configuration for colliding attribute IDs

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -60,7 +60,7 @@ def patch_cluster_for_testing(cluster: zigpy.zcl.Cluster) -> None:
         ]
     )
     cluster.configure_reporting_multiple = AsyncMock(
-        return_value=zcl_f.ConfigureReportingResponse.deserialize(b"\x00")[0]
+        side_effect=lambda config: dict.fromkeys(config, zcl_f.Status.SUCCESS)
     )
     cluster.read_attributes = AsyncMock(wraps=cluster.read_attributes)
     cluster.read_attributes_raw = AsyncMock(side_effect=_read_attribute_raw)

--- a/tests/common.py
+++ b/tests/common.py
@@ -55,9 +55,7 @@ def patch_cluster_for_testing(cluster: zigpy.zcl.Cluster) -> None:
 
     cluster.bind = AsyncMock(return_value=[0])
     cluster.configure_reporting = AsyncMock(
-        return_value=[
-            [zcl_f.ConfigureReportingResponseRecord(zcl_f.Status.SUCCESS, 0x00, 0xAABB)]
-        ]
+        side_effect=lambda config: dict.fromkeys(config, zcl_f.Status.SUCCESS)
     )
     cluster.configure_reporting_multiple = AsyncMock(
         side_effect=lambda config: dict.fromkeys(config, zcl_f.Status.SUCCESS)

--- a/tests/test_cluster_handlers.py
+++ b/tests/test_cluster_handlers.py
@@ -938,13 +938,13 @@ async def test_configure_reporting(zha_gateway: Gateway) -> None:
         spec_set=cluster.bind,
         return_value=[zdo_t.Status.SUCCESS],  # ZDOCmd.Bind_rsp
     )
+
+    def mock_configure_reporting_multiple(config):
+        return dict.fromkeys(config, foundation.Status.SUCCESS)
+
     cluster.configure_reporting_multiple = AsyncMock(
         spec_set=cluster.configure_reporting_multiple,
-        return_value=[
-            foundation.ConfigureReportingResponseRecord(
-                status=foundation.Status.SUCCESS
-            )
-        ],
+        side_effect=mock_configure_reporting_multiple,
     )
 
     cluster_handler = TestZigbeeClusterHandler(cluster, endpoint)
@@ -971,38 +971,31 @@ async def test_configure_reporting(zha_gateway: Gateway) -> None:
 @pytest.mark.parametrize(
     ("response", "expected_statuses"),
     [
-        # Single SUCCESS in a list: all attributes marked as SUCCESS (ZCL 2.5.8.1.3)
+        # All attributes succeeded
         (
-            [
-                foundation.ConfigureReportingResponseRecord(
-                    status=foundation.Status.SUCCESS
-                )
-            ],
+            {
+                Color.AttributeDefs.current_x: foundation.Status.SUCCESS,
+                Color.AttributeDefs.current_y: foundation.Status.SUCCESS,
+            },
             {"current_x": "SUCCESS", "current_y": "SUCCESS"},
         ),
-        # Empty list: unexpected response, all attributes marked as FAILURE
+        # Empty dict: unexpected response, all attributes marked as FAILURE
         (
-            [],
+            {},
             {"current_x": "FAILURE", "current_y": "FAILURE"},
         ),
         # Per-attribute results: mixed success/failure
         (
-            [
-                foundation.ConfigureReportingResponseRecord(
-                    status=foundation.Status.SUCCESS,
-                    attrid=Color.AttributeDefs.current_x.id,
-                ),
-                foundation.ConfigureReportingResponseRecord(
-                    status=foundation.Status.UNSUPPORTED_ATTRIBUTE,
-                    attrid=Color.AttributeDefs.current_y.id,
-                ),
-            ],
+            {
+                Color.AttributeDefs.current_x: foundation.Status.SUCCESS,
+                Color.AttributeDefs.current_y: foundation.Status.UNSUPPORTED_ATTRIBUTE,
+            },
             {"current_x": "SUCCESS", "current_y": "UNSUPPORTED_ATTRIBUTE"},
         ),
     ],
     ids=[
-        "single_success_list",
-        "empty_list",
+        "all_success",
+        "empty_dict",
         "mixed_per_attribute",
     ],
 )

--- a/tests/test_cluster_handlers.py
+++ b/tests/test_cluster_handlers.py
@@ -1083,11 +1083,7 @@ async def test_invalid_cluster_handler(zha_gateway: Gateway, caplog) -> None:  #
     cluster = zigpy_ep.add_input_cluster(Color.cluster_id)
     cluster.configure_reporting_multiple = AsyncMock(
         spec_set=cluster.configure_reporting_multiple,
-        return_value=[
-            foundation.ConfigureReportingResponseRecord(
-                status=foundation.Status.SUCCESS
-            )
-        ],
+        side_effect=lambda config: dict.fromkeys(config, foundation.Status.SUCCESS),
     )
 
     mock_zha_device = mock.AsyncMock(spec=Device)
@@ -1128,11 +1124,7 @@ async def test_standard_cluster_handler(
     cluster = zigpy_ep.add_input_cluster(Color.cluster_id)
     cluster.configure_reporting_multiple = AsyncMock(
         spec_set=cluster.configure_reporting_multiple,
-        return_value=[
-            foundation.ConfigureReportingResponseRecord(
-                status=foundation.Status.SUCCESS
-            )
-        ],
+        side_effect=lambda config: dict.fromkeys(config, foundation.Status.SUCCESS),
     )
 
     mock_zha_device = mock.AsyncMock(spec=Device)
@@ -1168,11 +1160,7 @@ async def test_exposed_feature_cluster_handler(
     cluster = zigpy_ep.add_input_cluster(Color.cluster_id)
     cluster.configure_reporting_multiple = AsyncMock(
         spec_set=cluster.configure_reporting_multiple,
-        return_value=[
-            foundation.ConfigureReportingResponseRecord(
-                status=foundation.Status.SUCCESS
-            )
-        ],
+        side_effect=lambda config: dict.fromkeys(config, foundation.Status.SUCCESS),
     )
 
     mock_zha_device = mock.AsyncMock(spec=Device)

--- a/tests/test_cluster_handlers.py
+++ b/tests/test_cluster_handlers.py
@@ -1116,11 +1116,45 @@ async def test_configure_reporting_status_empty_second_chunk(
 
     await cluster_handler.async_configure()
 
-    cfg_rpt_event = mock_emit.call_args_list[1][0][1]
-    assert cfg_rpt_event.attributes["current_x"]["status"] == "SUCCESS"
-    assert cfg_rpt_event.attributes["current_y"]["status"] == "SUCCESS"
-    assert cfg_rpt_event.attributes["current_hue"]["status"] == "SUCCESS"
-    assert cfg_rpt_event.attributes["color_temperature"]["status"] == "FAILURE"
+    expected_statuses = {
+        "current_x": "SUCCESS",
+        "current_y": "SUCCESS",
+        "current_hue": "SUCCESS",
+        "color_temperature": "FAILURE",
+    }
+
+    assert mock_emit.call_args_list == [
+        mock.call(
+            ZHA_CLUSTER_HANDLER_MSG_BIND,
+            ClusterBindEvent(
+                cluster_name=cluster.name,
+                cluster_id=cluster.cluster_id,
+                cluster_handler_unique_id=cluster_handler.unique_id,
+                success=True,
+            ),
+        ),
+        mock.call(
+            ZHA_CLUSTER_HANDLER_MSG_CFG_RPT,
+            ClusterConfigureReportingEvent(
+                cluster_name=cluster.name,
+                cluster_id=cluster.cluster_id,
+                cluster_handler_unique_id=cluster_handler.unique_id,
+                attributes={
+                    attr_name: {
+                        "min": 1,
+                        "max": 60,
+                        "id": attr_name,
+                        "name": attr_name,
+                        "change": idx + 1,
+                        "status": expected_status,
+                    }
+                    for idx, (attr_name, expected_status) in enumerate(
+                        expected_statuses.items()
+                    )
+                },
+            ),
+        ),
+    ]
 
 
 async def test_invalid_cluster_handler(zha_gateway: Gateway, caplog) -> None:  # pylint: disable=unused-argument

--- a/tests/test_cluster_handlers.py
+++ b/tests/test_cluster_handlers.py
@@ -1068,6 +1068,61 @@ async def test_configure_reporting_status(
     ]
 
 
+async def test_configure_reporting_status_empty_second_chunk(
+    zha_gateway: Gateway,
+) -> None:
+    """Test that an empty response for one chunk doesn't overwrite other chunks' statuses."""
+    zigpy_coordinator_device: ZigpyDevice = zigpy_coordinator_device_mock(zha_gateway)
+    endpoint: Endpoint = endpoint_mock(zigpy_coordinator_device)
+
+    class TestClusterHandler(ClusterHandler):
+        BIND = True
+        REPORT_CONFIG = (
+            AttrReportConfig(attr="current_x", config=(1, 60, 1)),
+            AttrReportConfig(attr="current_y", config=(1, 60, 2)),
+            AttrReportConfig(attr="current_hue", config=(1, 60, 3)),
+            # 4th attribute forces a second chunk (REPORT_CONFIG_ATTR_PER_REQ=3)
+            AttrReportConfig(attr="color_temperature", config=(1, 60, 4)),
+        )
+
+    mock_ep = mock.AsyncMock()
+    mock_ep.profile_id = zigpy.profiles.zha.PROFILE_ID
+    mock_ep.device.zdo = AsyncMock()
+
+    cluster = Color(mock_ep)
+    cluster.bind = AsyncMock(
+        spec_set=cluster.bind,
+        return_value=[zdo_t.Status.SUCCESS],
+    )
+
+    # Chunk 1 succeeds, chunk 2 returns empty dict
+    chunk_responses = [
+        {
+            Color.AttributeDefs.current_x: foundation.Status.SUCCESS,
+            Color.AttributeDefs.current_y: foundation.Status.SUCCESS,
+            Color.AttributeDefs.current_hue: foundation.Status.SUCCESS,
+        },
+        {},
+    ]
+    cluster.configure_reporting_multiple = AsyncMock(
+        spec_set=cluster.configure_reporting_multiple,
+        side_effect=chunk_responses,
+    )
+
+    cluster_handler = TestClusterHandler(cluster, endpoint)
+
+    mock_emit = MagicMock()
+    cluster_handler._endpoint.device.emit = mock_emit
+
+    await cluster_handler.async_configure()
+
+    cfg_rpt_event = mock_emit.call_args_list[1][0][1]
+    assert cfg_rpt_event.attributes["current_x"]["status"] == "SUCCESS"
+    assert cfg_rpt_event.attributes["current_y"]["status"] == "SUCCESS"
+    assert cfg_rpt_event.attributes["current_hue"]["status"] == "SUCCESS"
+    assert cfg_rpt_event.attributes["color_temperature"]["status"] == "FAILURE"
+
+
 async def test_invalid_cluster_handler(zha_gateway: Gateway, caplog) -> None:  # pylint: disable=unused-argument
     """Test setting up a cluster handler that fails to match properly."""
 

--- a/zha/zigbee/cluster_handlers/__init__.py
+++ b/zha/zigbee/cluster_handlers/__init__.py
@@ -434,6 +434,7 @@ class ClusterHandler(LogMixin, EventBase):
         event_data: dict[str, dict[str, Any]],
     ) -> None:
         """Parse configure reporting result."""
+        attr_by_id = {attr_def.id: attr_def for attr_def in attrs}
         attr_names = {attr_def.name for attr_def in attrs}
         if not res:
             self.debug(
@@ -463,11 +464,9 @@ class ClusterHandler(LogMixin, EventBase):
             return
 
         for record in res:
-            event_data[self.cluster.find_attribute(record.attrid).name]["status"] = (
-                record.status.name
-            )
+            event_data[attr_by_id[record.attrid].name]["status"] = record.status.name
         failed = [
-            self.cluster.find_attribute(record.attrid).name
+            attr_by_id[record.attrid].name
             for record in res
             if record.status != Status.SUCCESS
         ]

--- a/zha/zigbee/cluster_handlers/__init__.py
+++ b/zha/zigbee/cluster_handlers/__init__.py
@@ -399,7 +399,7 @@ class ClusterHandler(LogMixin, EventBase):
                 res = await RETRYABLE_REQUEST_DECORATOR(
                     self.cluster.configure_reporting_multiple
                 )(reports)
-                self._configure_reporting_status(res, event_data)
+                self._configure_reporting_status(res, event_data, set(reports.keys()))
             except (zigpy.exceptions.ZigbeeException, TimeoutError) as ex:
                 self.debug(
                     "failed to set reporting on '%s' cluster for: %s",
@@ -426,11 +426,12 @@ class ClusterHandler(LogMixin, EventBase):
         self,
         res: dict[ZCLAttributeDef, Status],
         event_data: dict[str, dict[str, Any]],
+        requested_attrs: set[ZCLAttributeDef],
     ) -> None:
         """Parse configure reporting result."""
         if not res:
-            for data in event_data.values():
-                data["status"] = Status.FAILURE.name
+            for attr_def in requested_attrs:
+                event_data[attr_def.name]["status"] = Status.FAILURE.name
             return
 
         for attr_def, status in res.items():

--- a/zha/zigbee/cluster_handlers/__init__.py
+++ b/zha/zigbee/cluster_handlers/__init__.py
@@ -20,12 +20,7 @@ from zigpy.zcl import (
     AttributeUpdatedEvent,
     AttributeWrittenEvent,
 )
-from zigpy.zcl.foundation import (
-    CommandSchema,
-    ConfigureReportingResponseRecord,
-    Status,
-    ZCLAttributeDef,
-)
+from zigpy.zcl.foundation import CommandSchema, Status, ZCLAttributeDef
 from zigpy.zcl.helpers import ReportingConfig
 
 from zha.application.const import (
@@ -404,7 +399,7 @@ class ClusterHandler(LogMixin, EventBase):
                 res = await RETRYABLE_REQUEST_DECORATOR(
                     self.cluster.configure_reporting_multiple
                 )(reports)
-                self._configure_reporting_status(reports, res, event_data)
+                self._configure_reporting_status(res, event_data)
             except (zigpy.exceptions.ZigbeeException, TimeoutError) as ex:
                 self.debug(
                     "failed to set reporting on '%s' cluster for: %s",
@@ -429,61 +424,41 @@ class ClusterHandler(LogMixin, EventBase):
 
     def _configure_reporting_status(
         self,
-        attrs: dict[ZCLAttributeDef, ReportingConfig],
-        res: list[ConfigureReportingResponseRecord],
+        res: dict[ZCLAttributeDef, Status],
         event_data: dict[str, dict[str, Any]],
     ) -> None:
         """Parse configure reporting result."""
-        attr_by_id = {attr_def.id: attr_def for attr_def in attrs}
-        attr_names = {attr_def.name for attr_def in attrs}
         if not res:
-            self.debug(
-                "attr reporting for '%s' on '%s': %s",
-                attr_names,
-                self.name,
-                res,
-            )
-            for attr_name in attr_names:
-                event_data[attr_name]["status"] = Status.FAILURE.name
-            return
-        if len(res) == 1 and res[0].status == Status.SUCCESS:
-            self.debug(
-                "Successfully configured reporting for '%s' on '%s' cluster: %s",
-                attr_names,
-                self.name,
-                res,
-            )
-            # 2.5.8.1.3 Status Field
-            # The status field specifies the status of the Configure Reporting operation attempted on this attribute,
-            # as detailed in 2.5.7.3. Note that attribute status records are not included for successfully configured
-            # attributes, in order to save bandwidth. In the case of successful configuration of all attributes,
-            # only a single attribute status record SHALL be included in the command, with the status field set to
-            # SUCCESS and the direction and attribute identifier fields omitted.
-            for attr_name in attr_names:
-                event_data[attr_name]["status"] = Status.SUCCESS.name
+            for data in event_data.values():
+                data["status"] = Status.FAILURE.name
             return
 
-        for record in res:
-            event_data[attr_by_id[record.attrid].name]["status"] = record.status.name
+        for attr_def, status in res.items():
+            event_data[attr_def.name]["status"] = status.name
+
         failed = [
-            attr_by_id[record.attrid].name
-            for record in res
-            if record.status != Status.SUCCESS
+            attr_def.name
+            for attr_def, status in res.items()
+            if status != Status.SUCCESS
         ]
-        self.debug(
-            "Failed to configure reporting for '%s' on '%s' cluster: %s",
-            failed,
-            self.name,
-            res,
-        )
-        success = attr_names - set(failed)
-        self.debug(
-            "Successfully configured reporting for '%s' on '%s' cluster",
-            success,
-            self.name,
-        )
-        for attr_name in success:
-            event_data[attr_name]["status"] = Status.SUCCESS.name
+        if failed:
+            self.debug(
+                "Failed to configure reporting for '%s' on '%s' cluster: %s",
+                failed,
+                self.name,
+                res,
+            )
+        success = [
+            attr_def.name
+            for attr_def, status in res.items()
+            if status == Status.SUCCESS
+        ]
+        if success:
+            self.debug(
+                "Successfully configured reporting for '%s' on '%s' cluster",
+                success,
+                self.name,
+            )
 
     async def async_configure(self) -> None:
         """Set cluster binding and attribute reporting."""


### PR DESCRIPTION
## Proposed change

This PR fixes an issue where `_configure_reporting_status` was raising an issue that multiple attribute definitions where found for the same ID (but with different manufacturer codes) if attribute reporting was attempted for an attribute with a colliding ID.

This is based on top of zigpy changes, where `configure_reporting_multiple` now returns a `dict[ZCLAttributeDef, foundation.Status]` (instead of a list with `ConfigureReportingResponseRecord`):
- https://github.com/zigpy/zigpy/pull/1785

With those changes, we can correctly identify the attributes that reporting was set up for (or not).