### PR TITLE
Clean up default reporting config errors

### DIFF
--- a/zha/zigbee/cluster_handlers/general.py
+++ b/zha/zigbee/cluster_handlers/general.py
@@ -304,7 +304,7 @@ class BinaryInputClusterHandler(ClusterHandler):
     REPORT_CONFIG = (
         AttrReportConfig(
             attr=BinaryInput.AttributeDefs.present_value.name,
-            config=REPORT_CONFIG_DEFAULT,
+            config=REPORT_CONFIG_IMMEDIATE,
         ),
     )
 
@@ -325,7 +325,7 @@ class BinaryOutputClusterHandler(ClusterHandler):
     REPORT_CONFIG = (
         AttrReportConfig(
             attr=BinaryOutput.AttributeDefs.present_value.name,
-            config=REPORT_CONFIG_DEFAULT,
+            config=REPORT_CONFIG_IMMEDIATE,
         ),
     )
 
@@ -363,7 +363,7 @@ class BinaryValueClusterHandler(ClusterHandler):
     REPORT_CONFIG = (
         AttrReportConfig(
             attr=BinaryValue.AttributeDefs.present_value.name,
-            config=REPORT_CONFIG_DEFAULT,
+            config=REPORT_CONFIG_IMMEDIATE,
         ),
     )
 

--- a/zha/zigbee/cluster_handlers/hvac.py
+++ b/zha/zigbee/cluster_handlers/hvac.py
@@ -91,15 +91,15 @@ class ThermostatClusterHandler(ClusterHandler):
         ),
         AttrReportConfig(
             attr=Thermostat.AttributeDefs.running_mode.name,
-            config=REPORT_CONFIG_CLIMATE,
+            config=REPORT_CONFIG_CLIMATE_DISCRETE,
         ),
         AttrReportConfig(
             attr=Thermostat.AttributeDefs.running_state.name,
-            config=REPORT_CONFIG_CLIMATE_DEMAND,
+            config=REPORT_CONFIG_CLIMATE_DISCRETE,
         ),
         AttrReportConfig(
             attr=Thermostat.AttributeDefs.system_mode.name,
-            config=REPORT_CONFIG_CLIMATE,
+            config=REPORT_CONFIG_CLIMATE_DISCRETE,
         ),
         AttrReportConfig(
             attr=Thermostat.AttributeDefs.occupancy.name,


### PR DESCRIPTION
I ran into a few errors in our default reporting config:
1. BinaryInput, BinaryOutput, and BinaryValue should use `REPORT_CONFIG_IMMEDIATE`, not `REPORT_CONFIG_DEFAULT`.
2. The various `state` and `mode` Thermostat cluster attributes should use a discrete reporting config, since the "minimum change" will be ignored.