### PR TITLE
Fix NaN values being recognized as non-values

### DIFF
--- a/tests/data/devices/frient-a-s-scazb-141.json
+++ b/tests/data/devices/frient-a-s-scazb-141.json
@@ -1,0 +1,1229 @@
+{
+  "version": 1,
+  "ieee": "ab:cd:ef:12:18:f2:e7:e6",
+  "nwk": "0xEA73",
+  "manufacturer": "frient A/S",
+  "model": "SCAZB-141",
+  "friendly_manufacturer": "frient A/S",
+  "friendly_model": "SCAZB-141",
+  "name": "frient A/S SCAZB-141",
+  "quirk_applied": false,
+  "quirk_class": "zigpy.device.Device",
+  "exposes_features": [],
+  "manufacturer_code": 4117,
+  "power_source": "Battery or Unknown",
+  "lqi": 204,
+  "rssi": -49,
+  "last_seen": "2026-03-18T23:32:55.749336+00:00",
+  "available": true,
+  "device_type": "EndDevice",
+  "active_coordinator": false,
+  "node_descriptor": {
+    "logical_type": "EndDevice",
+    "complex_descriptor_available": false,
+    "user_descriptor_available": false,
+    "reserved": 0,
+    "aps_flags": 0,
+    "frequency_band": 8,
+    "mac_capability_flags": 128,
+    "manufacturer_code": 4117,
+    "maximum_buffer_size": 82,
+    "maximum_incoming_transfer_size": 1500,
+    "server_mask": 11264,
+    "maximum_outgoing_transfer_size": 1500,
+    "descriptor_capability_field": 0
+  },
+  "endpoints": {
+    "1": {
+      "profile_id": 49353,
+      "device_type": {
+        "name": "unknown",
+        "id": 1
+      },
+      "in_clusters": [
+        {
+          "cluster_id": "0x0005",
+          "endpoint_attribute": "scenes",
+          "attributes": []
+        },
+        {
+          "cluster_id": "0x0006",
+          "endpoint_attribute": "on_off",
+          "attributes": []
+        }
+      ],
+      "out_clusters": []
+    },
+    "35": {
+      "profile_id": 260,
+      "device_type": {
+        "name": "IAS_ZONE",
+        "id": 1026
+      },
+      "in_clusters": [
+        {
+          "cluster_id": "0x0000",
+          "endpoint_attribute": "basic",
+          "attributes": [
+            {
+              "id": "0x0006",
+              "name": "date_code",
+              "zcl_type": "string",
+              "value": "2023-03-29 11:39"
+            },
+            {
+              "id": "0x0004",
+              "name": "manufacturer",
+              "zcl_type": "string",
+              "value": "frient A/S"
+            },
+            {
+              "id": "0x0005",
+              "name": "model",
+              "zcl_type": "string",
+              "value": "SCAZB-141"
+            },
+            {
+              "id": "0x4000",
+              "name": "sw_build_id",
+              "zcl_type": "string",
+              "unsupported": true
+            },
+            {
+              "id": "0x0000",
+              "name": "zcl_version",
+              "zcl_type": "uint8",
+              "value": 3
+            }
+          ]
+        },
+        {
+          "cluster_id": "0x0001",
+          "endpoint_attribute": "power",
+          "attributes": [
+            {
+              "id": "0x003e",
+              "name": "battery_alarm_state",
+              "zcl_type": "map32",
+              "value": 0
+            },
+            {
+              "id": "0x0021",
+              "name": "battery_percentage_remaining",
+              "zcl_type": "uint8",
+              "unsupported": true
+            },
+            {
+              "id": "0x0033",
+              "name": "battery_quantity",
+              "zcl_type": "uint8",
+              "value": 1
+            },
+            {
+              "id": "0x0031",
+              "name": "battery_size",
+              "zcl_type": "enum8",
+              "value": 2
+            },
+            {
+              "id": "0x0020",
+              "name": "battery_voltage",
+              "zcl_type": "uint8",
+              "value": 29
+            }
+          ]
+        },
+        {
+          "cluster_id": "0x0003",
+          "endpoint_attribute": "identify",
+          "attributes": []
+        },
+        {
+          "cluster_id": "0x000f",
+          "endpoint_attribute": "binary_input",
+          "attributes": [
+            {
+              "id": "0x0004",
+              "name": "active_text",
+              "zcl_type": "string",
+              "unsupported": true
+            },
+            {
+              "id": "0x001c",
+              "name": "description",
+              "zcl_type": "string",
+              "value": "Smoke"
+            },
+            {
+              "id": "0x0055",
+              "name": "present_value",
+              "zcl_type": "bool",
+              "value": 0
+            },
+            {
+              "id": "0x0067",
+              "name": "reliability",
+              "zcl_type": "enum8",
+              "value": 0
+            },
+            {
+              "id": "0x006f",
+              "name": "status_flags",
+              "zcl_type": "map8",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "cluster_id": "0x0020",
+          "endpoint_attribute": "poll_control",
+          "attributes": []
+        },
+        {
+          "cluster_id": "0x0500",
+          "endpoint_attribute": "ias_zone",
+          "attributes": [
+            {
+              "id": "0x0010",
+              "name": "cie_addr",
+              "zcl_type": "EUI64",
+              "value": [
+                50,
+                79,
+                50,
+                2,
+                0,
+                141,
+                21,
+                0
+              ]
+            },
+            {
+              "id": "0x0000",
+              "name": "zone_state",
+              "zcl_type": "enum8",
+              "value": 0
+            },
+            {
+              "id": "0x0002",
+              "name": "zone_status",
+              "zcl_type": "map16",
+              "value": 48
+            },
+            {
+              "id": "0x0001",
+              "name": "zone_type",
+              "zcl_type": "enum16",
+              "value": 40
+            }
+          ]
+        },
+        {
+          "cluster_id": "0x0502",
+          "endpoint_attribute": "ias_wd",
+          "attributes": []
+        }
+      ],
+      "out_clusters": [
+        {
+          "cluster_id": "0x0003",
+          "endpoint_attribute": "identify",
+          "attributes": []
+        },
+        {
+          "cluster_id": "0x000a",
+          "endpoint_attribute": "time",
+          "attributes": []
+        },
+        {
+          "cluster_id": "0x0019",
+          "endpoint_attribute": "ota",
+          "attributes": [
+            {
+              "id": "0x0002",
+              "name": "current_file_version",
+              "zcl_type": "uint32",
+              "value": 67587
+            }
+          ]
+        }
+      ]
+    },
+    "38": {
+      "profile_id": 260,
+      "device_type": {
+        "name": "TEMPERATURE_SENSOR",
+        "id": 770
+      },
+      "in_clusters": [
+        {
+          "cluster_id": "0x0000",
+          "endpoint_attribute": "basic",
+          "attributes": []
+        },
+        {
+          "cluster_id": "0x0003",
+          "endpoint_attribute": "identify",
+          "attributes": []
+        },
+        {
+          "cluster_id": "0x0402",
+          "endpoint_attribute": "temperature",
+          "attributes": [
+            {
+              "id": "0x0000",
+              "name": "measured_value",
+              "zcl_type": "int16",
+              "value": 2037
+            }
+          ]
+        }
+      ],
+      "out_clusters": []
+    },
+    "46": {
+      "profile_id": 260,
+      "device_type": {
+        "name": "IAS_ZONE",
+        "id": 1026
+      },
+      "in_clusters": [
+        {
+          "cluster_id": "0x0000",
+          "endpoint_attribute": "basic",
+          "attributes": []
+        },
+        {
+          "cluster_id": "0x0003",
+          "endpoint_attribute": "identify",
+          "attributes": []
+        },
+        {
+          "cluster_id": "0x000f",
+          "endpoint_attribute": "binary_input",
+          "attributes": [
+            {
+              "id": "0x0004",
+              "name": "active_text",
+              "zcl_type": "string",
+              "unsupported": true
+            },
+            {
+              "id": "0x001c",
+              "name": "description",
+              "zcl_type": "string",
+              "value": "Carbon Monoxide"
+            },
+            {
+              "id": "0x0055",
+              "name": "present_value",
+              "zcl_type": "bool",
+              "value": 0
+            },
+            {
+              "id": "0x0067",
+              "name": "reliability",
+              "zcl_type": "enum8",
+              "value": 0
+            },
+            {
+              "id": "0x006f",
+              "name": "status_flags",
+              "zcl_type": "map8",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "cluster_id": "0x040c",
+          "endpoint_attribute": "carbon_monoxide_concentration",
+          "attributes": [
+            {
+              "id": "0x0000",
+              "name": "measured_value",
+              "zcl_type": "single",
+              "value": 0.0
+            }
+          ]
+        },
+        {
+          "cluster_id": "0x0500",
+          "endpoint_attribute": "ias_zone",
+          "attributes": [
+            {
+              "id": "0x0010",
+              "name": "cie_addr",
+              "zcl_type": "EUI64",
+              "value": [
+                50,
+                79,
+                50,
+                2,
+                0,
+                141,
+                21,
+                0
+              ]
+            },
+            {
+              "id": "0x0000",
+              "name": "zone_state",
+              "zcl_type": "enum8",
+              "value": 0
+            },
+            {
+              "id": "0x0002",
+              "name": "zone_status",
+              "zcl_type": "map16",
+              "value": 48
+            },
+            {
+              "id": "0x0001",
+              "name": "zone_type",
+              "zcl_type": "enum16",
+              "value": 551
+            }
+          ]
+        }
+      ],
+      "out_clusters": [
+        {
+          "cluster_id": "0x0003",
+          "endpoint_attribute": "identify",
+          "attributes": []
+        }
+      ]
+    }
+  },
+  "original_signature": {
+    "manufacturer": "frient A/S",
+    "model": "SCAZB-141",
+    "node_desc": {
+      "logical_type": 2,
+      "complex_descriptor_available": 0,
+      "user_descriptor_available": 0,
+      "reserved": 0,
+      "aps_flags": 0,
+      "frequency_band": 8,
+      "mac_capability_flags": 128,
+      "manufacturer_code": 4117,
+      "maximum_buffer_size": 82,
+      "maximum_incoming_transfer_size": 1500,
+      "server_mask": 11264,
+      "maximum_outgoing_transfer_size": 1500,
+      "descriptor_capability_field": 0
+    },
+    "endpoints": {
+      "1": {
+        "profile_id": "0xc0c9",
+        "device_type": "0x0001",
+        "input_clusters": [
+          "0x0005",
+          "0x0006"
+        ],
+        "output_clusters": []
+      },
+      "35": {
+        "profile_id": "0x0104",
+        "device_type": "0x0402",
+        "input_clusters": [
+          "0x0000",
+          "0x0001",
+          "0x0003",
+          "0x000f",
+          "0x0020",
+          "0x0500",
+          "0x0502"
+        ],
+        "output_clusters": [
+          "0x0003",
+          "0x000a",
+          "0x0019"
+        ]
+      },
+      "38": {
+        "profile_id": "0x0104",
+        "device_type": "0x0302",
+        "input_clusters": [
+          "0x0000",
+          "0x0003",
+          "0x0402"
+        ],
+        "output_clusters": []
+      },
+      "46": {
+        "profile_id": "0x0104",
+        "device_type": "0x0402",
+        "input_clusters": [
+          "0x0000",
+          "0x0003",
+          "0x000f",
+          "0x0500",
+          "0x040c"
+        ],
+        "output_clusters": [
+          "0x0003"
+        ]
+      }
+    }
+  },
+  "zha_lib_entities": {
+    "binary_sensor": [
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:18:f2:e7:e6-35-1280",
+          "migrate_unique_ids": [],
+          "platform": "binary_sensor",
+          "class_name": "IASZone",
+          "translation_key": null,
+          "translation_placeholders": null,
+          "device_class": "smoke",
+          "state_class": null,
+          "entity_category": null,
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "IASZoneClusterHandler",
+              "generic_id": "cluster_handler_0x0500",
+              "endpoint_id": 35,
+              "cluster": {
+                "id": 1280,
+                "name": "IAS Zone",
+                "type": "server"
+              },
+              "id": "35:0x0500",
+              "unique_id": "ab:cd:ef:12:18:f2:e7:e6:35:0x0500",
+              "status": "INITIALIZED",
+              "value_attribute": null
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:18:f2:e7:e6",
+          "endpoint_id": 35,
+          "available": true,
+          "group_id": null,
+          "attribute_name": "zone_status"
+        },
+        "state": {
+          "class_name": "IASZone",
+          "available": true,
+          "state": false
+        }
+      },
+      {
+        "info_object": {
+          "fallback_name": "Smoke",
+          "unique_id": "ab:cd:ef:12:18:f2:e7:e6-35-15",
+          "migrate_unique_ids": [],
+          "platform": "binary_sensor",
+          "class_name": "BinaryInputWithDescription",
+          "translation_key": null,
+          "translation_placeholders": null,
+          "device_class": null,
+          "state_class": null,
+          "entity_category": null,
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "BinaryInputClusterHandler",
+              "generic_id": "cluster_handler_0x000f",
+              "endpoint_id": 35,
+              "cluster": {
+                "id": 15,
+                "name": "Binary Input (Basic)",
+                "type": "server"
+              },
+              "id": "35:0x000f",
+              "unique_id": "ab:cd:ef:12:18:f2:e7:e6:35:0x000f",
+              "status": "INITIALIZED",
+              "value_attribute": "present_value"
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:18:f2:e7:e6",
+          "endpoint_id": 35,
+          "available": true,
+          "group_id": null,
+          "attribute_name": "present_value"
+        },
+        "state": {
+          "class_name": "BinaryInputWithDescription",
+          "available": true,
+          "state": false
+        }
+      },
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:18:f2:e7:e6-46-1280",
+          "migrate_unique_ids": [],
+          "platform": "binary_sensor",
+          "class_name": "IASZone",
+          "translation_key": "ias_zone",
+          "translation_placeholders": null,
+          "device_class": null,
+          "state_class": null,
+          "entity_category": null,
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "IASZoneClusterHandler",
+              "generic_id": "cluster_handler_0x0500",
+              "endpoint_id": 46,
+              "cluster": {
+                "id": 1280,
+                "name": "IAS Zone",
+                "type": "server"
+              },
+              "id": "46:0x0500",
+              "unique_id": "ab:cd:ef:12:18:f2:e7:e6:46:0x0500",
+              "status": "INITIALIZED",
+              "value_attribute": null
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:18:f2:e7:e6",
+          "endpoint_id": 46,
+          "available": true,
+          "group_id": null,
+          "attribute_name": "zone_status"
+        },
+        "state": {
+          "class_name": "IASZone",
+          "available": true,
+          "state": false
+        }
+      },
+      {
+        "info_object": {
+          "fallback_name": "Carbon Monoxide",
+          "unique_id": "ab:cd:ef:12:18:f2:e7:e6-46-15",
+          "migrate_unique_ids": [],
+          "platform": "binary_sensor",
+          "class_name": "BinaryInputWithDescription",
+          "translation_key": null,
+          "translation_placeholders": null,
+          "device_class": null,
+          "state_class": null,
+          "entity_category": null,
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "BinaryInputClusterHandler",
+              "generic_id": "cluster_handler_0x000f",
+              "endpoint_id": 46,
+              "cluster": {
+                "id": 15,
+                "name": "Binary Input (Basic)",
+                "type": "server"
+              },
+              "id": "46:0x000f",
+              "unique_id": "ab:cd:ef:12:18:f2:e7:e6:46:0x000f",
+              "status": "INITIALIZED",
+              "value_attribute": "present_value"
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:18:f2:e7:e6",
+          "endpoint_id": 46,
+          "available": true,
+          "group_id": null,
+          "attribute_name": "present_value"
+        },
+        "state": {
+          "class_name": "BinaryInputWithDescription",
+          "available": true,
+          "state": false
+        }
+      }
+    ],
+    "button": [
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:18:f2:e7:e6-35-3",
+          "migrate_unique_ids": [],
+          "platform": "button",
+          "class_name": "IdentifyButton",
+          "translation_key": null,
+          "translation_placeholders": null,
+          "device_class": "identify",
+          "state_class": null,
+          "entity_category": "diagnostic",
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "IdentifyClusterHandler",
+              "generic_id": "cluster_handler_0x0003",
+              "endpoint_id": 35,
+              "cluster": {
+                "id": 3,
+                "name": "Identify",
+                "type": "server"
+              },
+              "id": "35:0x0003",
+              "unique_id": "ab:cd:ef:12:18:f2:e7:e6:35:0x0003",
+              "status": "INITIALIZED",
+              "value_attribute": null
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:18:f2:e7:e6",
+          "endpoint_id": 35,
+          "available": true,
+          "group_id": null,
+          "command": "identify",
+          "args": [
+            5
+          ],
+          "kwargs": {}
+        },
+        "state": {
+          "class_name": "IdentifyButton",
+          "available": true
+        }
+      }
+    ],
+    "select": [
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:18:f2:e7:e6-35-1282-SirenLevel",
+          "migrate_unique_ids": [],
+          "platform": "select",
+          "class_name": "DefaultSirenLevelSelectEntity",
+          "translation_key": "default_siren_level",
+          "translation_placeholders": null,
+          "device_class": null,
+          "state_class": null,
+          "entity_category": "config",
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "IasWdClusterHandler",
+              "generic_id": "cluster_handler_0x0502",
+              "endpoint_id": 35,
+              "cluster": {
+                "id": 1282,
+                "name": "IAS Warning Device",
+                "type": "server"
+              },
+              "id": "35:0x0502",
+              "unique_id": "ab:cd:ef:12:18:f2:e7:e6:35:0x0502",
+              "status": "INITIALIZED",
+              "value_attribute": null
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:18:f2:e7:e6",
+          "endpoint_id": 35,
+          "available": true,
+          "group_id": null,
+          "enum": "SirenLevel",
+          "options": [
+            "Low level sound",
+            "Medium level sound",
+            "High level sound",
+            "Very high level sound"
+          ]
+        },
+        "state": {
+          "class_name": "DefaultSirenLevelSelectEntity",
+          "available": true,
+          "state": null
+        }
+      },
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:18:f2:e7:e6-35-1282-Strobe",
+          "migrate_unique_ids": [],
+          "platform": "select",
+          "class_name": "DefaultStrobeSelectEntity",
+          "translation_key": "default_strobe",
+          "translation_placeholders": null,
+          "device_class": null,
+          "state_class": null,
+          "entity_category": "config",
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "IasWdClusterHandler",
+              "generic_id": "cluster_handler_0x0502",
+              "endpoint_id": 35,
+              "cluster": {
+                "id": 1282,
+                "name": "IAS Warning Device",
+                "type": "server"
+              },
+              "id": "35:0x0502",
+              "unique_id": "ab:cd:ef:12:18:f2:e7:e6:35:0x0502",
+              "status": "INITIALIZED",
+              "value_attribute": null
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:18:f2:e7:e6",
+          "endpoint_id": 35,
+          "available": true,
+          "group_id": null,
+          "enum": "Strobe",
+          "options": [
+            "No Strobe",
+            "Strobe"
+          ]
+        },
+        "state": {
+          "class_name": "DefaultStrobeSelectEntity",
+          "available": true,
+          "state": null
+        }
+      },
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:18:f2:e7:e6-35-1282-StrobeLevel",
+          "migrate_unique_ids": [],
+          "platform": "select",
+          "class_name": "DefaultStrobeLevelSelectEntity",
+          "translation_key": "default_strobe_level",
+          "translation_placeholders": null,
+          "device_class": null,
+          "state_class": null,
+          "entity_category": "config",
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "IasWdClusterHandler",
+              "generic_id": "cluster_handler_0x0502",
+              "endpoint_id": 35,
+              "cluster": {
+                "id": 1282,
+                "name": "IAS Warning Device",
+                "type": "server"
+              },
+              "id": "35:0x0502",
+              "unique_id": "ab:cd:ef:12:18:f2:e7:e6:35:0x0502",
+              "status": "INITIALIZED",
+              "value_attribute": null
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:18:f2:e7:e6",
+          "endpoint_id": 35,
+          "available": true,
+          "group_id": null,
+          "enum": "StrobeLevel",
+          "options": [
+            "Low level strobe",
+            "Medium level strobe",
+            "High level strobe",
+            "Very high level strobe"
+          ]
+        },
+        "state": {
+          "class_name": "DefaultStrobeLevelSelectEntity",
+          "available": true,
+          "state": null
+        }
+      },
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:18:f2:e7:e6-35-1282-WarningMode",
+          "migrate_unique_ids": [],
+          "platform": "select",
+          "class_name": "DefaultToneSelectEntity",
+          "translation_key": "default_siren_tone",
+          "translation_placeholders": null,
+          "device_class": null,
+          "state_class": null,
+          "entity_category": "config",
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "IasWdClusterHandler",
+              "generic_id": "cluster_handler_0x0502",
+              "endpoint_id": 35,
+              "cluster": {
+                "id": 1282,
+                "name": "IAS Warning Device",
+                "type": "server"
+              },
+              "id": "35:0x0502",
+              "unique_id": "ab:cd:ef:12:18:f2:e7:e6:35:0x0502",
+              "status": "INITIALIZED",
+              "value_attribute": null
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:18:f2:e7:e6",
+          "endpoint_id": 35,
+          "available": true,
+          "group_id": null,
+          "enum": "WarningMode",
+          "options": [
+            "Stop",
+            "Burglar",
+            "Fire",
+            "Emergency",
+            "Police Panic",
+            "Fire Panic",
+            "Emergency Panic"
+          ]
+        },
+        "state": {
+          "class_name": "DefaultToneSelectEntity",
+          "available": true,
+          "state": null
+        }
+      }
+    ],
+    "sensor": [
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:18:f2:e7:e6-35-0-lqi",
+          "migrate_unique_ids": [],
+          "platform": "sensor",
+          "class_name": "LQISensor",
+          "translation_key": "lqi",
+          "translation_placeholders": null,
+          "device_class": null,
+          "state_class": "measurement",
+          "entity_category": "diagnostic",
+          "entity_registry_enabled_default": false,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "BasicClusterHandler",
+              "generic_id": "cluster_handler_0x0000",
+              "endpoint_id": 35,
+              "cluster": {
+                "id": 0,
+                "name": "Basic",
+                "type": "server"
+              },
+              "id": "35:0x0000",
+              "unique_id": "ab:cd:ef:12:18:f2:e7:e6:35:0x0000",
+              "status": "INITIALIZED",
+              "value_attribute": null
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:18:f2:e7:e6",
+          "endpoint_id": 35,
+          "available": true,
+          "group_id": null,
+          "suggested_display_precision": null,
+          "unit": null
+        },
+        "state": {
+          "class_name": "LQISensor",
+          "available": true,
+          "state": 204
+        }
+      },
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:18:f2:e7:e6-35-0-rssi",
+          "migrate_unique_ids": [],
+          "platform": "sensor",
+          "class_name": "RSSISensor",
+          "translation_key": "rssi",
+          "translation_placeholders": null,
+          "device_class": "signal_strength",
+          "state_class": "measurement",
+          "entity_category": "diagnostic",
+          "entity_registry_enabled_default": false,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "BasicClusterHandler",
+              "generic_id": "cluster_handler_0x0000",
+              "endpoint_id": 35,
+              "cluster": {
+                "id": 0,
+                "name": "Basic",
+                "type": "server"
+              },
+              "id": "35:0x0000",
+              "unique_id": "ab:cd:ef:12:18:f2:e7:e6:35:0x0000",
+              "status": "INITIALIZED",
+              "value_attribute": null
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:18:f2:e7:e6",
+          "endpoint_id": 35,
+          "available": true,
+          "group_id": null,
+          "suggested_display_precision": null,
+          "unit": "dBm"
+        },
+        "state": {
+          "class_name": "RSSISensor",
+          "available": true,
+          "state": -49
+        }
+      },
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:18:f2:e7:e6-35-1",
+          "migrate_unique_ids": [],
+          "platform": "sensor",
+          "class_name": "Battery",
+          "translation_key": null,
+          "translation_placeholders": null,
+          "device_class": "battery",
+          "state_class": "measurement",
+          "entity_category": "diagnostic",
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "PowerConfigurationClusterHandler",
+              "generic_id": "cluster_handler_0x0001",
+              "endpoint_id": 35,
+              "cluster": {
+                "id": 1,
+                "name": "Power Configuration",
+                "type": "server"
+              },
+              "id": "35:0x0001",
+              "unique_id": "ab:cd:ef:12:18:f2:e7:e6:35:0x0001",
+              "status": "INITIALIZED",
+              "value_attribute": "battery_voltage"
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:18:f2:e7:e6",
+          "endpoint_id": 35,
+          "available": true,
+          "group_id": null,
+          "suggested_display_precision": 0,
+          "unit": "%"
+        },
+        "state": {
+          "class_name": "Battery",
+          "available": true,
+          "state": null,
+          "battery_size": "Other",
+          "battery_quantity": 1,
+          "battery_voltage": 2.9
+        },
+        "extra_state_attributes": [
+          "battery_quantity",
+          "battery_size",
+          "battery_voltage"
+        ]
+      },
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:18:f2:e7:e6-38-1026",
+          "migrate_unique_ids": [],
+          "platform": "sensor",
+          "class_name": "Temperature",
+          "translation_key": null,
+          "translation_placeholders": null,
+          "device_class": "temperature",
+          "state_class": "measurement",
+          "entity_category": null,
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "TemperatureMeasurementClusterHandler",
+              "generic_id": "cluster_handler_0x0402",
+              "endpoint_id": 38,
+              "cluster": {
+                "id": 1026,
+                "name": "Temperature Measurement",
+                "type": "server"
+              },
+              "id": "38:0x0402",
+              "unique_id": "ab:cd:ef:12:18:f2:e7:e6:38:0x0402",
+              "status": "INITIALIZED",
+              "value_attribute": "measured_value"
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:18:f2:e7:e6",
+          "endpoint_id": 38,
+          "available": true,
+          "group_id": null,
+          "suggested_display_precision": null,
+          "unit": "\u00b0C"
+        },
+        "state": {
+          "class_name": "Temperature",
+          "available": true,
+          "state": 20.37
+        }
+      },
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:18:f2:e7:e6-46-1036",
+          "migrate_unique_ids": [],
+          "platform": "sensor",
+          "class_name": "CarbonMonoxideConcentration",
+          "translation_key": null,
+          "translation_placeholders": null,
+          "device_class": "carbon_monoxide",
+          "state_class": "measurement",
+          "entity_category": null,
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "CarbonMonoxideConcentrationClusterHandler",
+              "generic_id": "cluster_handler_0x040c",
+              "endpoint_id": 46,
+              "cluster": {
+                "id": 1036,
+                "name": "Carbon Monoxide (CO) Concentration",
+                "type": "server"
+              },
+              "id": "46:0x040c",
+              "unique_id": "ab:cd:ef:12:18:f2:e7:e6:46:0x040c",
+              "status": "INITIALIZED",
+              "value_attribute": "measured_value"
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:18:f2:e7:e6",
+          "endpoint_id": 46,
+          "available": true,
+          "group_id": null,
+          "suggested_display_precision": 0,
+          "unit": "ppm"
+        },
+        "state": {
+          "class_name": "CarbonMonoxideConcentration",
+          "available": true,
+          "state": 0.0
+        }
+      }
+    ],
+    "siren": [
+      {
+        "info_object": {
+          "fallback_name": "Siren",
+          "unique_id": "ab:cd:ef:12:18:f2:e7:e6-35-1282",
+          "migrate_unique_ids": [],
+          "platform": "siren",
+          "class_name": "Siren",
+          "translation_key": null,
+          "translation_placeholders": null,
+          "device_class": null,
+          "state_class": null,
+          "entity_category": null,
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": true,
+          "cluster_handlers": [
+            {
+              "class_name": "IasWdClusterHandler",
+              "generic_id": "cluster_handler_0x0502",
+              "endpoint_id": 35,
+              "cluster": {
+                "id": 1282,
+                "name": "IAS Warning Device",
+                "type": "server"
+              },
+              "id": "35:0x0502",
+              "unique_id": "ab:cd:ef:12:18:f2:e7:e6:35:0x0502",
+              "status": "INITIALIZED",
+              "value_attribute": null
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:18:f2:e7:e6",
+          "endpoint_id": 35,
+          "available": true,
+          "group_id": null,
+          "available_tones": {
+            "1": "Burglar",
+            "2": "Fire",
+            "3": "Emergency",
+            "4": "Police Panic",
+            "5": "Fire Panic",
+            "6": "Emergency Panic"
+          },
+          "supported_features": 31
+        },
+        "state": {
+          "class_name": "Siren",
+          "available": true,
+          "state": false
+        }
+      }
+    ],
+    "update": [
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:18:f2:e7:e6-35-25-firmware_update",
+          "migrate_unique_ids": [],
+          "platform": "update",
+          "class_name": "FirmwareUpdateEntity",
+          "translation_key": null,
+          "translation_placeholders": null,
+          "device_class": "firmware",
+          "state_class": null,
+          "entity_category": "config",
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "OtaClientClusterHandler",
+              "generic_id": "cluster_handler_0x0019_client",
+              "endpoint_id": 35,
+              "cluster": {
+                "id": 25,
+                "name": "Ota",
+                "type": "client"
+              },
+              "id": "35:0x0019_client",
+              "unique_id": "ab:cd:ef:12:18:f2:e7:e6:35:0x0019_CLIENT",
+              "status": "INITIALIZED",
+              "value_attribute": null
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:18:f2:e7:e6",
+          "endpoint_id": 35,
+          "available": true,
+          "group_id": null,
+          "supported_features": 7
+        },
+        "state": {
+          "class_name": "FirmwareUpdateEntity",
+          "available": true,
+          "installed_version": "0x00010803",
+          "in_progress": false,
+          "update_percentage": null,
+          "latest_version": null,
+          "release_summary": null,
+          "release_notes": null,
+          "release_url": null
+        }
+      }
+    ]
+  },
+  "neighbors": [],
+  "routes": []
+}

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2071,36 +2071,30 @@ async def test_ignore_non_value(zha_gateway: Gateway) -> None:
 async def test_ignore_nan_value(zha_gateway: Gateway) -> None:
     """Test sensor updates ignoring NaN values (e.g. from CO concentration sensors)."""
 
-    zigpy_dev = create_mock_zigpy_device(
-        zha_gateway,
-        {
-            1: {
-                SIG_EP_INPUT: [
-                    measurement.CarbonMonoxideConcentration.cluster_id,
-                ],
-                SIG_EP_OUTPUT: [],
-                SIG_EP_TYPE: zha.DeviceType.IAS_ZONE,
-                SIG_EP_PROFILE: zha.PROFILE_ID,
-            },
-        },
-        attributes={
-            1: {
-                "carbon_monoxide_concentration": {
-                    "measured_value": 0.001,
-                },
-            },
-        },
+    zigpy_dev = await zigpy_device_from_json(
+        zha_gateway.application_controller,
+        "tests/data/devices/frient-a-s-scazb-141.json",
     )
 
     zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
-    cluster = zha_device.device.endpoints[1].carbon_monoxide_concentration
+    cluster = zha_device.device.endpoints[46].carbon_monoxide_concentration
     entity = get_entity(
         zha_device,
         platform=Platform.SENSOR,
         entity_type=sensor.CarbonMonoxideConcentration,
     )
 
-    # Normal value
+    # Initial value from the diagnostics file (0.0 * 1e6 = 0.0 ppm)
+    assert entity.state["state"] == 0.0
+
+    # Normal attribute report
+    await send_attributes_report(
+        zha_gateway,
+        cluster,
+        {
+            measurement.CarbonMonoxideConcentration.AttributeDefs.measured_value.id: 0.001
+        },
+    )
     assert entity.state["state"] == 1000.0
 
     # NaN attribute value should result in None state

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2068,6 +2068,54 @@ async def test_ignore_non_value(zha_gateway: Gateway) -> None:
     assert entity.state["state"] is None
 
 
+async def test_ignore_nan_value(zha_gateway: Gateway) -> None:
+    """Test sensor updates ignoring NaN values (e.g. from CO concentration sensors)."""
+
+    zigpy_dev = create_mock_zigpy_device(
+        zha_gateway,
+        {
+            1: {
+                SIG_EP_INPUT: [
+                    measurement.CarbonMonoxideConcentration.cluster_id,
+                ],
+                SIG_EP_OUTPUT: [],
+                SIG_EP_TYPE: zha.DeviceType.IAS_ZONE,
+                SIG_EP_PROFILE: zha.PROFILE_ID,
+            },
+        },
+        attributes={
+            1: {
+                "carbon_monoxide_concentration": {
+                    "measured_value": 0.001,
+                },
+            },
+        },
+    )
+
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
+    cluster = zha_device.device.endpoints[1].carbon_monoxide_concentration
+    entity = get_entity(
+        zha_device,
+        platform=Platform.SENSOR,
+        entity_type=sensor.CarbonMonoxideConcentration,
+    )
+
+    # Normal value
+    assert entity.state["state"] == 1000.0
+
+    # NaN attribute value should result in None state
+    await send_attributes_report(
+        zha_gateway,
+        cluster,
+        {
+            measurement.CarbonMonoxideConcentration.AttributeDefs.measured_value.id: float(
+                "nan"
+            ),
+        },
+    )
+    assert entity.state["state"] is None
+
+
 @pytest.mark.parametrize(
     ("resolution", "precision"),
     [

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -10,6 +10,7 @@ from datetime import date, datetime, timedelta
 import enum
 import functools
 import logging
+import math
 import numbers
 import typing
 from typing import TYPE_CHECKING, Any, cast
@@ -364,6 +365,9 @@ class Sensor(BaseSensor):
         self, value: int | float, *, attr_def: foundation.ZCLAttributeDef | None = None
     ) -> bool:
         """Ignore non-value numerical values."""
+        if isinstance(value, float) and math.isnan(value):
+            return True
+
         if attr_def is None:
             attr_def = self._attr_def
 


### PR DESCRIPTION
## AI summary
- Handle `NaN` float values in sensor `_is_non_value` by adding a `math.isnan()` check, since IEEE 754 `NaN != NaN` causes the existing `==` comparison against `data_type.non_value` to silently pass through
  - Note/TODO: Can we fix this in a better way?
- Sensors (e.g. CO concentration) now return `None` instead of propagating `NaN` to Home Assistant (which caused errors because of the state class)

## Test plan
- Added `test_ignore_nan_value` using the frient SCAZB-141 diagnostics file, verifying that a `NaN` attribute report on the carbon monoxide concentration cluster results in `None` state
