### PR TITLE
Fix carbon monoxide IAS zone device class mapping

### DIFF
--- a/tests/data/devices/tze200-hr0tdd47-ts0601.json
+++ b/tests/data/devices/tze200-hr0tdd47-ts0601.json
@@ -186,7 +186,7 @@
           "class_name": "IASZone",
           "translation_key": null,
           "translation_placeholders": null,
-          "device_class": "gas",
+          "device_class": "carbon_monoxide",
           "state_class": null,
           "entity_category": null,
           "entity_registry_enabled_default": true,

--- a/tests/data/devices/tze284-rjxqso4a-ts0601.json
+++ b/tests/data/devices/tze284-rjxqso4a-ts0601.json
@@ -192,7 +192,7 @@
           "class_name": "IASZone",
           "translation_key": null,
           "translation_placeholders": null,
-          "device_class": "gas",
+          "device_class": "carbon_monoxide",
           "state_class": null,
           "entity_category": null,
           "entity_registry_enabled_default": true,

--- a/zha/application/platforms/binary_sensor/const.py
+++ b/zha/application/platforms/binary_sensor/const.py
@@ -99,6 +99,6 @@ IAS_ZONE_CLASS_MAPPING = {
     IasZone.ZoneType.Contact_Switch: BinarySensorDeviceClass.OPENING,
     IasZone.ZoneType.Fire_Sensor: BinarySensorDeviceClass.SMOKE,
     IasZone.ZoneType.Water_Sensor: BinarySensorDeviceClass.MOISTURE,
-    IasZone.ZoneType.Carbon_Monoxide_Sensor: BinarySensorDeviceClass.GAS,
+    IasZone.ZoneType.Carbon_Monoxide_Sensor: BinarySensorDeviceClass.CO,
     IasZone.ZoneType.Vibration_Movement_Sensor: BinarySensorDeviceClass.VIBRATION,
 }


### PR DESCRIPTION
## Proposed change

This changes the device class for the `IasZone.ZoneType.Carbon_Monoxide_Sensor` from `BinarySensorDeviceClass.GAS` to `CO`. This is needed for the Frient US smoke sensor

## Additional information

- For some reason, this device has `zone_type` `0x0227`, which is not mapped. The quirk will change it using `_CONSTANT_ATTRIBUTES`, as ZHA unsets the device class if `zone_type` is set, but doesn't contain a known value.
- There's also an issue where `change_entity_metadata` takes a `str` for `new_device_class`, not the actual `StrEnum` member for `BinarySensorDeviceClass`. See: https://github.com/zigpy/zha-device-handlers/pull/3780#issuecomment-3682778811
- But as we now use `_CONSTANT_ATTRIBUTES` for this due to the two issues mentioned above, both ZHA issues can be addressed later.
- The Frient US smoke sensor is already part of the diagnostics, but as the quirk is not present yet, its diagnostics don't yet change.