### PR TITLE
[RFC/DRAFT/WIP] ZBT-2 coordinator LED support

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class _FakeApp(ControllerApplication):
+    _ezsp = None
+
     async def add_endpoint(self, descriptor: zdo_t.SimpleDescriptor):
         pass
 

--- a/tests/test_coordinator_light.py
+++ b/tests/test_coordinator_light.py
@@ -1,13 +1,14 @@
 """Test coordinator LED light support."""
 
-import asyncio
+from collections.abc import AsyncGenerator
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 from bellows.ezsp.xncp import FirmwareFeatures
 import pytest
 
 from tests.common import get_entity
+import tests.conftest as test_conftest
 from zha.application import Platform
 from zha.application.gateway import Gateway
 from zha.application.platforms.light import (
@@ -16,6 +17,24 @@ from zha.application.platforms.light import (
     _xy_brightness_to_rgb,
 )
 from zha.application.platforms.light.const import ColorMode
+
+
+@pytest.fixture
+async def zbt2_gateway(
+    zha_data,
+    zigpy_app_controller,
+    caplog,  # pylint: disable=unused-argument
+) -> AsyncGenerator[Gateway, None]:
+    """Set up a ZBT-2-capable gateway."""
+    zigpy_app_controller.state.node_info.manufacturer = "Nabu Casa"
+    zigpy_app_controller.state.node_info.model = "Home Assistant Connect ZBT-2"
+    zigpy_app_controller._ezsp = SimpleNamespace(
+        _xncp_features=FirmwareFeatures.LED_CONTROL,
+        xncp_set_led_state=AsyncMock(),
+    )
+
+    async with test_conftest.TestGateway(zha_data, zigpy_app_controller) as gateway:
+        yield gateway
 
 
 async def test_coordinator_led_not_exposed_without_feature(
@@ -30,192 +49,108 @@ async def test_coordinator_led_not_exposed_without_feature(
         )
 
 
-async def test_coordinator_led_entity(zha_data, zigpy_app_controller) -> None:
+async def test_coordinator_led_entity(zbt2_gateway: Gateway) -> None:
     """Test coordinator LED light discovery and control."""
-    zigpy_app_controller.state.node_info.manufacturer = "Nabu Casa"
-    zigpy_app_controller.state.node_info.model = "Home Assistant Connect ZBT-2"
-    zigpy_app_controller._ezsp = SimpleNamespace(
-        _xncp_features=FirmwareFeatures.LED_CONTROL,
-        xncp_set_led_state=AsyncMock(),
+    entity = get_entity(
+        zbt2_gateway.coordinator_zha_device,
+        platform=Platform.LIGHT,
+        exact_entity_type=CoordinatorLED,
     )
+    ezsp = zbt2_gateway.application_controller._ezsp
 
-    with (
-        patch(
-            "bellows.zigbee.application.ControllerApplication.new",
-            return_value=zigpy_app_controller,
-        ),
-        patch(
-            "bellows.zigbee.application.ControllerApplication",
-            return_value=zigpy_app_controller,
-        ),
-    ):
-        gateway = await Gateway.async_from_config(zha_data)
-        await gateway.async_initialize()
-        await gateway.async_block_till_done()
-        await gateway.async_initialize_devices_and_entities()
+    assert entity.state["on"] is False
+    assert entity.state["color_mode"] == ColorMode.XY
+    assert entity.state["supported_color_modes"] == {ColorMode.XY}
 
-    try:
-        coordinator = gateway.coordinator_zha_device
-        entity = get_entity(
-            coordinator,
-            platform=Platform.LIGHT,
-            exact_entity_type=CoordinatorLED,
-        )
+    await entity.async_turn_on(brightness=128)
+    await zbt2_gateway.async_block_till_done()
 
-        assert entity.state["on"] is False
-        assert entity.state["color_mode"] == ColorMode.XY
-        assert entity.state["supported_color_modes"] == {ColorMode.XY}
+    expected_red, expected_green, expected_blue = _xy_brightness_to_rgb(
+        DEFAULT_COORDINATOR_LED_XY_COLOR[0],
+        DEFAULT_COORDINATOR_LED_XY_COLOR[1],
+        128,
+    )
+    assert ezsp.xncp_set_led_state.await_args_list[0].kwargs == {
+        "red": expected_red,
+        "green": expected_green,
+        "blue": expected_blue,
+    }
+    assert entity.state["on"] is True
+    assert entity.state["brightness"] == 128
+    assert entity.state["color_mode"] == ColorMode.XY
 
-        await entity.async_turn_on(brightness=128)
-        await gateway.async_block_till_done()
+    await entity.async_turn_off()
+    await zbt2_gateway.async_block_till_done()
 
-        expected_red, expected_green, expected_blue = _xy_brightness_to_rgb(
-            DEFAULT_COORDINATOR_LED_XY_COLOR[0],
-            DEFAULT_COORDINATOR_LED_XY_COLOR[1],
-            128,
-        )
-        assert zigpy_app_controller._ezsp.xncp_set_led_state.await_args_list[
-            0
-        ].kwargs == {
-            "red": expected_red,
-            "green": expected_green,
-            "blue": expected_blue,
-        }
-        assert entity.state["on"] is True
-        assert entity.state["brightness"] == 128
-        assert entity.state["color_mode"] == ColorMode.XY
-
-        await entity.async_turn_off()
-        await gateway.async_block_till_done()
-
-        assert zigpy_app_controller._ezsp.xncp_set_led_state.await_args_list[
-            1
-        ].kwargs == {
-            "red": 0,
-            "green": 0,
-            "blue": 0,
-        }
-        assert entity.state["on"] is False
-    finally:
-        await gateway.shutdown()
-        await asyncio.sleep(0)
+    assert ezsp.xncp_set_led_state.await_args_list[1].kwargs == {
+        "red": 0,
+        "green": 0,
+        "blue": 0,
+    }
+    assert entity.state["on"] is False
 
 
 async def test_coordinator_led_brightness_uses_current_xy_color(
-    zha_data, zigpy_app_controller
+    zbt2_gateway: Gateway,
 ) -> None:
     """Test that brightness-only updates preserve the current XY color."""
-    zigpy_app_controller.state.node_info.manufacturer = "Nabu Casa"
-    zigpy_app_controller.state.node_info.model = "Home Assistant Connect ZBT-2"
-    zigpy_app_controller._ezsp = SimpleNamespace(
-        _xncp_features=FirmwareFeatures.LED_CONTROL,
-        xncp_set_led_state=AsyncMock(),
+    entity = get_entity(
+        zbt2_gateway.coordinator_zha_device,
+        platform=Platform.LIGHT,
+        exact_entity_type=CoordinatorLED,
     )
+    ezsp = zbt2_gateway.application_controller._ezsp
 
-    with (
-        patch(
-            "bellows.zigbee.application.ControllerApplication.new",
-            return_value=zigpy_app_controller,
-        ),
-        patch(
-            "bellows.zigbee.application.ControllerApplication",
-            return_value=zigpy_app_controller,
-        ),
-    ):
-        gateway = await Gateway.async_from_config(zha_data)
-        await gateway.async_initialize()
-        await gateway.async_block_till_done()
-        await gateway.async_initialize_devices_and_entities()
+    red_xy = (0.64, 0.33)
+    await entity.async_turn_on(xy_color=red_xy, brightness=255)
+    await zbt2_gateway.async_block_till_done()
 
-    try:
-        entity = get_entity(
-            gateway.coordinator_zha_device,
-            platform=Platform.LIGHT,
-            exact_entity_type=CoordinatorLED,
-        )
+    await entity.async_turn_on(brightness=64)
+    await zbt2_gateway.async_block_till_done()
 
-        red_xy = (0.64, 0.33)
-        await entity.async_turn_on(xy_color=red_xy, brightness=255)
-        await gateway.async_block_till_done()
-
-        await entity.async_turn_on(brightness=64)
-        await gateway.async_block_till_done()
-
-        assert zigpy_app_controller._ezsp.xncp_set_led_state.await_args_list[
-            1
-        ].kwargs == {
-            "red": 64,
-            "green": 22,
-            "blue": 11,
-        }
-        assert entity.state["xy_color"] == red_xy
-        assert entity.state["brightness"] == 64
-    finally:
-        await gateway.shutdown()
-        await asyncio.sleep(0)
+    assert ezsp.xncp_set_led_state.await_args_list[1].kwargs == {
+        "red": 64,
+        "green": 22,
+        "blue": 11,
+    }
+    assert entity.state["xy_color"] == red_xy
+    assert entity.state["brightness"] == 64
 
 
 async def test_coordinator_led_restores_attributes_and_replays_on_state(
-    zha_data, zigpy_app_controller
+    zbt2_gateway: Gateway,
 ) -> None:
     """Test that coordinator LED restoration replays the previous on-state."""
-    zigpy_app_controller.state.node_info.manufacturer = "Nabu Casa"
-    zigpy_app_controller.state.node_info.model = "Home Assistant Connect ZBT-2"
-    zigpy_app_controller._ezsp = SimpleNamespace(
-        _xncp_features=FirmwareFeatures.LED_CONTROL,
-        xncp_set_led_state=AsyncMock(),
+    entity = get_entity(
+        zbt2_gateway.coordinator_zha_device,
+        platform=Platform.LIGHT,
+        exact_entity_type=CoordinatorLED,
     )
+    ezsp = zbt2_gateway.application_controller._ezsp
 
-    with (
-        patch(
-            "bellows.zigbee.application.ControllerApplication.new",
-            return_value=zigpy_app_controller,
-        ),
-        patch(
-            "bellows.zigbee.application.ControllerApplication",
-            return_value=zigpy_app_controller,
-        ),
-    ):
-        gateway = await Gateway.async_from_config(zha_data)
-        await gateway.async_initialize()
-        await gateway.async_block_till_done()
-        await gateway.async_initialize_devices_and_entities()
+    entity.restore_external_state_attributes(
+        state=True,
+        off_with_transition=False,
+        off_brightness=None,
+        brightness=80,
+        color_temp=None,
+        xy_color=(0.64, 0.33),
+        color_mode=ColorMode.XY,
+        effect=None,
+    )
+    await zbt2_gateway.async_block_till_done()
 
-    try:
-        entity = get_entity(
-            gateway.coordinator_zha_device,
-            platform=Platform.LIGHT,
-            exact_entity_type=CoordinatorLED,
-        )
-
-        entity.restore_external_state_attributes(
-            state=True,
-            off_with_transition=False,
-            off_brightness=None,
-            brightness=80,
-            color_temp=None,
-            xy_color=(0.64, 0.33),
-            color_mode=ColorMode.XY,
-            effect=None,
-        )
-        await gateway.async_block_till_done()
-
-        expected_red, expected_green, expected_blue = _xy_brightness_to_rgb(
-            0.64,
-            0.33,
-            80,
-        )
-        assert zigpy_app_controller._ezsp.xncp_set_led_state.await_args_list[
-            0
-        ].kwargs == {
-            "red": expected_red,
-            "green": expected_green,
-            "blue": expected_blue,
-        }
-        assert entity.state["on"] is True
-        assert entity.state["brightness"] == 80
-        assert entity.state["xy_color"] == (0.64, 0.33)
-        assert entity.state["color_mode"] == ColorMode.XY
-    finally:
-        await gateway.shutdown()
-        await asyncio.sleep(0)
+    expected_red, expected_green, expected_blue = _xy_brightness_to_rgb(
+        0.64,
+        0.33,
+        80,
+    )
+    assert ezsp.xncp_set_led_state.await_args_list[0].kwargs == {
+        "red": expected_red,
+        "green": expected_green,
+        "blue": expected_blue,
+    }
+    assert entity.state["on"] is True
+    assert entity.state["brightness"] == 80
+    assert entity.state["xy_color"] == (0.64, 0.33)
+    assert entity.state["color_mode"] == ColorMode.XY

--- a/tests/test_coordinator_light.py
+++ b/tests/test_coordinator_light.py
@@ -12,6 +12,7 @@ import tests.conftest as test_conftest
 from zha.application import Platform
 from zha.application.gateway import Gateway
 from zha.application.platforms.light import (
+    DEFAULT_COORDINATOR_LED_BRIGHTNESS,
     DEFAULT_COORDINATOR_LED_XY_COLOR,
     CoordinatorLED,
     _xy_brightness_to_rgb,
@@ -88,6 +89,33 @@ async def test_coordinator_led_entity(zbt2_gateway: Gateway) -> None:
         "blue": 0,
     }
     assert entity.state["on"] is False
+
+
+async def test_coordinator_led_first_turn_on_uses_firmware_dim_white_default(
+    zbt2_gateway: Gateway,
+) -> None:
+    """Test that the first turn_on without a brightness uses the firmware dim white level."""
+    entity = get_entity(
+        zbt2_gateway.coordinator_zha_device,
+        platform=Platform.LIGHT,
+        exact_entity_type=CoordinatorLED,
+    )
+    ezsp = zbt2_gateway.application_controller._ezsp
+
+    await entity.async_turn_on()
+    await zbt2_gateway.async_block_till_done()
+
+    expected_red, expected_green, expected_blue = _xy_brightness_to_rgb(
+        DEFAULT_COORDINATOR_LED_XY_COLOR[0],
+        DEFAULT_COORDINATOR_LED_XY_COLOR[1],
+        DEFAULT_COORDINATOR_LED_BRIGHTNESS,
+    )
+    assert ezsp.xncp_set_led_state.await_args_list[0].kwargs == {
+        "red": expected_red,
+        "green": expected_green,
+        "blue": expected_blue,
+    }
+    assert entity.state["brightness"] == DEFAULT_COORDINATOR_LED_BRIGHTNESS
 
 
 async def test_coordinator_led_brightness_uses_current_xy_color(

--- a/tests/test_coordinator_light.py
+++ b/tests/test_coordinator_light.py
@@ -1,0 +1,221 @@
+"""Test coordinator LED light support."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from bellows.ezsp.xncp import FirmwareFeatures
+import pytest
+
+from tests.common import get_entity
+from zha.application import Platform
+from zha.application.gateway import Gateway
+from zha.application.platforms.light import (
+    DEFAULT_COORDINATOR_LED_XY_COLOR,
+    CoordinatorLED,
+    _xy_brightness_to_rgb,
+)
+from zha.application.platforms.light.const import ColorMode
+
+
+async def test_coordinator_led_not_exposed_without_feature(
+    zha_gateway: Gateway,
+) -> None:
+    """Test that the coordinator LED entity is not exposed without support."""
+    with pytest.raises(KeyError):
+        get_entity(
+            zha_gateway.coordinator_zha_device,
+            platform=Platform.LIGHT,
+            exact_entity_type=CoordinatorLED,
+        )
+
+
+async def test_coordinator_led_entity(zha_data, zigpy_app_controller) -> None:
+    """Test coordinator LED light discovery and control."""
+    zigpy_app_controller.state.node_info.manufacturer = "Nabu Casa"
+    zigpy_app_controller.state.node_info.model = "Home Assistant Connect ZBT-2"
+    zigpy_app_controller._ezsp = SimpleNamespace(
+        _xncp_features=FirmwareFeatures.LED_CONTROL,
+        xncp_set_led_state=AsyncMock(),
+    )
+
+    with (
+        patch(
+            "bellows.zigbee.application.ControllerApplication.new",
+            return_value=zigpy_app_controller,
+        ),
+        patch(
+            "bellows.zigbee.application.ControllerApplication",
+            return_value=zigpy_app_controller,
+        ),
+    ):
+        gateway = await Gateway.async_from_config(zha_data)
+        await gateway.async_initialize()
+        await gateway.async_block_till_done()
+        await gateway.async_initialize_devices_and_entities()
+
+    try:
+        coordinator = gateway.coordinator_zha_device
+        entity = get_entity(
+            coordinator,
+            platform=Platform.LIGHT,
+            exact_entity_type=CoordinatorLED,
+        )
+
+        assert entity.state["on"] is False
+        assert entity.state["color_mode"] == ColorMode.XY
+        assert entity.state["supported_color_modes"] == {ColorMode.XY}
+
+        await entity.async_turn_on(brightness=128)
+        await gateway.async_block_till_done()
+
+        expected_red, expected_green, expected_blue = _xy_brightness_to_rgb(
+            DEFAULT_COORDINATOR_LED_XY_COLOR[0],
+            DEFAULT_COORDINATOR_LED_XY_COLOR[1],
+            128,
+        )
+        assert zigpy_app_controller._ezsp.xncp_set_led_state.await_args_list[
+            0
+        ].kwargs == {
+            "red": expected_red,
+            "green": expected_green,
+            "blue": expected_blue,
+        }
+        assert entity.state["on"] is True
+        assert entity.state["brightness"] == 128
+        assert entity.state["color_mode"] == ColorMode.XY
+
+        await entity.async_turn_off()
+        await gateway.async_block_till_done()
+
+        assert zigpy_app_controller._ezsp.xncp_set_led_state.await_args_list[
+            1
+        ].kwargs == {
+            "red": 0,
+            "green": 0,
+            "blue": 0,
+        }
+        assert entity.state["on"] is False
+    finally:
+        await gateway.shutdown()
+        await asyncio.sleep(0)
+
+
+async def test_coordinator_led_brightness_uses_current_xy_color(
+    zha_data, zigpy_app_controller
+) -> None:
+    """Test that brightness-only updates preserve the current XY color."""
+    zigpy_app_controller.state.node_info.manufacturer = "Nabu Casa"
+    zigpy_app_controller.state.node_info.model = "Home Assistant Connect ZBT-2"
+    zigpy_app_controller._ezsp = SimpleNamespace(
+        _xncp_features=FirmwareFeatures.LED_CONTROL,
+        xncp_set_led_state=AsyncMock(),
+    )
+
+    with (
+        patch(
+            "bellows.zigbee.application.ControllerApplication.new",
+            return_value=zigpy_app_controller,
+        ),
+        patch(
+            "bellows.zigbee.application.ControllerApplication",
+            return_value=zigpy_app_controller,
+        ),
+    ):
+        gateway = await Gateway.async_from_config(zha_data)
+        await gateway.async_initialize()
+        await gateway.async_block_till_done()
+        await gateway.async_initialize_devices_and_entities()
+
+    try:
+        entity = get_entity(
+            gateway.coordinator_zha_device,
+            platform=Platform.LIGHT,
+            exact_entity_type=CoordinatorLED,
+        )
+
+        red_xy = (0.64, 0.33)
+        await entity.async_turn_on(xy_color=red_xy, brightness=255)
+        await gateway.async_block_till_done()
+
+        await entity.async_turn_on(brightness=64)
+        await gateway.async_block_till_done()
+
+        assert zigpy_app_controller._ezsp.xncp_set_led_state.await_args_list[
+            1
+        ].kwargs == {
+            "red": 64,
+            "green": 22,
+            "blue": 11,
+        }
+        assert entity.state["xy_color"] == red_xy
+        assert entity.state["brightness"] == 64
+    finally:
+        await gateway.shutdown()
+        await asyncio.sleep(0)
+
+
+async def test_coordinator_led_restores_attributes_and_replays_on_state(
+    zha_data, zigpy_app_controller
+) -> None:
+    """Test that coordinator LED restoration replays the previous on-state."""
+    zigpy_app_controller.state.node_info.manufacturer = "Nabu Casa"
+    zigpy_app_controller.state.node_info.model = "Home Assistant Connect ZBT-2"
+    zigpy_app_controller._ezsp = SimpleNamespace(
+        _xncp_features=FirmwareFeatures.LED_CONTROL,
+        xncp_set_led_state=AsyncMock(),
+    )
+
+    with (
+        patch(
+            "bellows.zigbee.application.ControllerApplication.new",
+            return_value=zigpy_app_controller,
+        ),
+        patch(
+            "bellows.zigbee.application.ControllerApplication",
+            return_value=zigpy_app_controller,
+        ),
+    ):
+        gateway = await Gateway.async_from_config(zha_data)
+        await gateway.async_initialize()
+        await gateway.async_block_till_done()
+        await gateway.async_initialize_devices_and_entities()
+
+    try:
+        entity = get_entity(
+            gateway.coordinator_zha_device,
+            platform=Platform.LIGHT,
+            exact_entity_type=CoordinatorLED,
+        )
+
+        entity.restore_external_state_attributes(
+            state=True,
+            off_with_transition=False,
+            off_brightness=None,
+            brightness=80,
+            color_temp=None,
+            xy_color=(0.64, 0.33),
+            color_mode=ColorMode.XY,
+            effect=None,
+        )
+        await gateway.async_block_till_done()
+
+        expected_red, expected_green, expected_blue = _xy_brightness_to_rgb(
+            0.64,
+            0.33,
+            80,
+        )
+        assert zigpy_app_controller._ezsp.xncp_set_led_state.await_args_list[
+            0
+        ].kwargs == {
+            "red": expected_red,
+            "green": expected_green,
+            "blue": expected_blue,
+        }
+        assert entity.state["on"] is True
+        assert entity.state["brightness"] == 80
+        assert entity.state["xy_color"] == (0.64, 0.33)
+        assert entity.state["color_mode"] == ColorMode.XY
+    finally:
+        await gateway.shutdown()
+        await asyncio.sleep(0)

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -8,8 +8,10 @@ from dataclasses import astuple
 import functools
 import itertools
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
+from bellows.ezsp.xncp import FirmwareFeatures
+import bellows.zigbee.application
 from zigpy.quirks.v2 import (
     BinarySensorMetadata,
     CustomDeviceV2,
@@ -159,7 +161,7 @@ def discover_device_entities(device: Device) -> Iterator[BaseEntity]:
 @ignore_exceptions_during_iteration
 def discover_coordinator_device_entities(
     device: Device,
-) -> Iterator[sensor.DeviceCounterSensor]:
+) -> Iterator[BaseEntity]:
     """Discover entities for the coordinator device."""
     _LOGGER.debug(
         "Discovering entities for coordinator device: %s-%s",
@@ -167,6 +169,23 @@ def discover_coordinator_device_entities(
         device.name,
     )
     state: State = device.gateway.application_controller.state
+
+    if device.gateway.radio_type is zha_const.RadioType.ezsp:
+        app_controller = cast(
+            bellows.zigbee.application.ControllerApplication,
+            device.gateway.application_controller,
+        )
+        ezsp = app_controller._ezsp
+
+        if ezsp is not None and FirmwareFeatures.LED_CONTROL in ezsp._xncp_features:
+            yield light.CoordinatorLED(device)
+
+            _LOGGER.debug(
+                "'%s' platform -> '%s' using %s",
+                Platform.LIGHT,
+                light.CoordinatorLED.__name__,
+                "bellows XNCP LED control",
+            )
 
     for counter_groups in (
         "counters",

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -25,6 +25,7 @@ from zha.application.platforms import (
     BaseEntity,
     BaseEntityInfo,
     ClusterHandlerMatch,
+    EntityCategory,
     GroupEntity,
     PlatformEntity,
     PlatformFeatureGroup,
@@ -263,6 +264,224 @@ class BaseLight(BaseEntity, ABC):
             self._color_mode = color_mode
         if effect is not None:
             self._effect = effect
+
+
+DEFAULT_COORDINATOR_LED_XY_COLOR = (0.3127, 0.3290)
+
+
+def _clamp_rgb_channel(value: float) -> int:
+    """Clamp an RGB channel to an 8-bit integer."""
+    return max(0, min(255, int(round(value))))
+
+
+def _xy_brightness_to_rgb(x: float, y: float, brightness: int) -> tuple[int, int, int]:
+    """Convert XY + brightness into an RGB tuple."""
+    if y <= 0 or brightness <= 0:
+        return (0, 0, 0)
+
+    y_luma = 1.0
+    x_tristimulus = (y_luma / y) * x
+    z_tristimulus = (y_luma / y) * (1 - x - y)
+
+    red = (x_tristimulus * 1.656492) - (y_luma * 0.354851) - (z_tristimulus * 0.255038)
+    green = (
+        -(x_tristimulus * 0.707196) + (y_luma * 1.655397) + (z_tristimulus * 0.036152)
+    )
+    blue = (x_tristimulus * 0.051713) - (y_luma * 0.121364) + (z_tristimulus * 1.01153)
+
+    if red > blue and red > green and red > 1.0:
+        green /= red
+        blue /= red
+        red = 1.0
+    elif green > blue and green > red and green > 1.0:
+        red /= green
+        blue /= green
+        green = 1.0
+    elif blue > red and blue > green and blue > 1.0:
+        red /= blue
+        green /= blue
+        blue = 1.0
+
+    def gamma_correct(value: float) -> float:
+        value = max(0.0, value)
+        if value <= 0.0031308:
+            return 12.92 * value
+        return (1.055 * pow(value, 1 / 2.4)) - 0.055
+
+    scale = min(255, brightness) / 255
+    return (
+        _clamp_rgb_channel(gamma_correct(red) * 255 * scale),
+        _clamp_rgb_channel(gamma_correct(green) * 255 * scale),
+        _clamp_rgb_channel(gamma_correct(blue) * 255 * scale),
+    )
+
+
+class CoordinatorLED(BaseLight):
+    """Coordinator LED control exposed through bellows XNCP."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_fallback_name = "Coordinator LED"
+    _attr_primary = False
+
+    def __init__(self, zha_device: Device) -> None:
+        """Init the coordinator LED entity."""
+        slugified_device_id = zha_device.unique_id.replace(":", "-")
+        super().__init__(unique_id=f"{slugified_device_id}_coordinator_led")
+        self._device = zha_device
+        self._state = False
+        self._brightness = 255
+        self._color_mode = ColorMode.XY
+        self._supported_color_modes = {ColorMode.XY}
+        self._xy_color = DEFAULT_COORDINATOR_LED_XY_COLOR
+        self._restore_on_startup = False
+
+    @functools.cached_property
+    def info_object(self) -> LightEntityInfo:
+        """Return a representation of the coordinator LED."""
+        return dataclasses.replace(
+            super().info_object,
+            device_ieee=self._device.ieee,
+            available=self.available,
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return entity availability."""
+        return self._device.available
+
+    @property
+    def state(self) -> dict[str, Any]:
+        """Return the state of the coordinator LED."""
+        response = super().state
+        response["available"] = self.available
+        return response
+
+    def on_add(self) -> None:
+        """Run when entity is added."""
+        super().on_add()
+        self._schedule_restore_turn_on()
+
+    def restore_external_state_attributes(
+        self,
+        *,
+        state: bool | None,
+        off_with_transition: bool | None,
+        off_brightness: int | None,
+        brightness: int | None,
+        color_temp: int | None,
+        xy_color: tuple[float, float] | None,
+        color_mode: ColorMode | None,
+        effect: str | None,
+    ) -> None:
+        """Restore coordinator LED state and replay the last on-state optimistically."""
+        super().restore_external_state_attributes(
+            state=False,
+            off_with_transition=off_with_transition,
+            off_brightness=off_brightness,
+            brightness=brightness,
+            color_temp=color_temp,
+            xy_color=xy_color,
+            color_mode=color_mode,
+            effect=effect,
+        )
+        self._restore_on_startup = bool(state)
+        self._schedule_restore_turn_on()
+
+    def _schedule_restore_turn_on(self) -> None:
+        """Replay the restored LED state after startup."""
+        if not self._restore_on_startup or not self.available:
+            return
+
+        self._restore_on_startup = False
+        task = self._device.gateway.async_create_task(
+            self._async_restore_turn_on(),
+            name=f"{self.unique_id}_restore_turn_on",
+        )
+        self._tracked_tasks.append(task)
+
+        def remove_task(done_task: asyncio.Task) -> None:
+            with contextlib.suppress(ValueError):
+                self._tracked_tasks.remove(done_task)
+
+        task.add_done_callback(remove_task)
+
+    async def _async_restore_turn_on(self) -> None:
+        """Restore the last known LED state after startup."""
+        try:
+            await self.async_turn_on(
+                brightness=self._brightness,
+                xy_color=self._xy_color,
+            )
+        except Exception:  # pylint: disable=broad-except
+            self.error("Failed to restore coordinator LED state", exc_info=True)
+
+    def _get_rgb_color(
+        self,
+        brightness: int | None,
+        xy_color: tuple[float, float] | None,
+    ) -> tuple[int, int, int]:
+        """Resolve the RGB color to send to the adapter."""
+        if brightness is not None:
+            target_brightness = max(DEFAULT_MIN_BRIGHTNESS, min(255, brightness))
+            self._brightness = target_brightness
+        elif self._brightness is None:
+            target_brightness = 255
+            self._brightness = target_brightness
+        else:
+            target_brightness = self._brightness
+
+        if xy_color is not None:
+            self._xy_color = xy_color
+            return _xy_brightness_to_rgb(xy_color[0], xy_color[1], target_brightness)
+
+        if self._xy_color is not None:
+            return _xy_brightness_to_rgb(
+                self._xy_color[0], self._xy_color[1], target_brightness
+            )
+
+        self._xy_color = DEFAULT_COORDINATOR_LED_XY_COLOR
+        return _xy_brightness_to_rgb(
+            self._xy_color[0], self._xy_color[1], target_brightness
+        )
+
+    async def _async_set_led_state(self, red: int, green: int, blue: int) -> None:
+        """Send the LED state to the coordinator."""
+        ezsp = getattr(self._device.gateway.application_controller, "_ezsp", None)
+        if ezsp is None or not hasattr(ezsp, "xncp_set_led_state"):
+            raise RuntimeError("Coordinator does not expose XNCP LED control")
+
+        await ezsp.xncp_set_led_state(red=red, green=green, blue=blue)
+
+    async def async_turn_on(
+        self,
+        *,
+        transition: float | None = None,
+        brightness: int | None = None,
+        effect: str | None = None,
+        flash: FlashMode | None = None,
+        color_temp: int | None = None,
+        xy_color: tuple[int, int] | None = None,
+    ) -> None:
+        """Turn the entity on."""
+        del transition, effect, flash, color_temp
+
+        resolved_xy_color: tuple[float, float] | None = None
+        if xy_color is not None:
+            resolved_xy_color = (float(xy_color[0]), float(xy_color[1]))
+        elif self._xy_color is None and self._color_mode == ColorMode.XY:
+            resolved_xy_color = DEFAULT_COORDINATOR_LED_XY_COLOR
+
+        red, green, blue = self._get_rgb_color(brightness, resolved_xy_color)
+        await self._async_set_led_state(red=red, green=green, blue=blue)
+        self._state = True
+        self.maybe_emit_state_changed_event()
+
+    async def async_turn_off(self, *, transition: float | None = None) -> None:
+        """Turn the entity off."""
+        del transition
+        await self._async_set_led_state(red=0, green=0, blue=0)
+        self._state = False
+        self.maybe_emit_state_changed_event()
 
 
 class BaseClusterHandlerLight(BaseLight):

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -463,7 +463,6 @@ class CoordinatorLED(BaseLight):
         xy_color: tuple[int, int] | None = None,
     ) -> None:
         """Turn the entity on."""
-        del transition, effect, flash, color_temp
 
         resolved_xy_color: tuple[float, float] | None = None
         if xy_color is not None:
@@ -478,7 +477,6 @@ class CoordinatorLED(BaseLight):
 
     async def async_turn_off(self, *, transition: float | None = None) -> None:
         """Turn the entity off."""
-        del transition
         await self._async_set_led_state(red=0, green=0, blue=0)
         self._state = False
         self.maybe_emit_state_changed_event()

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -267,6 +267,7 @@ class BaseLight(BaseEntity, ABC):
 
 
 DEFAULT_COORDINATOR_LED_XY_COLOR = (0.3127, 0.3290)
+DEFAULT_COORDINATOR_LED_BRIGHTNESS = 75
 
 
 def _clamp_rgb_channel(value: float) -> int:
@@ -329,7 +330,7 @@ class CoordinatorLED(BaseLight):
         super().__init__(unique_id=f"{slugified_device_id}_coordinator_led")
         self._device = zha_device
         self._state = False
-        self._brightness = 255
+        self._brightness = DEFAULT_COORDINATOR_LED_BRIGHTNESS
         self._color_mode = ColorMode.XY
         self._supported_color_modes = {ColorMode.XY}
         self._xy_color = DEFAULT_COORDINATOR_LED_XY_COLOR
@@ -425,7 +426,7 @@ class CoordinatorLED(BaseLight):
             target_brightness = max(DEFAULT_MIN_BRIGHTNESS, min(255, brightness))
             self._brightness = target_brightness
         elif self._brightness is None:
-            target_brightness = 255
+            target_brightness = DEFAULT_COORDINATOR_LED_BRIGHTNESS
             self._brightness = target_brightness
         else:
             target_brightness = self._brightness


### PR DESCRIPTION
DRAFT. Just playing around for now.

## Proposed change

This adds experimental support for directly controlling the ZBT-2 coordinator LED using firmware extensions.
The changes work (with the linked bellows PR), but this is very experimental and rough. Nothing that should be merged.

### Notes:
- This PR directly accesses bellows internals for the firmware extensions(!)
  - We could either making this more generic using zigpy as an intermediate layer, similar to how "network country code" firmware extensions are handled?
  - Or, we could have bellows expose a "more public API" for directly using firmware extensions, like this.
- When we reset ZBT-2 firmware whilst connecting, the LED color is turned off, as the ZBT-2 does not persist LED state.
  - So, ZHA now creates a task to restore the last LED state in `on_add`. That way, you'll only see the ZBT-2 LED turn off for a few seconds when ZHA is reloaded (or HA restarted).
  - It might be worth looking into making this persistent within ZBT-2 firmware, though also consider allowing for ways to turn it off, e.g. when switching to Z2M – at least holding down the reset button should also clear the LED state.
- When the light is turned on for the first time by the user, we send a default `DEFAULT_COORDINATOR_LED_XY_COLOR` color.
  - Currently, this should match the `LED_COLOR_WHITE_DIM` color from firmware (`RGB8(75, 75, 75)`)
  - This shows up as "white" with 29% brightness in HA when first turning on the light.
  - The router firmware uses another blue color when searching for a network. Should we also use that here?
- There is currently no command for properly turning the light off and handing control back to the firmware.
  - [`led_manager_clear_pattern(LED_PRIORITY_MANUAL)`](https://github.com/NabuCasa/silabs-firmware-builder/blob/827ac16ae5dffe6ca531880b15da64622b8fe1a6/extension/nabucasa_hardware_extension/src/led_manager.c#L147-L150) is not supported via firmware extensions, so ZHA turns the light "black" to turn it off.
  - This might be something to expose in firmware and bellows, though I don't think it realistically matters with current coordinator firmware behavior. E.g. if we wipe network settings, we reset firmware anyway, so it should start blinking again(?)
- It is somewhat confusing that the coordinator device page in HA also shows ZHA light groups.
  - As a config entity, the ZBT-2 LED is somewhat differentiated, but this is still something we should improved:
  - The following PR would change the behavior for Zigbee groups in HA to use a dedicated device/service: https://github.com/home-assistant/core/pull/162307 


## Additional information

Requires bellows PR:
- https://github.com/zigpy/bellows/pull/710