### PR TITLE
Adapt to zigpy OTA event refactor

### DIFF
--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -234,10 +234,17 @@ async def test_firmware_update_success(zha_gateway: Gateway) -> None:
         == f"0x{fw_image.firmware.header.file_version:08x}"
     )
 
+    ota_completed = False
+
     async def endpoint_reply(cluster, sequence, data, **kwargs):
+        nonlocal ota_completed
         if cluster == general.Ota.cluster_id:
             hdr, cmd = ota_cluster.deserialize(data)
             if isinstance(cmd, general.Ota.ImageNotifyCommand):
+                if ota_completed:
+                    # Post-OTA image_notify: ignore or don't respond
+                    return
+
                 zigpy_device.packet_received(
                     make_packet(
                         zigpy_device,
@@ -253,6 +260,11 @@ async def test_firmware_update_success(zha_gateway: Gateway) -> None:
             elif isinstance(
                 cmd, general.Ota.ClientCommandDefs.query_next_image_response.schema
             ):
+                # After a successful OTA, zigpy sends a post-OTA image_notify
+                # which triggers a query_next_image -> NO_IMAGE_AVAILABLE exchange
+                if cmd.status == foundation.Status.NO_IMAGE_AVAILABLE:
+                    return
+
                 assert cmd.status == foundation.Status.SUCCESS
                 assert cmd.manufacturer_code == fw_image.firmware.header.manufacturer_id
                 assert cmd.image_type == fw_image.firmware.header.image_type
@@ -346,6 +358,8 @@ async def test_firmware_update_success(zha_gateway: Gateway) -> None:
                 assert cmd.current_time == 0
                 assert cmd.upgrade_time == 0
 
+                ota_completed = True
+
                 def read_new_fw_version(*args, **kwargs):
                     ota_cluster.update_attribute(
                         attrid=general.Ota.AttributeDefs.current_file_version.id,
@@ -429,6 +443,9 @@ async def test_firmware_update_raises(zha_gateway: Gateway) -> None:
             elif isinstance(
                 cmd, general.Ota.ClientCommandDefs.query_next_image_response.schema
             ):
+                if cmd.status == foundation.Status.NO_IMAGE_AVAILABLE:
+                    return
+
                 assert cmd.status == foundation.Status.SUCCESS
                 assert cmd.manufacturer_code == fw_image.firmware.header.manufacturer_id
                 assert cmd.image_type == fw_image.firmware.header.image_type

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -764,3 +764,74 @@ async def test_firmware_update_multiple_upgrades_combined_release_notes(
         "Release notes for v1."
     )
     assert entity.state[ATTR_RELEASE_NOTES] == expected_release_notes
+
+
+async def test_firmware_update_cached_on_startup(zha_gateway: Gateway) -> None:
+    """Test that entities pick up cached OTA state from zigpy on startup."""
+    zigpy_device = zigpy_device_mock(zha_gateway)
+    installed_fw_version = 0x12345678
+
+    ota_cluster = zigpy_device.endpoints[1].out_clusters[general.Ota.cluster_id]
+    ota_cluster.PLUGGED_ATTR_READS = {
+        general.Ota.AttributeDefs.current_file_version.name: installed_fw_version
+    }
+    update_attribute_cache(ota_cluster)
+
+    fw_image = create_fw_image(installed_fw_version + 10)
+
+    zigpy_device.application.ota.get_ota_images = AsyncMock(
+        return_value=OtaImagesResult(
+            upgrades=(fw_image,),
+            downgrades=(),
+        )
+    )
+
+    # Pre-populate the cluster's cached query command (as if the device had
+    # previously sent a query_next_image before ZHA restarted)
+    ota_cluster.last_query_cmd = general.QueryNextImageCommand(
+        field_control=fw_image.firmware.header.field_control,
+        manufacturer_code=zigpy_device.node_desc.manufacturer_code,
+        image_type=fw_image.firmware.header.image_type,
+        current_file_version=installed_fw_version,
+    )
+
+    # Join the device — on_add triggers check_cluster_for_ota
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
+    await zha_gateway.async_block_till_done()
+
+    entity = get_entity(zha_device, platform=Platform.UPDATE)
+    assert entity.state[ATTR_INSTALLED_VERSION] == f"0x{installed_fw_version:08x}"
+    assert (
+        entity.state[ATTR_LATEST_VERSION]
+        == f"0x{fw_image.firmware.header.file_version:08x}"
+    )
+
+
+async def test_firmware_update_no_cached_query_on_startup(
+    zha_gateway: Gateway,
+) -> None:
+    """Test that entities don't error when there's no cached query on startup."""
+    zigpy_device = zigpy_device_mock(zha_gateway)
+    installed_fw_version = 0x12345678
+
+    ota_cluster = zigpy_device.endpoints[1].out_clusters[general.Ota.cluster_id]
+    ota_cluster.PLUGGED_ATTR_READS = {
+        general.Ota.AttributeDefs.current_file_version.name: installed_fw_version
+    }
+    update_attribute_cache(ota_cluster)
+
+    zigpy_device.application.ota.get_ota_images = AsyncMock(
+        return_value=OtaImagesResult(upgrades=(), downgrades=())
+    )
+
+    # No last_query_cmd — check_cluster_for_ota should be a no-op
+    assert ota_cluster.last_query_cmd is None
+
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
+    await zha_gateway.async_block_till_done()
+
+    entity = get_entity(zha_device, platform=Platform.UPDATE)
+    assert entity.state[ATTR_INSTALLED_VERSION] == f"0x{installed_fw_version:08x}"
+    assert entity.state[ATTR_LATEST_VERSION] is None
+    # get_ota_images should not have been called since there's no cached query
+    zigpy_device.application.ota.get_ota_images.assert_not_called()

--- a/zha/application/platforms/update.py
+++ b/zha/application/platforms/update.py
@@ -314,6 +314,7 @@ class FirmwareUpdateEntity(BaseFirmwareUpdateEntity):
         """Call when entity is added."""
         super().on_add()
 
+        ota_cluster = self._ota_cluster_handler.cluster
         self._on_remove_callbacks.append(
             self._ota_cluster_handler.on_event(
                 CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
@@ -321,10 +322,15 @@ class FirmwareUpdateEntity(BaseFirmwareUpdateEntity):
             )
         )
         self._on_remove_callbacks.append(
-            self._ota_cluster_handler.cluster.on_event(
+            ota_cluster.on_event(
                 OtaImageAvailableEvent.event_type,
                 self._handle_ota_image_available,
             )
+        )
+
+        # Check for cached OTA image availability from zigpy
+        ota_cluster.create_catching_task(
+            self.device.device.application.ota.check_cluster_for_ota(ota_cluster)
         )
 
     def _get_cluster_version(self) -> str | None:
@@ -368,6 +374,7 @@ class FirmwareUpdateServerEntity(BaseFirmwareUpdateEntity):
         """Call when entity is added."""
         super().on_add()
 
+        ota_cluster = self._ota_cluster_handler.cluster
         self._on_remove_callbacks.append(
             self._ota_cluster_handler.on_event(
                 CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
@@ -375,10 +382,15 @@ class FirmwareUpdateServerEntity(BaseFirmwareUpdateEntity):
             )
         )
         self._on_remove_callbacks.append(
-            self._ota_cluster_handler.cluster.on_event(
+            ota_cluster.on_event(
                 OtaImageAvailableEvent.event_type,
                 self._handle_ota_image_available,
             )
+        )
+
+        # Check for cached OTA image availability from zigpy
+        ota_cluster.create_catching_task(
+            self.device.device.application.ota.check_cluster_for_ota(ota_cluster)
         )
 
     def _get_cluster_version(self) -> str | None:

--- a/zha/application/platforms/update.py
+++ b/zha/application/platforms/update.py
@@ -11,7 +11,8 @@ import logging
 from typing import TYPE_CHECKING, Any, Final
 
 from zigpy.ota import OtaImagesResult, OtaImageWithMetadata
-from zigpy.zcl.clusters.general import Ota, QueryNextImageCommand
+from zigpy.zcl import OtaImageAvailableEvent
+from zigpy.zcl.clusters.general import Ota
 from zigpy.zcl.foundation import Status
 
 from zha.application import Platform
@@ -178,17 +179,16 @@ class BaseFirmwareUpdateEntity(PlatformEntity, ABC):
             self._attr_installed_version = f"0x{event.attribute_value:08x}"
             self.maybe_emit_state_changed_event()
 
-    def device_ota_image_query_result(
+    def _handle_ota_image_available(
         self,
-        images_result: OtaImagesResult,
-        query_next_img_command: QueryNextImageCommand,
+        event: OtaImageAvailableEvent,
     ) -> None:
-        """Handle ota update available signal from Zigpy."""
+        """Handle OTA image availability event from zigpy."""
 
-        current_version = query_next_img_command.current_file_version
+        current_version = event.query_cmd.current_file_version
         self._attr_installed_version = f"0x{current_version:08x}"
 
-        self._compatible_images = images_result
+        self._compatible_images = event.images_result
         self._attr_latest_version = None
         self._attr_release_summary = None
         self._attr_release_notes = None
@@ -196,16 +196,16 @@ class BaseFirmwareUpdateEntity(PlatformEntity, ABC):
 
         latest_firmware: OtaImageWithMetadata | None = None
 
-        if images_result.upgrades:
+        if event.images_result.upgrades:
             # If there are upgrades, cache the image and indicate that we should upgrade
-            latest_firmware = images_result.upgrades[0]
+            latest_firmware = event.images_result.upgrades[0]
             self._attr_latest_version = f"0x{latest_firmware.version:08x}"
             self._attr_release_summary = latest_firmware.metadata.changelog or None
             self._attr_release_url = latest_firmware.metadata.release_url or None
 
             # Combine release notes from all upgrades (newest to oldest)
             release_notes_parts = []
-            for firmware in images_result.upgrades:
+            for firmware in event.images_result.upgrades:
                 if firmware.metadata.release_notes:
                     release_notes_parts.append(
                         f"## 0x{firmware.version:08x}\n{firmware.metadata.release_notes}"
@@ -213,10 +213,12 @@ class BaseFirmwareUpdateEntity(PlatformEntity, ABC):
             self._attr_release_notes = (
                 "\n\n".join(release_notes_parts) if release_notes_parts else None
             )
-        elif images_result.downgrades:
+        elif event.images_result.downgrades:
             # If not, note the version of the most recent firmware
             latest_firmware = None
-            self._attr_latest_version = f"0x{images_result.downgrades[0].version:08x}"
+            self._attr_latest_version = (
+                f"0x{event.images_result.downgrades[0].version:08x}"
+            )
 
         self.maybe_emit_state_changed_event()
 
@@ -312,7 +314,6 @@ class FirmwareUpdateEntity(BaseFirmwareUpdateEntity):
         """Call when entity is added."""
         super().on_add()
 
-        self.device.device.add_listener(self)
         self._on_remove_callbacks.append(
             self._ota_cluster_handler.on_event(
                 CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
@@ -320,7 +321,10 @@ class FirmwareUpdateEntity(BaseFirmwareUpdateEntity):
             )
         )
         self._on_remove_callbacks.append(
-            lambda: self.device.device.remove_listener(self)
+            self._ota_cluster_handler.cluster.on_event(
+                OtaImageAvailableEvent.event_type,
+                self._handle_ota_image_available,
+            )
         )
 
     def _get_cluster_version(self) -> str | None:
@@ -364,7 +368,6 @@ class FirmwareUpdateServerEntity(BaseFirmwareUpdateEntity):
         """Call when entity is added."""
         super().on_add()
 
-        self.device.device.add_listener(self)
         self._on_remove_callbacks.append(
             self._ota_cluster_handler.on_event(
                 CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
@@ -372,7 +375,10 @@ class FirmwareUpdateServerEntity(BaseFirmwareUpdateEntity):
             )
         )
         self._on_remove_callbacks.append(
-            lambda: self.device.device.remove_listener(self)
+            self._ota_cluster_handler.cluster.on_event(
+                OtaImageAvailableEvent.event_type,
+                self._handle_ota_image_available,
+            )
         )
 
     def _get_cluster_version(self) -> str | None:


### PR DESCRIPTION
Tested and working with linked zigpy PR.

## AI summary

Adapt to zigpy OTA refactor (`OtaImageAvailableEvent`, post-OTA `image_notify`)

- Replace `device.add_listener` / `device_ota_image_query_result` with `on_event` listener for `OtaImageAvailableEvent` on the OTA cluster
- Remove device listener registration from both `FirmwareUpdateEntity` and `FirmwareUpdateServerEntity`
- Update tests to handle post-OTA `image_notify` → `NO_IMAGE_AVAILABLE` exchange

PR:
- https://github.com/zigpy/zigpy/pull/1799
- https://github.com/zigpy/zha/pull/718

HA Core change:
- https://github.com/home-assistant/core/compare/dev...TheJulianJES:tjj/zha-deps-bump-20260324