### PR TITLE
Add test for endpoint initialization failure

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1369,8 +1369,10 @@ async def test_initialize_endpoint_failure(zha_gateway: Gateway) -> None:
     zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
 
     with patch.object(
-        list(zha_device.endpoints.values())[0],
+        zha_device.endpoints[1],
         "async_initialize",
         side_effect=Exception("endpoint init failed"),
-    ):
+    ) as mock_async_initialize:
         await zha_device.async_initialize(from_cache=True)
+
+    assert mock_async_initialize.call_count == 1

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1358,3 +1358,19 @@ async def test_device_on_remove_pending_entity_failure(
 
     assert "Failed to remove pending entity" in caplog.text
     assert "Pending entity removal failed" in caplog.text
+
+
+async def test_initialize_endpoint_failure(zha_gateway: Gateway) -> None:
+    """Test that a failing endpoint doesn't prevent device initialization."""
+    zigpy_dev = await zigpy_device_from_json(
+        zha_gateway.application_controller,
+        "tests/data/devices/ikea-of-sweden-tradfri-bulb-gu10-ws-400lm.json",
+    )
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
+
+    with patch.object(
+        list(zha_device.endpoints.values())[0],
+        "async_initialize",
+        side_effect=Exception("endpoint init failed"),
+    ):
+        await zha_device.async_initialize(from_cache=True)


### PR DESCRIPTION
## Proposed change

This adds a small test for endpoint initialization failure here:
https://github.com/zigpy/zha/blob/58484615fc2473fa1bad92bb9323036e3f376e3c/zha/zigbee/device.py#L995-L996

Needed for code coverage in below PR (since a surrounding line is touched by that PR):
- https://github.com/zigpy/zha/pull/517