### PR TITLE
Add BEGA light color temperature channel

### DIFF
--- a/tests/data/devices/bega-gantenbrink-leuchten-kg-smart-dimmable-light.json
+++ b/tests/data/devices/bega-gantenbrink-leuchten-kg-smart-dimmable-light.json
@@ -1,0 +1,1099 @@
+{
+  "version": 1,
+  "ieee": "ab:cd:ef:12:1a:5e:2c:1e",
+  "nwk": "0x1D54",
+  "manufacturer": "BEGA Gantenbrink-Leuchten KG",
+  "model": "Smart Dimmable Light",
+  "friendly_manufacturer": "BEGA Gantenbrink-Leuchten KG",
+  "friendly_model": "Smart Dimmable Light",
+  "name": "BEGA Gantenbrink-Leuchten KG Smart Dimmable Light",
+  "quirk_applied": true,
+  "quirk_class": "zigpy.quirks.v2.CustomDeviceV2",
+  "exposes_features": [
+    "bega.light_switchable_white"
+  ],
+  "manufacturer_code": 4357,
+  "power_source": "Mains",
+  "lqi": 172,
+  "rssi": -57,
+  "last_seen": "2026-03-24T14:12:33.275750+00:00",
+  "available": true,
+  "device_type": "Router",
+  "active_coordinator": false,
+  "node_descriptor": {
+    "logical_type": "Router",
+    "complex_descriptor_available": false,
+    "user_descriptor_available": false,
+    "reserved": 0,
+    "aps_flags": 0,
+    "frequency_band": 8,
+    "mac_capability_flags": 142,
+    "manufacturer_code": 4357,
+    "maximum_buffer_size": 82,
+    "maximum_incoming_transfer_size": 82,
+    "server_mask": 11264,
+    "maximum_outgoing_transfer_size": 82,
+    "descriptor_capability_field": 0
+  },
+  "endpoints": {
+    "1": {
+      "profile_id": 260,
+      "device_type": {
+        "name": "DIMMABLE_LIGHT",
+        "id": 257
+      },
+      "in_clusters": [
+        {
+          "cluster_id": "0x0000",
+          "endpoint_attribute": "basic",
+          "attributes": [
+            {
+              "id": "0x0013",
+              "name": "alarm_mask",
+              "zcl_type": "map8",
+              "unsupported": true
+            },
+            {
+              "id": "0x0001",
+              "name": "app_version",
+              "zcl_type": "uint8",
+              "value": 0
+            },
+            {
+              "id": "0xfffd",
+              "name": "cluster_revision",
+              "zcl_type": "uint16",
+              "value": 3
+            },
+            {
+              "id": "0x0006",
+              "name": "date_code",
+              "zcl_type": "string",
+              "value": "2024-11-19"
+            },
+            {
+              "id": "0x0012",
+              "name": "device_enabled",
+              "zcl_type": "bool",
+              "unsupported": true
+            },
+            {
+              "id": "0x0014",
+              "name": "disable_local_config",
+              "zcl_type": "map8",
+              "unsupported": true
+            },
+            {
+              "id": "0x0008",
+              "name": "generic_device_class",
+              "zcl_type": "enum8",
+              "value": 255
+            },
+            {
+              "id": "0x0009",
+              "name": "generic_device_type",
+              "zcl_type": "enum8",
+              "value": 255
+            },
+            {
+              "id": "0x0003",
+              "name": "hw_version",
+              "zcl_type": "uint8",
+              "value": 0
+            },
+            {
+              "id": "0x0010",
+              "name": "location_desc",
+              "zcl_type": "string",
+              "value": ""
+            },
+            {
+              "id": "0x0004",
+              "name": "manufacturer",
+              "zcl_type": "string",
+              "value": "BEGA Gantenbrink-Leuchten KG"
+            },
+            {
+              "id": "0x000c",
+              "name": "manufacturer_version_details",
+              "zcl_type": "string",
+              "unsupported": true
+            },
+            {
+              "id": "0x0005",
+              "name": "model",
+              "zcl_type": "string",
+              "value": "Smart Dimmable Light"
+            },
+            {
+              "id": "0x0011",
+              "name": "physical_env",
+              "zcl_type": "enum8",
+              "value": 0
+            },
+            {
+              "id": "0x0007",
+              "name": "power_source",
+              "zcl_type": "enum8",
+              "value": 1
+            },
+            {
+              "id": "0x000a",
+              "name": "product_code",
+              "zcl_type": "octstr",
+              "value": {
+                "__type": "<class 'bytes'>",
+                "repr": "b'24953\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00'"
+              }
+            },
+            {
+              "id": "0x000e",
+              "name": "product_label",
+              "zcl_type": "string",
+              "unsupported": true
+            },
+            {
+              "id": "0x000b",
+              "name": "product_url",
+              "zcl_type": "string",
+              "value": "www.bega.de "
+            },
+            {
+              "id": "0xfffe",
+              "name": "reporting_status",
+              "zcl_type": "enum8",
+              "unsupported": true
+            },
+            {
+              "id": "0x000d",
+              "name": "serial_number",
+              "zcl_type": "string",
+              "unsupported": true
+            },
+            {
+              "id": "0x0002",
+              "name": "stack_version",
+              "zcl_type": "uint8",
+              "value": 6
+            },
+            {
+              "id": "0x4000",
+              "name": "sw_build_id",
+              "zcl_type": "string",
+              "value": "10030057"
+            },
+            {
+              "id": "0x0000",
+              "name": "zcl_version",
+              "zcl_type": "uint8",
+              "value": 8
+            }
+          ]
+        },
+        {
+          "cluster_id": "0x0003",
+          "endpoint_attribute": "identify",
+          "attributes": []
+        },
+        {
+          "cluster_id": "0x0004",
+          "endpoint_attribute": "groups",
+          "attributes": []
+        },
+        {
+          "cluster_id": "0x0005",
+          "endpoint_attribute": "scenes",
+          "attributes": []
+        },
+        {
+          "cluster_id": "0x0006",
+          "endpoint_attribute": "on_off",
+          "attributes": [
+            {
+              "id": "0x0000",
+              "name": "on_off",
+              "zcl_type": "bool",
+              "value": 1
+            },
+            {
+              "id": "0x4003",
+              "name": "start_up_on_off",
+              "zcl_type": "enum8",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "cluster_id": "0x0008",
+          "endpoint_attribute": "level",
+          "attributes": [
+            {
+              "id": "0x0000",
+              "name": "current_level",
+              "zcl_type": "uint8",
+              "value": 94
+            },
+            {
+              "id": "0x0014",
+              "name": "default_move_rate",
+              "zcl_type": "uint8",
+              "value": 75
+            },
+            {
+              "id": "0x0013",
+              "name": "off_transition_time",
+              "zcl_type": "uint16",
+              "value": 10
+            },
+            {
+              "id": "0x0011",
+              "name": "on_level",
+              "zcl_type": "uint8",
+              "value": 255
+            },
+            {
+              "id": "0x0010",
+              "name": "on_off_transition_time",
+              "zcl_type": "uint16",
+              "value": 0
+            },
+            {
+              "id": "0x0012",
+              "name": "on_transition_time",
+              "zcl_type": "uint16",
+              "value": 10
+            },
+            {
+              "id": "0x4000",
+              "name": "start_up_current_level",
+              "zcl_type": "uint8",
+              "value": 255
+            },
+            {
+              "id": "0x4002",
+              "name": "switchable_color_temperature_1",
+              "zcl_type": "uint16",
+              "value": 4000
+            },
+            {
+              "id": "0x4003",
+              "name": "switchable_color_temperature_2",
+              "zcl_type": "uint16",
+              "value": 3000
+            },
+            {
+              "id": "0x4001",
+              "name": "switchable_white",
+              "zcl_type": "bool",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "cluster_id": "0xfcbe",
+          "endpoint_attribute": "manufacturer_specific",
+          "attributes": []
+        },
+        {
+          "cluster_id": "0xfcc5",
+          "endpoint_attribute": "manufacturer_specific",
+          "attributes": []
+        },
+        {
+          "cluster_id": "0xffff",
+          "endpoint_attribute": "manufacturer_specific",
+          "attributes": []
+        }
+      ],
+      "out_clusters": [
+        {
+          "cluster_id": "0x0003",
+          "endpoint_attribute": "identify",
+          "attributes": []
+        },
+        {
+          "cluster_id": "0x0004",
+          "endpoint_attribute": "groups",
+          "attributes": []
+        },
+        {
+          "cluster_id": "0x0005",
+          "endpoint_attribute": "scenes",
+          "attributes": []
+        },
+        {
+          "cluster_id": "0x0006",
+          "endpoint_attribute": "on_off",
+          "attributes": []
+        },
+        {
+          "cluster_id": "0x0008",
+          "endpoint_attribute": "level",
+          "attributes": []
+        },
+        {
+          "cluster_id": "0x0019",
+          "endpoint_attribute": "ota",
+          "attributes": [
+            {
+              "id": "0x0002",
+              "name": "current_file_version",
+              "zcl_type": "uint32",
+              "value": 10030057
+            }
+          ]
+        },
+        {
+          "cluster_id": "0x0300",
+          "endpoint_attribute": "light_color",
+          "attributes": [
+            {
+              "id": "0x400a",
+              "name": "color_capabilities",
+              "zcl_type": "map16",
+              "unsupported": true
+            },
+            {
+              "id": "0x0007",
+              "name": "color_temperature",
+              "zcl_type": "uint16",
+              "unsupported": true
+            }
+          ]
+        },
+        {
+          "cluster_id": "0xfcc5",
+          "endpoint_attribute": "manufacturer_specific",
+          "attributes": []
+        }
+      ]
+    },
+    "242": {
+      "profile_id": 41440,
+      "device_type": {
+        "name": "PROXY_BASIC",
+        "id": 97
+      },
+      "in_clusters": [],
+      "out_clusters": [
+        {
+          "cluster_id": "0x0021",
+          "endpoint_attribute": "green_power",
+          "attributes": []
+        }
+      ]
+    }
+  },
+  "original_signature": {
+    "manufacturer": "BEGA Gantenbrink-Leuchten KG",
+    "model": "Smart Dimmable Light",
+    "node_desc": {
+      "logical_type": 1,
+      "complex_descriptor_available": 0,
+      "user_descriptor_available": 0,
+      "reserved": 0,
+      "aps_flags": 0,
+      "frequency_band": 8,
+      "mac_capability_flags": 142,
+      "manufacturer_code": 4357,
+      "maximum_buffer_size": 82,
+      "maximum_incoming_transfer_size": 82,
+      "server_mask": 11264,
+      "maximum_outgoing_transfer_size": 82,
+      "descriptor_capability_field": 0
+    },
+    "endpoints": {
+      "1": {
+        "profile_id": "0x0104",
+        "device_type": "0x0101",
+        "input_clusters": [
+          "0x0000",
+          "0x0003",
+          "0x0004",
+          "0x0005",
+          "0x0006",
+          "0x0008",
+          "0xffff",
+          "0xfcbe",
+          "0xfcc5"
+        ],
+        "output_clusters": [
+          "0x0003",
+          "0x0004",
+          "0x0005",
+          "0x0006",
+          "0x0008",
+          "0x0019",
+          "0x0300",
+          "0xfcc5"
+        ]
+      },
+      "242": {
+        "profile_id": "0xa1e0",
+        "device_type": "0x0061",
+        "input_clusters": [],
+        "output_clusters": [
+          "0x0021"
+        ]
+      }
+    }
+  },
+  "zha_lib_entities": {
+    "button": [
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:1a:5e:2c:1e-1-3",
+          "migrate_unique_ids": [],
+          "platform": "button",
+          "class_name": "IdentifyButton",
+          "translation_key": null,
+          "translation_placeholders": null,
+          "device_class": "identify",
+          "state_class": null,
+          "entity_category": "diagnostic",
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "IdentifyClusterHandler",
+              "generic_id": "cluster_handler_0x0003",
+              "endpoint_id": 1,
+              "cluster": {
+                "id": 3,
+                "name": "Identify",
+                "type": "server"
+              },
+              "id": "1:0x0003",
+              "unique_id": "ab:cd:ef:12:1a:5e:2c:1e:1:0x0003",
+              "status": "INITIALIZED",
+              "value_attribute": null
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:1a:5e:2c:1e",
+          "endpoint_id": 1,
+          "available": true,
+          "group_id": null,
+          "command": "identify",
+          "args": [
+            5
+          ],
+          "kwargs": {}
+        },
+        "state": {
+          "class_name": "IdentifyButton",
+          "available": true
+        }
+      }
+    ],
+    "light": [
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:1a:5e:2c:1e-1",
+          "migrate_unique_ids": [],
+          "platform": "light",
+          "class_name": "Light",
+          "translation_key": "light",
+          "translation_placeholders": null,
+          "device_class": null,
+          "state_class": null,
+          "entity_category": null,
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": true,
+          "cluster_handlers": [
+            {
+              "class_name": "OnOffClusterHandler",
+              "generic_id": "cluster_handler_0x0006",
+              "endpoint_id": 1,
+              "cluster": {
+                "id": 6,
+                "name": "On/Off",
+                "type": "server"
+              },
+              "id": "1:0x0006",
+              "unique_id": "ab:cd:ef:12:1a:5e:2c:1e:1:0x0006",
+              "status": "INITIALIZED",
+              "value_attribute": "on_off"
+            },
+            {
+              "class_name": "LevelControlClusterHandler",
+              "generic_id": "cluster_handler_0x0008",
+              "endpoint_id": 1,
+              "cluster": {
+                "id": 8,
+                "name": "Level control",
+                "type": "server"
+              },
+              "id": "1:0x0008",
+              "unique_id": "ab:cd:ef:12:1a:5e:2c:1e:1:0x0008",
+              "status": "INITIALIZED",
+              "value_attribute": "current_level"
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:1a:5e:2c:1e",
+          "endpoint_id": 1,
+          "available": true,
+          "group_id": null,
+          "effect_list": [
+            "off"
+          ],
+          "supported_features": 40,
+          "min_mireds": 153,
+          "max_mireds": 500
+        },
+        "state": {
+          "class_name": "Light",
+          "available": true,
+          "on": true,
+          "brightness": 94,
+          "xy_color": null,
+          "color_temp": null,
+          "effect_list": [
+            "off"
+          ],
+          "effect": "off",
+          "supported_features": 40,
+          "color_mode": "brightness",
+          "supported_color_modes": [
+            "brightness",
+            "onoff"
+          ],
+          "off_with_transition": false,
+          "off_brightness": null
+        },
+        "extra_state_attributes": [
+          "off_brightness",
+          "off_with_transition"
+        ]
+      }
+    ],
+    "number": [
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:1a:5e:2c:1e-1-8-default_move_rate",
+          "migrate_unique_ids": [],
+          "platform": "number",
+          "class_name": "DefaultMoveRateConfigurationEntity",
+          "translation_key": "default_move_rate",
+          "translation_placeholders": null,
+          "device_class": null,
+          "state_class": null,
+          "entity_category": "config",
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "LevelControlClusterHandler",
+              "generic_id": "cluster_handler_0x0008",
+              "endpoint_id": 1,
+              "cluster": {
+                "id": 8,
+                "name": "Level control",
+                "type": "server"
+              },
+              "id": "1:0x0008",
+              "unique_id": "ab:cd:ef:12:1a:5e:2c:1e:1:0x0008",
+              "status": "INITIALIZED",
+              "value_attribute": "current_level"
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:1a:5e:2c:1e",
+          "endpoint_id": 1,
+          "available": true,
+          "group_id": null,
+          "mode": "auto",
+          "native_max_value": 254,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
+        },
+        "state": {
+          "class_name": "DefaultMoveRateConfigurationEntity",
+          "available": true,
+          "state": 75
+        }
+      },
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:1a:5e:2c:1e-1-8-off_transition_time",
+          "migrate_unique_ids": [],
+          "platform": "number",
+          "class_name": "OffTransitionTimeConfigurationEntity",
+          "translation_key": "off_transition_time",
+          "translation_placeholders": null,
+          "device_class": null,
+          "state_class": null,
+          "entity_category": "config",
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "LevelControlClusterHandler",
+              "generic_id": "cluster_handler_0x0008",
+              "endpoint_id": 1,
+              "cluster": {
+                "id": 8,
+                "name": "Level control",
+                "type": "server"
+              },
+              "id": "1:0x0008",
+              "unique_id": "ab:cd:ef:12:1a:5e:2c:1e:1:0x0008",
+              "status": "INITIALIZED",
+              "value_attribute": "current_level"
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:1a:5e:2c:1e",
+          "endpoint_id": 1,
+          "available": true,
+          "group_id": null,
+          "mode": "auto",
+          "native_max_value": 65534,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
+        },
+        "state": {
+          "class_name": "OffTransitionTimeConfigurationEntity",
+          "available": true,
+          "state": 10
+        }
+      },
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:1a:5e:2c:1e-1-8-on_level",
+          "migrate_unique_ids": [],
+          "platform": "number",
+          "class_name": "OnLevelConfigurationEntity",
+          "translation_key": "on_level",
+          "translation_placeholders": null,
+          "device_class": null,
+          "state_class": null,
+          "entity_category": "config",
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "LevelControlClusterHandler",
+              "generic_id": "cluster_handler_0x0008",
+              "endpoint_id": 1,
+              "cluster": {
+                "id": 8,
+                "name": "Level control",
+                "type": "server"
+              },
+              "id": "1:0x0008",
+              "unique_id": "ab:cd:ef:12:1a:5e:2c:1e:1:0x0008",
+              "status": "INITIALIZED",
+              "value_attribute": "current_level"
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:1a:5e:2c:1e",
+          "endpoint_id": 1,
+          "available": true,
+          "group_id": null,
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
+        },
+        "state": {
+          "class_name": "OnLevelConfigurationEntity",
+          "available": true,
+          "state": 255
+        }
+      },
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:1a:5e:2c:1e-1-8-on_off_transition_time",
+          "migrate_unique_ids": [],
+          "platform": "number",
+          "class_name": "OnOffTransitionTimeConfigurationEntity",
+          "translation_key": "on_off_transition_time",
+          "translation_placeholders": null,
+          "device_class": null,
+          "state_class": null,
+          "entity_category": "config",
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "LevelControlClusterHandler",
+              "generic_id": "cluster_handler_0x0008",
+              "endpoint_id": 1,
+              "cluster": {
+                "id": 8,
+                "name": "Level control",
+                "type": "server"
+              },
+              "id": "1:0x0008",
+              "unique_id": "ab:cd:ef:12:1a:5e:2c:1e:1:0x0008",
+              "status": "INITIALIZED",
+              "value_attribute": "current_level"
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:1a:5e:2c:1e",
+          "endpoint_id": 1,
+          "available": true,
+          "group_id": null,
+          "mode": "auto",
+          "native_max_value": 65535,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
+        },
+        "state": {
+          "class_name": "OnOffTransitionTimeConfigurationEntity",
+          "available": true,
+          "state": 0
+        }
+      },
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:1a:5e:2c:1e-1-8-on_transition_time",
+          "migrate_unique_ids": [],
+          "platform": "number",
+          "class_name": "OnTransitionTimeConfigurationEntity",
+          "translation_key": "on_transition_time",
+          "translation_placeholders": null,
+          "device_class": null,
+          "state_class": null,
+          "entity_category": "config",
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "LevelControlClusterHandler",
+              "generic_id": "cluster_handler_0x0008",
+              "endpoint_id": 1,
+              "cluster": {
+                "id": 8,
+                "name": "Level control",
+                "type": "server"
+              },
+              "id": "1:0x0008",
+              "unique_id": "ab:cd:ef:12:1a:5e:2c:1e:1:0x0008",
+              "status": "INITIALIZED",
+              "value_attribute": "current_level"
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:1a:5e:2c:1e",
+          "endpoint_id": 1,
+          "available": true,
+          "group_id": null,
+          "mode": "auto",
+          "native_max_value": 65534,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
+        },
+        "state": {
+          "class_name": "OnTransitionTimeConfigurationEntity",
+          "available": true,
+          "state": 10
+        }
+      },
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:1a:5e:2c:1e-1-8-start_up_current_level",
+          "migrate_unique_ids": [],
+          "platform": "number",
+          "class_name": "StartUpCurrentLevelConfigurationEntity",
+          "translation_key": "start_up_current_level",
+          "translation_placeholders": null,
+          "device_class": null,
+          "state_class": null,
+          "entity_category": "config",
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "LevelControlClusterHandler",
+              "generic_id": "cluster_handler_0x0008",
+              "endpoint_id": 1,
+              "cluster": {
+                "id": 8,
+                "name": "Level control",
+                "type": "server"
+              },
+              "id": "1:0x0008",
+              "unique_id": "ab:cd:ef:12:1a:5e:2c:1e:1:0x0008",
+              "status": "INITIALIZED",
+              "value_attribute": "current_level"
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:1a:5e:2c:1e",
+          "endpoint_id": 1,
+          "available": true,
+          "group_id": null,
+          "mode": "auto",
+          "native_max_value": 255,
+          "native_min_value": 0,
+          "native_step": 1.0,
+          "native_unit_of_measurement": null
+        },
+        "state": {
+          "class_name": "StartUpCurrentLevelConfigurationEntity",
+          "available": true,
+          "state": 255
+        }
+      }
+    ],
+    "select": [
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:1a:5e:2c:1e-1-6-StartUpOnOff",
+          "migrate_unique_ids": [],
+          "platform": "select",
+          "class_name": "StartupOnOffSelectEntity",
+          "translation_key": "start_up_on_off",
+          "translation_placeholders": null,
+          "device_class": null,
+          "state_class": null,
+          "entity_category": "config",
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "OnOffClusterHandler",
+              "generic_id": "cluster_handler_0x0006",
+              "endpoint_id": 1,
+              "cluster": {
+                "id": 6,
+                "name": "On/Off",
+                "type": "server"
+              },
+              "id": "1:0x0006",
+              "unique_id": "ab:cd:ef:12:1a:5e:2c:1e:1:0x0006",
+              "status": "INITIALIZED",
+              "value_attribute": "on_off"
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:1a:5e:2c:1e",
+          "endpoint_id": 1,
+          "available": true,
+          "group_id": null,
+          "enum": "StartUpOnOff",
+          "options": [
+            "Off",
+            "On",
+            "Toggle",
+            "PreviousValue"
+          ]
+        },
+        "state": {
+          "class_name": "StartupOnOffSelectEntity",
+          "available": true,
+          "state": "On"
+        }
+      },
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:1a:5e:2c:1e-1-8-switchable_white",
+          "migrate_unique_ids": [],
+          "platform": "select",
+          "class_name": "BegaColorTemperatureChannelSelect",
+          "translation_key": "color_temperature_channel",
+          "translation_placeholders": null,
+          "device_class": null,
+          "state_class": null,
+          "entity_category": "config",
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "LevelControlClusterHandler",
+              "generic_id": "cluster_handler_0x0008",
+              "endpoint_id": 1,
+              "cluster": {
+                "id": 8,
+                "name": "Level control",
+                "type": "server"
+              },
+              "id": "1:0x0008",
+              "unique_id": "ab:cd:ef:12:1a:5e:2c:1e:1:0x0008",
+              "status": "INITIALIZED",
+              "value_attribute": "current_level"
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:1a:5e:2c:1e",
+          "endpoint_id": 1,
+          "available": true,
+          "group_id": null,
+          "enum": "BegaColorTemperatureChannel",
+          "options": [
+            "Warm White",
+            "Cool White"
+          ]
+        },
+        "state": {
+          "class_name": "BegaColorTemperatureChannelSelect",
+          "available": true,
+          "state": "Warm White"
+        }
+      }
+    ],
+    "sensor": [
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:1a:5e:2c:1e-1-0-lqi",
+          "migrate_unique_ids": [],
+          "platform": "sensor",
+          "class_name": "LQISensor",
+          "translation_key": "lqi",
+          "translation_placeholders": null,
+          "device_class": null,
+          "state_class": "measurement",
+          "entity_category": "diagnostic",
+          "entity_registry_enabled_default": false,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "BasicClusterHandler",
+              "generic_id": "cluster_handler_0x0000",
+              "endpoint_id": 1,
+              "cluster": {
+                "id": 0,
+                "name": "Basic",
+                "type": "server"
+              },
+              "id": "1:0x0000",
+              "unique_id": "ab:cd:ef:12:1a:5e:2c:1e:1:0x0000",
+              "status": "INITIALIZED",
+              "value_attribute": null
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:1a:5e:2c:1e",
+          "endpoint_id": 1,
+          "available": true,
+          "group_id": null,
+          "suggested_display_precision": null,
+          "unit": null
+        },
+        "state": {
+          "class_name": "LQISensor",
+          "available": true,
+          "state": 172
+        }
+      },
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:1a:5e:2c:1e-1-0-rssi",
+          "migrate_unique_ids": [],
+          "platform": "sensor",
+          "class_name": "RSSISensor",
+          "translation_key": "rssi",
+          "translation_placeholders": null,
+          "device_class": "signal_strength",
+          "state_class": "measurement",
+          "entity_category": "diagnostic",
+          "entity_registry_enabled_default": false,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "BasicClusterHandler",
+              "generic_id": "cluster_handler_0x0000",
+              "endpoint_id": 1,
+              "cluster": {
+                "id": 0,
+                "name": "Basic",
+                "type": "server"
+              },
+              "id": "1:0x0000",
+              "unique_id": "ab:cd:ef:12:1a:5e:2c:1e:1:0x0000",
+              "status": "INITIALIZED",
+              "value_attribute": null
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:1a:5e:2c:1e",
+          "endpoint_id": 1,
+          "available": true,
+          "group_id": null,
+          "suggested_display_precision": null,
+          "unit": "dBm"
+        },
+        "state": {
+          "class_name": "RSSISensor",
+          "available": true,
+          "state": -57
+        }
+      }
+    ],
+    "update": [
+      {
+        "info_object": {
+          "fallback_name": null,
+          "unique_id": "ab:cd:ef:12:1a:5e:2c:1e-1-25-firmware_update",
+          "migrate_unique_ids": [],
+          "platform": "update",
+          "class_name": "FirmwareUpdateEntity",
+          "translation_key": null,
+          "translation_placeholders": null,
+          "device_class": "firmware",
+          "state_class": null,
+          "entity_category": "config",
+          "entity_registry_enabled_default": true,
+          "enabled": true,
+          "primary": false,
+          "cluster_handlers": [
+            {
+              "class_name": "OtaClientClusterHandler",
+              "generic_id": "cluster_handler_0x0019_client",
+              "endpoint_id": 1,
+              "cluster": {
+                "id": 25,
+                "name": "Ota",
+                "type": "client"
+              },
+              "id": "1:0x0019_client",
+              "unique_id": "ab:cd:ef:12:1a:5e:2c:1e:1:0x0019_CLIENT",
+              "status": "INITIALIZED",
+              "value_attribute": null
+            }
+          ],
+          "device_ieee": "ab:cd:ef:12:1a:5e:2c:1e",
+          "endpoint_id": 1,
+          "available": true,
+          "group_id": null,
+          "supported_features": 7
+        },
+        "state": {
+          "class_name": "FirmwareUpdateEntity",
+          "available": true,
+          "installed_version": "0x00990be9",
+          "in_progress": false,
+          "update_percentage": null,
+          "latest_version": null,
+          "release_summary": null,
+          "release_notes": null,
+          "release_url": null
+        }
+      }
+    ]
+  },
+  "neighbors": [],
+  "routes": []
+}

--- a/tests/data/devices/bega-gantenbrink-leuchten-kg-smart-dimmable-light.json
+++ b/tests/data/devices/bega-gantenbrink-leuchten-kg-smart-dimmable-light.json
@@ -941,14 +941,14 @@
           "group_id": null,
           "enum": "BegaColorTemperatureChannel",
           "options": [
-            "Warm White",
-            "Cool White"
+            "Warm white",
+            "Cool white"
           ]
         },
         "state": {
           "class_name": "BegaColorTemperatureChannelSelect",
           "available": true,
-          "state": "Warm White"
+          "state": "Warm white"
         }
       }
     ],

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -286,16 +286,16 @@ async def test_bega_color_temperature_channel_select(zha_gateway: Gateway) -> No
         platform=Platform.SELECT,
         qualifier="switchable_white",
     )
-    assert entity.state["state"] == "Warm White"
-    assert entity.info_object.options == ["Warm White", "Cool White"]
+    assert entity.state["state"] == "Warm white"
+    assert entity.info_object.options == ["Warm white", "Cool white"]
 
     # send attribute report from device
     await send_attributes_report(
         zha_gateway,
         cluster,
-        {"switchable_white": BegaColorTemperatureChannel.Cool_White},
+        {"switchable_white": BegaColorTemperatureChannel.Cool_white},
     )
-    assert entity.state["state"] == "Cool White"
+    assert entity.state["state"] == "Cool white"
 
     # test selecting an option
     Write_Attributes_rsp = foundation.GENERAL_COMMANDS[
@@ -315,12 +315,12 @@ async def test_bega_color_temperature_channel_select(zha_gateway: Gateway) -> No
         ),
         patch.object(cluster, "write_attributes", wraps=cluster.write_attributes),
     ):
-        await entity.async_select_option("Warm White")
+        await entity.async_select_option("Warm white")
         await zha_gateway.async_block_till_done()
-        assert entity.state["state"] == "Warm White"
+        assert entity.state["state"] == "Warm white"
         assert cluster.write_attributes.call_count == 1
         assert cluster.write_attributes.call_args == call(
-            {"switchable_white": BegaColorTemperatureChannel.Warm_White},
+            {"switchable_white": BegaColorTemperatureChannel.Warm_white},
             manufacturer=UNDEFINED,
         )
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -335,12 +335,12 @@ async def test_bega_color_temperature_channel_select_unsupported(
     )
 
     cluster = zigpy_device.endpoints[1].in_clusters[general.LevelControl.cluster_id]
-    # Set both color temperatures to 0xFFFF (unsupported)
-    cluster._attr_cache[cluster.find_attribute("switchable_color_temperature_1").id] = (
-        0xFFFF
+    # Override color temperatures to 0xFFFF (unsupported)
+    cluster.update_attribute(
+        cluster.find_attribute("switchable_color_temperature_1").id, 0xFFFF
     )
-    cluster._attr_cache[cluster.find_attribute("switchable_color_temperature_2").id] = (
-        0xFFFF
+    cluster.update_attribute(
+        cluster.find_attribute("switchable_color_temperature_2").id, 0xFFFF
     )
 
     zha_device = await join_zigpy_device(zha_gateway, zigpy_device)

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import call, patch
 
+import pytest
 from zhaquirks import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -321,4 +322,32 @@ async def test_bega_color_temperature_channel_select(zha_gateway: Gateway) -> No
         assert cluster.write_attributes.call_args == call(
             {"switchable_white": BegaColorTemperatureChannel.Warm_White},
             manufacturer=UNDEFINED,
+        )
+
+
+async def test_bega_color_temperature_channel_select_unsupported(
+    zha_gateway: Gateway,
+) -> None:
+    """Test BEGA select entity is not created when color temps are 0xFFFF."""
+    zigpy_device = await zigpy_device_from_json(
+        zha_gateway.application_controller,
+        "tests/data/devices/bega-gantenbrink-leuchten-kg-smart-dimmable-light.json",
+    )
+
+    cluster = zigpy_device.endpoints[1].in_clusters[general.LevelControl.cluster_id]
+    # Set both color temperatures to 0xFFFF (unsupported)
+    cluster._attr_cache[cluster.find_attribute("switchable_color_temperature_1").id] = (
+        0xFFFF
+    )
+    cluster._attr_cache[cluster.find_attribute("switchable_color_temperature_2").id] = (
+        0xFFFF
+    )
+
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
+
+    with pytest.raises(KeyError):
+        get_entity(
+            zha_device,
+            platform=Platform.SELECT,
+            qualifier="switchable_white",
         )

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -27,11 +27,15 @@ from tests.common import (
     get_entity,
     join_zigpy_device,
     send_attributes_report,
+    zigpy_device_from_json,
 )
 from zha.application import Platform
 from zha.application.gateway import Gateway
 from zha.application.platforms import EntityCategory
-from zha.application.platforms.select import AqaraMotionSensitivities
+from zha.application.platforms.select import (
+    AqaraMotionSensitivities,
+    BegaColorTemperatureChannel,
+)
 
 
 async def test_select(zha_gateway: Gateway) -> None:
@@ -264,3 +268,57 @@ async def test_non_zcl_select_state_restoration(zha_gateway: Gateway) -> None:
         state=security.IasWd.Warning.WarningMode.Fire.name
     )
     assert entity.state["state"] == security.IasWd.Warning.WarningMode.Fire.name
+
+
+async def test_bega_color_temperature_channel_select(zha_gateway: Gateway) -> None:
+    """Test BEGA color temperature channel select entity."""
+    zigpy_device = await zigpy_device_from_json(
+        zha_gateway.application_controller,
+        "tests/data/devices/bega-gantenbrink-leuchten-kg-smart-dimmable-light.json",
+    )
+
+    cluster = zigpy_device.endpoints[1].in_clusters[general.LevelControl.cluster_id]
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
+
+    entity = get_entity(
+        zha_device,
+        platform=Platform.SELECT,
+        qualifier="switchable_white",
+    )
+    assert entity.state["state"] == "Warm White"
+    assert entity.info_object.options == ["Warm White", "Cool White"]
+
+    # send attribute report from device
+    await send_attributes_report(
+        zha_gateway,
+        cluster,
+        {"switchable_white": BegaColorTemperatureChannel.Cool_White},
+    )
+    assert entity.state["state"] == "Cool White"
+
+    # test selecting an option
+    Write_Attributes_rsp = foundation.GENERAL_COMMANDS[
+        foundation.GeneralCommand.Write_Attributes_rsp
+    ].schema
+
+    with (
+        patch(
+            "zigpy.device.Device.request",
+            return_value=Write_Attributes_rsp(
+                status_records=[
+                    foundation.WriteAttributesStatusRecord(
+                        status=foundation.Status.SUCCESS
+                    )
+                ]
+            ),
+        ),
+        patch.object(cluster, "write_attributes", wraps=cluster.write_attributes),
+    ):
+        await entity.async_select_option("Warm White")
+        await zha_gateway.async_block_till_done()
+        assert entity.state["state"] == "Warm White"
+        assert cluster.write_attributes.call_count == 1
+        assert cluster.write_attributes.call_args == call(
+            {"switchable_white": BegaColorTemperatureChannel.Warm_White},
+            manufacturer=UNDEFINED,
+        )

--- a/zha/application/platforms/select.py
+++ b/zha/application/platforms/select.py
@@ -1024,8 +1024,8 @@ class SinopeLightLEDOnColorSelect(ZCLEnumSelectEntity):
 class BegaColorTemperatureChannel(types.enum8):
     """BEGA switchable white color temperature channel enum."""
 
-    Warm_White = 0x00
-    Cool_White = 0x01
+    Warm_white = 0x00
+    Cool_white = 0x01
 
 
 @register_entity(LevelControl.cluster_id)

--- a/zha/application/platforms/select.py
+++ b/zha/application/platforms/select.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 from zhaquirks.danfoss import thermostat as danfoss_thermostat
 from zhaquirks.quirk_ids import (
+    BEGA_LIGHT_SWITCHABLE_WHITE,
     DANFOSS_ALLY_THERMOSTAT,
     SIREN_BASIC,
     TUYA_PLUG_MANUFACTURER,
@@ -20,7 +21,7 @@ from zhaquirks.xiaomi.aqara.magnet_ac01 import OppleCluster as MagnetAC01OppleCl
 from zhaquirks.xiaomi.aqara.switch_acn047 import OppleCluster as T2RelayOppleCluster
 from zigpy import types
 from zigpy.quirks.v2 import ZCLEnumMetadata
-from zigpy.zcl.clusters.general import OnOff
+from zigpy.zcl.clusters.general import LevelControl, OnOff
 from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
 from zigpy.zcl.clusters.measurement import OccupancySensing
 from zigpy.zcl.clusters.security import IasWd
@@ -40,6 +41,7 @@ from zha.zigbee.cluster_handlers.const import (
     CLUSTER_HANDLER_ATTRIBUTE_UPDATED,
     CLUSTER_HANDLER_IAS_WD,
     CLUSTER_HANDLER_INOVELLI,
+    CLUSTER_HANDLER_LEVEL,
     CLUSTER_HANDLER_OCCUPANCY,
     CLUSTER_HANDLER_ON_OFF,
     CLUSTER_HANDLER_THERMOSTAT,
@@ -1016,4 +1018,26 @@ class SinopeLightLEDOnColorSelect(ZCLEnumSelectEntity):
     _cluster_handler_match = ClusterHandlerMatch(
         cluster_handlers=frozenset({"sinope_manufacturer_specific"}),
         models=SINOPE_MODELS,
+    )
+
+
+class BegaColorTemperatureChannel(types.enum8):
+    """BEGA switchable white color temperature channel enum."""
+
+    Warm_White = 0x00
+    Cool_White = 0x01
+
+
+@register_entity(LevelControl.cluster_id)
+class BegaColorTemperatureChannelSelect(ZCLEnumSelectEntity):
+    """Select entity for switching BEGA light color temperature channel."""
+
+    _unique_id_suffix = "switchable_white"
+    _attribute_name = "switchable_white"
+    _enum = BegaColorTemperatureChannel
+    _attr_translation_key: str = "color_temperature_channel"
+
+    _cluster_handler_match = ClusterHandlerMatch(
+        cluster_handlers=frozenset({CLUSTER_HANDLER_LEVEL}),
+        exposed_features=frozenset({BEGA_LIGHT_SWITCHABLE_WHITE}),
     )

--- a/zha/application/platforms/select.py
+++ b/zha/application/platforms/select.py
@@ -1041,3 +1041,19 @@ class BegaColorTemperatureChannelSelect(ZCLEnumSelectEntity):
         cluster_handlers=frozenset({CLUSTER_HANDLER_LEVEL}),
         exposed_features=frozenset({BEGA_LIGHT_SWITCHABLE_WHITE}),
     )
+
+    def _is_supported(self) -> bool:
+        """Check if the light supports switchable color temperatures."""
+        cluster = self._cluster_handler.cluster
+        temp_1 = cluster.get("switchable_color_temperature_1")
+        temp_2 = cluster.get("switchable_color_temperature_2")
+
+        if temp_1 == 0xFFFF and temp_2 == 0xFFFF:
+            _LOGGER.debug(
+                "Both color temperatures are 0xFFFF (unsupported) - "
+                "skipping %s entity creation",
+                self.__class__.__name__,
+            )
+            return False
+
+        return super()._is_supported()

--- a/zha/zigbee/cluster_handlers/general.py
+++ b/zha/zigbee/cluster_handlers/general.py
@@ -7,7 +7,7 @@ from collections.abc import Coroutine
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Final
 
-from zhaquirks.quirk_ids import TUYA_PLUG_ONOFF
+from zhaquirks.quirk_ids import BEGA_LIGHT_SWITCHABLE_WHITE, TUYA_PLUG_ONOFF
 import zigpy.exceptions
 import zigpy.types as t
 import zigpy.zcl
@@ -438,6 +438,16 @@ class LevelControlClusterHandler(ClusterHandler):
         LevelControl.AttributeDefs.default_move_rate.name: True,
         LevelControl.AttributeDefs.start_up_current_level.name: True,
     }
+
+    def __init__(self, cluster: zigpy.zcl.Cluster, endpoint: Endpoint) -> None:
+        """Initialize LevelControlClusterHandler."""
+        super().__init__(cluster, endpoint)
+
+        if BEGA_LIGHT_SWITCHABLE_WHITE in endpoint.device.exposes_features:
+            self.ZCL_INIT_ATTRS = self.ZCL_INIT_ATTRS.copy()
+            self.ZCL_INIT_ATTRS["switchable_white"] = True
+            self.ZCL_INIT_ATTRS["switchable_color_temperature_1"] = True
+            self.ZCL_INIT_ATTRS["switchable_color_temperature_2"] = True
 
     @property
     def current_level(self) -> int | None:


### PR DESCRIPTION
## Proposed change

Some BEGA lights have a driver that allows you to switch between two color temperatures. This is something that should only be changed sometimes, e.g. after setup. This PR adds support for that.

For lights where this feature is not supported, the attributes are still available to be read but `switchable_color_temperature_1` and `switchable_color_temperature_2` shall have the value `0xFFFF`. This is why we need a ZHA entity to implement this, instead of a basic quirks v2 entity.


### Note 1

As only two color temperatures are supported (as separate channels) and this isn't meant to be adjusted all the time, it does not make sense to try and hack this into the light entity. The HA frontend would still show a smooth gradient for the color temperature and it's not possible to properly display either just (e.g.) 3000K or 4000K there, without allowing any values in between that.

This is why a separate config select entity is added.


### Note 2: 

ZHA currently assumes that `Bool.false` is warm-white and `Bool.true` is cool-white. We intentionally do not use whatever color temperatures are available on the `switchable_color_temperature_X` attributes, as we'd need to use that as state for the select entity. This could then differ between lights.

If it turns out the rule mentioned above doesn't apply to all devices, we could either rename the options to "Channel 1" and "Chanel 2", or have ZHA automatically swap what the select entity options do when chosen. For now, I'd not this, until it becomes clear that we actually need this (or not).

### Note 3:

It would also be good to know if the `switchable_white` attribute returns `UNSUPPORTED_ATTRIBUTE` on dimmable-only lights, or if `0xFFFF` for the other two attributes is the only indication this feature is not supported.
Most other entities just check the attribute they base state on.


## Additional information

Requires (and see for more information):
- https://github.com/zigpy/zha-device-handlers/pull/4852