### PR TITLE
Adjust sensor test to use different diagnostics file

### DIFF
--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2157,7 +2157,7 @@ async def test_enum_sensor(zha_gateway: Gateway) -> None:
     registry = DeviceRegistry()
     zigpy_dev = await zigpy_device_from_json(
         zha_gateway.application_controller,
-        "tests/data/devices/third-reality-inc-3rsm0147z.json",
+        "tests/data/devices/centralite-3405-l.json",
     )
 
     zigpy_dev.endpoints[1].power.update_attribute(


### PR DESCRIPTION
## Proposed change

This changes the diagnostics file for the `test_enum_sensor` to `centralite-3405-l.json`.

## Additional information

This is needed for the next quirks bump, as the Third Reality `3rsm0147z` device has a built-in v2 quirk with that version, returned by `zigpy_device_from_json`. `registry.get_device` will not apply the quirk defined in the test then.

We may want to not use `zigpy_device_from_json` in this test at all to avoid issues like this.