### PR TITLE
Fix `setpoint_change_source_timestamp` not being initialized

### DIFF
--- a/zha/zigbee/cluster_handlers/hvac.py
+++ b/zha/zigbee/cluster_handlers/hvac.py
@@ -126,6 +126,7 @@ class ThermostatClusterHandler(ClusterHandler):
         Thermostat.AttributeDefs.min_heat_setpoint_limit.name: True,
         Thermostat.AttributeDefs.local_temperature_calibration.name: True,
         Thermostat.AttributeDefs.setpoint_change_source.name: True,
+        Thermostat.AttributeDefs.setpoint_change_source_timestamp.name: True,
     }
 
     @property


### PR DESCRIPTION
## Proposed change

This adds `setpoint_change_source_timestamp` to `ZCL_INIT_ATTRS` for the thermostat cluster.
Otherwise, the "Timestamp" entity will be created for every thermostat, even if the device returns `UNSUPPORTED_ATTRIBUTE` when it's read.

## Additional information

This was missed in:
- https://github.com/zigpy/zha/pull/224