### PR TITLE
Experiment cleaning up light class

### DIFF
--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -1839,6 +1839,140 @@ async def test_on_with_off_color(zha_gateway: Gateway) -> None:
 
 
 @patch(
+    "zigpy.zcl.clusters.lighting.Color.request",
+    new=AsyncMock(return_value=[sentinel.data, zcl_f.Status.SUCCESS]),
+)
+@patch(
+    "zigpy.zcl.clusters.general.OnOff.request",
+    new=AsyncMock(return_value=[sentinel.data, zcl_f.Status.SUCCESS]),
+)
+async def test_turn_on_disables_effect_before_color_commands(
+    zha_gateway: Gateway,
+) -> None:
+    """Test switching away from colorloop disables it before changing color mode."""
+    device_light = await device_light_3_mock(zha_gateway)
+    entity = get_entity(device_light, platform=Platform.LIGHT)
+
+    cluster_on_off = device_light.device.endpoints[1].on_off
+    cluster_color = device_light.device.endpoints[1].light_color
+
+    entity.restore_external_state_attributes(
+        state=True,
+        off_with_transition=False,
+        off_brightness=None,
+        brightness=100,
+        color_temp=None,
+        xy_color=(0.5, 0.5),
+        color_mode=ColorMode.XY,
+        effect="colorloop",
+    )
+
+    cluster_on_off.request.reset_mock()
+    cluster_color.request.reset_mock()
+
+    await entity.async_turn_on(color_temp=235)
+
+    assert cluster_on_off.request.call_count == 1
+    assert cluster_on_off.request.await_count == 1
+    assert cluster_color.request.call_count == 2
+    assert cluster_color.request.await_count == 2
+
+    assert cluster_color.request.call_args_list[0] == call(
+        False,
+        cluster_color.commands_by_name["color_loop_set"].id,
+        cluster_color.commands_by_name["color_loop_set"].schema,
+        update_flags=lighting.Color.ColorLoopUpdateFlags.Action,
+        action=lighting.Color.ColorLoopAction.Deactivate,
+        direction=lighting.Color.ColorLoopDirection.Decrement,
+        time=0,
+        start_hue=0,
+        expect_reply=True,
+        manufacturer=None,
+    )
+    assert cluster_color.request.call_args_list[1] == call(
+        False,
+        cluster_color.commands_by_name["move_to_color_temp"].id,
+        cluster_color.commands_by_name["move_to_color_temp"].schema,
+        color_temp_mireds=235,
+        transition_time=0,
+        expect_reply=True,
+        manufacturer=None,
+    )
+
+    assert entity.state["effect"] == "off"
+    assert entity.state["color_mode"] == ColorMode.COLOR_TEMP
+    assert entity.state["color_temp"] == 235
+    assert entity.state["xy_color"] is None
+
+
+@patch(
+    "zigpy.zcl.clusters.lighting.Color.request",
+    new=AsyncMock(return_value=[sentinel.data, zcl_f.Status.SUCCESS]),
+)
+@patch(
+    "zigpy.zcl.clusters.general.LevelControl.request",
+    new=AsyncMock(return_value=[sentinel.data, zcl_f.Status.SUCCESS]),
+)
+async def test_turn_on_from_off_still_disables_stale_effect(
+    zha_gateway: Gateway,
+) -> None:
+    """Test stale colorloop state is cleared even when turn_on starts from off."""
+    device_light = await device_light_3_mock(zha_gateway)
+    entity = get_entity(device_light, platform=Platform.LIGHT)
+
+    cluster_level = device_light.device.endpoints[1].level
+    cluster_color = device_light.device.endpoints[1].light_color
+
+    entity.restore_external_state_attributes(
+        state=False,
+        off_with_transition=False,
+        off_brightness=None,
+        brightness=100,
+        color_temp=None,
+        xy_color=(0.5, 0.5),
+        color_mode=ColorMode.XY,
+        effect="colorloop",
+    )
+
+    cluster_level.request.reset_mock()
+    cluster_color.request.reset_mock()
+
+    await entity.async_turn_on(color_temp=235)
+
+    assert cluster_level.request.call_count == 2
+    assert cluster_level.request.await_count == 2
+    assert cluster_color.request.call_count == 2
+    assert cluster_color.request.await_count == 2
+
+    assert cluster_color.request.call_args_list[0] == call(
+        False,
+        cluster_color.commands_by_name["move_to_color_temp"].id,
+        cluster_color.commands_by_name["move_to_color_temp"].schema,
+        color_temp_mireds=235,
+        transition_time=0,
+        expect_reply=True,
+        manufacturer=None,
+    )
+    assert cluster_color.request.call_args_list[1] == call(
+        False,
+        cluster_color.commands_by_name["color_loop_set"].id,
+        cluster_color.commands_by_name["color_loop_set"].schema,
+        update_flags=lighting.Color.ColorLoopUpdateFlags.Action,
+        action=lighting.Color.ColorLoopAction.Deactivate,
+        direction=lighting.Color.ColorLoopDirection.Decrement,
+        time=0,
+        start_hue=0,
+        expect_reply=True,
+        manufacturer=None,
+    )
+
+    assert entity.state["effect"] == "off"
+    assert entity.state["color_mode"] == ColorMode.COLOR_TEMP
+    assert entity.state["color_temp"] == 235
+    assert entity.state["xy_color"] is None
+
+
+@patch(
     "zigpy.zcl.clusters.general.OnOff.request",
     new=AsyncMock(return_value=[sentinel.data, zcl_f.Status.SUCCESS]),
 )

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -368,21 +368,21 @@ class BaseClusterHandlerLight(BaseLight):
         set_transition_flag = (
             brightness_supported or color_temp is not None or xy_color is not None
         ) and self._zha_config_enable_light_transitioning_flag
-        transition_time = (
-            (
-                duration + DEFAULT_EXTRA_TRANSITION_DELAY_SHORT
-                if (
-                    (brightness is not None or transition is not None)
-                    and brightness_supported
-                    or (self._off_with_transition and self._off_brightness is not None)
-                    or color_temp is not None
-                    or xy_color is not None
-                )
-                else DEFAULT_ON_OFF_TRANSITION + DEFAULT_EXTRA_TRANSITION_DELAY_SHORT
+
+        if not set_transition_flag:
+            transition_time = 0.0
+        elif (
+            (brightness is not None or transition is not None)
+            and brightness_supported
+            or (self._off_with_transition and self._off_brightness is not None)
+            or color_temp is not None
+            or xy_color is not None
+        ):
+            transition_time = duration + DEFAULT_EXTRA_TRANSITION_DELAY_SHORT
+        else:
+            transition_time = (
+                DEFAULT_ON_OFF_TRANSITION + DEFAULT_EXTRA_TRANSITION_DELAY_SHORT
             )
-            if set_transition_flag
-            else 0
-        )
 
         # If we need to pause attribute report parsing, we'll do so here.
         # After successful calls, we later start a timer to unset the flag after

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -345,12 +345,10 @@ class BaseClusterHandlerLight(BaseLight):
         xy_color: tuple[int, int] | None = None,
     ) -> None:
         """Turn the entity on."""
+        # If 0 is passed in, some devices still need the minimum default
         duration = (
             transition if transition is not None else self._zha_config_transition
-        ) or (
-            # if 0 is passed in some devices still need the minimum default
-            self._DEFAULT_MIN_TRANSITION_TIME
-        )
+        ) or self._DEFAULT_MIN_TRANSITION_TIME
 
         execute_if_off_supported = (
             self._GROUP_SUPPORTS_EXECUTE_IF_OFF

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -476,6 +476,15 @@ class BaseClusterHandlerLight(BaseLight):
             level = self._brightness or 254
 
         t_log: dict[str, Any] = {}
+        started_on = self._state
+        deactivate_effect_after_turn_on = (
+            self._color_cluster_handler is not None
+            and not started_on
+            and self._effect == EFFECT_COLORLOOP
+            and effect != EFFECT_COLORLOOP
+        )
+
+        await self._async_deactivate_effect_before_turn_on(effect, t_log)
 
         try:
             await self._async_turn_on_commands(
@@ -506,31 +515,23 @@ class BaseClusterHandlerLight(BaseLight):
         # attribute reports after the completed transition).
         self.async_transition_start_timer(transition_time)
 
-        if self._color_cluster_handler is not None:
-            if effect == EFFECT_COLORLOOP:
-                result = await self._color_cluster_handler.color_loop_set(
-                    update_flags=(
-                        Color.ColorLoopUpdateFlags.Action
-                        | Color.ColorLoopUpdateFlags.Direction
-                        | Color.ColorLoopUpdateFlags.Time
-                    ),
-                    action=Color.ColorLoopAction.Activate_from_current_hue,
-                    direction=Color.ColorLoopDirection.Increment,
-                    time=transition if transition else 7,
-                    start_hue=0,
-                )
-                t_log["color_loop_set"] = result
-                self._effect = EFFECT_COLORLOOP
-            elif self._effect == EFFECT_COLORLOOP and effect != EFFECT_COLORLOOP:
-                result = await self._color_cluster_handler.color_loop_set(
-                    update_flags=Color.ColorLoopUpdateFlags.Action,
-                    action=Color.ColorLoopAction.Deactivate,
-                    direction=Color.ColorLoopDirection.Decrement,
-                    time=0,
-                    start_hue=0,
-                )
-                t_log["color_loop_set"] = result
-                self._effect = EFFECT_OFF
+        if deactivate_effect_after_turn_on:
+            await self._async_deactivate_effect_after_turn_on(t_log)
+
+        if self._color_cluster_handler is not None and effect == EFFECT_COLORLOOP:
+            result = await self._color_cluster_handler.color_loop_set(
+                update_flags=(
+                    Color.ColorLoopUpdateFlags.Action
+                    | Color.ColorLoopUpdateFlags.Direction
+                    | Color.ColorLoopUpdateFlags.Time
+                ),
+                action=Color.ColorLoopAction.Activate_from_current_hue,
+                direction=Color.ColorLoopDirection.Increment,
+                time=transition if transition else 7,
+                start_hue=0,
+            )
+            t_log["color_loop_set"] = result
+            self._effect = EFFECT_COLORLOOP
 
         if flash is not None:
             assert self._identify_cluster_handler is not None
@@ -544,6 +545,47 @@ class BaseClusterHandlerLight(BaseLight):
         self._off_brightness = None
         self.debug("turned on: %s", t_log)
         self.maybe_emit_state_changed_event()
+
+    async def _async_deactivate_effect_before_turn_on(
+        self,
+        effect: str | None,
+        t_log: dict[str, Any],
+    ) -> None:
+        """Disable an active effect before sending other state-changing commands."""
+        if (
+            self._color_cluster_handler is None
+            or not self._state
+            or self._effect != EFFECT_COLORLOOP
+            or effect == EFFECT_COLORLOOP
+        ):
+            return
+
+        result = await self._color_cluster_handler.color_loop_set(
+            update_flags=Color.ColorLoopUpdateFlags.Action,
+            action=Color.ColorLoopAction.Deactivate,
+            direction=Color.ColorLoopDirection.Decrement,
+            time=0,
+            start_hue=0,
+        )
+        t_log["color_loop_set"] = result
+        self._effect = EFFECT_OFF
+
+    async def _async_deactivate_effect_after_turn_on(
+        self,
+        t_log: dict[str, Any],
+    ) -> None:
+        """Disable an active effect after turn-on when the light started off."""
+        assert self._color_cluster_handler is not None
+
+        result = await self._color_cluster_handler.color_loop_set(
+            update_flags=Color.ColorLoopUpdateFlags.Action,
+            action=Color.ColorLoopAction.Deactivate,
+            direction=Color.ColorLoopDirection.Decrement,
+            time=0,
+            start_hue=0,
+        )
+        t_log["color_loop_set"] = result
+        self._effect = EFFECT_OFF
 
     async def _async_turn_on_commands(  # noqa: C901
         self,

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -350,12 +350,13 @@ class BaseClusterHandlerLight(BaseLight):
             transition if transition is not None else self._zha_config_transition
         ) or self._DEFAULT_MIN_TRANSITION_TIME
 
-        execute_if_off_supported = (
-            self._GROUP_SUPPORTS_EXECUTE_IF_OFF
-            if isinstance(self, LightGroup)
-            else self._color_cluster_handler
-            and self._color_cluster_handler.execute_if_off_supported
-        )
+        if isinstance(self, LightGroup):
+            execute_if_off_supported = self._GROUP_SUPPORTS_EXECUTE_IF_OFF
+        else:
+            execute_if_off_supported = (
+                self._color_cluster_handler is not None
+                and self._color_cluster_handler.execute_if_off_supported
+            )
 
         # A device theoretically could lie about having brightness support and omit the
         # actual LevelControl cluster needed to control it

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -501,8 +501,6 @@ class BaseClusterHandlerLight(BaseLight):
                 level=level,
                 execute_if_off_supported=execute_if_off_supported,
                 brightness_supported=brightness_supported,
-                set_transition_flag=set_transition_flag,
-                transition_time=transition_time,
                 new_color_provided_while_off=new_color_provided_while_off,
                 t_log=t_log,
             )
@@ -579,10 +577,8 @@ class BaseClusterHandlerLight(BaseLight):
         level: int,
         execute_if_off_supported: bool,
         brightness_supported: bool,
-        set_transition_flag: bool,
-        transition_time: float,
         new_color_provided_while_off: bool,
-        t_log: dict,
+        t_log: dict[str, Any],
     ) -> None:
         """Execute ZCL commands for turning on. Raises _ZCLCommandFailure on failure."""
 
@@ -692,11 +688,14 @@ class BaseClusterHandlerLight(BaseLight):
             and self._level_cluster_handler is not None
         )
 
-        transition_time = (
-            transition or self._DEFAULT_MIN_TRANSITION_TIME
-            if transition is not None
-            else DEFAULT_ON_OFF_TRANSITION
-        ) + DEFAULT_EXTRA_TRANSITION_DELAY_SHORT
+        if transition is not None:
+            transition_time = (
+                transition or self._DEFAULT_MIN_TRANSITION_TIME
+            ) + DEFAULT_EXTRA_TRANSITION_DELAY_SHORT
+        else:
+            transition_time = (
+                DEFAULT_ON_OFF_TRANSITION + DEFAULT_EXTRA_TRANSITION_DELAY_SHORT
+            )
 
         # Start pausing attribute report parsing
         if self._zha_config_enable_light_transitioning_flag:
@@ -735,7 +734,7 @@ class BaseClusterHandlerLight(BaseLight):
                     # current_level is set to 1 after transitioning to level 0,
                     # needed for correct state with light groups
                     self._brightness = 1
-                    self._off_with_transition = transition is not None
+                    self._off_with_transition = True
 
             self.maybe_emit_state_changed_event()
         finally:
@@ -747,11 +746,11 @@ class BaseClusterHandlerLight(BaseLight):
 
     async def async_handle_color_commands(
         self,
-        color_temp,
-        duration,
-        xy_color,
-        new_color_provided_while_off,
-        t_log,
+        color_temp: int | None,
+        duration: float,
+        xy_color: tuple[int, int] | None,
+        new_color_provided_while_off: bool,
+        t_log: dict[str, Any],
         on_failure: _ZCLFailureAction,
     ) -> None:
         """Process ZCL color commands. Raises _ZCLCommandFailure on failure."""
@@ -827,10 +826,11 @@ class BaseClusterHandlerLight(BaseLight):
         """Unsubscribe transition listener."""
         if self._transition_listener:
             self._transition_listener.cancel()
-            self._transition_listener = None
 
             with contextlib.suppress(ValueError):
                 self._tracked_handles.remove(self._transition_listener)
+
+            self._transition_listener = None
 
     def _async_cleanup_transition_if_stuck(self, guarded: bool) -> None:
         """Call async_transition_complete if the flag is set but no timer is running.

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -484,7 +484,13 @@ class BaseClusterHandlerLight(BaseLight):
             and effect != EFFECT_COLORLOOP
         )
 
-        await self._async_deactivate_effect_before_turn_on(effect, t_log)
+        if (
+            self._color_cluster_handler is not None
+            and self._state
+            and self._effect == EFFECT_COLORLOOP
+            and effect != EFFECT_COLORLOOP
+        ):
+            await self._async_deactivate_color_loop(t_log)
 
         try:
             await self._async_turn_on_commands(
@@ -516,7 +522,7 @@ class BaseClusterHandlerLight(BaseLight):
         self.async_transition_start_timer(transition_time)
 
         if deactivate_effect_after_turn_on:
-            await self._async_deactivate_effect_after_turn_on(t_log)
+            await self._async_deactivate_color_loop(t_log)
 
         if self._color_cluster_handler is not None and effect == EFFECT_COLORLOOP:
             result = await self._color_cluster_handler.color_loop_set(
@@ -546,35 +552,11 @@ class BaseClusterHandlerLight(BaseLight):
         self.debug("turned on: %s", t_log)
         self.maybe_emit_state_changed_event()
 
-    async def _async_deactivate_effect_before_turn_on(
-        self,
-        effect: str | None,
-        t_log: dict[str, Any],
-    ) -> None:
-        """Disable an active effect before sending other state-changing commands."""
-        if (
-            self._color_cluster_handler is None
-            or not self._state
-            or self._effect != EFFECT_COLORLOOP
-            or effect == EFFECT_COLORLOOP
-        ):
-            return
-
-        result = await self._color_cluster_handler.color_loop_set(
-            update_flags=Color.ColorLoopUpdateFlags.Action,
-            action=Color.ColorLoopAction.Deactivate,
-            direction=Color.ColorLoopDirection.Decrement,
-            time=0,
-            start_hue=0,
-        )
-        t_log["color_loop_set"] = result
-        self._effect = EFFECT_OFF
-
-    async def _async_deactivate_effect_after_turn_on(
+    async def _async_deactivate_color_loop(
         self,
         t_log: dict[str, Any],
     ) -> None:
-        """Disable an active effect after turn-on when the light started off."""
+        """Deactivate the color loop effect."""
         assert self._color_cluster_handler is not None
 
         result = await self._color_cluster_handler.color_loop_set(

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -10,6 +10,7 @@ from collections import Counter
 import contextlib
 import dataclasses
 from dataclasses import dataclass
+from enum import Enum
 import functools
 import itertools
 import logging
@@ -92,6 +93,20 @@ if TYPE_CHECKING:
     from zha.zigbee.group import Group
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class _ZCLFailureAction(Enum):
+    """Action to take when a ZCL command fails."""
+
+    COMPLETE_IF_NO_LISTENER = "complete_if_no_listener"
+    START_TIMER = "start_timer"
+
+
+class _ZCLCommandFailure(Exception):
+    """Raised when a ZCL command does not return Status.SUCCESS."""
+
+    def __init__(self, action: _ZCLFailureAction) -> None:
+        self.action = action
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -288,6 +303,12 @@ class BaseClusterHandlerLight(BaseLight):
 
         self._internal_supported_color_modes: set[ColorMode] = set()
 
+    @staticmethod
+    def _check_result(result, on_failure: _ZCLFailureAction) -> None:
+        """Raise _ZCLCommandFailure if the ZCL command did not succeed."""
+        if result[1] is not Status.SUCCESS:
+            raise _ZCLCommandFailure(on_failure)
+
     @property
     @abstractmethod
     def _gateway(self) -> Gateway:
@@ -394,7 +415,7 @@ class BaseClusterHandlerLight(BaseLight):
             # the light does not get stuck in a transitioning state indefinitely.
             self._async_cleanup_transition_if_stuck(set_transition_flag)
 
-    async def _async_turn_on_impl(  # noqa: C901
+    async def _async_turn_on_impl(
         self,
         *,
         transition: float | None,
@@ -454,127 +475,31 @@ class BaseClusterHandlerLight(BaseLight):
         else:
             level = self._brightness or 254
 
-        t_log = {}
+        t_log: dict[str, Any] = {}
 
-        if new_color_provided_while_off:
-            assert self._level_cluster_handler is not None
-
-            # If the light is currently off, we first need to turn it on at a low
-            # brightness level with no transition.
-            # After that, we set it to the desired color/temperature with no transition.
-            result = await self._level_cluster_handler.move_to_level_with_on_off(
-                level=DEFAULT_MIN_BRIGHTNESS,
-                transition_time=int(10 * self._DEFAULT_MIN_TRANSITION_TIME),
-            )
-            t_log["move_to_level_with_on_off"] = result
-            if result[1] is not Status.SUCCESS:
-                # First 'move to level' call failed, so if the transitioning delay
-                # isn't running from a previous call,
-                # the flag can be unset immediately
-                if set_transition_flag and not self._transition_listener:
-                    self.async_transition_complete()
-                self.debug("turned on: %s", t_log)
-                return
-            # Currently only setting it to "on", as the correct level state will
-            # be set at the second move_to_level call
-            self._state = True
-
-        if execute_if_off_supported:
-            self.debug("handling color commands before turning on/level")
-            if not await self.async_handle_color_commands(
-                color_temp,
-                duration,  # duration is ignored by lights when off
-                xy_color,
-                new_color_provided_while_off,
-                t_log,
-            ):
-                # Color calls before on/level calls failed,
-                # so if the transitioning delay isn't running from a previous call,
-                # the flag can be unset immediately
-                if set_transition_flag and not self._transition_listener:
-                    self.async_transition_complete()
-                self.debug("turned on: %s", t_log)
-                return
-
-        if (
-            (brightness is not None or transition is not None)
-            and not new_color_provided_while_off
-            and brightness_supported
-        ):
-            assert self._level_cluster_handler is not None
-
-            result = await self._level_cluster_handler.move_to_level_with_on_off(
+        try:
+            await self._async_turn_on_commands(
+                brightness=brightness,
+                transition=transition,
+                color_temp=color_temp,
+                xy_color=xy_color,
+                duration=duration,
                 level=level,
-                transition_time=int(10 * duration),
+                execute_if_off_supported=execute_if_off_supported,
+                brightness_supported=brightness_supported,
+                set_transition_flag=set_transition_flag,
+                transition_time=transition_time,
+                new_color_provided_while_off=new_color_provided_while_off,
+                t_log=t_log,
             )
-            t_log["move_to_level_with_on_off"] = result
-            if result[1] is not Status.SUCCESS:
-                # First 'move to level' call failed, so if the transitioning delay
-                # isn't running from a previous call, the flag can be unset immediately
+        except _ZCLCommandFailure as exc:
+            if exc.action == _ZCLFailureAction.COMPLETE_IF_NO_LISTENER:
                 if set_transition_flag and not self._transition_listener:
                     self.async_transition_complete()
-                self.debug("turned on: %s", t_log)
-                return
-            self._state = bool(level)
-            if level:
-                self._brightness = level
-
-        if (
-            (brightness is None and transition is None)
-            and not new_color_provided_while_off
-            or (self._FORCE_ON and brightness != 0)
-        ):
-            assert self._on_off_cluster_handler is not None
-
-            # since FORCE_ON lights don't turn on with move_to_level_with_on_off,
-            # we should call the on command on the on_off cluster
-            # if brightness is not 0.
-            result = await self._on_off_cluster_handler.on()
-            t_log["on_off"] = result
-            if result[1] is not Status.SUCCESS:
-                # 'On' call failed, but as brightness may still transition
-                # (for FORCE_ON lights), we start the timer to unset the flag after
-                # the transition_time if necessary.
+            elif exc.action == _ZCLFailureAction.START_TIMER:
                 self.async_transition_start_timer(transition_time)
-                self.debug("turned on: %s", t_log)
-                return
-            self._state = True
-
-        if not execute_if_off_supported:
-            self.debug("handling color commands after turning on/level")
-            if not await self.async_handle_color_commands(
-                color_temp,
-                duration,
-                xy_color,
-                new_color_provided_while_off,
-                t_log,
-            ):
-                # Color calls failed, but as brightness may still transition,
-                # we start the timer to unset the flag
-                self.async_transition_start_timer(transition_time)
-                self.debug("turned on: %s", t_log)
-                return
-
-        if new_color_provided_while_off:
-            assert self._level_cluster_handler is not None
-
-            # The light has the correct color, so we can now transition
-            # it to the correct brightness level.
-            result = await self._level_cluster_handler.move_to_level(
-                level=level, transition_time=int(10 * duration)
-            )
-            t_log["move_to_level_if_color"] = result
-            if result[1] is not Status.SUCCESS:
-                # Second 'move to level' call failed; the light is on but at the
-                # wrong brightness. If no previous timer is running, unset the flag
-                # immediately so attribute reports are not ignored indefinitely.
-                if set_transition_flag and not self._transition_listener:
-                    self.async_transition_complete()
-                self.debug("turned on: %s", t_log)
-                return
-            self._state = bool(level)
-            if level:
-                self._brightness = level
+            self.debug("turned on: %s", t_log)
+            return
 
         # Our light is guaranteed to have just started the transitioning process
         # if necessary, so we start the delay for the transition (to stop parsing
@@ -619,6 +544,123 @@ class BaseClusterHandlerLight(BaseLight):
         self._off_brightness = None
         self.debug("turned on: %s", t_log)
         self.maybe_emit_state_changed_event()
+
+    async def _async_turn_on_commands(  # noqa: C901
+        self,
+        *,
+        brightness: int | None,
+        transition: float | None,
+        color_temp: int | None,
+        xy_color: tuple[int, int] | None,
+        duration: float,
+        level: int,
+        execute_if_off_supported: bool,
+        brightness_supported: bool,
+        set_transition_flag: bool,
+        transition_time: float,
+        new_color_provided_while_off: bool,
+        t_log: dict,
+    ) -> None:
+        """Execute ZCL commands for turning on. Raises _ZCLCommandFailure on failure."""
+
+        if new_color_provided_while_off:
+            assert self._level_cluster_handler is not None
+
+            # If the light is currently off, we first need to turn it on at a low
+            # brightness level with no transition.
+            # After that, we set it to the desired color/temperature with no transition.
+            result = await self._level_cluster_handler.move_to_level_with_on_off(
+                level=DEFAULT_MIN_BRIGHTNESS,
+                transition_time=int(10 * self._DEFAULT_MIN_TRANSITION_TIME),
+            )
+            t_log["move_to_level_with_on_off"] = result
+            # First 'move to level' call failed, so if the transitioning delay
+            # isn't running from a previous call, the flag can be unset immediately
+            self._check_result(result, _ZCLFailureAction.COMPLETE_IF_NO_LISTENER)
+            # Currently only setting it to "on", as the correct level state will
+            # be set at the second move_to_level call
+            self._state = True
+
+        if execute_if_off_supported:
+            self.debug("handling color commands before turning on/level")
+            # Color calls before on/level calls failed,
+            # so if the transitioning delay isn't running from a previous call,
+            # the flag can be unset immediately
+            await self.async_handle_color_commands(
+                color_temp,
+                duration,  # duration is ignored by lights when off
+                xy_color,
+                new_color_provided_while_off,
+                t_log,
+                on_failure=_ZCLFailureAction.COMPLETE_IF_NO_LISTENER,
+            )
+
+        if (
+            (brightness is not None or transition is not None)
+            and not new_color_provided_while_off
+            and brightness_supported
+        ):
+            assert self._level_cluster_handler is not None
+
+            result = await self._level_cluster_handler.move_to_level_with_on_off(
+                level=level,
+                transition_time=int(10 * duration),
+            )
+            t_log["move_to_level_with_on_off"] = result
+            # First 'move to level' call failed, so if the transitioning delay
+            # isn't running from a previous call, the flag can be unset immediately
+            self._check_result(result, _ZCLFailureAction.COMPLETE_IF_NO_LISTENER)
+            self._state = bool(level)
+            if level:
+                self._brightness = level
+
+        if (
+            (brightness is None and transition is None)
+            and not new_color_provided_while_off
+            or (self._FORCE_ON and brightness != 0)
+        ):
+            assert self._on_off_cluster_handler is not None
+
+            # since FORCE_ON lights don't turn on with move_to_level_with_on_off,
+            # we should call the on command on the on_off cluster
+            # if brightness is not 0.
+            result = await self._on_off_cluster_handler.on()
+            t_log["on_off"] = result
+            # 'On' call failed, but as brightness may still transition
+            # (for FORCE_ON lights), we start the timer to unset the flag after
+            # the transition_time if necessary.
+            self._check_result(result, _ZCLFailureAction.START_TIMER)
+            self._state = True
+
+        if not execute_if_off_supported:
+            self.debug("handling color commands after turning on/level")
+            # Color calls failed, but as brightness may still transition,
+            # we start the timer to unset the flag
+            await self.async_handle_color_commands(
+                color_temp,
+                duration,
+                xy_color,
+                new_color_provided_while_off,
+                t_log,
+                on_failure=_ZCLFailureAction.START_TIMER,
+            )
+
+        if new_color_provided_while_off:
+            assert self._level_cluster_handler is not None
+
+            # The light has the correct color, so we can now transition
+            # it to the correct brightness level.
+            result = await self._level_cluster_handler.move_to_level(
+                level=level, transition_time=int(10 * duration)
+            )
+            t_log["move_to_level_if_color"] = result
+            # Second 'move to level' call failed; the light is on but at the
+            # wrong brightness. If no previous timer is running, unset the flag
+            # immediately so attribute reports are not ignored indefinitely.
+            self._check_result(result, _ZCLFailureAction.COMPLETE_IF_NO_LISTENER)
+            self._state = bool(level)
+            if level:
+                self._brightness = level
 
     async def async_turn_off(self, *, transition: float | None = None) -> None:
         """Turn the entity off."""
@@ -687,8 +729,9 @@ class BaseClusterHandlerLight(BaseLight):
         xy_color,
         new_color_provided_while_off,
         t_log,
-    ):
-        """Process ZCL color commands."""
+        on_failure: _ZCLFailureAction,
+    ) -> None:
+        """Process ZCL color commands. Raises _ZCLCommandFailure on failure."""
         transition_time = (
             self._DEFAULT_MIN_TRANSITION_TIME
             if new_color_provided_while_off
@@ -703,8 +746,7 @@ class BaseClusterHandlerLight(BaseLight):
                 transition_time=int(10 * transition_time),
             )
             t_log["move_to_color_temp"] = result
-            if result[1] is not Status.SUCCESS:
-                return False
+            self._check_result(result, on_failure)
             self._color_mode = ColorMode.COLOR_TEMP
             self._color_temp = color_temp
             self._xy_color = None
@@ -718,13 +760,10 @@ class BaseClusterHandlerLight(BaseLight):
                 transition_time=int(10 * transition_time),
             )
             t_log["move_to_color"] = result
-            if result[1] is not Status.SUCCESS:
-                return False
+            self._check_result(result, on_failure)
             self._color_mode = ColorMode.XY
             self._xy_color = xy_color
             self._color_temp = None
-
-        return True
 
     @property
     def is_transitioning(self) -> bool:


### PR DESCRIPTION
DRAFT. We need full test coverage first. This is also still experimental.

## Proposed change

This adds a `_check_result` method to the light class that raises if the status is not `SUCCESS`.
Depending on the `_ZCLFailureAction`, the exception handling differs for the transition timing.

https://github.com/zigpy/zha/pull/733 is also pulled in temporarily. Other clean-ups are applied as well.

### Background

The light class basically works perfectly, except for turning off an effect when also switching color modes (affecting some lights). This would be fixed with PR #733. However, the light class also has potential to be cleaned up a bit.

In order to handle transitions and intermediate command failures correctly, you need a lot of conditionals to correctly handle all possible failure states. Other Zigbee implementations often do not do this correctly, causing incorrect state in Home Assistant when one command fails to deliver.

However, we can still clean up our light class a lot. One idea for this failed command handling is the one implemented in this PR. We likely want more test coverage for all edge-cases (group lights, assumed state, turn on after being turned off with a transition (internal brightness differs), ...) before trying any clean-up PRs though.


## Additional information

Somewhat related:
- https://github.com/zigpy/zha/pull/678
- https://github.com/zigpy/zha/pull/733