### PR TITLE
Fix BEGA color temp channel unsupported check

### DIFF
--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -325,22 +325,31 @@ async def test_bega_color_temperature_channel_select(zha_gateway: Gateway) -> No
         )
 
 
+@pytest.mark.parametrize(
+    ("temp_1", "temp_2"),
+    [
+        (0xFFFF, 0xFFFF),
+        (0xFFFF, 3000),
+        (3000, 0xFFFF),
+    ],
+)
 async def test_bega_color_temperature_channel_select_unsupported(
     zha_gateway: Gateway,
+    temp_1: int,
+    temp_2: int,
 ) -> None:
-    """Test BEGA select entity is not created when color temps are 0xFFFF."""
+    """Test BEGA select entity is not created when a color temp is 0xFFFF."""
     zigpy_device = await zigpy_device_from_json(
         zha_gateway.application_controller,
         "tests/data/devices/bega-gantenbrink-leuchten-kg-smart-dimmable-light.json",
     )
 
     cluster = zigpy_device.endpoints[1].in_clusters[general.LevelControl.cluster_id]
-    # Override color temperatures to 0xFFFF (unsupported)
     cluster.update_attribute(
-        cluster.find_attribute("switchable_color_temperature_1").id, 0xFFFF
+        cluster.find_attribute("switchable_color_temperature_1").id, temp_1
     )
     cluster.update_attribute(
-        cluster.find_attribute("switchable_color_temperature_2").id, 0xFFFF
+        cluster.find_attribute("switchable_color_temperature_2").id, temp_2
     )
 
     zha_device = await join_zigpy_device(zha_gateway, zigpy_device)

--- a/zha/application/platforms/select.py
+++ b/zha/application/platforms/select.py
@@ -1048,9 +1048,9 @@ class BegaColorTemperatureChannelSelect(ZCLEnumSelectEntity):
         temp_1 = cluster.get("switchable_color_temperature_1")
         temp_2 = cluster.get("switchable_color_temperature_2")
 
-        if temp_1 == 0xFFFF and temp_2 == 0xFFFF:
+        if temp_1 == 0xFFFF or temp_2 == 0xFFFF:
             _LOGGER.debug(
-                "Both color temperatures are 0xFFFF (unsupported) - "
+                "A color temperature is 0xFFFF (unsupported) - "
                 "skipping %s entity creation",
                 self.__class__.__name__,
             )


### PR DESCRIPTION
## Proposed change

This fixes an issue where the "Color temperature channel" select entity for BEGA lights was created, even if the light driver only supports one color temperature channel. On truly "dimmable only" lights with one driver channel only, one attribute still has the correct color temperature (e.g. 3000K), with the other one being set to `0xFFFF`.

To fix this, we just do not create the select entity if either driver channel's color temperature is `0xFFFF`.

## Additional information

Follow-up to:
- https://github.com/zigpy/zha/pull/721

To note again: These lights are **not** tunable color temperature lights. They can only be fixed to either 3000K or 4000K (depends on exact model). So, this cannot be represented in the Home Assistant light entity model and an extra select entity is needed to switch the driver channel. See the above PR for more notes on this.