### PR TITLE
Disable light default move rate config entity by default

### DIFF
--- a/tests/data/devices/bega-gantenbrink-leuchten-kg-smart-dimmable-light.json
+++ b/tests/data/devices/bega-gantenbrink-leuchten-kg-smart-dimmable-light.json
@@ -583,7 +583,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/inovelli-vzm30-sn.json
+++ b/tests/data/devices/inovelli-vzm30-sn.json
@@ -909,7 +909,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/ledvance-flex-rgbw.json
+++ b/tests/data/devices/ledvance-flex-rgbw.json
@@ -484,7 +484,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/ledvance-outdoor-accent-light-rgb.json
+++ b/tests/data/devices/ledvance-outdoor-accent-light-rgb.json
@@ -460,7 +460,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/legrand-dimmer-switch-w-o-neutral.json
+++ b/tests/data/devices/legrand-dimmer-switch-w-o-neutral.json
@@ -563,7 +563,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/schneider-electric-lk-dimmer.json
+++ b/tests/data/devices/schneider-electric-lk-dimmer.json
@@ -664,7 +664,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -401,6 +401,7 @@ class DefaultMoveRateConfigurationEntity(NumberConfigurationEntity):
     """Representation of a ZHA default move rate configuration entity."""
 
     _unique_id_suffix = "default_move_rate"
+    _attr_entity_registry_enabled_default = False
     _attr_native_min_value: float = 0x00
     _attr_native_max_value: float = 0xFE
     _attribute_name = "default_move_rate"


### PR DESCRIPTION
## Proposed change

This disables the "Default move rate" config entity for lights by default.

## Additional information

The entity is not really used at all, unless you directly bind a remote to it, or send raw ZCL `move` commands.

Most lights also do not support it, but for the ones that do, we now disable the entity by default with this PR to clean up the "Configuration" section on the device page a bit. Most people don't have any clue what this entity does.

### Notes

The entity is **not** disabled for existing (paired) devices, only for ones paired with this version of ZHA (and newer).
The entity can still be enabled using Home Assistant.