### PR TITLE
Disable light transition time number entities by default

### DIFF
--- a/tests/data/devices/adurosmart-eria-ad-rgbw3001.json
+++ b/tests/data/devices/adurosmart-eria-ad-rgbw3001.json
@@ -526,7 +526,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [
@@ -620,7 +620,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [
@@ -667,7 +667,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/aqara-lumi-light-acn132.json
+++ b/tests/data/devices/aqara-lumi-light-acn132.json
@@ -483,7 +483,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [
@@ -577,7 +577,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [
@@ -624,7 +624,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/aqara-lumi-light-agl003.json
+++ b/tests/data/devices/aqara-lumi-light-agl003.json
@@ -832,7 +832,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [
@@ -926,7 +926,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [
@@ -973,7 +973,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/aqara-lumi-light-agl005.json
+++ b/tests/data/devices/aqara-lumi-light-agl005.json
@@ -838,7 +838,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [
@@ -932,7 +932,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [
@@ -979,7 +979,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/bega-gantenbrink-leuchten-kg-smart-dimmable-light.json
+++ b/tests/data/devices/bega-gantenbrink-leuchten-kg-smart-dimmable-light.json
@@ -630,7 +630,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [
@@ -724,7 +724,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [
@@ -771,7 +771,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/ewelink-ck-bl702-al-01-7009-z102lg03-1.json
+++ b/tests/data/devices/ewelink-ck-bl702-al-01-7009-z102lg03-1.json
@@ -562,7 +562,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/ikea-of-sweden-ormanas-led-strip.json
+++ b/tests/data/devices/ikea-of-sweden-ormanas-led-strip.json
@@ -690,7 +690,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-w-op-ch-400lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-w-op-ch-400lm.json
@@ -446,7 +446,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-ws-opal-400lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-ws-opal-400lm.json
@@ -612,7 +612,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e14-ws-globe-470lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e14-ws-globe-470lm.json
@@ -557,7 +557,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-opal-1000lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-opal-1000lm.json
@@ -446,7 +446,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-w-opal-1000lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-w-opal-1000lm.json
@@ -440,7 +440,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-ws-opal-980lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-ws-opal-980lm.json
@@ -592,7 +592,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e27-ws-globe-1055lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e27-ws-globe-1055lm.json
@@ -573,7 +573,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e27-ww-g95-cl-470lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e27-ww-g95-cl-470lm.json
@@ -426,7 +426,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-gu10-ws-400lm.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-gu10-ws-400lm.json
@@ -618,7 +618,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-gu10-ww-345lm8.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-gu10-ww-345lm8.json
@@ -421,7 +421,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/innr-ae-280-c.json
+++ b/tests/data/devices/innr-ae-280-c.json
@@ -544,7 +544,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/innr-rs-232-c.json
+++ b/tests/data/devices/innr-rs-232-c.json
@@ -514,7 +514,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [
@@ -608,7 +608,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [
@@ -655,7 +655,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/innr-sp-120.json
+++ b/tests/data/devices/innr-sp-120.json
@@ -628,7 +628,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/innr-sp-242.json
+++ b/tests/data/devices/innr-sp-242.json
@@ -622,7 +622,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [
@@ -716,7 +716,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [
@@ -763,7 +763,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/inovelli-vzm30-sn.json
+++ b/tests/data/devices/inovelli-vzm30-sn.json
@@ -1003,7 +1003,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/inovelli-vzm31-sn.json
+++ b/tests/data/devices/inovelli-vzm31-sn.json
@@ -2024,7 +2024,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/inovelli-vzm35-sn.json
+++ b/tests/data/devices/inovelli-vzm35-sn.json
@@ -1826,7 +1826,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/ledvance-a60s-rgbw.json
+++ b/tests/data/devices/ledvance-a60s-rgbw.json
@@ -890,7 +890,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/ledvance-flex-rgbw.json
+++ b/tests/data/devices/ledvance-flex-rgbw.json
@@ -531,7 +531,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [
@@ -625,7 +625,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [
@@ -672,7 +672,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/ledvance-outdoor-accent-light-rgb.json
+++ b/tests/data/devices/ledvance-outdoor-accent-light-rgb.json
@@ -507,7 +507,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [
@@ -601,7 +601,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [
@@ -648,7 +648,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/legrand-dimmer-switch-w-o-neutral.json
+++ b/tests/data/devices/legrand-dimmer-switch-w-o-neutral.json
@@ -610,7 +610,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [
@@ -704,7 +704,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [
@@ -751,7 +751,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/lk-zbt-onoffplug-d0001.json
+++ b/tests/data/devices/lk-zbt-onoffplug-d0001.json
@@ -355,7 +355,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/lumi-lumi-light-aqcn02.json
+++ b/tests/data/devices/lumi-lumi-light-aqcn02.json
@@ -487,7 +487,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/orvibo-250bccf66c41421b91b5e3242942c164.json
+++ b/tests/data/devices/orvibo-250bccf66c41421b91b5e3242942c164.json
@@ -496,7 +496,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [
@@ -543,7 +543,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [
@@ -590,7 +590,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/schneider-electric-lk-dimmer.json
+++ b/tests/data/devices/schneider-electric-lk-dimmer.json
@@ -758,7 +758,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/sunricher-hk-dim.json
+++ b/tests/data/devices/sunricher-hk-dim.json
@@ -939,7 +939,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/sunricher-hk-ln-dim-a.json
+++ b/tests/data/devices/sunricher-hk-ln-dim-a.json
@@ -446,7 +446,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/the-home-depot-ecosmart-zbt-a19-cct-bulb.json
+++ b/tests/data/devices/the-home-depot-ecosmart-zbt-a19-cct-bulb.json
@@ -603,7 +603,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/third-reality-inc-3rsnl02043z.json
+++ b/tests/data/devices/third-reality-inc-3rsnl02043z.json
@@ -644,7 +644,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/tz3000-mgusv51k-ts0052.json
+++ b/tests/data/devices/tz3000-mgusv51k-ts0052.json
@@ -403,7 +403,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/tz3210-r5afgmkl-ts0505b.json
+++ b/tests/data/devices/tz3210-r5afgmkl-ts0505b.json
@@ -495,7 +495,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [
@@ -589,7 +589,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/tests/data/devices/zbeacon-ts0505.json
+++ b/tests/data/devices/zbeacon-ts0505.json
@@ -504,7 +504,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [
@@ -598,7 +598,7 @@
           "device_class": null,
           "state_class": null,
           "entity_category": "config",
-          "entity_registry_enabled_default": true,
+          "entity_registry_enabled_default": false,
           "enabled": true,
           "primary": false,
           "cluster_handlers": [

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -341,6 +341,7 @@ class OnOffTransitionTimeConfigurationEntity(NumberConfigurationEntity):
     """Representation of a ZHA on off transition time configuration entity."""
 
     _unique_id_suffix = "on_off_transition_time"
+    _attr_entity_registry_enabled_default = False
     _attr_native_min_value: float = 0x0000
     _attr_native_max_value: float = 0xFFFF
     _attribute_name = "on_off_transition_time"
@@ -371,6 +372,7 @@ class OnTransitionTimeConfigurationEntity(NumberConfigurationEntity):
     """Representation of a ZHA on transition time configuration entity."""
 
     _unique_id_suffix = "on_transition_time"
+    _attr_entity_registry_enabled_default = False
     _attr_native_min_value: float = 0x0000
     _attr_native_max_value: float = 0xFFFE
     _attribute_name = "on_transition_time"
@@ -386,6 +388,7 @@ class OffTransitionTimeConfigurationEntity(NumberConfigurationEntity):
     """Representation of a ZHA off transition time configuration entity."""
 
     _unique_id_suffix = "off_transition_time"
+    _attr_entity_registry_enabled_default = False
     _attr_native_min_value: float = 0x0000
     _attr_native_max_value: float = 0xFFFE
     _attribute_name = "off_transition_time"


### PR DESCRIPTION
DRAFT. Do not merge yet – see question at the bottom.

## Proposed change

This disables the various transition config entities for lights by default.

## Additional information

These entities are rarely used, as it also depends on how you turn on the light (e.g. with a brightness, or without), whether these apply, or the global ZHA option.

It also depends on the light when the individual "On transition time" and "Off transition time" entities are used, versus the "On/off transition time" entity. E.g. for most lights (and per spec), "On/off transition time" should not be used, unless both "On transition time" and "Off transition time" have a non-value, so `65535`. We disallow setting this value via the number entity, for some reason.

### Notes

The entity is **not** disabled for existing (paired) devices, only for ones paired with this version of ZHA (and newer).
The entity can still be enabled using Home Assistant.

### Thoughts / Question

I'm not completely certain we should disable all these entities by default. Maybe we can conditionally only disable the "On/off transition time" entity if both the "On transition time" and "Off transition time" entities are supported as well? (Because in that case, the devices do not use the on/off entity, unless the on + off entities are set to none values.)