### PR TITLE
Remove pyserial dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,6 @@ dependencies = [
     "zigpy-xbee==0.21.1",
     "zigpy-zigate==0.14.0",
     "zha-quirks==1.1.1",
-    "pyserial==3.5",
-    "pyserial-asyncio-fast",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Proposed change

This removes the explicit `pyserial` and `pyserial-asyncio-fast` dependencies we had (for some reason).

## Additional information

Zigpy (and thus ZHA) exclusively use [Serialx](https://github.com/puddly/serialx) now after the following PRs:
- https://github.com/zigpy/zha/pull/743 / https://github.com/zigpy/zigpy/pull/1815
- https://github.com/zigpy/zha/pull/744
- https://github.com/zigpy/zha/pull/745