### PR TITLE
Fix race in `device_initialized` causing KeyError on rapid rejoin

### DIFF
--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -557,6 +557,46 @@ async def test_gateway_device_initialized(
     )
 
 
+async def test_gateway_device_initialized_no_keyerror_on_rapid_rejoin(
+    zha_gateway: Gateway,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Regression test for #748.
+
+    When a device sends a second join announcement before the first
+    initialization task completes, the cancelled task's done-callback
+    must not pop the dict entry that now belongs to the replacement
+    task — otherwise the replacement's own done-callback raises KeyError.
+    """
+    zigpy_dev_basic = create_mock_zigpy_device(zha_gateway, ZIGPY_DEVICE_BASIC)
+
+    loop = asyncio.get_running_loop()
+    captured_exceptions: list[BaseException] = []
+    original_handler = loop.get_exception_handler()
+
+    def capture_exception(loop_, context):
+        if (exc := context.get("exception")) is not None:
+            captured_exceptions.append(exc)
+        if original_handler is not None:
+            original_handler(loop_, context)
+
+    loop.set_exception_handler(capture_exception)
+    try:
+        zha_gateway.device_initialized(zigpy_dev_basic)
+        zha_gateway.device_initialized(zigpy_dev_basic)
+        await zha_gateway.async_block_till_done()
+    finally:
+        loop.set_exception_handler(original_handler)
+
+    assert (
+        f"Cancelling previous initialization task for device {zigpy_dev_basic.ieee}"
+        in caplog.text
+    )
+    keyerrors = [e for e in captured_exceptions if isinstance(e, KeyError)]
+    assert not keyerrors, f"done-callback raised KeyError(s): {keyerrors}"
+    assert zigpy_dev_basic.ieee not in zha_gateway._device_init_tasks
+
+
 def test_gateway_raw_device_initialized(
     zha_gateway: Gateway,
 ) -> None:

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -444,11 +444,11 @@ class Gateway(AsyncUtilMixin, EventBase):
             eager_start=True,
         )
 
-        def _remove_init_task(task: asyncio.Task, ieee: EUI64 = device.ieee) -> None:
+        def _remove_init_task(task: asyncio.Task) -> None:
             # Only remove the entry if it still points at this task; a cancelled
             # task's done-callback must not pop the replacement task's entry.
-            if self._device_init_tasks.get(ieee) is task:
-                del self._device_init_tasks[ieee]
+            if self._device_init_tasks.get(device.ieee) is task:
+                del self._device_init_tasks[device.ieee]
 
         init_task.add_done_callback(_remove_init_task)
 

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -443,7 +443,14 @@ class Gateway(AsyncUtilMixin, EventBase):
             name=f"device_initialized_task_{str(device.ieee)}:0x{device.nwk:04x}",
             eager_start=True,
         )
-        init_task.add_done_callback(lambda _: self._device_init_tasks.pop(device.ieee))
+
+        def _remove_init_task(task: asyncio.Task, ieee: EUI64 = device.ieee) -> None:
+            # Only remove the entry if it still points at this task; a cancelled
+            # task's done-callback must not pop the replacement task's entry.
+            if self._device_init_tasks.get(ieee) is task:
+                del self._device_init_tasks[ieee]
+
+        init_task.add_done_callback(_remove_init_task)
 
     def device_left(self, device: zigpy.device.Device) -> None:
         """Handle device leaving the network."""


### PR DESCRIPTION
## Summary

Fixes a real data-corruption bug filed in #748: when a device sends a second join announcement before the first initialization task completes, the unconditional `pop(device.ieee)` in the lambda done-callback removes the dict entry that now belongs to the replacement task — and the replacement's own done-callback then raises `KeyError`, leaving `_device_init_tasks` in an inconsistent state.

## Root cause

Pre-fix code at `zha/application/gateway.py:446`:

```python
init_task.add_done_callback(lambda _: self._device_init_tasks.pop(device.ieee))
```

Sequence that triggers the bug (3 rapid `device_initialized` events for the same IEEE):

1. Event A → `task_1` created; `_device_init_tasks[X] = task_1`
2. Event B → `task_1.cancel()`; `_device_init_tasks[X] = task_2`
3. `task_1`'s done-callback fires (cancellation) → pops `X` from dict — but the entry now belongs to `task_2`. **Dict is now empty even though `task_2` is still running.**
4. Event C → check `if X in dict` is **False** → no cancellation; `task_3` created; `_device_init_tasks[X] = task_3`. **`task_2` and `task_3` are now both running concurrently for the same device, but only `task_3` is tracked.**
5. `task_2` completes (it was never cancelled at step 4) → its done-callback pops `X` → **clobbers `task_3`'s entry**
6. `task_3` completes → tries to pop → **KeyError**

The unhandled `KeyError` surfaces in the asyncio default exception handler, and steps 4–5 leave the dict in a state where ZHA cannot correctly cancel a stale init task on the next join.

## Fix

Replace the lambda with a named callback that removes the dict entry **only if it still points at this task**. The cancelled task's callback no longer clobbers the replacement task's entry; subsequent `device_initialized` events correctly find and cancel the in-flight task.

```python
def _remove_init_task(task: asyncio.Task, ieee: EUI64 = device.ieee) -> None:
    if self._device_init_tasks.get(ieee) is task:
        del self._device_init_tasks[ieee]
```

## Scope of this fix — important caveat

This patch fixes the **`KeyError` and the `_device_init_tasks` bookkeeping**. It does **not** by itself stop the user-visible "Interview complete → Configuring → unavailable, repeat" loop reported in #748.

After in-the-wild testing on a deployment with affected Aqara `lumi.light.agl005` devices, that UI loop has a separate root cause: the bulb sends repeated join announcements within the duration of an interview. With the bookkeeping correct, every new announcement now cleanly cancels the in-flight interview — which means an interview never finishes if announcements keep arriving inside its window. Pre-patch, the broken bookkeeping accidentally allowed some interviews to complete in the background (without cancellation), masking this deeper interaction.

So:
- **What this patch does fix:** the `KeyError` exception, the inconsistent `_device_init_tasks` state, and the cascading mis-cancellation in any interleaving of three or more rapid `device_initialized` events for the same IEEE.
- **What this patch does NOT fix on its own:** the underlying re-announcement loop. A complete fix likely needs an additional change — e.g. debouncing repeated `device_initialized` events for the same IEEE within a small window, or letting an in-flight interview run to completion rather than always cancelling. That deserves its own design discussion and is out of scope for this PR.

## Alternatives considered

**A. Minimal one-character fix — `pop(device.ieee, None)`.** Stops the crash but lets a cancelled task's callback silently delete the active task's entry. A subsequent `device_initialized` would then not find the running task and would not cancel it — leaving the bookkeeping wrong while hiding the symptom. **Rejected:** masks the root cause.

**B. Make `device_initialized` async and `await` the cancellation before creating the replacement.** Eliminates the concurrency window entirely so only one `async_device_initialized` ever runs per IEEE. **Rejected for this PR:** larger blast radius (sync→async signature change, every caller in zigpy needs verification, awaiting cancellation can stall if the running task is blocked on a Zigbee request). Worth doing as a follow-up if maintainers want stricter serialization.

**C. Per-IEEE `asyncio.Lock` wrapping `async_device_initialized`.** Same effect as B with arguably nicer ergonomics, but accumulates `Lock` objects per device and needs cleanup logic. **Rejected:** more machinery than the bug warrants.

**D. Move cleanup inside `async_device_initialized` via a `finally` block.** Same race as the lambda — `task_1`'s `finally` could still pop after `task_2` overwrote the dict entry. **Rejected:** doesn't actually fix the bug.

**E. Debounce rapid re-announcements (would address the deeper UI loop).** Skip a `device_initialized` event if one fired for the same IEEE within the last N seconds AND a task is currently running. **Not included here:** policy change with non-obvious implications (e.g. interaction with legitimate orphan-recovery rejoins). Should be its own PR with test cases.

The patch as written is the smallest change that makes the dict bookkeeping consistent in all interleavings.

## Risks

| Risk | Evaluation |
|---|---|
| Stale dict entry if a task hangs forever | Pre-existing — old code had the same property (only cleans up via done-callback). No new leak vector introduced. |
| `KeyError` no longer surfaces as a canary | Acceptable — the dict is private and only mutated in `device_initialized` + this one callback, so there is no third caller whose misuse the canary would have caught. |
| **Pre-existing concurrency window unchanged** | `task_1` may still be running `async_device_initialized` when `task_2` starts and momentarily contend on the same device's cluster handlers / Zigbee requests. This patch does not make that worse, and it is independent of the `KeyError` filed in #748. Addressing it is the scope of alternative B. |
| **Cancellation now actually works on every rapid rejoin** | This is the *correct* behavior, but means rapid re-announcements will now reliably interrupt interviews. Pre-patch, broken bookkeeping accidentally allowed some interviews to complete uncancelled. See "Scope" caveat above. |
| TOCTOU between `dict.get()` and `del` | Impossible — single-threaded event-loop code with no `await` between them. |
| Ordering vs the existing `_tracked_completable_tasks.remove` done-callback | Independent dicts; FIFO callback execution per asyncio docs. Neither blocks the other. |
| Memory growth from closure capture | Same lifetime as the lambda it replaces. |
| `eager_start=True` causing the callback to run before the dict is assigned | When the task completes synchronously, the callback is `call_soon`'d for the next tick, by which point the dict assignment has already happened in the same synchronous block. Verified by the regression test. |
| Compatibility | Pure Python, no new imports, no API change, no dependency bumps. Pre-commit (codespell, mypy, ruff lint, ruff format) passes. |

## Regression test

The existing `test_gateway_device_initialized` already calls `device_initialized` twice in rapid succession but couldn't detect the failure — `KeyError` is raised inside a done-callback so it goes to the loop's exception handler, not the test.

Added `test_gateway_device_initialized_no_keyerror_on_rapid_rejoin` which installs a custom asyncio exception handler, captures any exceptions raised in callbacks, and asserts no `KeyError` surfaces. Verified the test fails on `dev` HEAD without the fix and passes with it.

## Before / after evidence from a live HA install

### Before (HA 2026.4.3, zha 1.1.2 unpatched — from the user's logs in #748)

The race fires, then crashes the done-callback. Reported `count: 101, first occurred 4 days earlier`:

```
WARNING (zha.application.gateway) Cancelling previous initialization task for device 54:ef:44:10:01:0f:f6:79
Cancelling previous initialization task for device 54:ef:44:10:01:0f:f6:d5
...

ERROR (homeassistant) Error doing job: Exception in callback Gateway.device_initialized.<locals>.<lambda>() at /usr/local/lib/python3.14/site-packages/zha/application/gateway.py:446 (task: None)

Traceback (most recent call last):
  File "/usr/local/lib/python3.14/asyncio/events.py", line 94, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/local/lib/python3.14/site-packages/zha/application/gateway.py", line 446, in <lambda>
    init_task.add_done_callback(lambda _: self._device_init_tasks.pop(device.ieee))
KeyError: 54:ef:44:10:01:1f:02:b2
```

### After (same HA install, patched `gateway.py` deployed in place)

Mass power-cycle of mains-powered Aqara `lumi.light.agl005` routers triggered the same race path:

```
2026-04-25 14:21:35  Device 0x4dde (54:ef:44:10:01:0f:f7:61) joined the network
2026-04-25 14:21:35  Device 0x4dde (54:ef:44:10:01:0f:f7:61) joined the network   ← rapid duplicate
2026-04-25 14:21:35  Device 0x198e (54:ef:44:10:01:0f:f4:b3) joined the network
2026-04-25 14:21:36  Device 0x198e (54:ef:44:10:01:0f:f4:b3) joined the network   ← rapid duplicate
2026-04-25 14:21:36  Device 0x198e (54:ef:44:10:01:0f:f4:b3) joined the network   ← and another
...
2026-04-25 14:21:54  WARNING  Cancelling previous initialization task for device 54:ef:44:10:01:1a:8c:1a
```

Counts in the same log window after the patched code took over:

| Signal | Count |
|---|---|
| `Cancelling previous initialization` (race path triggered) | ≥ 2 (proves we hit the path the bug crashed in) |
| `gateway.py:446` mentions | **0** |
| `Error doing job: Exception in callback Gateway.device_initialized` | **0** |
| `KeyError` from this code path | **0** |

The bookkeeping now stays correct through arbitrarily many cancel/replace cycles. (The deeper re-announcement loop is a separate issue — see "Scope" caveat above.)

## Test plan

- [x] Existing `test_gateway_device_initialized` still passes
- [x] New regression test fails before the fix, passes after
- [x] Full unit-test suite passes (1326 tests)
- [x] `pre-commit` passes (codespell, mypy, ruff lint, ruff format)
- [x] Verified live in Home Assistant 2026.4.3 (zha 1.1.2): patched `gateway.py` deployed, race path triggered repeatedly during real-world rejoin storms, zero `KeyError` events, `_device_init_tasks` remains consistent

Closes #748 (the `KeyError`/bookkeeping bug). Likely also relevant to #740, though the visible "Configuring loop" symptom in both reports may need a follow-up debounce/serialization change to fully resolve.