### PR TITLE
Use latest Python versions in CI workflow, add Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
     with:
       CODE_FOLDER: zha
       CACHE_VERSION: 2
-      PYTHON_VERSION_DEFAULT: "3.12.10"
+      PYTHON_VERSION_DEFAULT: "3.12"
       PRE_COMMIT_CACHE_PATH: ~/.cache/pre-commit
       MINIMUM_COVERAGE_PERCENTAGE: 95
-      PYTHON_MATRIX: '"3.12.10", "3.13.3"'
+      PYTHON_MATRIX: '"3.12", "3.13", "3.14"'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
https://github.com/zigpy/zha/pull/752 got stuck on creating the cache key correctly, which means it's now reserved for 24 hours, even though it's not showing for deletion. This is a great time to use the latest Python versions and add 3.14 to CI.