### PR TITLE
Fix quirks v2 entity non-values

### DIFF
--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2068,6 +2068,64 @@ async def test_ignore_non_value(zha_gateway: Gateway) -> None:
     assert entity.state["state"] is None
 
 
+async def test_ignore_non_value_quirks_v2(zha_gateway: Gateway) -> None:
+    """Test quirks v2 sensor entities ignore ZCL datatype non-values."""
+
+    registry = DeviceRegistry()
+    zigpy_dev = create_mock_zigpy_device(
+        zha_gateway,
+        {
+            1: {
+                SIG_EP_INPUT: [
+                    general.Basic.cluster_id,
+                    measurement.RelativeHumidity.cluster_id,
+                ],
+                SIG_EP_OUTPUT: [],
+                SIG_EP_TYPE: zigpy.profiles.zha.DeviceType.SIMPLE_SENSOR,
+                SIG_EP_PROFILE: zigpy.profiles.zha.PROFILE_ID,
+            }
+        },
+        manufacturer="manufacturer",
+        model="model",
+    )
+
+    (
+        QuirkBuilder(zigpy_dev.manufacturer, zigpy_dev.model, registry=registry)
+        .sensor(
+            measurement.RelativeHumidity.AttributeDefs.measured_value.name,
+            measurement.RelativeHumidity.cluster_id,
+            translation_key="quirks_humidity",
+            fallback_name="Quirks humidity",
+        )
+        .add_to_registry()
+    )
+
+    zigpy_device_ = registry.get_device(zigpy_dev)
+    assert isinstance(zigpy_device_, CustomDeviceV2)
+    cluster = zigpy_device_.endpoints[1].humidity
+
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device_)
+    entity = get_entity(
+        zha_device, platform=Platform.SENSOR, qualifier="measured_value"
+    )
+
+    # Normal attribute report
+    await send_attributes_report(
+        zha_gateway,
+        cluster,
+        {measurement.RelativeHumidity.AttributeDefs.measured_value.id: 5000},
+    )
+    assert entity.state["state"] == 5000
+
+    # Invalid attribute value (uint16 non_value), should be ignored
+    await send_attributes_report(
+        zha_gateway,
+        cluster,
+        {measurement.RelativeHumidity.AttributeDefs.measured_value.id: 0xFFFF},
+    )
+    assert entity.state["state"] is None
+
+
 async def test_ignore_nan_value(zha_gateway: Gateway) -> None:
     """Test sensor updates ignoring NaN values (e.g. from CO concentration sensors)."""
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2069,60 +2069,29 @@ async def test_ignore_non_value(zha_gateway: Gateway) -> None:
 
 
 async def test_ignore_non_value_quirks_v2(zha_gateway: Gateway) -> None:
-    """Test quirks v2 sensor entities ignore ZCL datatype non-values."""
+    """Test quirks v2 sensor entities ignore ZCL datatype non-values.
 
-    registry = DeviceRegistry()
-    zigpy_dev = create_mock_zigpy_device(
-        zha_gateway,
-        {
-            1: {
-                SIG_EP_INPUT: [
-                    general.Basic.cluster_id,
-                    measurement.RelativeHumidity.cluster_id,
-                ],
-                SIG_EP_OUTPUT: [],
-                SIG_EP_TYPE: zigpy.profiles.zha.DeviceType.SIMPLE_SENSOR,
-                SIG_EP_PROFILE: zigpy.profiles.zha.PROFILE_ID,
-            }
-        },
-        manufacturer="manufacturer",
-        model="model",
+    Regression for the frient AQSZB-110 VOC sensor (custom develco
+    `develco_voc_level` cluster `0xfc03`), which is a generic
+    `sensor.Sensor` entity created via quirks v2 metadata.
+    """
+
+    zigpy_dev = await zigpy_device_from_json(
+        zha_gateway.application_controller,
+        "tests/data/devices/frient-a-s-aqszb-110.json",
     )
+    assert isinstance(zigpy_dev, CustomDeviceV2)
 
-    (
-        QuirkBuilder(zigpy_dev.manufacturer, zigpy_dev.model, registry=registry)
-        .sensor(
-            measurement.RelativeHumidity.AttributeDefs.measured_value.name,
-            measurement.RelativeHumidity.cluster_id,
-            translation_key="quirks_humidity",
-            fallback_name="Quirks humidity",
-        )
-        .add_to_registry()
-    )
-
-    zigpy_device_ = registry.get_device(zigpy_dev)
-    assert isinstance(zigpy_device_, CustomDeviceV2)
-    cluster = zigpy_device_.endpoints[1].humidity
-
-    zha_device = await join_zigpy_device(zha_gateway, zigpy_device_)
-    entity = get_entity(
-        zha_device, platform=Platform.SENSOR, qualifier="measured_value"
-    )
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
+    cluster = zha_device.device.endpoints[38].develco_voc_level
+    entity = get_entity(zha_device, platform=Platform.SENSOR, qualifier="voc_level")
 
     # Normal attribute report
-    await send_attributes_report(
-        zha_gateway,
-        cluster,
-        {measurement.RelativeHumidity.AttributeDefs.measured_value.id: 5000},
-    )
-    assert entity.state["state"] == 5000
+    await send_attributes_report(zha_gateway, cluster, {"measured_value": 100})
+    assert entity.state["state"] == 100
 
     # Invalid attribute value (uint16 non_value), should be ignored
-    await send_attributes_report(
-        zha_gateway,
-        cluster,
-        {measurement.RelativeHumidity.AttributeDefs.measured_value.id: 0xFFFF},
-    )
+    await send_attributes_report(zha_gateway, cluster, {"measured_value": 0xFFFF})
     assert entity.state["state"] is None
 
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2069,12 +2069,7 @@ async def test_ignore_non_value(zha_gateway: Gateway) -> None:
 
 
 async def test_ignore_non_value_quirks_v2(zha_gateway: Gateway) -> None:
-    """Test quirks v2 sensor entities ignore ZCL datatype non-values.
-
-    Regression for the frient AQSZB-110 VOC sensor (custom develco
-    `develco_voc_level` cluster `0xfc03`), which is a generic
-    `sensor.Sensor` entity created via quirks v2 metadata.
-    """
+    """Test quirks v2 sensor entities also ignore ZCL datatype non-values."""
 
     zigpy_dev = await zigpy_device_from_json(
         zha_gateway.application_controller,

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -374,9 +374,7 @@ class Sensor(BaseSensor):
 
         if attr_def is None:
             attr_def = self._attr_def
-
-        if attr_def is None:
-            return False
+        assert attr_def is not None
 
         data_type = foundation.DataType.from_type_id(attr_def.zcl_type)
         return value == data_type.non_value

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -253,12 +253,9 @@ class Sensor(BaseSensor):
 
         super().__init__(cluster_handlers, endpoint, device, **kwargs)
 
-        # `_attribute_name` may be set by `_init_from_quirks_metadata` (called
-        # from `super().__init__()`) for quirks v2 entities, so resolve the
-        # attribute definition only after that.
+        # After super() for quirks v2 entities
         if self._attribute_name is not None:
-            # If the attribute definition does not exist, this entity will be
-            # filtered out via `is_supported`
+            # Invalid attribute names filtered by is_supported
             with contextlib.suppress(KeyError):
                 self._attr_def = self._cluster_handler.cluster.find_attribute(
                     self._attribute_name

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -251,15 +251,19 @@ class Sensor(BaseSensor):
         self._cluster_handler: ClusterHandler = cluster_handlers[0]
         self._attr_def: foundation.ZCLAttributeDef | None = None
 
+        super().__init__(cluster_handlers, endpoint, device, **kwargs)
+
+        # `_attribute_name` may be set by `_init_from_quirks_metadata` (called
+        # from `super().__init__()`) for quirks v2 entities, so resolve the
+        # attribute definition only after that.
         if self._attribute_name is not None:
-            # If the attribute definition does not exist, this entity will be filtered
-            # out via `is_supported`
+            # If the attribute definition does not exist, this entity will be
+            # filtered out via `is_supported`
             with contextlib.suppress(KeyError):
                 self._attr_def = self._cluster_handler.cluster.find_attribute(
                     self._attribute_name
                 )
 
-        super().__init__(cluster_handlers, endpoint, device, **kwargs)
         self.recompute_capabilities()
 
     def on_add(self) -> None:


### PR DESCRIPTION
## Proposed change

Move `super().__init__()` in the `Sensor` class, so `_attribute_name` is set by the base class before we set `_attr_def` based on that in the `Sensor` class. 

---

## AI summary

ZCL numeric measurement attributes use a sentinel value to mean "no measurement available" (e.g. `0xFFFF` for `uint16`, `-32768` for `int16`). `Sensor._is_non_value` is supposed to map those to `None` so the entity reports as Unknown in HA. For specialized sensor classes (Temperature, Humidity, etc.) this works, but for **quirks v2** entities — which use the generic `sensor.Sensor` class — the sentinel was leaking through as the raw integer state.

Reported via diagnostics on a frient AQSZB-110: the device's humidity sensor (standard `RelativeHumidity` cluster, specialized `Humidity` class) correctly reported `None` when the measurement was unavailable, but its VOC sensor (custom `develco_voc_level` cluster `0xfc03`, generic `Sensor` class via quirks v2) reported `65535` instead of `None`.

## Root cause

`Sensor.__init__` looked up the attribute definition before calling `super().__init__()`:

```python
if self._attribute_name is not None:
    self._attr_def = self._cluster_handler.cluster.find_attribute(self._attribute_name)

super().__init__(cluster_handlers, endpoint, device, **kwargs)
```

For specialized subclasses, `_attribute_name = "measured_value"` is a class attribute, so this works. For quirks v2 entities, `_attribute_name` is set inside `_init_from_quirks_metadata`, which runs from `super().__init__()` — i.e. *after* the lookup. So `_attr_def` stayed `None`, and `_is_non_value` short-circuited to `False` (no attr def → can't know the type's non_value), letting the sentinel through.

## Fix

Move the `find_attribute` lookup after `super().__init__()` so `_attribute_name` is resolved (whether from a class attribute or from quirks v2 metadata) before we use it.

## Cleanup

The previous `if attr_def is None: return False` guard inside `_is_non_value` is dropped in a follow-up commit — after the init-order fix it's no longer reachable through `native_value` / `formatter` (specialized sensors set `_attribute_name` as a class attribute; quirks v2 entities have it set via `_init_from_quirks_metadata`; sensors whose attribute isn't on the cluster fail `_is_supported` or short-circuit at `raw_state is None`). The guard was the exact mechanism that masked this bug, so removing it makes any future regression surface loudly. An `assert attr_def is not None` is kept to narrow the type for mypy.

## Tests

- `test_ignore_non_value_quirks_v2` — loads the existing `tests/data/devices/frient-a-s-aqszb-110.json` fixture (the device from the original report), reports `0xFFFF` on the develco `develco_voc_level` cluster, asserts the entity state is `None`. Mirrors the shape of the adjacent `test_ignore_non_value` / `test_ignore_nan_value`. Confirmed to fail without the fix.
