### PR TITLE
Fix firmware update error message missing exception type

### DIFF
--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -506,6 +506,49 @@ async def test_firmware_update_raises(zha_gateway: Gateway) -> None:
         await zha_gateway.async_block_till_done()
 
 
+async def test_firmware_update_empty_exception_message(zha_gateway: Gateway) -> None:
+    """Bare ``TimeoutError()`` from zigpy must still produce an identifiable message."""
+    zigpy_device = zigpy_device_mock(zha_gateway)
+    zha_device, ota_cluster, fw_image, installed_fw_version = await setup_test_data(
+        zha_gateway, zigpy_device
+    )
+
+    entity = get_entity(zha_device, platform=Platform.UPDATE)
+
+    await ota_cluster._handle_query_next_image(
+        foundation.ZCLHeader.cluster(
+            tsn=0x12, command_id=general.Ota.ServerCommandDefs.query_next_image.id
+        ),
+        general.QueryNextImageCommand(
+            field_control=fw_image.firmware.header.field_control,
+            manufacturer_code=zha_device.manufacturer_code,
+            image_type=fw_image.firmware.header.image_type,
+            current_file_version=installed_fw_version,
+            hardware_version=1,
+        ),
+    )
+    await zha_gateway.async_block_till_done()
+
+    raised = TimeoutError()
+    assert str(raised) == ""
+
+    with (
+        patch(
+            "zigpy.device.Device.update_firmware",
+            AsyncMock(side_effect=raised),
+        ),
+        pytest.raises(ZHAException) as exc_info,
+    ):
+        await entity.async_install(
+            version=f"0x{fw_image.firmware.header.file_version:08x}"
+        )
+        await zha_gateway.async_block_till_done()
+
+    assert str(exc_info.value) == "Update was not successful: TimeoutError()"
+    assert exc_info.value.__cause__ is raised
+    assert not entity.state[ATTR_IN_PROGRESS]
+
+
 async def test_firmware_update_downgrade(zha_gateway: Gateway) -> None:
     """Test ZHA update platform - force a firmware downgrade."""
     zigpy_device = zigpy_device_mock(zha_gateway)

--- a/zha/application/platforms/update.py
+++ b/zha/application/platforms/update.py
@@ -262,7 +262,9 @@ class BaseFirmwareUpdateEntity(PlatformEntity, ABC):
         except Exception as ex:
             self._attr_in_progress = False
             self.maybe_emit_state_changed_event()
-            raise ZHAException(f"Update was not successful: {ex}") from ex
+            raise ZHAException(
+                f"Update was not successful: {str(ex) or repr(ex)}"
+            ) from ex
 
         # If the update finished but was not successful, we should also throw an error
         if result != Status.SUCCESS:


### PR DESCRIPTION
## Proposed change

This fixes an issue where a `TimeoutError` during an update showed "Update was not successful: " as an error message. With this PR, we now show the exception type itself (`repr(ex)`) if the exception string (`str(ex)`) is empty.

A test is also added, though I'm not sure how necessary it really is. It does run and test the added code, so I've kept it for now (as this isn't done otherwise).

### When this happens

This only really happens with devices that have a `PollControl` cluster. Otherwise, we should always get a `DeliveryError`. Maybe something to address in a future zigpy PR(?)

## AI summary

<details><summary>Long AI summary (click to expand)</summary>
<p>

Preserve exception type in firmware update error messages

## Problem

When a firmware update fails because the underlying `update_firmware()` call raises a bare `TimeoutError()` — the canonical case being `asyncio.timeout()` cancelling its inner await in zigpy (`zigpy/device.py:689`, `async with asyncio_timeout(timeout): await future`) — the user-facing error message is empty after the colon:

```
Update was not successful:
```

`BaseFirmwareUpdateEntity.async_install` catches the exception and re-raises it as:

```python
raise ZHAException(f"Update was not successful: {ex}") from ex
```

For `TimeoutError()` (and any other exception constructed without arguments), `str(ex) == ""`, so the f-string interpolates nothing and the user sees no clue about what went wrong.

## Fix

Fall back to `repr(ex)` when `str(ex)` is empty:

```python
raise ZHAException(
    f"Update was not successful: {str(ex) or repr(ex)}"
) from ex
```

Now a bare `TimeoutError()` renders as `Update was not successful: TimeoutError()`. Exceptions with non-empty `str()` are unaffected — `"bad version"` still shows up as `Update was not successful: bad version`, not `ValueError('bad version')`.

The `or` form is safe across exceptions reachable from `except Exception`:

- `KeyboardInterrupt` / `SystemExit` / `asyncio.CancelledError` derive from `BaseException`, so they don't reach this clause.
- The fallback only evaluates `repr(ex)` when `str(ex)` is empty, and `BaseException.__repr__` is built-in and never raises.
- Whitespace-only or `"0"`-style strings stay as-is (truthy in `or`); contrived but accurate.

The second `raise ZHAException(f"Update was not successful: {result}")` branch (the `result != Status.SUCCESS` path) is left alone — `Status` always renders meaningfully.

## Tests

- `test_firmware_update_empty_exception_message` — patches `Device.update_firmware` to raise a bare `TimeoutError()` and asserts the resulting `ZHAException` message is exactly `Update was not successful: TimeoutError()` and that `__cause__` chaining is preserved. Confirmed to fail before the fix (message was `Update was not successful: ` with a trailing space).


</p>
</details> 

