### PR TITLE
Fix `prevent_default_entity_creation` removing quirks v2 entities

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -16,13 +16,13 @@ from zigpy.quirks.v2 import (
     ExposesFeatureMetadata,
     QuirkBuilder,
 )
-from zigpy.quirks.v2.homeassistant import EntityType
+from zigpy.quirks.v2.homeassistant import PERCENTAGE, EntityType
 from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
 import zigpy.types
 from zigpy.typing import UNDEFINED
 from zigpy.zcl import ClusterType
 from zigpy.zcl.clusters import general
-from zigpy.zcl.clusters.general import Ota, PowerConfiguration
+from zigpy.zcl.clusters.general import AnalogInput, Ota, PowerConfiguration
 from zigpy.zcl.clusters.lighting import Color
 from zigpy.zcl.clusters.measurement import CarbonDioxideConcentration
 from zigpy.zcl.foundation import Status, WriteAttributesResponse
@@ -1037,27 +1037,33 @@ async def test_quirks_v2_prevent_default_entities_does_not_remove_v2_entities(
     """Test prevent_default_entity_creation does not remove quirks v2 entities.
 
     `prevent_default_entity_creation` is meant to suppress default ZHA entities
-    only; quirks-v2-defined entities (via `.sensor(...)` etc.) must survive even
-    when the predicate would otherwise match them — e.g. when the v2 entity
-    reuses the same `unique_id_suffix` as the default entity in order to
-    preserve the existing HA entity registry entry.
+    only; quirks-v2-defined entities (via `.sensor(...)` etc.) must survive
+    even when the predicate would otherwise match them — e.g. when the v2
+    entity deliberately reuses the same `unique_id_suffix` as the default
+    entity in order to preserve the existing HA entity registry entry.
     """
     registry = DeviceRegistry()
 
     (
-        QuirkBuilder("CentraLite", "3405-L", registry=registry)
-        # Broad rule: matches every entity on the PowerConfiguration cluster on
-        # endpoint 1, which includes the default `Battery` sensor *and* the
-        # quirks v2 sensor added below.
+        QuirkBuilder("Espressif", "ZigbeeAnalogDevice", registry=registry)
+        # Both the prevent rule and the v2 sensor target the same suffix —
+        # without the fix this rule would remove the v2 sensor as well.
         .prevent_default_entity_creation(
             endpoint_id=1,
-            cluster_id=PowerConfiguration.cluster_id,
+            cluster_id=AnalogInput.cluster_id,
+            unique_id_suffix="analog_input",
         )
         .sensor(
-            attribute_name=PowerConfiguration.AttributeDefs.battery_quantity.name,
-            cluster_id=PowerConfiguration.cluster_id,
-            translation_key="battery_quantity",
-            fallback_name="Battery quantity",
+            attribute_name=AnalogInput.AttributeDefs.present_value.name,
+            cluster_id=AnalogInput.cluster_id,
+            # Match the default ZHA `AnalogInputSensor._unique_id_suffix` so
+            # the new entity inherits the existing HA entity registry entry.
+            unique_id_suffix="analog_input",
+            device_class=SensorDeviceClass.AQI,
+            state_class=SensorStateClass.MEASUREMENT,
+            unit=PERCENTAGE,
+            translation_key="dirty_level",
+            fallback_name="Dirty Level",
         )
         .add_to_registry()
     )
@@ -1065,27 +1071,24 @@ async def test_quirks_v2_prevent_default_entities_does_not_remove_v2_entities(
     zigpy_dev = registry.get_device(
         await zigpy_device_from_json(
             zha_gateway.application_controller,
-            "tests/data/devices/centralite-3405-l.json",
+            "tests/data/devices/espressif-zigbeeanalogdevice.json",
         )
     )
 
     zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
 
-    # Default `Battery` sensor was removed by the prevent rule.
-    with pytest.raises(KeyError):
-        zha_device.get_platform_entity(
-            Platform.SENSOR,
-            unique_id="00:0d:6f:00:05:65:83:f2-1-1",
-        )
-
-    # The quirks v2 sensor survived even though the prevent predicate matched
-    # it as well (same endpoint + cluster).
-    v2_entity = get_entity(
-        zha_device, platform=Platform.SENSOR, qualifier="battery_quantity"
-    )
-    assert v2_entity is not None
-    assert v2_entity._from_quirks_v2 is True
-    assert v2_entity.translation_key == "battery_quantity"
+    # The v2 sensor survived even though the prevent predicate (matched by
+    # `unique_id_suffix="analog_input"`) also matches it.
+    sensors = [
+        e
+        for e in zha_device.platform_entities.values()
+        if e.PLATFORM == Platform.SENSOR and "analog_input" in e.unique_id
+    ]
+    assert len(sensors) == 1
+    (sensor,) = sensors
+    assert sensor._from_quirks_v2 is True
+    assert sensor.translation_key == "dirty_level"
+    assert sensor._attr_device_class == SensorDeviceClass.AQI
 
 
 async def test_quirks_v2_change_entity_metadata(zha_gateway: Gateway) -> None:

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1031,6 +1031,63 @@ async def test_quirks_v2_prevent_default_entities(zha_gateway: Gateway) -> None:
     assert len(zha_device.platform_entities) == 7
 
 
+async def test_quirks_v2_prevent_default_entities_does_not_remove_v2_entities(
+    zha_gateway: Gateway,
+) -> None:
+    """Test prevent_default_entity_creation does not remove quirks v2 entities.
+
+    `prevent_default_entity_creation` is meant to suppress default ZHA entities
+    only; quirks-v2-defined entities (via `.sensor(...)` etc.) must survive even
+    when the predicate would otherwise match them — e.g. when the v2 entity
+    reuses the same `unique_id_suffix` as the default entity in order to
+    preserve the existing HA entity registry entry.
+    """
+    registry = DeviceRegistry()
+
+    (
+        QuirkBuilder("CentraLite", "3405-L", registry=registry)
+        # Broad rule: matches every entity on the PowerConfiguration cluster on
+        # endpoint 1, which includes the default `Battery` sensor *and* the
+        # quirks v2 sensor added below.
+        .prevent_default_entity_creation(
+            endpoint_id=1,
+            cluster_id=PowerConfiguration.cluster_id,
+        )
+        .sensor(
+            attribute_name=PowerConfiguration.AttributeDefs.battery_quantity.name,
+            cluster_id=PowerConfiguration.cluster_id,
+            translation_key="battery_quantity",
+            fallback_name="Battery quantity",
+        )
+        .add_to_registry()
+    )
+
+    zigpy_dev = registry.get_device(
+        await zigpy_device_from_json(
+            zha_gateway.application_controller,
+            "tests/data/devices/centralite-3405-l.json",
+        )
+    )
+
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
+
+    # Default `Battery` sensor was removed by the prevent rule.
+    with pytest.raises(KeyError):
+        zha_device.get_platform_entity(
+            Platform.SENSOR,
+            unique_id="00:0d:6f:00:05:65:83:f2-1-1",
+        )
+
+    # The quirks v2 sensor survived even though the prevent predicate matched
+    # it as well (same endpoint + cluster).
+    v2_entity = get_entity(
+        zha_device, platform=Platform.SENSOR, qualifier="battery_quantity"
+    )
+    assert v2_entity is not None
+    assert v2_entity._from_quirks_v2 is True
+    assert v2_entity.translation_key == "battery_quantity"
+
+
 async def test_quirks_v2_change_entity_metadata(zha_gateway: Gateway) -> None:
     """Test quirks v2 can change entity metadata."""
     registry = DeviceRegistry()

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -449,6 +449,11 @@ class PlatformEntity(BaseEntity):
     # entities using the same cluster handler/cluster id for the entity.
     _unique_id_suffix: str | None = None
 
+    # True when this entity was constructed from quirks v2 EntityMetadata.
+    # Used to scope filters like `prevent_default_entity_creation` to default
+    # ZHA entities only.
+    _from_quirks_v2: bool = False
+
     _migrate_platform_unique_ids: tuple[tuple[UniqueIdMigration, str]] | None = None
 
     # Auto-discovery for the entity
@@ -491,6 +496,8 @@ class PlatformEntity(BaseEntity):
 
     def _init_from_quirks_metadata(self, entity_metadata: EntityMetadata) -> None:
         """Init this entity from the quirks metadata."""
+        self._from_quirks_v2 = True
+
         if entity_metadata.initially_disabled:
             self._attr_entity_registry_enabled_default = False
 

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -963,6 +963,13 @@ class Device(LogMixin, EventBase):
         if self.quirk_metadata is None:
             return False
 
+        # `prevent_default_entity_creation` only targets default ZHA entities.
+        # Entities defined by the quirk itself (via quirks v2 EntityMetadata,
+        # e.g. `.sensor(...)`) are not removed here, even when the predicate
+        # would otherwise match them.
+        if entity._from_quirks_v2:
+            return False
+
         for meta in self.quirk_metadata.disabled_default_entities:
             _LOGGER.debug("Checking if entity %s is removed by %s", entity, meta)
 


### PR DESCRIPTION
## Proposed change

This fixes an issue where `prevent_default_entity_creation` also prevented creation of custom-defined quirks v2 entites.
The PR tracks created quirks v2 entities, so they're later excluded by the check that's done for preventing entity creation.

## Additional information

Fixes an issue discovered in:
- https://github.com/zigpy/zha-device-handlers/issues/4870

This is needed, so you can apply `prevent_default_entity_creation` to an entire `cluster_id` but still create custom-defined quirks v2 entities that are not removed. It's also required if you want to replace a default ZHA-discovered entity, like `AnalogInput`, and replace it with your own custom-defined quirks v2 entity that uses the same `unique_id_suffix`.

Peviously, `prevent_default_entity_creation` removed the custom-defined quirks v2 entity in both cases. This is fixed.

### TODO

- Shorten AI comments?

## AI summary

<details><summary>AI summary (click to expand)</summary>
<p>

The `.prevent_default_entity_creation(...)` quirks v2 builder is documented as a way to suppress **default** ZHA entities so a quirk can replace them. In practice the filter ran against every entity returned from discovery, so it also removed entities defined by the quirk itself via `.sensor(...)` / `.binary_sensor(...)` / etc. when the predicate happened to match.

Surfaced via [zigpy/zha-device-handlers#4870](https://github.com/zigpy/zha-device-handlers/issues/4870) (Third Reality 3RAP0149BZ): the device has an `AnalogInput` cluster whose `application_type = 0xFFFF` is parsed as `type=Temp_Degrees_C`, so ZHA's default `AnalogInputSensor` materializes as a phantom temperature entity. The natural quirk is to (a) suppress the default and (b) expose `present_value` as a "Dirty Level" AQI sensor via `.sensor(...)`. Reusing `unique_id_suffix="analog_input"` on the v2 sensor is desirable here because it preserves the existing HA entity registry entry (entity_id, history, customizations). But with both rules referencing `analog_input`, the filter removed both entities and the user was left with nothing.

## Root cause

`Device._is_entity_removed_by_quirk` iterates `quirk_metadata.disabled_default_entities` and matches on `endpoint_id` / `cluster_id` / `cluster_type` / `unique_id_suffix` / `function`. None of those criteria distinguish a default ZHA entity from a quirks-v2-defined one — they're both `PlatformEntity` instances on the same cluster handlers — so any predicate broad enough to cover the default entity also catches the v2 replacement.

## Fix

- Track origin on `PlatformEntity`: add `_from_quirks_v2: bool = False` and flip it to `True` inside `_init_from_quirks_metadata` (which runs only when the entity is constructed from a quirks v2 `EntityMetadata`).
- Short-circuit `_is_entity_removed_by_quirk` for those entities, so `prevent_default_entity_creation` only affects default ZHA entities — matching the documented intent.

The two pieces are split across commits 1 and 2 purely for review clarity: commit 1 adds the flag (no behavior change), commit 2 makes the filter consult it (the actual bugfix).

## Tests

`test_quirks_v2_prevent_default_entities_does_not_remove_v2_entities` reuses the existing `tests/data/devices/espressif-zigbeeanalogdevice.json` fixture (also has `AnalogInput` on endpoint 1, so it can stand in for the issue's repro without a new fixture file). The quirk:

- Adds a `prevent_default_entity_creation(endpoint_id=1, cluster_id=AnalogInput.cluster_id, unique_id_suffix="analog_input")` rule that matches the default `AnalogInputSensor`'s `_unique_id_suffix = "analog_input"`.
- Adds a `.sensor(...)` that **deliberately reuses** `unique_id_suffix="analog_input"` to preserve the existing entity registry entry.

The test asserts the v2 sensor survives (`_from_quirks_v2 is True`, `translation_key == "dirty_level"`, `device_class == AQI`) while the default entity is removed.

Confirmed to fail without commit 2's `device.py` check (the v2 sensor is removed alongside the default) and to pass with it.


</p>
</details> 

