### PR TITLE
Fix on/off-only lights reverting to off after rapid turn_off/turn_on

### DIFF
--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -2069,6 +2069,61 @@ async def test_turn_on_during_off_transition(zha_gateway: Gateway) -> None:
     assert bool(entity.state["on"]) is False
 
 
+@patch(
+    "zigpy.zcl.clusters.general.OnOff.request",
+    new=AsyncMock(return_value=[sentinel.data, zcl_f.Status.SUCCESS]),
+)
+async def test_on_off_only_rapid_toggle_does_not_revert(
+    zha_gateway: Gateway,
+) -> None:
+    """Test rapid turn_off then turn_on on an on/off-only light does not revert to off.
+
+    On/off-only lights have no brightness transition to wait for, so turn_off
+    must not arm the transitioning flag/timer. Otherwise a buffered on_off=False
+    report from the off command would override the optimistic on-state when
+    the timer fires after the follow-up turn_on.
+    """
+    zigpy_device = create_mock_zigpy_device(zha_gateway, LIGHT_ON_OFF)
+    on_off_cluster = zigpy_device.endpoints[1].on_off
+    on_off_cluster.PLUGGED_ATTR_READS = {"on_off": 1}
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
+
+    entity = get_entity(zha_device, platform=Platform.LIGHT)
+    assert bool(entity.state["on"]) is True
+
+    # Turn off, then immediately turn back on (within the default ~1.5s window).
+    await entity.async_turn_off()
+    await zha_gateway.async_block_till_done()
+    assert bool(entity.state["on"]) is False
+    # On/off-only lights have no transition to wait for.
+    assert not entity.is_transitioning
+
+    # The device's on_off=False report from the off command arrives.
+    await send_attributes_report(
+        zha_gateway,
+        on_off_cluster,
+        {general.OnOff.AttributeDefs.on_off.id: 0},
+    )
+    await zha_gateway.async_block_till_done()
+
+    await entity.async_turn_on()
+    await zha_gateway.async_block_till_done()
+    assert bool(entity.state["on"]) is True
+
+    # The device's on_off=True report from the on command arrives.
+    await send_attributes_report(
+        zha_gateway,
+        on_off_cluster,
+        {general.OnOff.AttributeDefs.on_off.id: 1},
+    )
+    await zha_gateway.async_block_till_done()
+
+    # Wait past the old 1.5s timer window. State must remain on.
+    await asyncio.sleep(2)
+    await zha_gateway.async_block_till_done()
+    assert bool(entity.state["on"]) is True
+
+
 async def test_light_state_restoration(zha_gateway: Gateway) -> None:
     """Test the light state restoration function."""
     device_light_3 = await device_light_3_mock(zha_gateway)

--- a/zha/application/platforms/light/__init__.py
+++ b/zha/application/platforms/light/__init__.py
@@ -633,8 +633,13 @@ class BaseClusterHandlerLight(BaseLight):
             else DEFAULT_ON_OFF_TRANSITION
         ) + DEFAULT_EXTRA_TRANSITION_DELAY_SHORT
 
-        # Start pausing attribute report parsing
-        if self._zha_config_enable_light_transitioning_flag:
+        # Start pausing attribute report parsing, but not for on/off-only
+        # lights (they have no transition to wait for, and a follow-up
+        # turn_on would not clear the buffered off-report).
+        set_transition_flag = (
+            brightness_supported and self._zha_config_enable_light_transitioning_flag
+        )
+        if set_transition_flag:
             self.async_transition_set_flag()
 
         try:
@@ -654,7 +659,7 @@ class BaseClusterHandlerLight(BaseLight):
                 result = await self._on_off_cluster_handler.off()
 
             # Pause parsing attribute reports until transition is complete
-            if self._zha_config_enable_light_transitioning_flag:
+            if set_transition_flag:
                 self.async_transition_start_timer(transition_time)
             self.debug("turned off: %s", result)
             if result[1] is not Status.SUCCESS:
@@ -676,9 +681,7 @@ class BaseClusterHandlerLight(BaseLight):
         finally:
             # If the task was cancelled before the transition timer was started,
             # clean up the transitioning flag so the light does not get stuck.
-            self._async_cleanup_transition_if_stuck(
-                self._zha_config_enable_light_transitioning_flag
-            )
+            self._async_cleanup_transition_if_stuck(set_transition_flag)
 
     async def async_handle_color_commands(
         self,


### PR DESCRIPTION
## Proposed change

This fixes an issue where on/off-only lights (so ones that do not support brightness) incorrectly revert their state to "off" when quickly turning the light off, and then back on again.

The underlying issue was that we only set the transitioning flag in `turn_on` for lights supporting brightness, but always in `turn_off`, which should not have been the case. Thus, the `turn_on` call didn't cancel/restart the `turn_off` timer.

To fix this, we just do not set the flag for on/off-only lights. They do not need at all, since they have no brightness/transitions, so we can always parse attribute reports.

## Additional information

- Fixes https://github.com/zigpy/zha/issues/766

As a little background: The transitioning flag and timer is needed because Zigbee lights always send their current brightness, even during ongoing transitions.

However, in Home Assistant, we need to show the target brightness instead. Otherwise, you see the brightness slider going back down instantly after moving it up, then slowly moving back up (but only for lights that support attribute reporting). There's also some other issues this fixes (including for group lights that would have very jumpy/weird state otherwise, especially if some lights do not support attribute reporting).

In general, the light class needs to cover a lot(!) of edge-cases, and generally does so successfully. But there are plans to clean up the entire class a bit, e.g. with https://github.com/zigpy/zha/pull/734.

## AI summary

<details><summary>Useful-ish AI summary (click to expand)</summary>
<p>

Fixes #766. `async_turn_off` unconditionally armed the transitioning flag and a ~1.5s timer whenever `_zha_config_enable_light_transitioning_flag` was set. For on/off-only lights this causes a rapid `turn_off → turn_on` sequence to revert to off after the timer fires, even though the device is on and never received another command.

## Root cause

`async_transition_set_flag` (`light/__init__.py:734`) is the only path that resets `_transition_brightness_buffer` and cancels the pending timer. `async_turn_on` calls it only when its `set_transition_flag` predicate is true:

```python
set_transition_flag = (
    brightness_supported or color_temp is not None or xy_color is not None
) and self._zha_config_enable_light_transitioning_flag
```

For an on/off-only light, `brightness_supported` is False and there are no `color_temp` / `xy_color` runtime params, so `async_turn_on` never resets the buffer or cancels the timer left over from `async_turn_off`. The sequence:

1. `turn_off`: flag armed, 1.5s timer scheduled, optimistic `_state = False`
2. Device's `on_off=False` report arrives → `_transition_brightness_buffer = 0` (because `is_transitioning` is True)
3. `turn_on`: `set_transition_flag` is False → `async_transition_set_flag` is **not** called → buffer and timer survive; the only state change is the optimistic `_state = True`
4. Device's `on_off=True` report arrives → ignored: the buffered-attribute handler only resets the buffer when the value is falsy
5. Original timer fires → `async_transition_complete` reads `buffer == 0` and overrides `_state = False` ⇒ revert to off

## Fix

Mirror `async_turn_on`'s predicate in `async_turn_off`: gate the flag set, timer start, and stuck-cleanup on `brightness_supported`. On/off-only lights have no transition to wait for, so the flag had no useful purpose for them.

Brightness-supporting lights are unaffected: any follow-up `turn_on` already arms the flag (since `brightness_supported` is true), which resets the buffer and cancels the previous timer cleanly. That existing path is unchanged.

A narrow theoretical edge case — a color-only light with no Level cluster, where `turn_on` is called with no `color_temp` / `xy_color` — is also covered by gating on `brightness_supported`. Such hardware is rare in practice.

## Regression test

Added `test_on_off_only_rapid_toggle_does_not_revert`: on an on/off-only light, calls `turn_off` then `turn_on`, replays both attribute reports, sleeps past the old 1.5s window, asserts state stays on. Verified the test fails on `dev` HEAD without the fix and passes with it.

</p>
</details> 