### PR TITLE
Use `uv` ecosystem in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: "/"
     schedule:
       interval: daily


### PR DESCRIPTION
Follow-up to this PR, so dependabot updates the `uv.lock` file:
- https://github.com/zigpy/zha/pull/773