### PR TITLE
Fix discovery crash from quirk removing ZCL attributes

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -2494,3 +2494,35 @@ async def test_broken_entity_state_does_not_break_device_init(
         await zha_device.async_initialize(from_cache=True)
 
     assert "Failed to emit state changed event" in caplog.text
+
+
+async def test_recompute_keeps_entity_that_cannot_answer(
+    zha_gateway: Gateway, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An existing entity is kept when its capability check raises.
+
+    Removing it is destructive - consumers delete its registry entry, losing
+    the user's customizations - so a broken check must not be treated as
+    "unsupported" for an entity that already exists.
+    """
+    zigpy_device = create_mock_zigpy_device(
+        zha_gateway,
+        {
+            1: {
+                SIG_EP_INPUT: [general.Basic.cluster_id, general.OnOff.cluster_id],
+                SIG_EP_OUTPUT: [],
+                SIG_EP_TYPE: zigpy.profiles.zha.DeviceType.ON_OFF_SWITCH,
+                SIG_EP_PROFILE: zigpy.profiles.zha.PROFILE_ID,
+            }
+        },
+    )
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
+    entity = get_entity(zha_device, platform=Platform.SWITCH)
+
+    with patch.object(
+        type(entity), "recompute_capabilities", side_effect=KeyError("on_off")
+    ):
+        await zha_device.recompute_entities()
+
+    assert "treating it as supported" in caplog.text
+    assert get_entity(zha_device, platform=Platform.SWITCH) is entity

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -2460,3 +2460,37 @@ async def test_async_reinterview_device_active_coordinator(
 
     assert "Skipping reinterview for active coordinator" in caplog.text
     mock_reinterview.assert_not_called()
+
+
+async def test_broken_entity_state_does_not_break_device_init(
+    zha_gateway: Gateway, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A single entity raising while computing its state must not fail setup.
+
+    Computing a state runs entity (and, for quirk entities, quirk-supplied)
+    code; letting it propagate would abort device initialization and, via
+    `load_devices`, take every other device down with it.
+    """
+    zigpy_device = create_mock_zigpy_device(
+        zha_gateway,
+        {
+            1: {
+                SIG_EP_INPUT: [general.Basic.cluster_id, general.OnOff.cluster_id],
+                SIG_EP_OUTPUT: [],
+                SIG_EP_TYPE: zigpy.profiles.zha.DeviceType.ON_OFF_SWITCH,
+                SIG_EP_PROFILE: zigpy.profiles.zha.PROFILE_ID,
+            }
+        },
+    )
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
+    entity = get_entity(zha_device, platform=Platform.SWITCH)
+
+    with patch.object(
+        type(entity),
+        "state",
+        new=property(lambda self: (_ for _ in ()).throw(KeyError("on_off"))),
+    ):
+        # must not raise
+        await zha_device.async_initialize(from_cache=True)
+
+    assert "Failed to emit state changed event" in caplog.text

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -3,12 +3,15 @@
 from unittest.mock import call
 
 import pytest
+from zhaquirks.builder import QuirkBuilder
+from zhaquirks.clusters import CustomCluster
 from zigpy.device import Device as ZigpyDevice
 from zigpy.exceptions import ZigbeeException
 from zigpy.profiles import zha
 import zigpy.types
 from zigpy.typing import UNDEFINED
 from zigpy.zcl.clusters import general, lighting
+import zigpy.zcl.foundation as zcl_f
 import zigpy.zdo.types as zdo_t
 
 from tests.common import (
@@ -26,6 +29,7 @@ from zha.application import Platform
 from zha.application.gateway import Gateway
 from zha.application.platforms import EntityCategory, PlatformEntity
 from zha.application.platforms.number.const import NumberMode
+from zha.quirks import DeviceRegistry
 
 ZIGPY_ANALOG_OUTPUT_DEVICE = {
     1: {
@@ -430,3 +434,49 @@ async def test_color_number(
     )
     await zha_gateway.async_block_till_done()
     assert entity.state.native_value == initial_value
+
+
+async def test_quirk_gutting_cluster_does_not_break_device_init(
+    zha_gateway: Gateway, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A quirk-gutted cluster must not abort device initialization.
+
+    `recompute_capabilities()` reads attributes that are not the entity's own
+    `_attribute_name`, so it raises `KeyError` on a cluster whose definitions a
+    quirk replaced. It runs before `is_supported()`, so an unguarded raise took
+    the whole ZHA setup down with it.
+    """
+
+    class GuttedAnalogOutput(CustomCluster, general.AnalogOutput):
+        """`AnalogOutput` that defines none of the standard attributes."""
+
+        class AttributeDefs(zcl_f.BaseAttributeDefs):
+            """Only a manufacturer-specific attribute."""
+
+            some_custom_attribute = zcl_f.ZCLAttributeDef(
+                id=0x6000, type=zigpy.types.uint8_t, is_manufacturer_specific=True
+            )
+
+    zigpy_dev = create_mock_zigpy_device(
+        zha_gateway,
+        ZIGPY_ANALOG_OUTPUT_DEVICE,
+        manufacturer="gutted_mfg",
+        model="gutted_model",
+    )
+
+    registry = DeviceRegistry()
+    (
+        QuirkBuilder(zigpy_dev.manufacturer, zigpy_dev.model)
+        .replaces(GuttedAnalogOutput)
+        .add_to_registry(registry)
+    )
+
+    # Device initialization succeeds and the entity that cannot work is dropped
+    zha_device = await join_zigpy_device(zha_gateway, registry.resolve(zigpy_dev))
+
+    assert not [
+        entity
+        for entity in zha_device.platform_entities.values()
+        if entity.PLATFORM == Platform.NUMBER
+    ]
+    assert "Failed to determine whether" in caplog.text

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1515,6 +1515,10 @@ class OppleCluster(CustomCluster, ManufacturerSpecificCluster):
     ep_attribute = "opple_cluster"
     attributes = {
         0x010C: ("last_feeding_size", t.uint16_t, True),
+        0x010D: ("power", t.uint16_t, True),
+        0x010E: ("energy", t.uint16_t, True),
+        0x010F: ("energy_delivered", t.uint16_t, True),
+        0x0110: ("energy_invalid_state_class", t.uint16_t, True),
     }
 
     def __init__(self, *args, **kwargs) -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -4,7 +4,7 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from functools import partial
-from typing import Any
+from typing import Any, Final
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -18,7 +18,7 @@ from zigpy.device import Device as ZigpyDevice
 from zigpy.profiles import zha
 import zigpy.profiles.zha
 import zigpy.types as t
-from zigpy.zcl import Cluster, ReportingConfig
+from zigpy.zcl import Cluster, ReportingConfig, foundation as zcl_f
 from zigpy.zcl.clusters import general, homeautomation, hvac, measurement, smartenergy
 from zigpy.zcl.clusters.general import AnalogInput, PowerConfiguration
 from zigpy.zcl.clusters.general_const import AnalogInputType, ApplicationType
@@ -2194,3 +2194,130 @@ async def test_em_poller_runs_independently_of_entity_enabled_state(
     active_power.enable()
     assert active_power.enabled is True
     assert not poll_task.done()
+
+
+class TrimmedElectricalMeasurementCluster(
+    CustomCluster, homeautomation.ElectricalMeasurement
+):
+    """EM cluster declaring only the attributes its device actually implements.
+
+    Mimics a quirk that replaces the standard attribute definitions with a
+    narrower set: `active_power` and the AC multiplier/divisor pair survive, the
+    deprecated `power_multiplier`/`power_divisor` fallbacks do not — even though
+    `ElectricalMeasurementActivePower` names them in its cluster config.
+    """
+
+    class AttributeDefs(zcl_f.BaseAttributeDefs):
+        """Attribute definitions not inheriting the standard cluster's."""
+
+        measurement_type: Final = EMAttrs.measurement_type
+        active_power: Final = EMAttrs.active_power
+        active_power_max: Final = EMAttrs.active_power_max
+        ac_power_multiplier: Final = EMAttrs.ac_power_multiplier
+        ac_power_divisor: Final = EMAttrs.ac_power_divisor
+
+
+async def test_em_poller_skips_disabled_entity_attributes(
+    zha_gateway: Gateway,
+) -> None:
+    """Disabling an entity drops its attributes from the next poll."""
+
+    zigpy_dev = elec_measurement_zigpy_device_mock(zha_gateway)
+    zha_dev = await join_zigpy_device(zha_gateway, zigpy_dev)
+    cluster = zha_dev.device.endpoints[1].electrical_measurement
+
+    poller = get_entity(
+        zha_dev,
+        platform=Platform.VIRTUAL,
+        exact_entity_type=sensor.ElectricalMeasurementPoller,
+    )
+    active_power = get_entity(
+        zha_dev,
+        platform=Platform.SENSOR,
+        exact_entity_type=sensor.ElectricalMeasurementActivePower,
+    )
+
+    async def poll() -> set[str]:
+        cluster.read_attributes.reset_mock()
+        await poller.async_update()
+        await zha_dev.gateway.async_block_till_done()
+        return {
+            a for call in cluster.read_attributes.call_args_list for a in call[0][0]
+        }
+
+    assert EMAttrs.active_power.name in await poll()
+
+    # the poller keeps running, but stops polling the disabled entity's attribute
+    active_power.disable()
+    polled_while_disabled = await poll()
+    assert EMAttrs.active_power.name not in polled_while_disabled
+    # ...while its siblings' attributes are still polled
+    assert EMAttrs.rms_voltage.name in polled_while_disabled
+
+    active_power.enable()
+    assert EMAttrs.active_power.name in await poll()
+
+
+async def test_em_poller_skips_attributes_missing_from_quirk_cluster(
+    zha_gateway: Gateway,
+) -> None:
+    """Attributes the cluster does not define are skipped, not fatal.
+
+    `is_attribute_unsupported()` raises `KeyError` for an undefined attribute, so
+    a cluster config naming one used to abort the whole poll — including the
+    valid attributes batched with it.
+    """
+
+    zigpy_dev = elec_measurement_zigpy_device_mock(zha_gateway)
+
+    registry = DeviceRegistry()
+    (
+        QuirkBuilder(zigpy_dev.manufacturer, zigpy_dev.model)
+        .replaces(TrimmedElectricalMeasurementCluster)
+        .add_to_registry(registry)
+    )
+
+    zigpy_dev = registry.resolve(zigpy_dev)
+    assert isinstance(zigpy_dev, CustomZigpyDevice)
+    cluster = zigpy_dev.endpoints[1].electrical_measurement
+    assert isinstance(cluster, TrimmedElectricalMeasurementCluster)
+    # `registry.resolve` swaps in the replaced cluster instance; patch its
+    # network methods so the poll can be observed
+    patch_cluster_for_testing(cluster)
+    cluster.PLUGGED_ATTR_READS = {
+        EMAttrs.ac_power_divisor.name: 10,
+        EMAttrs.ac_power_multiplier.name: 1,
+    }
+
+    zha_dev = await join_zigpy_device(zha_gateway, zigpy_dev)
+
+    # the entity exists: its own attribute is defined, only its config's are not
+    active_power = get_entity(
+        zha_dev,
+        platform=Platform.SENSOR,
+        exact_entity_type=sensor.ElectricalMeasurementActivePower,
+    )
+    assert active_power._attribute_name == EMAttrs.active_power.name
+    assert EMAttrs.power_divisor.name in (
+        attr_def.name
+        for attr_def in active_power._server_cluster_config[
+            homeautomation.ElectricalMeasurement.cluster_id
+        ].attributes
+    )
+
+    poller = get_entity(
+        zha_dev,
+        platform=Platform.VIRTUAL,
+        exact_entity_type=sensor.ElectricalMeasurementPoller,
+    )
+    cluster.read_attributes.reset_mock()
+    await poller.async_update()
+    await zha_dev.gateway.async_block_till_done()
+
+    polled = {a for call in cluster.read_attributes.call_args_list for a in call[0][0]}
+    # `power_multiplier` and `power_divisor` are silently dropped...
+    assert polled == {
+        EMAttrs.active_power.name,
+        EMAttrs.ac_power_multiplier.name,
+        EMAttrs.ac_power_divisor.name,
+    }

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -956,3 +956,47 @@ async def test_switch_missing_standard_attribute_definitions(
 
     with pytest.raises(KeyError):
         get_entity(zha_device, platform=Platform.SWITCH)
+
+
+async def test_quirk_switch_attribute_missing_from_cluster(
+    zha_gateway: Gateway, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A quirk switch naming an attribute the cluster lacks is skipped, not fatal.
+
+    Quirk entities are `always_supported`, so nothing used to stop such an entity
+    from being created; reading its state then raised `KeyError` out of device
+    initialization and failed the whole ZHA setup.
+    """
+
+    zigpy_dev = create_mock_zigpy_device(
+        zha_gateway,
+        ZIGPY_DEVICE,
+        manufacturer="manufacturer",
+        model="model",
+    )
+
+    registry = DeviceRegistry()
+    (
+        QuirkBuilder(zigpy_dev.manufacturer, zigpy_dev.model)
+        .switch(
+            "attribute_that_does_not_exist",
+            general.OnOff.cluster_id,
+            translation_key="nonexistent",
+            fallback_name="Nonexistent",
+        )
+        .add_to_registry(registry)
+    )
+
+    zha_device = await join_zigpy_device(zha_gateway, registry.resolve(zigpy_dev))
+
+    # The device still initializes and its regular on/off switch works
+    switch_entity = get_entity(zha_device, platform=Platform.SWITCH)
+    assert switch_entity._attribute_name == general.OnOff.AttributeDefs.on_off.name
+
+    # ...but no entity was created for the attribute the cluster does not have
+    assert not [
+        entity
+        for entity in zha_device.platform_entities.values()
+        if getattr(entity, "_attribute_name", None) == "attribute_that_does_not_exist"
+    ]
+    assert "which cluster 0x0006 does not have" in caplog.text

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -954,8 +954,11 @@ async def test_switch_missing_standard_attribute_definitions(
 
     zha_device = await join_zigpy_device(zha_gateway, zigpy_device_)
 
-    with pytest.raises(KeyError):
-        get_entity(zha_device, platform=Platform.SWITCH)
+    assert not [
+        entity
+        for entity in zha_device.platform_entities.values()
+        if entity.PLATFORM == Platform.SWITCH
+    ]
 
 
 async def test_quirk_switch_attribute_missing_from_cluster(

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -904,3 +904,49 @@ async def test_binary_output_cluster(zha_gateway: Gateway) -> None:
             manufacturer=UNDEFINED,
         )
     ]
+
+
+class MissingOnOffAttributeQuirk(CustomDevice):
+    """Quirk with an OnOff cluster missing standard attribute definitions.
+
+    Mimics broken custom v1 quirks that fully replace the `attributes` dict of
+    a standard cluster, e.g. with `attributes = LocalDataCluster.attributes.copy()`.
+    """
+
+    class BrokenOnOffCluster(CustomCluster, general.OnOff):
+        """OnOff cluster without the standard attribute definitions."""
+
+        attributes = {
+            0x6000: ("window_detection_temperature", t.int16s),
+            0x6001: ("window_detection_timeout_minutes", t.uint8_t),
+        }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [general.Basic.cluster_id, BrokenOnOffCluster],
+                OUTPUT_CLUSTERS: [],
+            },
+        }
+    }
+
+
+async def test_switch_missing_standard_attribute_definitions(
+    zha_gateway: Gateway,
+) -> None:
+    """Test quirk-replaced OnOff cluster without standard attribute definitions.
+
+    Device initialization must not fail and no switch entity is created.
+    """
+    zigpy_device = create_mock_zigpy_device(
+        zha_gateway,
+        ZIGPY_DEVICE,
+        manufacturer="_TZE200_ckud7u2l",
+        quirk=MissingOnOffAttributeQuirk,
+    )
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
+
+    with pytest.raises(KeyError):
+        get_entity(zha_device, platform=Platform.SWITCH)

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from typing import Final
 from unittest.mock import call, patch
 
 import pytest
@@ -910,14 +911,20 @@ async def test_binary_output_cluster(zha_gateway: Gateway) -> None:
 class MissingOnOffAttributesCluster(CustomCluster, general.OnOff):
     """OnOff cluster without the standard attribute definitions.
 
-    Mimics broken custom quirks that fully replace the `attributes` dict of
-    a standard cluster, e.g. with `attributes = LocalDataCluster.attributes.copy()`.
+    Mimics broken custom quirks that fully replace the attribute definitions of
+    a standard cluster, e.g. with `attributes = LocalDataCluster.attributes.copy()`
+    or an `AttributeDefs` class not inheriting the standard cluster's definitions.
     """
 
-    attributes = {
-        0x6000: ("window_detection_temperature", t.int16s),
-        0x6001: ("window_detection_timeout_minutes", t.uint8_t),
-    }
+    class AttributeDefs(zcl_f.BaseAttributeDefs):
+        """Attribute definitions not inheriting from `OnOff.AttributeDefs`."""
+
+        window_detection_temperature: Final = zcl_f.ZCLAttributeDef(
+            id=0x6000, type=t.int16s, is_manufacturer_specific=True
+        )
+        window_detection_timeout_minutes: Final = zcl_f.ZCLAttributeDef(
+            id=0x6001, type=t.uint8_t, is_manufacturer_specific=True
+        )
 
 
 async def test_switch_missing_standard_attribute_definitions(

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1000,3 +1000,81 @@ async def test_quirk_switch_attribute_missing_from_cluster(
         if getattr(entity, "_attribute_name", None) == "attribute_that_does_not_exist"
     ]
     assert "which cluster 0x0006 does not have" in caplog.text
+
+
+async def test_quirk_switch_inverter_attribute_missing_from_cluster(
+    zha_gateway: Gateway, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A quirk switch whose *inverter* attribute is missing is skipped, not fatal.
+
+    `inverted` reads the inverter attribute on every state computation, so a
+    missing definition there is just as fatal as a missing primary attribute.
+    """
+
+    zigpy_dev = create_mock_zigpy_device(
+        zha_gateway,
+        ZIGPY_DEVICE,
+        manufacturer="manufacturer_inv",
+        model="model_inv",
+    )
+
+    registry = DeviceRegistry()
+    (
+        QuirkBuilder(zigpy_dev.manufacturer, zigpy_dev.model)
+        .switch(
+            general.OnOff.AttributeDefs.start_up_on_off.name,
+            general.OnOff.cluster_id,
+            invert_attribute_name="inverter_that_does_not_exist",
+            translation_key="inverted",
+            fallback_name="Inverted",
+        )
+        .add_to_registry(registry)
+    )
+
+    zha_device = await join_zigpy_device(zha_gateway, registry.resolve(zigpy_dev))
+
+    assert not [
+        entity
+        for entity in zha_device.platform_entities.values()
+        if getattr(entity, "_inverter_attribute_name", None)
+        == "inverter_that_does_not_exist"
+    ]
+    assert "which cluster 0x0006 does not have" in caplog.text
+
+
+async def test_undefined_attribute_does_not_poison_initial_read(
+    zha_gateway: Gateway, caplog: pytest.LogCaptureFixture
+) -> None:
+    """One undefined attribute must not stop its valid siblings from being read.
+
+    `read_attributes()` resolves every name up front, so leaving an undefined
+    attribute in the batch used to fail the read for all of them.
+    """
+
+    zigpy_dev = create_mock_zigpy_device(
+        zha_gateway,
+        ZIGPY_DEVICE,
+        manufacturer="manufacturer_read",
+        model="model_read",
+    )
+
+    registry = DeviceRegistry()
+    (
+        QuirkBuilder(zigpy_dev.manufacturer, zigpy_dev.model)
+        .switch(
+            "attribute_that_does_not_exist",
+            general.OnOff.cluster_id,
+            translation_key="nonexistent",
+            fallback_name="Nonexistent",
+        )
+        .add_to_registry(registry)
+    )
+
+    zha_device = await join_zigpy_device(zha_gateway, registry.resolve(zigpy_dev))
+
+    assert "Failed to read attributes" not in caplog.text
+    assert "skipping their initial read" in caplog.text
+
+    # the standard on/off switch, whose attribute shares the read batch, still works
+    switch_entity = get_entity(zha_device, platform=Platform.SWITCH)
+    assert switch_entity._attribute_name == general.OnOff.AttributeDefs.on_off.name

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -14,6 +14,7 @@ from zhaquirks.const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
 )
+from zhaquirks.device import CustomZigpyDevice
 from zhaquirks.legacy import CustomDevice
 from zigpy.exceptions import ZigbeeException
 from zigpy.profiles import zha
@@ -906,30 +907,16 @@ async def test_binary_output_cluster(zha_gateway: Gateway) -> None:
     ]
 
 
-class MissingOnOffAttributeQuirk(CustomDevice):
-    """Quirk with an OnOff cluster missing standard attribute definitions.
+class MissingOnOffAttributesCluster(CustomCluster, general.OnOff):
+    """OnOff cluster without the standard attribute definitions.
 
-    Mimics broken custom v1 quirks that fully replace the `attributes` dict of
+    Mimics broken custom quirks that fully replace the `attributes` dict of
     a standard cluster, e.g. with `attributes = LocalDataCluster.attributes.copy()`.
     """
 
-    class BrokenOnOffCluster(CustomCluster, general.OnOff):
-        """OnOff cluster without the standard attribute definitions."""
-
-        attributes = {
-            0x6000: ("window_detection_temperature", t.int16s),
-            0x6001: ("window_detection_timeout_minutes", t.uint8_t),
-        }
-
-    replacement = {
-        ENDPOINTS: {
-            1: {
-                PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
-                INPUT_CLUSTERS: [general.Basic.cluster_id, BrokenOnOffCluster],
-                OUTPUT_CLUSTERS: [],
-            },
-        }
+    attributes = {
+        0x6000: ("window_detection_temperature", t.int16s),
+        0x6001: ("window_detection_timeout_minutes", t.uint8_t),
     }
 
 
@@ -940,13 +927,25 @@ async def test_switch_missing_standard_attribute_definitions(
 
     Device initialization must not fail and no switch entity is created.
     """
+    registry = DeviceRegistry()
     zigpy_device = create_mock_zigpy_device(
         zha_gateway,
         ZIGPY_DEVICE,
         manufacturer="_TZE200_ckud7u2l",
-        quirk=MissingOnOffAttributeQuirk,
+        model="TS0601",
     )
-    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
+
+    (
+        QuirkBuilder(zigpy_device.manufacturer, zigpy_device.model)
+        .replaces(MissingOnOffAttributesCluster)
+        .add_to_registry(registry)
+    )
+
+    zigpy_device_ = registry.resolve(zigpy_device)
+    assert isinstance(zigpy_device_, CustomZigpyDevice)
+    assert isinstance(zigpy_device_.endpoints[1].on_off, MissingOnOffAttributesCluster)
+
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device_)
 
     with pytest.raises(KeyError):
         get_entity(zha_device, platform=Platform.SWITCH)

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -588,26 +588,32 @@ class PlatformEntity(BaseEntity):
         self._from_quirk: bool = from_quirk
 
     def _is_valid(self) -> bool:
-        """Return False if the backing attribute is absent from the cluster.
+        """Return False if a backing attribute is absent from the cluster.
 
         Reading an attribute the cluster does not define raises `KeyError`, so
         such an entity can never work. Default discovery hits this routinely
         (optional attributes a quirk removed), but a quirk naming a missing
         attribute is an authoring error, so that case is logged loudly.
         """
-        attribute_name: str | int | None = getattr(self, "_attribute_name", None)
+        for attribute_name in (
+            getattr(self, "_attribute_name", None),
+            # An inverter attribute is read on every state computation too
+            getattr(self, "_inverter_attribute_name", None),
+        ):
+            if attribute_name is None:
+                continue
 
-        if attribute_name is None:
-            return super()._is_valid()
+            try:
+                # Resolves both attribute names and IDs, as quirks may use either
+                self._cluster.find_attribute(attribute_name)
+            except KeyError:
+                self._log_missing_attribute(attribute_name)
+                return False
 
-        try:
-            # Resolves both attribute names and IDs, as quirks may use either
-            self._cluster.find_attribute(attribute_name)
-        except KeyError:
-            pass
-        else:
-            return super()._is_valid()
+        return super()._is_valid()
 
+    def _log_missing_attribute(self, attribute_name: str | int) -> None:
+        """Log that the cluster has no definition for an attribute we need."""
         if self._from_quirk:
             _LOGGER.warning(
                 "Quirk for %s defines a %s entity for attribute %r, which cluster"
@@ -623,8 +629,6 @@ class PlatformEntity(BaseEntity):
                 attribute_name,
                 self.__class__.__name__,
             )
-
-        return False
 
     def _apply_quirk_entity_config(
         self,

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -303,10 +303,22 @@ class BaseEntity(LogMixin, EventBase):
 
     def is_supported(self) -> bool:
         """Return if the entity is supported for the device."""
+        if not self._is_valid():
+            return False
+
         if self._attr_always_supported:
             return True
 
         return self._is_supported()
+
+    def _is_valid(self) -> bool:
+        """Return if the entity is able to work at all, internal.
+
+        Unlike `_is_supported`, this is *not* bypassed by
+        `_attr_always_supported`: an entity failing it can never produce a
+        state, so creating it would only raise on every state read.
+        """
+        return True
 
     def _is_supported(self) -> bool:
         """Return if the entity is supported for the device, internal."""
@@ -573,6 +585,46 @@ class PlatformEntity(BaseEntity):
         self._device: Device = device
         self._endpoint = endpoint
         self._cluster: zigpy.zcl.Cluster = cluster
+        self._from_quirk: bool = from_quirk
+
+    def _is_valid(self) -> bool:
+        """Return False if the backing attribute is absent from the cluster.
+
+        Reading an attribute the cluster does not define raises `KeyError`, so
+        such an entity can never work. Default discovery hits this routinely
+        (optional attributes a quirk removed), but a quirk naming a missing
+        attribute is an authoring error, so that case is logged loudly.
+        """
+        attribute_name: str | int | None = getattr(self, "_attribute_name", None)
+
+        if attribute_name is None:
+            return super()._is_valid()
+
+        try:
+            # Resolves both attribute names and IDs, as quirks may use either
+            self._cluster.find_attribute(attribute_name)
+        except KeyError:
+            pass
+        else:
+            return super()._is_valid()
+
+        if self._from_quirk:
+            _LOGGER.warning(
+                "Quirk for %s defines a %s entity for attribute %r, which cluster"
+                " 0x%04X does not have - skipping entity creation",
+                self._device.model,
+                self.__class__.__name__,
+                attribute_name,
+                self._cluster.cluster_id,
+            )
+        else:
+            _LOGGER.debug(
+                "%s is not supported - skipping %s entity creation",
+                attribute_name,
+                self.__class__.__name__,
+            )
+
+        return False
 
     def _apply_quirk_entity_config(
         self,

--- a/zha/application/platforms/binary_sensor/__init__.py
+++ b/zha/application/platforms/binary_sensor/__init__.py
@@ -114,11 +114,6 @@ class BinarySensor(BaseBinarySensor):
         super().__init__(endpoint=endpoint, device=device, **kwargs)
         self.recompute_capabilities()
 
-    def _is_supported(self) -> bool:
-        if self._attribute_name not in self._cluster.attributes_by_name:
-            return False
-        return super()._is_supported()
-
     def on_add(self) -> None:
         """Run when entity is added."""
         super().on_add()

--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -296,9 +296,9 @@ class NumberConfigurationEntity(BaseNumber):
 
     def _is_supported(self) -> bool:
         """Return if the entity is supported for the device, internal."""
+        # `_is_valid` has already established that the attribute exists
         if (
-            self._attribute_name not in self._cluster.attributes_by_name
-            or self._cluster.is_attribute_unsupported(self._attribute_name)
+            self._cluster.is_attribute_unsupported(self._attribute_name)
             or self._cluster.get(self._attribute_name) is None
         ):
             _LOGGER.debug(

--- a/zha/application/platforms/select.py
+++ b/zha/application/platforms/select.py
@@ -287,9 +287,9 @@ class ZCLEnumSelectEntity(BaseSelectEntity, PlatformEntity):
             )
 
     def _is_supported(self) -> bool:
+        # `_is_valid` has already established that the attribute exists
         if (
-            self._attribute_name not in self._cluster.attributes_by_name
-            or self._cluster.is_attribute_unsupported(self._attribute_name)
+            self._cluster.is_attribute_unsupported(self._attribute_name)
             or self._cluster.get(self._attribute_name) is None
         ):
             _LOGGER.debug(

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -298,9 +298,8 @@ class Sensor(BaseSensor):
             )
 
     def _is_supported(self) -> bool:
-        if (
-            self._attribute_name not in self._cluster.attributes_by_name
-        ) or self._cluster.is_attribute_unsupported(self._attribute_name):
+        # `_is_valid` has already established that the attribute exists
+        if self._cluster.is_attribute_unsupported(self._attribute_name):
             _LOGGER.debug(
                 "%s is not supported - skipping %s entity creation",
                 self._attribute_name,
@@ -957,6 +956,15 @@ class AggregatedClusterPoller(VirtualEntity):
             return
         await self.async_update()
 
+    def _is_attribute_unusable(
+        self, attr: int | str | foundation.ZCLAttributeDef
+    ) -> bool:
+        """Return whether an attribute is unsupported or undefined on the cluster."""
+        try:
+            return self._cluster.is_attribute_unsupported(attr)
+        except KeyError:
+            return True
+
     async def async_update(self) -> None:
         """Poll the union of attrs read by enabled sibling entities."""
         attrs: set[str] = set()
@@ -967,9 +975,10 @@ class AggregatedClusterPoller(VirtualEntity):
                 continue
             if not entity.enabled:
                 continue
-            if entity._attribute_name and (
-                entity._attribute_name not in self._cluster.attributes_by_name
-                or self._cluster.is_attribute_unsupported(entity._attribute_name)
+            # `is_attribute_unsupported` raises `KeyError` for attributes the
+            # cluster does not define, so treat those as unsupported too
+            if entity._attribute_name and self._is_attribute_unusable(
+                entity._attribute_name
             ):
                 continue
             cfg = entity._server_cluster_config.get(self._cluster_id)
@@ -978,14 +987,10 @@ class AggregatedClusterPoller(VirtualEntity):
             for attr_def, attr_cfg in cfg.attributes.items():
                 if attr_cfg.reporting is None:
                     continue
-                attr_name = attr_def if isinstance(attr_def, str) else attr_def.name
-                if (
-                    attr_name not in self._cluster.attributes_by_name
-                    or self._cluster.is_attribute_unsupported(attr_name)
-                ):
+                if self._is_attribute_unusable(attr_def):
                     continue
 
-                attrs.add(attr_name)
+                attrs.add(attr_def if isinstance(attr_def, str) else attr_def.name)
 
         if not attrs:
             return

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -967,8 +967,9 @@ class AggregatedClusterPoller(VirtualEntity):
                 continue
             if not entity.enabled:
                 continue
-            if entity._attribute_name and self._cluster.is_attribute_unsupported(
-                entity._attribute_name
+            if entity._attribute_name and (
+                entity._attribute_name not in self._cluster.attributes_by_name
+                or self._cluster.is_attribute_unsupported(entity._attribute_name)
             ):
                 continue
             cfg = entity._server_cluster_config.get(self._cluster_id)
@@ -977,10 +978,14 @@ class AggregatedClusterPoller(VirtualEntity):
             for attr_def, attr_cfg in cfg.attributes.items():
                 if attr_cfg.reporting is None:
                     continue
-                if self._cluster.is_attribute_unsupported(attr_def):
+                attr_name = attr_def if isinstance(attr_def, str) else attr_def.name
+                if (
+                    attr_name not in self._cluster.attributes_by_name
+                    or self._cluster.is_attribute_unsupported(attr_name)
+                ):
                     continue
 
-                attrs.add(attr_def if isinstance(attr_def, str) else attr_def.name)
+                attrs.add(attr_name)
 
         if not attrs:
             return

--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -209,7 +209,10 @@ class Switch(PlatformEntity, BaseSwitch):  # type: ignore[misc]
             )
 
     def _is_supported(self) -> bool:
-        if self._cluster.is_attribute_unsupported(self._attribute_name):
+        if (
+            self._attribute_name not in self._cluster.attributes_by_name
+            or self._cluster.is_attribute_unsupported(self._attribute_name)
+        ):
             _LOGGER.debug(
                 "%s is not supported - skipping %s entity creation",
                 self._attribute_name,
@@ -859,8 +862,8 @@ class WindowCoveringInversionSwitch(ConfigurableAttributeSwitch):
 
         # this entity needs a second attribute to function
         if (
-            self._cluster.is_attribute_unsupported(window_covering_mode_attr)
-            or window_covering_mode_attr not in self._cluster.attributes_by_name
+            window_covering_mode_attr not in self._cluster.attributes_by_name
+            or self._cluster.is_attribute_unsupported(window_covering_mode_attr)
             or self._cluster.get(window_covering_mode_attr) is None
         ):
             _LOGGER.debug(

--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -209,10 +209,8 @@ class Switch(PlatformEntity, BaseSwitch):  # type: ignore[misc]
             )
 
     def _is_supported(self) -> bool:
-        if (
-            self._attribute_name not in self._cluster.attributes_by_name
-            or self._cluster.is_attribute_unsupported(self._attribute_name)
-        ):
+        # `_is_valid` has already established that the attribute exists
+        if self._cluster.is_attribute_unsupported(self._attribute_name):
             _LOGGER.debug(
                 "%s is not supported - skipping %s entity creation",
                 self._attribute_name,

--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -471,9 +471,9 @@ class ConfigurableAttributeSwitch(PlatformEntity):
             )
 
     def _is_supported(self) -> bool:
+        # `_is_valid` has already established that the attribute exists
         if (
-            self._attribute_name not in self._cluster.attributes_by_name
-            or self._cluster.is_attribute_unsupported(self._attribute_name)
+            self._cluster.is_attribute_unsupported(self._attribute_name)
             or self._cluster.get(self._attribute_name) is None
         ):
             _LOGGER.debug(
@@ -860,7 +860,9 @@ class WindowCoveringInversionSwitch(ConfigurableAttributeSwitch):
             WindowCovering.AttributeDefs.window_covering_mode.name
         )
 
-        # this entity needs a second attribute to function
+        # this entity needs a second attribute to function. `_is_valid` only covers
+        # `_attribute_name`, so this one needs its own existence check - and it has
+        # to come first, as the other two raise `KeyError` without a definition.
         if (
             window_covering_mode_attr not in self._cluster.attributes_by_name
             or self._cluster.is_attribute_unsupported(window_covering_mode_attr)

--- a/zha/zigbee/cluster_config.py
+++ b/zha/zigbee/cluster_config.py
@@ -178,6 +178,15 @@ async def configure_cluster_configs(
         for attr_name, attr_config in agg.attributes.items():
             if attr_config.reporting is None:
                 continue
+            if attr_name not in agg.cluster.attributes_by_name:
+                _LOGGER.debug(
+                    "[%s] Attribute %s has no definition on cluster %s,"
+                    " skipping reporting configuration",
+                    agg.cluster.endpoint.device.ieee,
+                    attr_name,
+                    agg.cluster.ep_attribute,
+                )
+                continue
             attr_def = agg.cluster.find_attribute(attr_name)
             reporting_attrs[attr_def] = attr_config.reporting
 

--- a/zha/zigbee/cluster_config.py
+++ b/zha/zigbee/cluster_config.py
@@ -66,6 +66,21 @@ class AggregatedClusterConfig:
     entities: list[BaseEntity] = field(default_factory=list)
 
 
+def _cluster_defines(cluster: zigpy.zcl.Cluster, attr_name: str) -> bool:
+    """Return whether the cluster has a definition for the attribute.
+
+    Cluster configs are aggregated from entities that have not been filtered by
+    `is_supported()` yet, so an attribute the cluster does not define (e.g. one
+    a quirk named or removed) can still reach the reads below - where zigpy
+    raises `KeyError` for it.
+    """
+    try:
+        cluster.find_attribute(attr_name)
+    except KeyError:
+        return False
+    return True
+
+
 def aggregate_cluster_configs(
     entities: Iterable[BaseEntity],
 ) -> dict[tuple[int, int, bool], AggregatedClusterConfig]:
@@ -178,12 +193,7 @@ async def configure_cluster_configs(
         for attr_name, attr_config in agg.attributes.items():
             if attr_config.reporting is None:
                 continue
-            # Configs are aggregated from entities that have not been filtered by
-            # `is_supported()` yet, so an attribute the cluster does not define
-            # (e.g. a quirk naming a nonexistent one) can still reach us here.
-            try:
-                attr_def = agg.cluster.find_attribute(attr_name)
-            except KeyError:
+            if not _cluster_defines(agg.cluster, attr_name):
                 _LOGGER.debug(
                     "[%s] Cluster %s has no attribute %r,"
                     " skipping reporting configuration",
@@ -192,6 +202,7 @@ async def configure_cluster_configs(
                     attr_name,
                 )
                 continue
+            attr_def = agg.cluster.find_attribute(attr_name)
             reporting_attrs[attr_def] = attr_config.reporting
 
         if reporting_attrs:
@@ -261,14 +272,31 @@ async def initialize_cluster_configs(
 ) -> None:
     """Read initial attribute values from aggregated configs."""
     for agg in configs.values():
+        # `read_attributes` resolves every name up front, so a single undefined
+        # attribute would fail the whole batch and stop its valid siblings from
+        # ever being read.
+        known_attrs = {
+            attr_name: attr_config
+            for attr_name, attr_config in agg.attributes.items()
+            if _cluster_defines(agg.cluster, attr_name)
+        }
+        if len(known_attrs) != len(agg.attributes):
+            _LOGGER.debug(
+                "[%s] Cluster %s has no definition for attributes %s,"
+                " skipping their initial read",
+                agg.cluster.endpoint.device.ieee,
+                agg.cluster.ep_attribute,
+                sorted(set(agg.attributes) - set(known_attrs)),
+            )
+
         cached_attrs = [
             attr_name
-            for attr_name, attr_config in agg.attributes.items()
+            for attr_name, attr_config in known_attrs.items()
             if not attr_config.read_on_startup
         ]
         fresh_attrs = [
             attr_name
-            for attr_name, attr_config in agg.attributes.items()
+            for attr_name, attr_config in known_attrs.items()
             if attr_config.read_on_startup
         ]
 

--- a/zha/zigbee/cluster_config.py
+++ b/zha/zigbee/cluster_config.py
@@ -178,16 +178,20 @@ async def configure_cluster_configs(
         for attr_name, attr_config in agg.attributes.items():
             if attr_config.reporting is None:
                 continue
-            if attr_name not in agg.cluster.attributes_by_name:
+            # Configs are aggregated from entities that have not been filtered by
+            # `is_supported()` yet, so an attribute the cluster does not define
+            # (e.g. a quirk naming a nonexistent one) can still reach us here.
+            try:
+                attr_def = agg.cluster.find_attribute(attr_name)
+            except KeyError:
                 _LOGGER.debug(
-                    "[%s] Attribute %s has no definition on cluster %s,"
+                    "[%s] Cluster %s has no attribute %r,"
                     " skipping reporting configuration",
                     agg.cluster.endpoint.device.ieee,
-                    attr_name,
                     agg.cluster.ep_attribute,
+                    attr_name,
                 )
                 continue
-            attr_def = agg.cluster.find_attribute(attr_name)
             reporting_attrs[attr_def] = attr_config.reporting
 
         if reporting_attrs:

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -1161,18 +1161,36 @@ class Device(LogMixin, EventBase):
                     ),
                 )
 
+    def _entity_supported(
+        self, entity: PlatformEntity, others: Iterable[PlatformEntity]
+    ) -> bool:
+        """Recompute an entity's capabilities and return whether it is supported.
+
+        Both steps run entity (and, for quirk entities, quirk-supplied) code that
+        reads attributes off the cluster. A quirk can leave a cluster without the
+        definitions that code assumes, and zigpy raises `KeyError` for those, so a
+        single broken entity would otherwise abort device initialization and, via
+        `load_devices`, fail the whole ZHA setup. An entity that cannot even be
+        asked whether it is supported certainly is not.
+        """
+        try:
+            entity.recompute_capabilities()
+            return entity.is_supported() and entity.is_supported_in_list(others)
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception(
+                "Failed to determine whether %s is supported - skipping it", entity
+            )
+            return False
+
     async def _add_pending_entities(self, *, emit_event: bool = True) -> None:
         """Add pending entities to the device."""
         all_entities = dict(self._platform_entities)
         new_entities: dict[tuple[Platform, str], PlatformEntity] = {}
 
         for entity in self._pending_entities:
-            entity.recompute_capabilities()
-
-            # Ignore unsupported entities
-            if not entity.is_supported() or not entity.is_supported_in_list(
-                all_entities.values()
-            ):
+            # Ignore unsupported entities - and entities that cannot even answer the
+            # question, which a quirk-gutted cluster produces (see `_entity_supported`)
+            if not self._entity_supported(entity, all_entities.values()):
                 await entity.on_remove()
                 continue
 
@@ -1229,9 +1247,7 @@ class Device(LogMixin, EventBase):
 
         # Remove all entities that are no longer supported
         for entity in entities[:]:
-            entity.recompute_capabilities()
-
-            if not entity.is_supported() or not entity.is_supported_in_list(entities):
+            if not self._entity_supported(entity, entities):
                 self.debug("Removing unsupported entity %s", entity)
                 await self._remove_entity(entity, remove=True)
                 entities.remove(entity)

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -1199,14 +1199,27 @@ class Device(LogMixin, EventBase):
         # the add event registers them), so silence their changes
         with suppress_events():
             for entity in new_entities.values():
-                entity.maybe_emit_state_changed_event()
+                self._safe_emit_state_changed_event(entity)
 
         # `_compute_primary_entity` above can flip `primary` on an existing entity, and
         # the caller may have recomputed their capabilities beforehand; emit so those
         # changes reach consumers.
         for key, entity in all_entities.items():
             if key not in new_entities:
-                entity.maybe_emit_state_changed_event()
+                self._safe_emit_state_changed_event(entity)
+
+    def _safe_emit_state_changed_event(self, entity: PlatformEntity) -> None:
+        """Emit an entity's state change, tolerating a broken entity.
+
+        Computing a state runs entity (and, for quirk entities, quirk-supplied)
+        code. Letting that propagate would abort device initialization and, via
+        `load_devices`, fail the whole ZHA setup — one bad entity would take
+        every device down with it.
+        """
+        try:
+            entity.maybe_emit_state_changed_event()
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Failed to emit state changed event for %s", entity)
 
     async def recompute_entities(self) -> None:
         """Recompute all entities for this device."""

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -1162,7 +1162,11 @@ class Device(LogMixin, EventBase):
                 )
 
     def _entity_supported(
-        self, entity: PlatformEntity, others: Iterable[PlatformEntity]
+        self,
+        entity: PlatformEntity,
+        others: Iterable[PlatformEntity],
+        *,
+        on_error: bool,
     ) -> bool:
         """Recompute an entity's capabilities and return whether it is supported.
 
@@ -1170,17 +1174,28 @@ class Device(LogMixin, EventBase):
         reads attributes off the cluster. A quirk can leave a cluster without the
         definitions that code assumes, and zigpy raises `KeyError` for those, so a
         single broken entity would otherwise abort device initialization and, via
-        `load_devices`, fail the whole ZHA setup. An entity that cannot even be
-        asked whether it is supported certainly is not.
+        `load_devices`, fail the whole ZHA setup.
+
+        `on_error` is what an entity that cannot answer the question counts as.
+        A prospective entity is dropped (it could never produce a state anyway),
+        but an entity that already exists is kept: removing it is destructive,
+        as consumers delete its registry entry along with the user's
+        customizations, and its state reads are contained on the paths that
+        run them here.
         """
         try:
             entity.recompute_capabilities()
             return entity.is_supported() and entity.is_supported_in_list(others)
         except Exception:  # pylint: disable=broad-except
-            _LOGGER.exception(
-                "Failed to determine whether %s is supported - skipping it", entity
+            self.error(
+                "Failed to determine whether %s entity %s is supported,"
+                " treating it as %s",
+                entity.PLATFORM,
+                entity.unique_id,
+                "supported" if on_error else "unsupported",
+                exc_info=True,
             )
-            return False
+            return on_error
 
     async def _add_pending_entities(self, *, emit_event: bool = True) -> None:
         """Add pending entities to the device."""
@@ -1190,7 +1205,9 @@ class Device(LogMixin, EventBase):
         for entity in self._pending_entities:
             # Ignore unsupported entities - and entities that cannot even answer the
             # question, which a quirk-gutted cluster produces (see `_entity_supported`)
-            if not self._entity_supported(entity, all_entities.values()):
+            if not self._entity_supported(
+                entity, all_entities.values(), on_error=False
+            ):
                 await entity.on_remove()
                 continue
 
@@ -1237,7 +1254,12 @@ class Device(LogMixin, EventBase):
         try:
             entity.maybe_emit_state_changed_event()
         except Exception:  # pylint: disable=broad-except
-            _LOGGER.exception("Failed to emit state changed event for %s", entity)
+            self.error(
+                "Failed to emit state changed event for %s entity %s",
+                entity.PLATFORM,
+                entity.unique_id,
+                exc_info=True,
+            )
 
     async def recompute_entities(self) -> None:
         """Recompute all entities for this device."""
@@ -1247,7 +1269,7 @@ class Device(LogMixin, EventBase):
 
         # Remove all entities that are no longer supported
         for entity in entities[:]:
-            if not self._entity_supported(entity, entities):
+            if not self._entity_supported(entity, entities, on_error=True):
                 self.debug("Removing unsupported entity %s", entity)
                 await self._remove_entity(entity, remove=True)
                 entities.remove(entity)


### PR DESCRIPTION
DRAFT.

## Proposed change

This fixes an issue where a (custom) quirk can remove standard ZCL attributes. Most entity platforms already have guards checking if the attribute even exists, but some do not. This adds them.

## Additional information

I'm not sure if this is something we should add – quirks shouldn't misbehave like this. Or are there valid use-cases for deleting ZCL attributes...? But currently, ZHA startup breaks completely when using [these custom quirks](https://github.com/jacekk015/zha_quirks).

Should address:
- https://github.com/home-assistant/core/issues/173265
- https://github.com/home-assistant/core/issues/178581

This "regression" was introduced with:
- https://github.com/zigpy/zha/pull/657

### AI summary

<details>
<summary>Issue and fix summary (CLICK TO EXPAND)</summary>

### Issue

A quirk can leave a cluster without a definition for an attribute that ZHA entity code reads. zigpy's `Cluster.is_attribute_unsupported()`, `find_attribute()` and `Cluster.get()` all raise `KeyError` for such a name (`get()` resolves the definition *outside* its own `try`, so it raises rather than returning the default).

That `KeyError` propagated through `Device._add_pending_entities()` → `Gateway.load_devices()` → HA's `async_setup_entry`, so **one broken quirk prevented the entire ZHA integration from starting** (`ConfigEntryNotReady` retry loop) — for every device, not just the affected one. Before #657 the cluster-handler-based code tolerated these clusters.

Two shapes of the same bug were reported:

- **home-assistant/core#173265** — a quirk *removes* standard attribute definitions. `ts0601_trv_moes.py` from [jacekk015/zha_quirks](https://github.com/jacekk015/zha_quirks) does `attributes = LocalDataCluster.attributes.copy()` on an `OnOff` cluster, leaving no `on_off` definition, and `Switch._is_supported()` then raised `KeyError: 'on_off'`.
- **home-assistant/core#178581** — a quirks v2 quirk *names* an attribute its cluster never defines (a custom Inovelli VZM32-SN quirk declaring a `relay_click_in_on_off_mode` switch, an attribute only the VZM30/VZM31 clusters have). Quirk entities are constructed with `_attr_always_supported = True`, and `BaseEntity.is_supported()` short-circuits on that *before* `_is_supported()` runs — so per-platform guards can never catch this case.

### Fix

A new `BaseEntity._is_valid()` hook, checked **before** the `_attr_always_supported` short-circuit. `PlatformEntity` implements it as "the attributes this entity is built around resolve on the cluster" (`_attribute_name` and `_inverter_attribute_name`, which `inverted` reads on every state computation). A missing definition is routine for default discovery (debug log — an optional attribute a quirk removed) but an authoring bug when a quirk explicitly asked for the entity (warning log).

That centralises the duplicated `attributes_by_name` membership checks previously scattered across switch/select/number/sensor/binary_sensor.

Guards that `_is_valid()` cannot replace, because they run over cluster configs aggregated *before* `is_supported()` filtering:

- `configure_cluster_configs()` — skips reporting configuration for attributes the cluster does not define.
- `initialize_cluster_configs()` — filters undefined names out of the read batch. `read_attributes()` resolves every name up front, so leaving one in failed the whole batch and left its valid siblings uninitialized.
- `AggregatedClusterPoller.async_update()` — treats an undefined attribute as unsupported instead of raising.

Finally, the crash class is closed at its seam rather than per call site. `recompute_capabilities()` and `is_supported()` read attributes that are *not* the entity's own `_attribute_name` — `min_present_value` on `AnalogOutput`, `description` on `BinaryOutput`, `zone_type` on `IasZone` — and both ran unguarded in `_add_pending_entities()`, so a quirk gutting any of those clusters still failed the whole setup. Both calls now go through `Device._entity_supported()`, which treats an entity that cannot answer the question as unsupported, mirroring the containment `_discover_new_entities()` already gives entity construction. `Device._add_pending_entities()` likewise no longer lets one entity's state computation abort device initialization.

Removal is deliberately not symmetric: a *prospective* entity that raises is dropped, but an *existing* one is kept, because removing it makes consumers delete its registry entry along with the user's customizations.

### Tests

Regression tests for each shape, all verified to fail on unpatched `dev`: a quirk replacing `OnOff` with a cluster whose `AttributeDefs` does not inherit the standard definitions; a quirks v2 switch naming a nonexistent attribute; the same for a nonexistent *inverter* attribute; a valid sibling attribute surviving a poisoned read batch; a quirk gutting `AnalogOutput` (the `recompute_capabilities()` path); and the state-emission and capability-check guards themselves.

`python -m tools.regenerate_diagnostics` produces no snapshot drift, so no currently shipped quirk relies on an entity this now skips.

</details>
