### PR TITLE
Allow OTA downgrades when a specific version is selected

### DIFF
--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -608,9 +608,10 @@ async def test_firmware_update_downgrade(zha_gateway: Gateway) -> None:
         )
         await zha_gateway.async_block_till_done()
 
-    # The downgrade image was used
+    # The downgrade image was used, with downgrades explicitly allowed since the
+    # user selected a specific version
     assert mock_update.mock_calls == [
-        call(image=fw_image_downgrade, progress_callback=ANY)
+        call(image=fw_image_downgrade, progress_callback=ANY, allow_downgrade=True)
     ]
 
     assert (

--- a/zha/application/platforms/update.py
+++ b/zha/application/platforms/update.py
@@ -263,6 +263,10 @@ class BaseFirmwareUpdateEntity(PlatformEntity, ABC):
             result = await self.device.device.update_firmware(
                 image=firmware,
                 progress_callback=self._update_progress,
+                # An explicitly selected version (not the automatic "install
+                # latest") authorizes installing an image older than the running
+                # firmware. The auto path only ever picks an upgrade.
+                allow_downgrade=(version is not None),
             )
         except Exception as ex:
             self._attr_in_progress = False


### PR DESCRIPTION
Required zigpy PR:
- https://github.com/zigpy/zigpy/pull/1840

## AI summary

ZHA's update entity lets the user pick a specific firmware from the list, which can include versions older than the currently running one. Previously, selecting an older version was silently rejected by zigpy with `NO_IMAGE_AVAILABLE` (surfaced as "Update was not successful: `<Status.NO_IMAGE_AVAILABLE: 152>`"), because installing an older image required `force=True` — a flag too blunt to use here (it also skips the compatibility check and rewrites the advertised version).

This PR wires up zigpy's new `allow_downgrade` parameter so an explicitly selected older image installs as expected.

## Change

In `async_install` (`zha/application/platforms/update.py`), pass `allow_downgrade=(version is not None)` to `Device.update_firmware`:

```python
result = await self.device.device.update_firmware(
    image=firmware,
    progress_callback=self._update_progress,
    allow_downgrade=(version is not None),
)
```

- `version is None` → the automatic "install latest" path, which only ever selects an upgrade, so the version guard stays on.
- `version is not None` → the user explicitly named a version (resolved against both upgrades and downgrades), which authorizes installing an older but still compatible image. Compatibility is still enforced by zigpy.

## Tests

`test_firmware_update_downgrade` updated to assert the call now includes `allow_downgrade=True` when a specific older version is selected.

## Dependency

Requires the zigpy release that adds the `allow_downgrade` parameter to `Device.update_firmware` / the OTA manager. The zigpy pin must be bumped to that release before this can merge (merge order: zigpy release first, then bump-and-merge here).

## Note on device behavior

`allow_downgrade` lets zigpy *offer* a downgrade; whether the device *accepts* it is up to the device firmware. Many devices hard-refuse downgrades at the bootloader (e.g. a Sonoff S60ZBTPF replies `query_next_image_response(SUCCESS)` but immediately returns `upgrade_end(INVALID_IMAGE)` without requesting a block). In those cases the user now sees the device's honest `INVALID_IMAGE` instead of zigpy's silent `NO_IMAGE_AVAILABLE`.
