### PR TITLE
Break circular import when `zha.zigbee.device` is imported first

### DIFF
--- a/zha/zigbee/group.py
+++ b/zha/zigbee/group.py
@@ -19,14 +19,13 @@ from zha.application.platforms import (
 )
 from zha.const import STATE_CHANGED
 from zha.mixins import LogMixin
-from zha.zigbee.device import ExtendedDeviceInfo
 
 if TYPE_CHECKING:
     from zigpy.group import Group as ZigpyGroup, GroupEndpoint
 
     from zha.application.gateway import Gateway
     from zha.application.platforms import GroupEntity
-    from zha.zigbee.device import Device
+    from zha.zigbee.device import Device, ExtendedDeviceInfo
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
Importing `zha.zigbee.device` before any module that pulls in `zha.zigbee.group`/`zha.application.discovery` raised:

    ImportError: cannot import name 'ExtendedDeviceInfo' from partially
    initialized module 'zha.zigbee.device'

The cycle is device -> application.discovery (eagerly imports the `fan` platform) -> zigbee.group -> zigbee.device, where `ExtendedDeviceInfo` is not yet defined.

`group.py` uses `from __future__ import annotations` and references `ExtendedDeviceInfo` only as a deferred annotation, so the runtime import is unnecessary. Move it under `TYPE_CHECKING` (next to the existing `Device` import) to break the cycle.