### PR TITLE
Slugify enum select and sensor option values for translation

### DIFF
--- a/tests/data/devices/adeo-sin-4-fp-21-equ.json
+++ b/tests/data/devices/adeo-sin-4-fp-21-equ.json
@@ -332,16 +332,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       },
       {
@@ -365,12 +365,12 @@
           "group_id": null,
           "enum": "NodOnPilotWireMode",
           "options": [
-            "Off",
-            "Comfort",
-            "Eco",
-            "FrostProtection",
-            "ComfortMinus1",
-            "ComfortMinus2"
+            "off",
+            "comfort",
+            "eco",
+            "frostprotection",
+            "comfortminus1",
+            "comfortminus2"
           ]
         },
         "state": {

--- a/tests/data/devices/adurosmart-eria-ad-rgbw3001-0x00000001.json
+++ b/tests/data/devices/adurosmart-eria-ad-rgbw3001-0x00000001.json
@@ -616,16 +616,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/aeotec-zga004.json
+++ b/tests/data/devices/aeotec-zga004.json
@@ -758,7 +758,7 @@
         "state": {
           "class_name": "WindowCoveringTypeSensor",
           "available": true,
-          "state": "Rollershade"
+          "state": "rollershade"
         }
       },
       {
@@ -786,7 +786,7 @@
         "state": {
           "class_name": "WindowCoveringTypeSensor",
           "available": true,
-          "state": "Shutter"
+          "state": "shutter"
         }
       }
     ],

--- a/tests/data/devices/aqara-lumi-light-acn132-0x00001a1a.json
+++ b/tests/data/devices/aqara-lumi-light-acn132-0x00001a1a.json
@@ -666,8 +666,8 @@
           "group_id": null,
           "enum": "LedStripT1Audio",
           "options": [
-            "Off",
-            "On"
+            "off",
+            "on"
           ]
         },
         "state": {
@@ -697,10 +697,10 @@
           "group_id": null,
           "enum": "LedStripT1AudioEffect",
           "options": [
-            "Random",
-            "Blink",
-            "Rainbow",
-            "Wave"
+            "random",
+            "blink",
+            "rainbow",
+            "wave"
           ]
         },
         "state": {
@@ -730,9 +730,9 @@
           "group_id": null,
           "enum": "LedStripT1AudioSensitivity",
           "options": [
-            "Low",
-            "Medium",
-            "High"
+            "low",
+            "medium",
+            "high"
           ]
         },
         "state": {
@@ -762,10 +762,10 @@
           "group_id": null,
           "enum": "LedStripT1PowerOnStateMode",
           "options": [
-            "On",
-            "Previous",
-            "Off",
-            "Toggle"
+            "on",
+            "previous",
+            "off",
+            "toggle"
           ]
         },
         "state": {
@@ -795,14 +795,14 @@
           "group_id": null,
           "enum": "LedStripT1Preset",
           "options": [
-            "Breathe",
-            "Rainbow",
-            "Sweep",
-            "Flashing",
-            "Strobe",
-            "ReversedRainbow",
-            "Colorful",
-            "Scan"
+            "breathe",
+            "rainbow",
+            "sweep",
+            "flashing",
+            "strobe",
+            "reversedrainbow",
+            "colorful",
+            "scan"
           ]
         },
         "state": {

--- a/tests/data/devices/aqara-lumi-motion-ac01-0x00000035.json
+++ b/tests/data/devices/aqara-lumi-motion-ac01-0x00000035.json
@@ -303,15 +303,15 @@
           "group_id": null,
           "enum": "AqaraApproachDistances",
           "options": [
-            "Far",
-            "Medium",
-            "Near"
+            "far",
+            "medium",
+            "near"
           ]
         },
         "state": {
           "class_name": "AqaraApproachDistance",
           "available": true,
-          "state": "Far"
+          "state": "far"
         }
       },
       {
@@ -335,14 +335,14 @@
           "group_id": null,
           "enum": "AqaraMonitoringModess",
           "options": [
-            "Undirected",
-            "Left Right"
+            "undirected",
+            "left_right"
           ]
         },
         "state": {
           "class_name": "AqaraMonitoringMode",
           "available": true,
-          "state": "Left Right"
+          "state": "left_right"
         }
       },
       {
@@ -366,15 +366,15 @@
           "group_id": null,
           "enum": "AqaraMotionSensitivities",
           "options": [
-            "Low",
-            "Medium",
-            "High"
+            "low",
+            "medium",
+            "high"
           ]
         },
         "state": {
           "class_name": "AqaraMotionSensitivity",
           "available": true,
-          "state": "High"
+          "state": "high"
         }
       }
     ],

--- a/tests/data/devices/aqara-lumi-sensor-occupy-agl1-0x0000001a.json
+++ b/tests/data/devices/aqara-lumi-sensor-occupy-agl1-0x0000001a.json
@@ -360,9 +360,9 @@
           "group_id": null,
           "enum": "AqaraMotionSensitivity",
           "options": [
-            "Low",
-            "Medium",
-            "High"
+            "low",
+            "medium",
+            "high"
           ]
         },
         "state": {

--- a/tests/data/devices/aqara-lumi-switch-acn047-0x0000001c.json
+++ b/tests/data/devices/aqara-lumi-switch-acn047-0x0000001c.json
@@ -845,14 +845,14 @@
           "group_id": null,
           "enum": "DecoupledMode",
           "options": [
-            "Decoupled",
-            "ControlRelay"
+            "decoupled",
+            "controlrelay"
           ]
         },
         "state": {
           "class_name": "AqaraT2RelayDecoupledMode",
           "available": true,
-          "state": "ControlRelay"
+          "state": "controlrelay"
         }
       },
       {
@@ -876,16 +876,16 @@
           "group_id": null,
           "enum": "StartupOnOff",
           "options": [
-            "On",
-            "Previous",
-            "Off",
-            "Toggle"
+            "on",
+            "previous",
+            "off",
+            "toggle"
           ]
         },
         "state": {
           "class_name": "AqaraT2RelayStartupOnOff",
           "available": true,
-          "state": "Previous"
+          "state": "previous"
         }
       },
       {
@@ -909,15 +909,15 @@
           "group_id": null,
           "enum": "SwitchMode",
           "options": [
-            "Power",
-            "Pulse",
-            "Dry"
+            "power",
+            "pulse",
+            "dry"
           ]
         },
         "state": {
           "class_name": "AqaraT2RelaySwitchMode",
           "available": true,
-          "state": "Power"
+          "state": "power"
         }
       },
       {
@@ -941,15 +941,15 @@
           "group_id": null,
           "enum": "SwitchType",
           "options": [
-            "Toggle",
-            "Momentary",
-            "NoSwitch"
+            "toggle",
+            "momentary",
+            "noswitch"
           ]
         },
         "state": {
           "class_name": "AqaraT2RelaySwitchType",
           "available": true,
-          "state": "Toggle"
+          "state": "toggle"
         }
       },
       {
@@ -973,14 +973,14 @@
           "group_id": null,
           "enum": "DecoupledMode",
           "options": [
-            "Decoupled",
-            "ControlRelay"
+            "decoupled",
+            "controlrelay"
           ]
         },
         "state": {
           "class_name": "AqaraT2RelayDecoupledMode",
           "available": true,
-          "state": "ControlRelay"
+          "state": "controlrelay"
         }
       }
     ],

--- a/tests/data/devices/aqara-lumi-switch-aeu003-0x00000e14.json
+++ b/tests/data/devices/aqara-lumi-switch-aeu003-0x00000e14.json
@@ -887,7 +887,7 @@
         "state": {
           "class_name": "WindowCoveringTypeSensor",
           "available": true,
-          "state": "Rollershade"
+          "state": "rollershade"
         }
       },
       {

--- a/tests/data/devices/awox-esmlfzm-w6-dimm.json
+++ b/tests/data/devices/awox-esmlfzm-w6-dimm.json
@@ -523,16 +523,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "On"
+          "state": "on"
         }
       }
     ],

--- a/tests/data/devices/bega-gantenbrink-leuchten-kg-smart-dimmable-light-0x00990be9.json
+++ b/tests/data/devices/bega-gantenbrink-leuchten-kg-smart-dimmable-light-0x00990be9.json
@@ -734,16 +734,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "On"
+          "state": "on"
         }
       },
       {
@@ -767,14 +767,14 @@
           "group_id": null,
           "enum": "BegaColorTemperatureChannel",
           "options": [
-            "Warm white",
-            "Cool white"
+            "warm_white",
+            "cool_white"
           ]
         },
         "state": {
           "class_name": "BegaColorTemperatureChannelSelect",
           "available": true,
-          "state": "Warm white"
+          "state": "warm_white"
         }
       }
     ],

--- a/tests/data/devices/bitron-video-902010-24a.json
+++ b/tests/data/devices/bitron-video-902010-24a.json
@@ -259,10 +259,10 @@
           "group_id": null,
           "enum": "SirenLevel",
           "options": [
-            "Low level sound",
-            "Medium level sound",
-            "High level sound",
-            "Very high level sound"
+            "low_level_sound",
+            "medium_level_sound",
+            "high_level_sound",
+            "very_high_level_sound"
           ]
         },
         "state": {
@@ -323,10 +323,10 @@
           "group_id": null,
           "enum": "StrobeLevel",
           "options": [
-            "Low level strobe",
-            "Medium level strobe",
-            "High level strobe",
-            "Very high level strobe"
+            "low_level_strobe",
+            "medium_level_strobe",
+            "high_level_strobe",
+            "very_high_level_strobe"
           ]
         },
         "state": {
@@ -356,13 +356,13 @@
           "group_id": null,
           "enum": "WarningMode",
           "options": [
-            "Stop",
-            "Burglar",
-            "Fire",
-            "Emergency",
-            "Police Panic",
-            "Fire Panic",
-            "Emergency Panic"
+            "stop",
+            "burglar",
+            "fire",
+            "emergency",
+            "police_panic",
+            "fire_panic",
+            "emergency_panic"
           ]
         },
         "state": {

--- a/tests/data/devices/bosch-rbsh-mms-zb-eu-0x11136760.json
+++ b/tests/data/devices/bosch-rbsh-mms-zb-eu-0x11136760.json
@@ -961,9 +961,9 @@
           "group_id": null,
           "enum": "BoschDeviceMode",
           "options": [
-            "Disabled",
-            "Cover",
-            "Light"
+            "disabled",
+            "cover",
+            "light"
           ]
         },
         "state": {
@@ -993,10 +993,10 @@
           "group_id": null,
           "enum": "BoschSwitchType",
           "options": [
-            "Button",
-            "Button key change",
-            "Rocker switch",
-            "Rocker switch key change"
+            "button",
+            "button_key_change",
+            "rocker_switch",
+            "rocker_switch_key_change"
           ]
         },
         "state": {
@@ -1026,16 +1026,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "Off"
+          "state": "off"
         }
       },
       {
@@ -1059,16 +1059,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "Off"
+          "state": "off"
         }
       }
     ],
@@ -1226,7 +1226,7 @@
         "state": {
           "class_name": "WindowCoveringTypeSensor",
           "available": true,
-          "state": "Tilt_blind_tilt_and_lift"
+          "state": "tilt_blind_tilt_and_lift"
         }
       },
       {

--- a/tests/data/devices/bosch-rbsh-rth0-bat-zb-eu-0x02086a30.json
+++ b/tests/data/devices/bosch-rbsh-rth0-bat-zb-eu-0x02086a30.json
@@ -738,17 +738,17 @@
           "group_id": null,
           "enum": "KeypadLockoutEnum",
           "options": [
-            "Unlock",
-            "Lock1",
-            "Lock2",
-            "Lock3",
-            "Lock4"
+            "unlock",
+            "lock1",
+            "lock2",
+            "lock3",
+            "lock4"
           ]
         },
         "state": {
           "class_name": "KeypadLockout",
           "available": true,
-          "state": "Unlock"
+          "state": "unlock"
         }
       },
       {
@@ -772,8 +772,8 @@
           "group_id": null,
           "enum": "BoschActuatorType",
           "options": [
-            "NormallyClosed",
-            "NormallyOpen"
+            "normallyclosed",
+            "normallyopen"
           ]
         },
         "state": {
@@ -803,10 +803,10 @@
           "group_id": null,
           "enum": "BoschHeaterType",
           "options": [
-            "UnderfloorHeating",
-            "Boiler",
-            "Radiator",
-            "CentralHeating"
+            "underfloorheating",
+            "boiler",
+            "radiator",
+            "centralheating"
           ]
         },
         "state": {
@@ -836,9 +836,9 @@
           "group_id": null,
           "enum": "BoschOperatingMode",
           "options": [
-            "Schedule",
-            "Manual",
-            "Pause"
+            "schedule",
+            "manual",
+            "pause"
           ]
         },
         "state": {
@@ -868,9 +868,9 @@
           "group_id": null,
           "enum": "BoschSensorConnection",
           "options": [
-            "NotUsed",
-            "WithoutRegulation",
-            "WithRegulation"
+            "notused",
+            "withoutregulation",
+            "withregulation"
           ]
         },
         "state": {
@@ -900,8 +900,8 @@
           "group_id": null,
           "enum": "TemperatureDisplayMode",
           "options": [
-            "Metric",
-            "Imperial"
+            "metric",
+            "imperial"
           ]
         },
         "state": {
@@ -931,9 +931,9 @@
           "group_id": null,
           "enum": "BoschValveStatusLed",
           "options": [
-            "Off",
-            "Normal",
-            "On"
+            "off",
+            "normal",
+            "on"
           ]
         },
         "state": {
@@ -1115,7 +1115,7 @@
         "state": {
           "class_name": "SetpointChangeSource",
           "available": true,
-          "state": "Manual"
+          "state": "manual"
         }
       },
       {

--- a/tests/data/devices/bosch-rbsh-rth0-zb-eu-0x03036a30.json
+++ b/tests/data/devices/bosch-rbsh-rth0-zb-eu-0x03036a30.json
@@ -864,17 +864,17 @@
           "group_id": null,
           "enum": "KeypadLockoutEnum",
           "options": [
-            "Unlock",
-            "Lock1",
-            "Lock2",
-            "Lock3",
-            "Lock4"
+            "unlock",
+            "lock1",
+            "lock2",
+            "lock3",
+            "lock4"
           ]
         },
         "state": {
           "class_name": "KeypadLockout",
           "available": true,
-          "state": "Unlock"
+          "state": "unlock"
         }
       },
       {
@@ -898,8 +898,8 @@
           "group_id": null,
           "enum": "BoschActuatorType",
           "options": [
-            "NormallyClosed",
-            "NormallyOpen"
+            "normallyclosed",
+            "normallyopen"
           ]
         },
         "state": {
@@ -929,10 +929,10 @@
           "group_id": null,
           "enum": "BoschHeaterType",
           "options": [
-            "UnderfloorHeating",
-            "Boiler",
-            "Radiator",
-            "CentralHeating"
+            "underfloorheating",
+            "boiler",
+            "radiator",
+            "centralheating"
           ]
         },
         "state": {
@@ -962,15 +962,15 @@
           "group_id": null,
           "enum": "BoschOperatingMode",
           "options": [
-            "Schedule",
-            "Manual",
-            "Pause"
+            "schedule",
+            "manual",
+            "pause"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Manual"
+          "state": "manual"
         }
       },
       {
@@ -994,9 +994,9 @@
           "group_id": null,
           "enum": "BoschSensorConnection",
           "options": [
-            "NotUsed",
-            "WithoutRegulation",
-            "WithRegulation"
+            "notused",
+            "withoutregulation",
+            "withregulation"
           ]
         },
         "state": {
@@ -1026,14 +1026,14 @@
           "group_id": null,
           "enum": "TemperatureDisplayMode",
           "options": [
-            "Metric",
-            "Imperial"
+            "metric",
+            "imperial"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Metric"
+          "state": "metric"
         }
       },
       {
@@ -1057,9 +1057,9 @@
           "group_id": null,
           "enum": "BoschValveStatusLed",
           "options": [
-            "Off",
-            "Normal",
-            "On"
+            "off",
+            "normal",
+            "on"
           ]
         },
         "state": {
@@ -1235,7 +1235,7 @@
         "state": {
           "class_name": "SetpointChangeSource",
           "available": true,
-          "state": "External"
+          "state": "external"
         }
       },
       {

--- a/tests/data/devices/bosch-rbsh-trv0-zb-eu-0x32051514.json
+++ b/tests/data/devices/bosch-rbsh-trv0-zb-eu-0x32051514.json
@@ -709,14 +709,14 @@
           "group_id": null,
           "enum": "BoschControlSequenceOfOperation",
           "options": [
-            "Cooling",
-            "Heating"
+            "cooling",
+            "heating"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Heating"
+          "state": "heating"
         }
       },
       {
@@ -740,14 +740,14 @@
           "group_id": null,
           "enum": "BoschDisplayOrientation",
           "options": [
-            "Normal",
-            "Flipped"
+            "normal",
+            "flipped"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Normal"
+          "state": "normal"
         }
       },
       {
@@ -771,14 +771,14 @@
           "group_id": null,
           "enum": "BoschDisplayedTemperature",
           "options": [
-            "Target",
-            "Measured"
+            "target",
+            "measured"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Target"
+          "state": "target"
         }
       }
     ],
@@ -956,7 +956,7 @@
         "state": {
           "class_name": "SetpointChangeSource",
           "available": true,
-          "state": "External"
+          "state": "external"
         }
       },
       {
@@ -1012,7 +1012,7 @@
         "state": {
           "class_name": "EnumSensor",
           "available": true,
-          "state": "Manual"
+          "state": "manual"
         }
       },
       {

--- a/tests/data/devices/bosch-rbsh-trv0-zb-eu-0x38011514.json
+++ b/tests/data/devices/bosch-rbsh-trv0-zb-eu-0x38011514.json
@@ -708,17 +708,17 @@
           "group_id": null,
           "enum": "KeypadLockoutEnum",
           "options": [
-            "Unlock",
-            "Lock1",
-            "Lock2",
-            "Lock3",
-            "Lock4"
+            "unlock",
+            "lock1",
+            "lock2",
+            "lock3",
+            "lock4"
           ]
         },
         "state": {
           "class_name": "KeypadLockout",
           "available": true,
-          "state": "Unlock"
+          "state": "unlock"
         }
       },
       {
@@ -742,14 +742,14 @@
           "group_id": null,
           "enum": "BoschControlSequenceOfOperation",
           "options": [
-            "Cooling",
-            "Heating"
+            "cooling",
+            "heating"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Heating"
+          "state": "heating"
         }
       },
       {
@@ -773,14 +773,14 @@
           "group_id": null,
           "enum": "BoschDisplayOrientation",
           "options": [
-            "Normal",
-            "Flipped"
+            "normal",
+            "flipped"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Normal"
+          "state": "normal"
         }
       },
       {
@@ -804,14 +804,14 @@
           "group_id": null,
           "enum": "BoschDisplayedTemperature",
           "options": [
-            "Target",
-            "Measured"
+            "target",
+            "measured"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Measured"
+          "state": "measured"
         }
       }
     ],
@@ -989,7 +989,7 @@
         "state": {
           "class_name": "SetpointChangeSource",
           "available": true,
-          "state": "Manual"
+          "state": "manual"
         }
       },
       {
@@ -1045,7 +1045,7 @@
         "state": {
           "class_name": "EnumSensor",
           "available": true,
-          "state": "Manual"
+          "state": "manual"
         }
       },
       {
@@ -1073,7 +1073,7 @@
         "state": {
           "class_name": "EnumSensor",
           "available": true,
-          "state": "CalibrationInProgress"
+          "state": "calibrationinprogress"
         }
       }
     ],

--- a/tests/data/devices/candeo-c-zb-lc20-dim-0x29013001.json
+++ b/tests/data/devices/candeo-c-zb-lc20-dim-0x29013001.json
@@ -340,16 +340,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/candeo-c-zb-lc20-rgb-0x31013001.json
+++ b/tests/data/devices/candeo-c-zb-lc20-rgb-0x31013001.json
@@ -399,16 +399,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "On"
+          "state": "on"
         }
       }
     ],

--- a/tests/data/devices/centralite-systems-3156105-0x1418468c.json
+++ b/tests/data/devices/centralite-systems-3156105-0x1418468c.json
@@ -610,17 +610,17 @@
           "group_id": null,
           "enum": "KeypadLockoutEnum",
           "options": [
-            "Unlock",
-            "Lock1",
-            "Lock2",
-            "Lock3",
-            "Lock4"
+            "unlock",
+            "lock1",
+            "lock2",
+            "lock3",
+            "lock4"
           ]
         },
         "state": {
           "class_name": "KeypadLockout",
           "available": true,
-          "state": "Unlock"
+          "state": "unlock"
         }
       }
     ],

--- a/tests/data/devices/climaxtechnology-sd8sc-00-00-03-12tc.json
+++ b/tests/data/devices/climaxtechnology-sd8sc-00-00-03-12tc.json
@@ -236,10 +236,10 @@
           "group_id": null,
           "enum": "SirenLevel",
           "options": [
-            "Low level sound",
-            "Medium level sound",
-            "High level sound",
-            "Very high level sound"
+            "low_level_sound",
+            "medium_level_sound",
+            "high_level_sound",
+            "very_high_level_sound"
           ]
         },
         "state": {
@@ -300,10 +300,10 @@
           "group_id": null,
           "enum": "StrobeLevel",
           "options": [
-            "Low level strobe",
-            "Medium level strobe",
-            "High level strobe",
-            "Very high level strobe"
+            "low_level_strobe",
+            "medium_level_strobe",
+            "high_level_strobe",
+            "very_high_level_strobe"
           ]
         },
         "state": {
@@ -333,13 +333,13 @@
           "group_id": null,
           "enum": "WarningMode",
           "options": [
-            "Stop",
-            "Burglar",
-            "Fire",
-            "Emergency",
-            "Police Panic",
-            "Fire Panic",
-            "Emergency Panic"
+            "stop",
+            "burglar",
+            "fire",
+            "emergency",
+            "police_panic",
+            "fire_panic",
+            "emergency_panic"
           ]
         },
         "state": {

--- a/tests/data/devices/computime-slt3c-0x02040105.json
+++ b/tests/data/devices/computime-slt3c-0x02040105.json
@@ -482,17 +482,17 @@
           "group_id": null,
           "enum": "KeypadLockoutEnum",
           "options": [
-            "Unlock",
-            "Lock1",
-            "Lock2",
-            "Lock3",
-            "Lock4"
+            "unlock",
+            "lock1",
+            "lock2",
+            "lock3",
+            "lock4"
           ]
         },
         "state": {
           "class_name": "KeypadLockout",
           "available": true,
-          "state": "Unlock"
+          "state": "unlock"
         }
       }
     ],

--- a/tests/data/devices/d5x84yu-et093wrg.json
+++ b/tests/data/devices/d5x84yu-et093wrg.json
@@ -954,7 +954,7 @@
         "state": {
           "class_name": "SetpointChangeSource",
           "available": true,
-          "state": "External"
+          "state": "external"
         }
       },
       {

--- a/tests/data/devices/danfoss-etrv0103-0x00000014.json
+++ b/tests/data/devices/danfoss-etrv0103-0x00000014.json
@@ -897,15 +897,15 @@
           "group_id": null,
           "enum": "DanfossAdaptationRunControlEnum",
           "options": [
-            "Nothing",
-            "Initiate",
-            "Cancel"
+            "nothing",
+            "initiate",
+            "cancel"
           ]
         },
         "state": {
           "class_name": "DanfossAdaptationRunControl",
           "available": true,
-          "state": "Nothing"
+          "state": "nothing"
         }
       },
       {
@@ -929,23 +929,23 @@
           "group_id": null,
           "enum": "DanfossControlAlgorithmScaleFactorEnum",
           "options": [
-            "quick 5min",
-            "quick 10min",
-            "quick 15min",
-            "quick 25min",
-            "moderate 30min",
-            "moderate 40min",
-            "moderate 50min",
-            "moderate 60min",
-            "moderate 70min",
-            "slow 80min",
-            "quick open disabled"
+            "quick_5min",
+            "quick_10min",
+            "quick_15min",
+            "quick_25min",
+            "moderate_30min",
+            "moderate_40min",
+            "moderate_50min",
+            "moderate_60min",
+            "moderate_70min",
+            "slow_80min",
+            "quick_open_disabled"
           ]
         },
         "state": {
           "class_name": "DanfossControlAlgorithmScaleFactor",
           "available": true,
-          "state": "quick 5min"
+          "state": "quick_5min"
         }
       },
       {
@@ -969,20 +969,20 @@
           "group_id": null,
           "enum": "DanfossExerciseDayOfTheWeekEnum",
           "options": [
-            "Sunday",
-            "Monday",
-            "Tuesday",
-            "Wednesday",
-            "Thursday",
-            "Friday",
-            "Saturday",
-            "Undefined"
+            "sunday",
+            "monday",
+            "tuesday",
+            "wednesday",
+            "thursday",
+            "friday",
+            "saturday",
+            "undefined"
           ]
         },
         "state": {
           "class_name": "DanfossExerciseDayOfTheWeek",
           "available": true,
-          "state": "Thursday"
+          "state": "thursday"
         }
       },
       {
@@ -1006,14 +1006,14 @@
           "group_id": null,
           "enum": "DanfossOrientationEnum",
           "options": [
-            "Horizontal",
-            "Vertical"
+            "horizontal",
+            "vertical"
           ]
         },
         "state": {
           "class_name": "DanfossOrientation",
           "available": true,
-          "state": "Horizontal"
+          "state": "horizontal"
         }
       },
       {
@@ -1037,17 +1037,17 @@
           "group_id": null,
           "enum": "KeypadLockoutEnum",
           "options": [
-            "Unlock",
-            "Lock1",
-            "Lock2",
-            "Lock3",
-            "Lock4"
+            "unlock",
+            "lock1",
+            "lock2",
+            "lock3",
+            "lock4"
           ]
         },
         "state": {
           "class_name": "KeypadLockout",
           "available": true,
-          "state": "Unlock"
+          "state": "unlock"
         }
       },
       {
@@ -1071,14 +1071,14 @@
           "group_id": null,
           "enum": "DanfossViewingDirectionEnum",
           "options": [
-            "Default",
-            "Inverted"
+            "default",
+            "inverted"
           ]
         },
         "state": {
           "class_name": "DanfossViewingDirection",
           "available": true,
-          "state": "Default"
+          "state": "default"
         }
       }
     ],
@@ -1370,7 +1370,7 @@
         "state": {
           "class_name": "DanfossOpenWindowDetection",
           "available": true,
-          "state": "Closed"
+          "state": "closed"
         }
       },
       {
@@ -1454,7 +1454,7 @@
         "state": {
           "class_name": "SetpointChangeSource",
           "available": true,
-          "state": "External"
+          "state": "external"
         }
       },
       {

--- a/tests/data/devices/datek-pop.json
+++ b/tests/data/devices/datek-pop.json
@@ -406,16 +406,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/ericsity-gl-c-008p-0x25013001.json
+++ b/tests/data/devices/ericsity-gl-c-008p-0x25013001.json
@@ -463,16 +463,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/ericsity-gl-c-009p-0x25013001.json
+++ b/tests/data/devices/ericsity-gl-c-009p-0x25013001.json
@@ -493,16 +493,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/ewelink-ck-bl702-al-01-7009-z102lg03-1-0x00001200.json
+++ b/tests/data/devices/ewelink-ck-bl702-al-01-7009-z102lg03-1-0x00001200.json
@@ -543,16 +543,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "Off"
+          "state": "off"
         }
       }
     ],

--- a/tests/data/devices/ewelink-ck-bl702-al-01-7009-z102lg03-1-0x00001203.json
+++ b/tests/data/devices/ewelink-ck-bl702-al-01-7009-z102lg03-1-0x00001203.json
@@ -537,16 +537,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "On"
+          "state": "on"
         }
       }
     ],

--- a/tests/data/devices/frient-a-s-sirzb-111-0x00020004.json
+++ b/tests/data/devices/frient-a-s-sirzb-111-0x00020004.json
@@ -327,10 +327,10 @@
           "group_id": null,
           "enum": "SirenLevel",
           "options": [
-            "Low level sound",
-            "Medium level sound",
-            "High level sound",
-            "Very high level sound"
+            "low_level_sound",
+            "medium_level_sound",
+            "high_level_sound",
+            "very_high_level_sound"
           ]
         },
         "state": {
@@ -391,10 +391,10 @@
           "group_id": null,
           "enum": "StrobeLevel",
           "options": [
-            "Low level strobe",
-            "Medium level strobe",
-            "High level strobe",
-            "Very high level strobe"
+            "low_level_strobe",
+            "medium_level_strobe",
+            "high_level_strobe",
+            "very_high_level_strobe"
           ]
         },
         "state": {
@@ -424,13 +424,13 @@
           "group_id": null,
           "enum": "WarningMode",
           "options": [
-            "Stop",
-            "Burglar",
-            "Fire",
-            "Emergency",
-            "Police Panic",
-            "Fire Panic",
-            "Emergency Panic"
+            "stop",
+            "burglar",
+            "fire",
+            "emergency",
+            "police_panic",
+            "fire_panic",
+            "emergency_panic"
           ]
         },
         "state": {

--- a/tests/data/devices/gledopto-gl-b-008p-0x00000006.json
+++ b/tests/data/devices/gledopto-gl-b-008p-0x00000006.json
@@ -516,16 +516,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/gledopto-gl-c-009p-0x17013001.json
+++ b/tests/data/devices/gledopto-gl-c-009p-0x17013001.json
@@ -462,16 +462,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "Off"
+          "state": "off"
         }
       }
     ],

--- a/tests/data/devices/gledopto-gl-c-009p-0x25013001.json
+++ b/tests/data/devices/gledopto-gl-c-009p-0x25013001.json
@@ -341,16 +341,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/gledopto-gl-c-009p-0x29013001.json
+++ b/tests/data/devices/gledopto-gl-c-009p-0x29013001.json
@@ -341,16 +341,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/gledopto-gl-sd-301p-0x26013001.json
+++ b/tests/data/devices/gledopto-gl-sd-301p-0x26013001.json
@@ -462,16 +462,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "On"
+          "state": "on"
         }
       }
     ],

--- a/tests/data/devices/gledpopto-gl-c-007p.json
+++ b/tests/data/devices/gledpopto-gl-c-007p.json
@@ -528,16 +528,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "Off"
+          "state": "off"
         }
       }
     ],

--- a/tests/data/devices/hobeian-zg-101zl.json
+++ b/tests/data/devices/hobeian-zg-101zl.json
@@ -439,16 +439,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "Toggle"
+          "state": "toggle"
         }
       }
     ],

--- a/tests/data/devices/hobeian-zg-229z.json
+++ b/tests/data/devices/hobeian-zg-229z.json
@@ -273,16 +273,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "On"
+          "state": "on"
         }
       }
     ],

--- a/tests/data/devices/homr-hrmsn01.json
+++ b/tests/data/devices/homr-hrmsn01.json
@@ -585,10 +585,10 @@
           "group_id": null,
           "enum": "SirenLevel",
           "options": [
-            "Low level sound",
-            "Medium level sound",
-            "High level sound",
-            "Very high level sound"
+            "low_level_sound",
+            "medium_level_sound",
+            "high_level_sound",
+            "very_high_level_sound"
           ]
         },
         "state": {
@@ -649,10 +649,10 @@
           "group_id": null,
           "enum": "StrobeLevel",
           "options": [
-            "Low level strobe",
-            "Medium level strobe",
-            "High level strobe",
-            "Very high level strobe"
+            "low_level_strobe",
+            "medium_level_strobe",
+            "high_level_strobe",
+            "very_high_level_strobe"
           ]
         },
         "state": {
@@ -682,13 +682,13 @@
           "group_id": null,
           "enum": "WarningMode",
           "options": [
-            "Stop",
-            "Burglar",
-            "Fire",
-            "Emergency",
-            "Police Panic",
-            "Fire Panic",
-            "Emergency Panic"
+            "stop",
+            "burglar",
+            "fire",
+            "emergency",
+            "police_panic",
+            "fire_panic",
+            "emergency_panic"
           ]
         },
         "state": {

--- a/tests/data/devices/ikea-of-sweden-fyrtur-block-out-roller-blind-0x23088631.json
+++ b/tests/data/devices/ikea-of-sweden-fyrtur-block-out-roller-blind-0x23088631.json
@@ -443,7 +443,7 @@
         "state": {
           "class_name": "WindowCoveringTypeSensor",
           "available": true,
-          "state": "Rollershade"
+          "state": "rollershade"
         }
       }
     ],

--- a/tests/data/devices/ikea-of-sweden-inspelning-smart-plug-0x02040045.json
+++ b/tests/data/devices/ikea-of-sweden-inspelning-smart-plug-0x02040045.json
@@ -568,16 +568,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "Off"
+          "state": "off"
         }
       }
     ],

--- a/tests/data/devices/ikea-of-sweden-ormanas-led-strip-0x01010010.json
+++ b/tests/data/devices/ikea-of-sweden-ormanas-led-strip-0x01010010.json
@@ -671,16 +671,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "On"
+          "state": "on"
         }
       }
     ],

--- a/tests/data/devices/ikea-of-sweden-praktlysing-cellular-blind-0x23088631.json
+++ b/tests/data/devices/ikea-of-sweden-praktlysing-cellular-blind-0x23088631.json
@@ -450,7 +450,7 @@
         "state": {
           "class_name": "WindowCoveringTypeSensor",
           "available": true,
-          "state": "Rollershade"
+          "state": "rollershade"
         }
       }
     ],

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-w-op-ch-400lm-0x23094631.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-w-op-ch-400lm-0x23094631.json
@@ -457,16 +457,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-ws-opal-400lm-0x23087631.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e12-ws-opal-400lm-0x23087631.json
@@ -593,16 +593,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e14-ws-globe-470lm-0x01010020.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e14-ws-globe-470lm-0x01010020.json
@@ -538,16 +538,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "On"
+          "state": "on"
         }
       }
     ],

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-opal-1000lm-0x23094631.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-opal-1000lm-0x23094631.json
@@ -457,16 +457,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-w-opal-1000lm-0x23094631.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-w-opal-1000lm-0x23094631.json
@@ -451,16 +451,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-ws-opal-980lm-0x23095631.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e26-ws-opal-980lm-0x23095631.json
@@ -573,16 +573,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e27-ws-globe-1055lm-0x02040005.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e27-ws-globe-1055lm-0x02040005.json
@@ -554,16 +554,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-e27-ww-g95-cl-470lm-0x00011006.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-e27-ww-g95-cl-470lm-0x00011006.json
@@ -437,16 +437,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "Off"
+          "state": "off"
         }
       }
     ],

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-gu10-ws-400lm-0x23095631.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-gu10-ws-400lm-0x23095631.json
@@ -599,16 +599,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-gu10-ww-345lm8.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-gu10-ww-345lm8.json
@@ -432,16 +432,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "On"
+          "state": "on"
         }
       }
     ],

--- a/tests/data/devices/ikea-of-sweden-tradfri-bulb-gu10-ww-400lm-0x23093631.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-bulb-gu10-ww-400lm-0x23093631.json
@@ -456,16 +456,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "On"
+          "state": "on"
         }
       }
     ],

--- a/tests/data/devices/ikea-of-sweden-tradfri-control-outlet-0x23089631.json
+++ b/tests/data/devices/ikea-of-sweden-tradfri-control-outlet-0x23089631.json
@@ -285,16 +285,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/innr-ae-280-c-0x20026a30.json
+++ b/tests/data/devices/innr-ae-280-c-0x20026a30.json
@@ -525,16 +525,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/innr-rb-285-c-0x10051567.json
+++ b/tests/data/devices/innr-rb-285-c-0x10051567.json
@@ -498,16 +498,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/innr-rs-232-c-0x22151511.json
+++ b/tests/data/devices/innr-rs-232-c-0x22151511.json
@@ -604,16 +604,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/innr-sp-234-0x31016610.json
+++ b/tests/data/devices/innr-sp-234-0x31016610.json
@@ -494,16 +494,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/innr-sp-240-0x191e3685.json
+++ b/tests/data/devices/innr-sp-240-0x191e3685.json
@@ -627,16 +627,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/innr-sp-242-0x17173685.json
+++ b/tests/data/devices/innr-sp-242-0x17173685.json
@@ -772,16 +772,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "Off"
+          "state": "off"
         }
       }
     ],

--- a/tests/data/devices/inovelli-vzm30-sn-0x01100100.json
+++ b/tests/data/devices/inovelli-vzm30-sn-0x01100100.json
@@ -998,16 +998,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],
@@ -1253,7 +1253,7 @@
         "state": {
           "class_name": "InovelliOverheated",
           "available": true,
-          "state": "Normal"
+          "state": "normal"
         }
       },
       {

--- a/tests/data/devices/inovelli-vzm30-sn.json
+++ b/tests/data/devices/inovelli-vzm30-sn.json
@@ -1551,16 +1551,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/inovelli-vzm31-sn-0x01020212.json
+++ b/tests/data/devices/inovelli-vzm31-sn-0x01020212.json
@@ -1715,16 +1715,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       },
       {
@@ -1748,14 +1748,14 @@
           "group_id": null,
           "enum": "InovelliDimmingMode",
           "options": [
-            "LeadingEdge",
-            "TrailingEdge"
+            "leadingedge",
+            "trailingedge"
           ]
         },
         "state": {
           "class_name": "InovelliDimmingModeEntity",
           "available": true,
-          "state": "LeadingEdge"
+          "state": "leadingedge"
         }
       },
       {
@@ -1779,14 +1779,14 @@
           "group_id": null,
           "enum": "InovelliOutputMode",
           "options": [
-            "Dimmer",
-            "OnOff"
+            "dimmer",
+            "onoff"
           ]
         },
         "state": {
           "class_name": "InovelliOutputModeEntity",
           "available": true,
-          "state": "OnOff"
+          "state": "onoff"
         }
       },
       {
@@ -1810,16 +1810,16 @@
           "group_id": null,
           "enum": "InovelliSwitchType",
           "options": [
-            "Single Pole",
-            "Three Way Dumb",
-            "Three Way AUX",
-            "Single Pole Full Sine"
+            "single_pole",
+            "three_way_dumb",
+            "three_way_aux",
+            "single_pole_full_sine"
           ]
         },
         "state": {
           "class_name": "InovelliSwitchTypeEntity",
           "available": true,
-          "state": "Single Pole"
+          "state": "single_pole"
         }
       }
     ],
@@ -2001,7 +2001,7 @@
         "state": {
           "class_name": "InovelliOverheated",
           "available": true,
-          "state": "Normal"
+          "state": "normal"
         }
       }
     ],

--- a/tests/data/devices/inovelli-vzm35-sn-0x02020107.json
+++ b/tests/data/devices/inovelli-vzm35-sn-0x02020107.json
@@ -1469,16 +1469,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       },
       {
@@ -1502,14 +1502,14 @@
           "group_id": null,
           "enum": "InovelliOutputMode",
           "options": [
-            "Dimmer",
-            "OnOff"
+            "dimmer",
+            "onoff"
           ]
         },
         "state": {
           "class_name": "InovelliOutputModeEntity",
           "available": true,
-          "state": "OnOff"
+          "state": "onoff"
         }
       },
       {
@@ -1533,23 +1533,23 @@
           "group_id": null,
           "enum": "InovelliFanLedScalingMode",
           "options": [
-            "VZM31SN",
-            "Grade 1",
-            "Grade 2",
-            "Grade 3",
-            "Grade 4",
-            "Grade 5",
-            "Grade 6",
-            "Grade 7",
-            "Grade 8",
-            "Grade 9",
-            "Adaptive"
+            "vzm31sn",
+            "grade_1",
+            "grade_2",
+            "grade_3",
+            "grade_4",
+            "grade_5",
+            "grade_6",
+            "grade_7",
+            "grade_8",
+            "grade_9",
+            "adaptive"
           ]
         },
         "state": {
           "class_name": "InovelliFanLedScalingModeEntity",
           "available": true,
-          "state": "Adaptive"
+          "state": "adaptive"
         }
       },
       {
@@ -1573,14 +1573,14 @@
           "group_id": null,
           "enum": "InovelliFanSwitchType",
           "options": [
-            "Load Only",
-            "Three Way AUX"
+            "load_only",
+            "three_way_aux"
           ]
         },
         "state": {
           "class_name": "InovelliFanSwitchTypeEntity",
           "available": true,
-          "state": "Load Only"
+          "state": "load_only"
         }
       }
     ],
@@ -1694,7 +1694,7 @@
         "state": {
           "class_name": "InovelliOverheated",
           "available": true,
-          "state": "Normal"
+          "state": "normal"
         }
       }
     ],

--- a/tests/data/devices/lds-zb-onoffplug-d0005-0x21186230.json
+++ b/tests/data/devices/lds-zb-onoffplug-d0005-0x21186230.json
@@ -440,16 +440,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/legrand-contactor.json
+++ b/tests/data/devices/legrand-contactor.json
@@ -631,16 +631,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/legrand-dimmer-switch-w-o-neutral-0x004d45ff.json
+++ b/tests/data/devices/legrand-dimmer-switch-w-o-neutral-0x004d45ff.json
@@ -682,16 +682,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "Toggle"
+          "state": "toggle"
         }
       }
     ],

--- a/tests/data/devices/legrand-light-switch-with-neutral-0x001c4203.json
+++ b/tests/data/devices/legrand-light-switch-with-neutral-0x001c4203.json
@@ -366,16 +366,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/legrand-light-switch-with-neutral.json
+++ b/tests/data/devices/legrand-light-switch-with-neutral.json
@@ -437,16 +437,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/legrand-mobile-outlet-0x006545ff.json
+++ b/tests/data/devices/legrand-mobile-outlet-0x006545ff.json
@@ -723,16 +723,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/lk-zbt-onoffplug-d0001-0x22036610.json
+++ b/tests/data/devices/lk-zbt-onoffplug-d0001-0x22036610.json
@@ -396,16 +396,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "On"
+          "state": "on"
         }
       }
     ],

--- a/tests/data/devices/lumi-lumi-airrtc-agl001-0x0000001e.json
+++ b/tests/data/devices/lumi-lumi-airrtc-agl001-0x0000001e.json
@@ -638,15 +638,15 @@
           "group_id": null,
           "enum": "AqaraThermostatPresetMode",
           "options": [
-            "Manual",
-            "Auto",
-            "Away"
+            "manual",
+            "auto",
+            "away"
           ]
         },
         "state": {
           "class_name": "AqaraThermostatPreset",
           "available": true,
-          "state": "Manual"
+          "state": "manual"
         }
       }
     ],

--- a/tests/data/devices/lumi-lumi-curtain-acn002-0x00000e1f.json
+++ b/tests/data/devices/lumi-lumi-curtain-acn002-0x00000e1f.json
@@ -530,15 +530,15 @@
           "group_id": null,
           "enum": "AqaraRollerDriverSpeed",
           "options": [
-            "Low",
-            "Medium",
-            "High"
+            "low",
+            "medium",
+            "high"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "High"
+          "state": "high"
         }
       }
     ],
@@ -687,7 +687,7 @@
         "state": {
           "class_name": "WindowCoveringTypeSensor",
           "available": true,
-          "state": "Rollershade"
+          "state": "rollershade"
         }
       }
     ],

--- a/tests/data/devices/lumi-lumi-curtain-acn002-0x00000f20.json
+++ b/tests/data/devices/lumi-lumi-curtain-acn002-0x00000f20.json
@@ -519,15 +519,15 @@
           "group_id": null,
           "enum": "AqaraRollerDriverSpeed",
           "options": [
-            "Low",
-            "Medium",
-            "High"
+            "low",
+            "medium",
+            "high"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "High"
+          "state": "high"
         }
       }
     ],
@@ -676,7 +676,7 @@
         "state": {
           "class_name": "WindowCoveringTypeSensor",
           "available": true,
-          "state": "Rollershade"
+          "state": "rollershade"
         }
       }
     ],

--- a/tests/data/devices/lumi-lumi-curtain-agl001-0x00000018.json
+++ b/tests/data/devices/lumi-lumi-curtain-agl001-0x00000018.json
@@ -459,7 +459,7 @@
         "state": {
           "class_name": "AqaraCurtainMotorPowerSourceSensor",
           "available": true,
-          "state": "Battery"
+          "state": "battery"
         }
       },
       {
@@ -579,7 +579,7 @@
         "state": {
           "class_name": "WindowCoveringTypeSensor",
           "available": true,
-          "state": "Drapery"
+          "state": "drapery"
         }
       },
       {
@@ -607,7 +607,7 @@
         "state": {
           "class_name": "AqaraCurtainHookStateSensor",
           "available": true,
-          "state": "Locked"
+          "state": "locked"
         }
       }
     ],

--- a/tests/data/devices/lumi-lumi-curtain-hagl04.json
+++ b/tests/data/devices/lumi-lumi-curtain-hagl04.json
@@ -442,7 +442,7 @@
         "state": {
           "class_name": "WindowCoveringTypeSensor",
           "available": true,
-          "state": "Drapery"
+          "state": "drapery"
         }
       }
     ],

--- a/tests/data/devices/lumi-lumi-magnet-ac01.json
+++ b/tests/data/devices/lumi-lumi-magnet-ac01.json
@@ -245,15 +245,15 @@
           "group_id": null,
           "enum": "DetectionDistance",
           "options": [
-            "TenMillimeters",
-            "TwentyMillimeters",
-            "ThirtyMillimeters"
+            "tenmillimeters",
+            "twentymillimeters",
+            "thirtymillimeters"
           ]
         },
         "state": {
           "class_name": "AqaraMagnetAC01DetectionDistance",
           "available": true,
-          "state": "TwentyMillimeters"
+          "state": "twentymillimeters"
         }
       }
     ],

--- a/tests/data/devices/lumi-lumi-motion-ac02.json
+++ b/tests/data/devices/lumi-lumi-motion-ac02.json
@@ -372,15 +372,15 @@
           "group_id": null,
           "enum": "AqaraMotionSensitivities",
           "options": [
-            "Low",
-            "Medium",
-            "High"
+            "low",
+            "medium",
+            "high"
           ]
         },
         "state": {
           "class_name": "AqaraMotionSensitivity",
           "available": true,
-          "state": "High"
+          "state": "high"
         }
       }
     ],

--- a/tests/data/devices/lumi-lumi-motion-agl04-0x00000019.json
+++ b/tests/data/devices/lumi-lumi-motion-agl04-0x00000019.json
@@ -355,15 +355,15 @@
           "group_id": null,
           "enum": "AqaraMotionSensitivities",
           "options": [
-            "Low",
-            "Medium",
-            "High"
+            "low",
+            "medium",
+            "high"
           ]
         },
         "state": {
           "class_name": "AqaraMotionSensitivity",
           "available": true,
-          "state": "High"
+          "state": "high"
         }
       }
     ],

--- a/tests/data/devices/lumi-lumi-remote-b28ac1.json
+++ b/tests/data/devices/lumi-lumi-remote-b28ac1.json
@@ -290,8 +290,8 @@
           "group_id": null,
           "enum": "AqaraSwitchClickMode",
           "options": [
-            "Single",
-            "Multiple"
+            "single",
+            "multiple"
           ]
         },
         "state": {
@@ -321,8 +321,8 @@
           "group_id": null,
           "enum": "AqaraSwitchOperationMode",
           "options": [
-            "Command",
-            "Event"
+            "command",
+            "event"
           ]
         },
         "state": {

--- a/tests/data/devices/lumi-lumi-switch-n0agl1-0x0000001e.json
+++ b/tests/data/devices/lumi-lumi-switch-n0agl1-0x0000001e.json
@@ -738,16 +738,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/lumi-lumi-switch-n0agl1.json
+++ b/tests/data/devices/lumi-lumi-switch-n0agl1.json
@@ -738,16 +738,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/namron-as-4512785-0x0000000e.json
+++ b/tests/data/devices/namron-as-4512785-0x0000000e.json
@@ -658,16 +658,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "Off"
+          "state": "off"
         }
       }
     ],

--- a/tests/data/devices/niko-nv-connectable-motor-control-3a-0x21160006.json
+++ b/tests/data/devices/niko-nv-connectable-motor-control-3a-0x21160006.json
@@ -540,7 +540,7 @@
         "state": {
           "class_name": "WindowCoveringTypeSensor",
           "available": true,
-          "state": "Rollershade"
+          "state": "rollershade"
         }
       }
     ],

--- a/tests/data/devices/nodon-sin-4-fp-21.json
+++ b/tests/data/devices/nodon-sin-4-fp-21.json
@@ -505,16 +505,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       },
       {
@@ -538,12 +538,12 @@
           "group_id": null,
           "enum": "NodOnPilotWireMode",
           "options": [
-            "Off",
-            "Comfort",
-            "Eco",
-            "FrostProtection",
-            "ComfortMinus1",
-            "ComfortMinus2"
+            "off",
+            "comfort",
+            "eco",
+            "frostprotection",
+            "comfortminus1",
+            "comfortminus2"
           ]
         },
         "state": {

--- a/tests/data/devices/nodon-sin-4-rs-20-0x00010300.json
+++ b/tests/data/devices/nodon-sin-4-rs-20-0x00010300.json
@@ -565,7 +565,7 @@
         "state": {
           "class_name": "WindowCoveringTypeSensor",
           "available": true,
-          "state": "Tilt_blind_tilt_and_lift"
+          "state": "tilt_blind_tilt_and_lift"
         }
       }
     ],

--- a/tests/data/devices/philips-7602031u7-0x01001d00.json
+++ b/tests/data/devices/philips-7602031u7-0x01001d00.json
@@ -546,16 +546,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "On"
+          "state": "on"
         }
       }
     ],

--- a/tests/data/devices/philips-915005988601-0x01002000.json
+++ b/tests/data/devices/philips-915005988601-0x01002000.json
@@ -498,16 +498,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "On"
+          "state": "on"
         }
       }
     ],

--- a/tests/data/devices/philips-lct014-0x01001a02.json
+++ b/tests/data/devices/philips-lct014-0x01001a02.json
@@ -512,16 +512,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "Off"
+          "state": "off"
         }
       }
     ],

--- a/tests/data/devices/philips-lct026.json
+++ b/tests/data/devices/philips-lct026.json
@@ -504,16 +504,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "On"
+          "state": "on"
         }
       }
     ],

--- a/tests/data/devices/philips-llc020-0x42006734.json
+++ b/tests/data/devices/philips-llc020-0x42006734.json
@@ -500,16 +500,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "Off"
+          "state": "off"
         }
       }
     ],

--- a/tests/data/devices/philips-sml001-0x42006bb7.json
+++ b/tests/data/devices/philips-sml001-0x42006bb7.json
@@ -373,15 +373,15 @@
           "group_id": null,
           "enum": "HueV1MotionSensitivities",
           "options": [
-            "Low",
-            "Medium",
-            "High"
+            "low",
+            "medium",
+            "high"
           ]
         },
         "state": {
           "class_name": "HueV1MotionSensitivity",
           "available": true,
-          "state": "High"
+          "state": "high"
         }
       }
     ],

--- a/tests/data/devices/philips-sml001-0x43007305.json
+++ b/tests/data/devices/philips-sml001-0x43007305.json
@@ -380,15 +380,15 @@
           "group_id": null,
           "enum": "HueV1MotionSensitivities",
           "options": [
-            "Low",
-            "Medium",
-            "High"
+            "low",
+            "medium",
+            "high"
           ]
         },
         "state": {
           "class_name": "HueV1MotionSensitivity",
           "available": true,
-          "state": "Low"
+          "state": "low"
         }
       }
     ],

--- a/tests/data/devices/philips-sml001-0x43007401.json
+++ b/tests/data/devices/philips-sml001-0x43007401.json
@@ -380,15 +380,15 @@
           "group_id": null,
           "enum": "HueV1MotionSensitivities",
           "options": [
-            "Low",
-            "Medium",
-            "High"
+            "low",
+            "medium",
+            "high"
           ]
         },
         "state": {
           "class_name": "HueV1MotionSensitivity",
           "available": true,
-          "state": "High"
+          "state": "high"
         }
       }
     ],

--- a/tests/data/devices/schneider-electric-eko07259-0x01001d00.json
+++ b/tests/data/devices/schneider-electric-eko07259-0x01001d00.json
@@ -2050,17 +2050,17 @@
           "group_id": null,
           "enum": "KeypadLockoutEnum",
           "options": [
-            "Unlock",
-            "Lock1",
-            "Lock2",
-            "Lock3",
-            "Lock4"
+            "unlock",
+            "lock1",
+            "lock2",
+            "lock3",
+            "lock4"
           ]
         },
         "state": {
           "class_name": "KeypadLockout",
           "available": true,
-          "state": "Unlock"
+          "state": "unlock"
         }
       },
       {
@@ -2084,15 +2084,15 @@
           "group_id": null,
           "enum": "SEControlType",
           "options": [
-            "OnOff",
-            "PI",
-            "NoControl"
+            "onoff",
+            "pi",
+            "nocontrol"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "NoControl"
+          "state": "nocontrol"
         }
       },
       {
@@ -2116,15 +2116,15 @@
           "group_id": null,
           "enum": "SEHeatTransferMedium",
           "options": [
-            "Nothing",
-            "Hydronic",
-            "Air"
+            "nothing",
+            "hydronic",
+            "air"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Nothing"
+          "state": "nothing"
         }
       },
       {
@@ -2148,18 +2148,18 @@
           "group_id": null,
           "enum": "SEHeatingEmitterType",
           "options": [
-            "Direct",
-            "Radiator",
-            "FanAssistedRadiator",
-            "RadiantPanel",
-            "Floor",
-            "NotSpecified"
+            "direct",
+            "radiator",
+            "fanassistedradiator",
+            "radiantpanel",
+            "floor",
+            "notspecified"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Floor"
+          "state": "floor"
         }
       },
       {
@@ -2183,20 +2183,20 @@
           "group_id": null,
           "enum": "SEHeatingFuel",
           "options": [
-            "Electricity",
-            "Gas",
-            "Oil",
-            "SolidFuel",
-            "Solar",
-            "ComunityHeating",
-            "HeatPump",
-            "NotSpecified"
+            "electricity",
+            "gas",
+            "oil",
+            "solidfuel",
+            "solar",
+            "comunityheating",
+            "heatpump",
+            "notspecified"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Electricity"
+          "state": "electricity"
         }
       },
       {
@@ -2220,14 +2220,14 @@
           "group_id": null,
           "enum": "SELocalTemperatureSourceSelect",
           "options": [
-            "Ambient",
-            "External"
+            "ambient",
+            "external"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Ambient"
+          "state": "ambient"
         }
       },
       {
@@ -2251,15 +2251,15 @@
           "group_id": null,
           "enum": "SEThermostatApplication",
           "options": [
-            "OccupiedSpace",
-            "Floor",
-            "NotKnown"
+            "occupiedspace",
+            "floor",
+            "notknown"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Floor"
+          "state": "floor"
         }
       },
       {
@@ -2283,19 +2283,19 @@
           "group_id": null,
           "enum": "SETemperatureSensorType",
           "options": [
-            "Sensor2kOhm",
-            "Sensor10kOhm",
-            "Sensor12kOhm",
-            "Sensor15kOhm",
-            "Sensor33kOhm",
-            "Sensor47kOhm",
-            "SensorAbsent"
+            "sensor2kohm",
+            "sensor10kohm",
+            "sensor12kohm",
+            "sensor15kohm",
+            "sensor33kohm",
+            "sensor47kohm",
+            "sensorabsent"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "SensorAbsent"
+          "state": "sensorabsent"
         }
       }
     ],
@@ -2465,7 +2465,7 @@
         "state": {
           "class_name": "EnumSensor",
           "available": true,
-          "state": "NormalOperation"
+          "state": "normaloperation"
         }
       },
       {

--- a/tests/data/devices/schneider-electric-evsckt-outlet-1-0x020a00ff.json
+++ b/tests/data/devices/schneider-electric-evsckt-outlet-1-0x020a00ff.json
@@ -488,16 +488,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "Off"
+          "state": "off"
         }
       }
     ],

--- a/tests/data/devices/schneider-electric-puck-shutter-1-0x020c02ff.json
+++ b/tests/data/devices/schneider-electric-puck-shutter-1-0x020c02ff.json
@@ -683,7 +683,7 @@
         "state": {
           "class_name": "WindowCoveringTypeSensor",
           "available": true,
-          "state": "Tilt_blind_tilt_and_lift"
+          "state": "tilt_blind_tilt_and_lift"
         }
       }
     ],

--- a/tests/data/devices/schneider-electric-s520619-0x01003500.json
+++ b/tests/data/devices/schneider-electric-s520619-0x01003500.json
@@ -791,17 +791,17 @@
           "group_id": null,
           "enum": "KeypadLockoutEnum",
           "options": [
-            "Unlock",
-            "Lock1",
-            "Lock2",
-            "Lock3",
-            "Lock4"
+            "unlock",
+            "lock1",
+            "lock2",
+            "lock3",
+            "lock4"
           ]
         },
         "state": {
           "class_name": "KeypadLockout",
           "available": true,
-          "state": "Unlock"
+          "state": "unlock"
         }
       }
     ],

--- a/tests/data/devices/schneider-electric-socket-outlet-1-0x020612ff.json
+++ b/tests/data/devices/schneider-electric-socket-outlet-1-0x020612ff.json
@@ -578,16 +578,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/schneider-electric-socket-outlet-2-0x020612ff.json
+++ b/tests/data/devices/schneider-electric-socket-outlet-2-0x020612ff.json
@@ -578,16 +578,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/sengled-e1c-nb7-0x0000001a.json
+++ b/tests/data/devices/sengled-e1c-nb7-0x0000001a.json
@@ -326,16 +326,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/shelly-2pm.json
+++ b/tests/data/devices/shelly-2pm.json
@@ -390,7 +390,7 @@
         "state": {
           "class_name": "WindowCoveringTypeSensor",
           "available": true,
-          "state": "Shutter"
+          "state": "shutter"
         }
       }
     ]

--- a/tests/data/devices/shelly-dimmer.json
+++ b/tests/data/devices/shelly-dimmer.json
@@ -813,16 +813,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/signify-netherlands-b-v-lca001-0x01002802.json
+++ b/tests/data/devices/signify-netherlands-b-v-lca001-0x01002802.json
@@ -529,16 +529,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "On"
+          "state": "on"
         }
       }
     ],

--- a/tests/data/devices/signify-netherlands-b-v-lca005-0x01002402.json
+++ b/tests/data/devices/signify-netherlands-b-v-lca005-0x01002402.json
@@ -510,16 +510,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/signify-netherlands-b-v-lca007-0x01001f0a.json
+++ b/tests/data/devices/signify-netherlands-b-v-lca007-0x01001f0a.json
@@ -498,16 +498,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/signify-netherlands-b-v-lcb001-0x01002800.json
+++ b/tests/data/devices/signify-netherlands-b-v-lcb001-0x01002800.json
@@ -535,16 +535,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/signify-netherlands-b-v-lcb002-0x01001f0a.json
+++ b/tests/data/devices/signify-netherlands-b-v-lcb002-0x01001f0a.json
@@ -498,16 +498,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/signify-netherlands-b-v-lce001-0x01002404.json
+++ b/tests/data/devices/signify-netherlands-b-v-lce001-0x01002404.json
@@ -498,16 +498,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "On"
+          "state": "on"
         }
       }
     ],

--- a/tests/data/devices/signify-netherlands-b-v-lcg006-0x01002502.json
+++ b/tests/data/devices/signify-netherlands-b-v-lcg006-0x01002502.json
@@ -498,16 +498,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/signify-netherlands-b-v-lcx004-0x01001802.json
+++ b/tests/data/devices/signify-netherlands-b-v-lcx004-0x01001802.json
@@ -492,16 +492,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/signify-netherlands-b-v-lta010-0x01002402.json
+++ b/tests/data/devices/signify-netherlands-b-v-lta010-0x01002402.json
@@ -486,16 +486,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "On"
+          "state": "on"
         }
       }
     ],

--- a/tests/data/devices/signify-netherlands-b-v-ltb003-0x01001f0a.json
+++ b/tests/data/devices/signify-netherlands-b-v-ltb003-0x01001f0a.json
@@ -492,16 +492,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/signify-netherlands-b-v-lwa003-0x01001f0a.json
+++ b/tests/data/devices/signify-netherlands-b-v-lwa003-0x01001f0a.json
@@ -369,16 +369,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/signify-netherlands-b-v-sml003-0x02003506.json
+++ b/tests/data/devices/signify-netherlands-b-v-sml003-0x02003506.json
@@ -337,17 +337,17 @@
           "group_id": null,
           "enum": "HueV2MotionSensitivities",
           "options": [
-            "Lowest",
-            "Low",
-            "Medium",
-            "High",
-            "Highest"
+            "lowest",
+            "low",
+            "medium",
+            "high",
+            "highest"
           ]
         },
         "state": {
           "class_name": "HueV2MotionSensitivity",
           "available": true,
-          "state": "High"
+          "state": "high"
         }
       }
     ],

--- a/tests/data/devices/signify-netherlands-b-v-sml004-0x02003506.json
+++ b/tests/data/devices/signify-netherlands-b-v-sml004-0x02003506.json
@@ -337,17 +337,17 @@
           "group_id": null,
           "enum": "HueV2MotionSensitivities",
           "options": [
-            "Lowest",
-            "Low",
-            "Medium",
-            "High",
-            "Highest"
+            "lowest",
+            "low",
+            "medium",
+            "high",
+            "highest"
           ]
         },
         "state": {
           "class_name": "HueV2MotionSensitivity",
           "available": true,
-          "state": "Lowest"
+          "state": "lowest"
         }
       }
     ],

--- a/tests/data/devices/smartwings-wm25-l-z-0x00000002.json
+++ b/tests/data/devices/smartwings-wm25-l-z-0x00000002.json
@@ -480,7 +480,7 @@
         "state": {
           "class_name": "WindowCoveringTypeSensor",
           "available": true,
-          "state": "Rollershade"
+          "state": "rollershade"
         }
       }
     ],

--- a/tests/data/devices/somfy-sonesse-28-wf-li-ion-roller-0x4100e158.json
+++ b/tests/data/devices/somfy-sonesse-28-wf-li-ion-roller-0x4100e158.json
@@ -433,7 +433,7 @@
         "state": {
           "class_name": "WindowCoveringTypeSensor",
           "available": true,
-          "state": "Rollershade"
+          "state": "rollershade"
         }
       },
       {

--- a/tests/data/devices/sonoff-dongle-e-r.json
+++ b/tests/data/devices/sonoff-dongle-e-r.json
@@ -638,16 +638,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       },
       {
@@ -671,16 +671,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/sonoff-mini-zbdim-0x00001005.json
+++ b/tests/data/devices/sonoff-mini-zbdim-0x00001005.json
@@ -619,16 +619,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/sonoff-mini-zbrbs-0x00001005.json
+++ b/tests/data/devices/sonoff-mini-zbrbs-0x00001005.json
@@ -393,8 +393,8 @@
           "group_id": null,
           "enum": "SonoffExternalSwitchTriggerType",
           "options": [
-            "edge trigger",
-            "pulse trigger"
+            "edge_trigger",
+            "pulse_trigger"
           ]
         },
         "state": {
@@ -486,7 +486,7 @@
         "state": {
           "class_name": "WindowCoveringTypeSensor",
           "available": true,
-          "state": "Rollershade"
+          "state": "rollershade"
         }
       },
       {

--- a/tests/data/devices/sonoff-s60zbtpg-0x00001002.json
+++ b/tests/data/devices/sonoff-s60zbtpg-0x00001002.json
@@ -572,16 +572,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "Off"
+          "state": "off"
         }
       }
     ],

--- a/tests/data/devices/sonoff-snzb-02d-0x00002300.json
+++ b/tests/data/devices/sonoff-snzb-02d-0x00002300.json
@@ -451,14 +451,14 @@
           "group_id": null,
           "enum": "TemperatureUnit",
           "options": [
-            "Celsius",
-            "Fahrenheit"
+            "celsius",
+            "fahrenheit"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Fahrenheit"
+          "state": "fahrenheit"
         }
       }
     ],

--- a/tests/data/devices/sonoff-snzb-06p-0x00001006.json
+++ b/tests/data/devices/sonoff-snzb-06p-0x00001006.json
@@ -281,15 +281,15 @@
           "group_id": null,
           "enum": "SonoffPresenceDetectionSensitivityEnum",
           "options": [
-            "Low",
-            "Medium",
-            "High"
+            "low",
+            "medium",
+            "high"
           ]
         },
         "state": {
           "class_name": "SonoffPresenceDetectionSensitivity",
           "available": true,
-          "state": "Low"
+          "state": "low"
         }
       }
     ],
@@ -375,7 +375,7 @@
         "state": {
           "class_name": "SonoffPresenceSenorIlluminationStatus",
           "available": true,
-          "state": "Light"
+          "state": "light"
         }
       }
     ],

--- a/tests/data/devices/sonoff-zbmicro-0x00001005.json
+++ b/tests/data/devices/sonoff-zbmicro-0x00001005.json
@@ -228,16 +228,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/sonoff-zbminil2-0x0000100e.json
+++ b/tests/data/devices/sonoff-zbminil2-0x0000100e.json
@@ -236,16 +236,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "Toggle"
+          "state": "toggle"
         }
       }
     ],

--- a/tests/data/devices/sonoff-zbminir2-0x00001004.json
+++ b/tests/data/devices/sonoff-zbminir2-0x00001004.json
@@ -367,16 +367,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "Off"
+          "state": "off"
         }
       },
       {
@@ -400,16 +400,16 @@
           "group_id": null,
           "enum": "SonoffExternalSwitchTriggerType",
           "options": [
-            "Edge trigger",
-            "Pulse trigger",
-            "Normally off follow trigger",
-            "Normally on follow trigger"
+            "edge_trigger",
+            "pulse_trigger",
+            "normally_off_follow_trigger",
+            "normally_on_follow_trigger"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Edge trigger"
+          "state": "edge_trigger"
         }
       }
     ],

--- a/tests/data/devices/sunricher-hk-dim-0x00000036.json
+++ b/tests/data/devices/sunricher-hk-dim-0x00000036.json
@@ -980,16 +980,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/sunricher-hk-ln-dim-a-0x00000039.json
+++ b/tests/data/devices/sunricher-hk-ln-dim-a-0x00000039.json
@@ -457,16 +457,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/sunricher-on-off-2ch-0x00000004.json
+++ b/tests/data/devices/sunricher-on-off-2ch-0x00000004.json
@@ -795,16 +795,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       },
       {
@@ -828,16 +828,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "Off"
+          "state": "off"
         }
       }
     ],

--- a/tests/data/devices/the-home-depot-ecosmart-zbt-a19-cct-bulb-0x21036500.json
+++ b/tests/data/devices/the-home-depot-ecosmart-zbt-a19-cct-bulb-0x21036500.json
@@ -584,16 +584,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/third-reality-inc-3rsb015bz-0x00000048.json
+++ b/tests/data/devices/third-reality-inc-3rsb015bz-0x00000048.json
@@ -518,7 +518,7 @@
         "state": {
           "class_name": "WindowCoveringTypeSensor",
           "available": true,
-          "state": "Rollershade"
+          "state": "rollershade"
         }
       }
     ],

--- a/tests/data/devices/third-reality-inc-3rsnl02043z-0x0000003c.json
+++ b/tests/data/devices/third-reality-inc-3rsnl02043z-0x0000003c.json
@@ -609,16 +609,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/third-reality-inc-3rsp019bz-0x1001301e.json
+++ b/tests/data/devices/third-reality-inc-3rsp019bz-0x1001301e.json
@@ -367,16 +367,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/third-reality-inc-3rsp02028bz-0x10013058.json
+++ b/tests/data/devices/third-reality-inc-3rsp02028bz-0x10013058.json
@@ -542,16 +542,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "Off"
+          "state": "off"
         }
       }
     ],

--- a/tests/data/devices/third-reality-inc-3rsp02064z-0x0000002f.json
+++ b/tests/data/devices/third-reality-inc-3rsp02064z-0x0000002f.json
@@ -742,16 +742,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "Off"
+          "state": "off"
         }
       }
     ],

--- a/tests/data/devices/tyst11-czk78ptr-zk78ptr.json
+++ b/tests/data/devices/tyst11-czk78ptr-zk78ptr.json
@@ -341,17 +341,17 @@
           "group_id": null,
           "enum": "KeypadLockoutEnum",
           "options": [
-            "Unlock",
-            "Lock1",
-            "Lock2",
-            "Lock3",
-            "Lock4"
+            "unlock",
+            "lock1",
+            "lock2",
+            "lock3",
+            "lock4"
           ]
         },
         "state": {
           "class_name": "KeypadLockout",
           "available": true,
-          "state": "Unlock"
+          "state": "unlock"
         }
       }
     ],

--- a/tests/data/devices/tyzb01-8scntis1-ts0216.json
+++ b/tests/data/devices/tyzb01-8scntis1-ts0216.json
@@ -314,10 +314,10 @@
           "group_id": null,
           "enum": "SirenLevel",
           "options": [
-            "Low level sound",
-            "Medium level sound",
-            "High level sound",
-            "Very high level sound"
+            "low_level_sound",
+            "medium_level_sound",
+            "high_level_sound",
+            "very_high_level_sound"
           ]
         },
         "state": {
@@ -378,10 +378,10 @@
           "group_id": null,
           "enum": "StrobeLevel",
           "options": [
-            "Low level strobe",
-            "Medium level strobe",
-            "High level strobe",
-            "Very high level strobe"
+            "low_level_strobe",
+            "medium_level_strobe",
+            "high_level_strobe",
+            "very_high_level_strobe"
           ]
         },
         "state": {
@@ -411,13 +411,13 @@
           "group_id": null,
           "enum": "WarningMode",
           "options": [
-            "Stop",
-            "Burglar",
-            "Fire",
-            "Emergency",
-            "Police Panic",
-            "Fire Panic",
-            "Emergency Panic"
+            "stop",
+            "burglar",
+            "fire",
+            "emergency",
+            "police_panic",
+            "fire_panic",
+            "emergency_panic"
           ]
         },
         "state": {

--- a/tests/data/devices/tz2000-k4yr34vv-sm0301.json
+++ b/tests/data/devices/tz2000-k4yr34vv-sm0301.json
@@ -443,16 +443,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "On"
+          "state": "on"
         }
       }
     ],

--- a/tests/data/devices/tz3000-303avxxt-ts011f.json
+++ b/tests/data/devices/tz3000-303avxxt-ts011f.json
@@ -524,15 +524,15 @@
           "group_id": null,
           "enum": "TuyaBacklightMode",
           "options": [
-            "Off",
-            "LightWhenOn",
-            "LightWhenOff"
+            "off",
+            "lightwhenon",
+            "lightwhenoff"
           ]
         },
         "state": {
           "class_name": "TuyaBacklightModeSelectEntity",
           "available": true,
-          "state": "LightWhenOn"
+          "state": "lightwhenon"
         }
       },
       {
@@ -556,15 +556,15 @@
           "group_id": null,
           "enum": "TuyaPowerOnState",
           "options": [
-            "Off",
-            "On",
-            "LastState"
+            "off",
+            "on",
+            "laststate"
           ]
         },
         "state": {
           "class_name": "TuyaPowerOnStateSelectEntity",
           "available": true,
-          "state": "LastState"
+          "state": "laststate"
         }
       }
     ],

--- a/tests/data/devices/tz3000-8nkb7mof-ts0121-0x00000042.json
+++ b/tests/data/devices/tz3000-8nkb7mof-ts0121-0x00000042.json
@@ -496,15 +496,15 @@
           "group_id": null,
           "enum": "TuyaBacklightMode",
           "options": [
-            "Off",
-            "LightWhenOn",
-            "LightWhenOff"
+            "off",
+            "lightwhenon",
+            "lightwhenoff"
           ]
         },
         "state": {
           "class_name": "TuyaBacklightModeSelectEntity",
           "available": true,
-          "state": "LightWhenOn"
+          "state": "lightwhenon"
         }
       },
       {
@@ -528,15 +528,15 @@
           "group_id": null,
           "enum": "TuyaPowerOnState",
           "options": [
-            "Off",
-            "On",
-            "LastState"
+            "off",
+            "on",
+            "laststate"
           ]
         },
         "state": {
           "class_name": "TuyaPowerOnStateSelectEntity",
           "available": true,
-          "state": "On"
+          "state": "on"
         }
       }
     ],

--- a/tests/data/devices/tz3000-drc9tuqb-ts0001-0x00000047.json
+++ b/tests/data/devices/tz3000-drc9tuqb-ts0001-0x00000047.json
@@ -333,15 +333,15 @@
           "group_id": null,
           "enum": "TuyaBacklightMode",
           "options": [
-            "Off",
-            "LightWhenOn",
-            "LightWhenOff"
+            "off",
+            "lightwhenon",
+            "lightwhenoff"
           ]
         },
         "state": {
           "class_name": "TuyaBacklightModeSelectEntity",
           "available": true,
-          "state": "Off"
+          "state": "off"
         }
       },
       {
@@ -365,15 +365,15 @@
           "group_id": null,
           "enum": "TuyaPowerOnState",
           "options": [
-            "Off",
-            "On",
-            "LastState"
+            "off",
+            "on",
+            "laststate"
           ]
         },
         "state": {
           "class_name": "TuyaPowerOnStateSelectEntity",
           "available": true,
-          "state": "LastState"
+          "state": "laststate"
         }
       }
     ],

--- a/tests/data/devices/tz3000-mw1pqqqt-ts0003-0x0000004a.json
+++ b/tests/data/devices/tz3000-mw1pqqqt-ts0003-0x0000004a.json
@@ -888,15 +888,15 @@
           "group_id": null,
           "enum": "TuyaBacklightMode",
           "options": [
-            "Off",
-            "LightWhenOn",
-            "LightWhenOff"
+            "off",
+            "lightwhenon",
+            "lightwhenoff"
           ]
         },
         "state": {
           "class_name": "TuyaBacklightModeSelectEntity",
           "available": true,
-          "state": "LightWhenOn"
+          "state": "lightwhenon"
         }
       },
       {
@@ -920,15 +920,15 @@
           "group_id": null,
           "enum": "TuyaPowerOnState",
           "options": [
-            "Off",
-            "On",
-            "LastState"
+            "off",
+            "on",
+            "laststate"
           ]
         },
         "state": {
           "class_name": "TuyaPowerOnStateSelectEntity",
           "available": true,
-          "state": "LastState"
+          "state": "laststate"
         }
       }
     ],

--- a/tests/data/devices/tz3000-okaz9tjs-ts011f.json
+++ b/tests/data/devices/tz3000-okaz9tjs-ts011f.json
@@ -452,16 +452,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/tz3000-p26flek3-ts0001-0x00000053.json
+++ b/tests/data/devices/tz3000-p26flek3-ts0001-0x00000053.json
@@ -340,15 +340,15 @@
           "group_id": null,
           "enum": "TuyaBacklightMode",
           "options": [
-            "Off",
-            "LightWhenOn",
-            "LightWhenOff"
+            "off",
+            "lightwhenon",
+            "lightwhenoff"
           ]
         },
         "state": {
           "class_name": "TuyaBacklightModeSelectEntity",
           "available": true,
-          "state": "Off"
+          "state": "off"
         }
       },
       {
@@ -372,15 +372,15 @@
           "group_id": null,
           "enum": "TuyaPowerOnState",
           "options": [
-            "Off",
-            "On",
-            "LastState"
+            "off",
+            "on",
+            "laststate"
           ]
         },
         "state": {
           "class_name": "TuyaPowerOnStateSelectEntity",
           "available": true,
-          "state": "LastState"
+          "state": "laststate"
         }
       }
     ],

--- a/tests/data/devices/tz3000-sgb0xhwn-ts011f-0x00000050.json
+++ b/tests/data/devices/tz3000-sgb0xhwn-ts011f-0x00000050.json
@@ -682,15 +682,15 @@
           "group_id": null,
           "enum": "TuyaBacklightMode",
           "options": [
-            "Off",
-            "LightWhenOn",
-            "LightWhenOff"
+            "off",
+            "lightwhenon",
+            "lightwhenoff"
           ]
         },
         "state": {
           "class_name": "TuyaBacklightModeSelectEntity",
           "available": true,
-          "state": "LightWhenOn"
+          "state": "lightwhenon"
         }
       },
       {
@@ -714,15 +714,15 @@
           "group_id": null,
           "enum": "TuyaPowerOnState",
           "options": [
-            "Off",
-            "On",
-            "LastState"
+            "off",
+            "on",
+            "laststate"
           ]
         },
         "state": {
           "class_name": "TuyaPowerOnStateSelectEntity",
           "available": true,
-          "state": "LastState"
+          "state": "laststate"
         }
       }
     ],

--- a/tests/data/devices/tz3000-tqlv4ug4-ts0001-0x00000048.json
+++ b/tests/data/devices/tz3000-tqlv4ug4-ts0001-0x00000048.json
@@ -666,15 +666,15 @@
           "group_id": null,
           "enum": "TuyaBacklightMode",
           "options": [
-            "Off",
-            "LightWhenOn",
-            "LightWhenOff"
+            "off",
+            "lightwhenon",
+            "lightwhenoff"
           ]
         },
         "state": {
           "class_name": "TuyaBacklightModeSelectEntity",
           "available": true,
-          "state": "LightWhenOn"
+          "state": "lightwhenon"
         }
       },
       {
@@ -698,15 +698,15 @@
           "group_id": null,
           "enum": "TuyaPowerOnState",
           "options": [
-            "Off",
-            "On",
-            "LastState"
+            "off",
+            "on",
+            "laststate"
           ]
         },
         "state": {
           "class_name": "TuyaPowerOnStateSelectEntity",
           "available": true,
-          "state": "On"
+          "state": "on"
         }
       }
     ],

--- a/tests/data/devices/tz3000-typdpbpg-ts011f-0x10013607.json
+++ b/tests/data/devices/tz3000-typdpbpg-ts011f-0x10013607.json
@@ -628,16 +628,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "On"
+          "state": "on"
         }
       },
       {
@@ -661,15 +661,15 @@
           "group_id": null,
           "enum": "TuyaBacklightMode",
           "options": [
-            "Off",
-            "LightWhenOn",
-            "LightWhenOff"
+            "off",
+            "lightwhenon",
+            "lightwhenoff"
           ]
         },
         "state": {
           "class_name": "TuyaBacklightModeSelectEntity",
           "available": true,
-          "state": "LightWhenOn"
+          "state": "lightwhenon"
         }
       },
       {
@@ -693,15 +693,15 @@
           "group_id": null,
           "enum": "TuyaPowerOnState",
           "options": [
-            "Off",
-            "On",
-            "LastState"
+            "off",
+            "on",
+            "laststate"
           ]
         },
         "state": {
           "class_name": "TuyaPowerOnStateSelectEntity",
           "available": true,
-          "state": "On"
+          "state": "on"
         }
       }
     ],

--- a/tests/data/devices/tz3000-u3oupgdy-ts0004-0x00000050.json
+++ b/tests/data/devices/tz3000-u3oupgdy-ts0004-0x00000050.json
@@ -757,15 +757,15 @@
           "group_id": null,
           "enum": "TuyaBacklightMode",
           "options": [
-            "Off",
-            "LightWhenOn",
-            "LightWhenOff"
+            "off",
+            "lightwhenon",
+            "lightwhenoff"
           ]
         },
         "state": {
           "class_name": "TuyaBacklightModeSelectEntity",
           "available": true,
-          "state": "LightWhenOn"
+          "state": "lightwhenon"
         }
       },
       {
@@ -789,15 +789,15 @@
           "group_id": null,
           "enum": "TuyaPowerOnState",
           "options": [
-            "Off",
-            "On",
-            "LastState"
+            "off",
+            "on",
+            "laststate"
           ]
         },
         "state": {
           "class_name": "TuyaPowerOnStateSelectEntity",
           "available": true,
-          "state": "Off"
+          "state": "off"
         }
       }
     ],

--- a/tests/data/devices/tz3000-u4kojtqz-ts0002-0x10013607.json
+++ b/tests/data/devices/tz3000-u4kojtqz-ts0002-0x10013607.json
@@ -442,16 +442,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       },
       {
@@ -475,16 +475,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/tz3000-w0qqde0g-ts011f.json
+++ b/tests/data/devices/tz3000-w0qqde0g-ts011f.json
@@ -470,15 +470,15 @@
           "group_id": null,
           "enum": "TuyaBacklightMode",
           "options": [
-            "Off",
-            "LightWhenOn",
-            "LightWhenOff"
+            "off",
+            "lightwhenon",
+            "lightwhenoff"
           ]
         },
         "state": {
           "class_name": "TuyaBacklightModeSelectEntity",
           "available": true,
-          "state": "LightWhenOn"
+          "state": "lightwhenon"
         }
       },
       {
@@ -502,15 +502,15 @@
           "group_id": null,
           "enum": "TuyaPowerOnState",
           "options": [
-            "Off",
-            "On",
-            "LastState"
+            "off",
+            "on",
+            "laststate"
           ]
         },
         "state": {
           "class_name": "TuyaPowerOnStateSelectEntity",
           "available": true,
-          "state": "LastState"
+          "state": "laststate"
         }
       }
     ],

--- a/tests/data/devices/tz3000-wkr3jqmr-ts0004.json
+++ b/tests/data/devices/tz3000-wkr3jqmr-ts0004.json
@@ -780,15 +780,15 @@
           "group_id": null,
           "enum": "TuyaBacklightMode",
           "options": [
-            "Off",
-            "LightWhenOn",
-            "LightWhenOff"
+            "off",
+            "lightwhenon",
+            "lightwhenoff"
           ]
         },
         "state": {
           "class_name": "TuyaBacklightModeSelectEntity",
           "available": true,
-          "state": "LightWhenOn"
+          "state": "lightwhenon"
         }
       },
       {
@@ -812,15 +812,15 @@
           "group_id": null,
           "enum": "TuyaPowerOnState",
           "options": [
-            "Off",
-            "On",
-            "LastState"
+            "off",
+            "on",
+            "laststate"
           ]
         },
         "state": {
           "class_name": "TuyaPowerOnStateSelectEntity",
           "available": true,
-          "state": "LastState"
+          "state": "laststate"
         }
       }
     ],

--- a/tests/data/devices/tz3000-wn65ixz9-ts0001-0x00000051.json
+++ b/tests/data/devices/tz3000-wn65ixz9-ts0001-0x00000051.json
@@ -333,15 +333,15 @@
           "group_id": null,
           "enum": "TuyaBacklightMode",
           "options": [
-            "Off",
-            "LightWhenOn",
-            "LightWhenOff"
+            "off",
+            "lightwhenon",
+            "lightwhenoff"
           ]
         },
         "state": {
           "class_name": "TuyaBacklightModeSelectEntity",
           "available": true,
-          "state": "LightWhenOn"
+          "state": "lightwhenon"
         }
       },
       {
@@ -365,15 +365,15 @@
           "group_id": null,
           "enum": "TuyaPowerOnState",
           "options": [
-            "Off",
-            "On",
-            "LastState"
+            "off",
+            "on",
+            "laststate"
           ]
         },
         "state": {
           "class_name": "TuyaPowerOnStateSelectEntity",
           "available": true,
-          "state": "On"
+          "state": "on"
         }
       }
     ],

--- a/tests/data/devices/tz3000-xkap8wtb-ts000f.json
+++ b/tests/data/devices/tz3000-xkap8wtb-ts000f.json
@@ -527,16 +527,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "On"
+          "state": "on"
         }
       }
     ],

--- a/tests/data/devices/tz3000-xxacnuab-ts0004.json
+++ b/tests/data/devices/tz3000-xxacnuab-ts0004.json
@@ -744,15 +744,15 @@
           "group_id": null,
           "enum": "TuyaPowerOnState",
           "options": [
-            "Off",
-            "On",
-            "LastState"
+            "off",
+            "on",
+            "laststate"
           ]
         },
         "state": {
           "class_name": "TuyaPowerOnStateSelectEntity",
           "available": true,
-          "state": "Off"
+          "state": "off"
         }
       }
     ],

--- a/tests/data/devices/tz3000-zv6x8bt2-ts011f.json
+++ b/tests/data/devices/tz3000-zv6x8bt2-ts011f.json
@@ -630,15 +630,15 @@
           "group_id": null,
           "enum": "TuyaBacklightMode",
           "options": [
-            "Off",
-            "LightWhenOn",
-            "LightWhenOff"
+            "off",
+            "lightwhenon",
+            "lightwhenoff"
           ]
         },
         "state": {
           "class_name": "TuyaBacklightModeSelectEntity",
           "available": true,
-          "state": "LightWhenOn"
+          "state": "lightwhenon"
         }
       },
       {
@@ -662,15 +662,15 @@
           "group_id": null,
           "enum": "TuyaPowerOnState",
           "options": [
-            "Off",
-            "On",
-            "LastState"
+            "off",
+            "on",
+            "laststate"
           ]
         },
         "state": {
           "class_name": "TuyaPowerOnStateSelectEntity",
           "available": true,
-          "state": "LastState"
+          "state": "laststate"
         }
       }
     ],

--- a/tests/data/devices/tz3210-bfwvfyx1-ts0505b.json
+++ b/tests/data/devices/tz3210-bfwvfyx1-ts0505b.json
@@ -478,16 +478,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/tz3210-j4pdtz9v-ts0001-0x00000062.json
+++ b/tests/data/devices/tz3210-j4pdtz9v-ts0001-0x00000062.json
@@ -318,15 +318,15 @@
           "group_id": null,
           "enum": "FingerBotMode",
           "options": [
-            "CLICK",
-            "SWITCH",
-            "PROGRAM"
+            "click",
+            "switch",
+            "program"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "SWITCH"
+          "state": "switch"
         }
       },
       {
@@ -350,8 +350,8 @@
           "group_id": null,
           "enum": "FingerBotReverse",
           "options": [
-            "UP ON",
-            "UP OFF"
+            "up_on",
+            "up_off"
           ]
         },
         "state": {

--- a/tests/data/devices/tz3210-r5afgmkl-ts0505b-0x10013607.json
+++ b/tests/data/devices/tz3210-r5afgmkl-ts0505b-0x10013607.json
@@ -554,16 +554,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/tze200-1n2zev06-ts0601.json
+++ b/tests/data/devices/tze200-1n2zev06-ts0601.json
@@ -228,10 +228,10 @@
           "group_id": null,
           "enum": "TuyaValveWeatherDelay",
           "options": [
-            "Disabled",
-            "Delayed 24h",
-            "Delayed 48h",
-            "Delayed 72h"
+            "disabled",
+            "delayed_24h",
+            "delayed_48h",
+            "delayed_72h"
           ]
         },
         "state": {

--- a/tests/data/devices/tze200-2aaelwxk-ts0225.json
+++ b/tests/data/devices/tze200-2aaelwxk-ts0225.json
@@ -1111,12 +1111,12 @@
           "group_id": null,
           "enum": "TuyaPresenceStateV02",
           "options": [
-            "Unoccupied",
-            "Large",
-            "Medium",
-            "Small",
-            "Huge",
-            "Gigantic"
+            "unoccupied",
+            "large",
+            "medium",
+            "small",
+            "huge",
+            "gigantic"
           ]
         },
         "state": {

--- a/tests/data/devices/tze200-3towulqd-ts0601-0x00000046.json
+++ b/tests/data/devices/tze200-3towulqd-ts0601-0x00000046.json
@@ -319,16 +319,16 @@
           "group_id": null,
           "enum": "TuyaMotionFadeTime",
           "options": [
-            " 10 seconds",
-            " 30 seconds",
-            " 60 seconds",
-            " 120 seconds"
+            "_10_seconds",
+            "_30_seconds",
+            "_60_seconds",
+            "_120_seconds"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": " 10 seconds"
+          "state": "_10_seconds"
         }
       },
       {
@@ -352,15 +352,15 @@
           "group_id": null,
           "enum": "TuyaMotionPresenceSensitivity",
           "options": [
-            "Low",
-            "Medium",
-            "High"
+            "low",
+            "medium",
+            "high"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Medium"
+          "state": "medium"
         }
       }
     ],

--- a/tests/data/devices/tze200-7ytb3h8u-ts0601-0x00000048.json
+++ b/tests/data/devices/tze200-7ytb3h8u-ts0601-0x00000048.json
@@ -379,14 +379,14 @@
           "group_id": null,
           "enum": "GiexIrrigationMode",
           "options": [
-            "Duration",
-            "Capacity"
+            "duration",
+            "capacity"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Duration"
+          "state": "duration"
         }
       },
       {
@@ -410,10 +410,10 @@
           "group_id": null,
           "enum": "GiexIrrigationWeatherDelay",
           "options": [
-            "NoDelay",
-            "TwentyFourHourDelay",
-            "FortyEightHourDelay",
-            "SeventyTwoHourDelay"
+            "nodelay",
+            "twentyfourhourdelay",
+            "fortyeighthourdelay",
+            "seventytwohourdelay"
           ]
         },
         "state": {

--- a/tests/data/devices/tze200-81isopgh-ts0601-0x00000048.json
+++ b/tests/data/devices/tze200-81isopgh-ts0601-0x00000048.json
@@ -314,10 +314,10 @@
           "group_id": null,
           "enum": "TuyaValveWeatherDelay",
           "options": [
-            "Disabled",
-            "Delayed 24h",
-            "Delayed 48h",
-            "Delayed 72h"
+            "disabled",
+            "delayed_24h",
+            "delayed_48h",
+            "delayed_72h"
           ]
         },
         "state": {

--- a/tests/data/devices/tze200-9caxna4s-ts0301-0x00000049.json
+++ b/tests/data/devices/tze200-9caxna4s-ts0301-0x00000049.json
@@ -412,7 +412,7 @@
         "state": {
           "class_name": "WindowCoveringTypeSensor",
           "available": true,
-          "state": "Rollershade"
+          "state": "rollershade"
         }
       }
     ],

--- a/tests/data/devices/tze200-a7sghmms-ts0601-0x00000048.json
+++ b/tests/data/devices/tze200-a7sghmms-ts0601-0x00000048.json
@@ -385,14 +385,14 @@
           "group_id": null,
           "enum": "GiexIrrigationMode",
           "options": [
-            "Duration",
-            "Capacity"
+            "duration",
+            "capacity"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Duration"
+          "state": "duration"
         }
       },
       {
@@ -416,16 +416,16 @@
           "group_id": null,
           "enum": "GiexIrrigationWeatherDelay",
           "options": [
-            "NoDelay",
-            "TwentyFourHourDelay",
-            "FortyEightHourDelay",
-            "SeventyTwoHourDelay"
+            "nodelay",
+            "twentyfourhourdelay",
+            "fortyeighthourdelay",
+            "seventytwohourdelay"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "NoDelay"
+          "state": "nodelay"
         }
       }
     ],

--- a/tests/data/devices/tze200-a7sghmms-ts0601.json
+++ b/tests/data/devices/tze200-a7sghmms-ts0601.json
@@ -305,8 +305,8 @@
           "group_id": null,
           "enum": "GiexIrrigationMode",
           "options": [
-            "Duration",
-            "Capacity"
+            "duration",
+            "capacity"
           ]
         },
         "state": {
@@ -336,10 +336,10 @@
           "group_id": null,
           "enum": "GiexIrrigationWeatherDelay",
           "options": [
-            "NoDelay",
-            "TwentyFourHourDelay",
-            "FortyEightHourDelay",
-            "SeventyTwoHourDelay"
+            "nodelay",
+            "twentyfourhourdelay",
+            "fortyeighthourdelay",
+            "seventytwohourdelay"
           ]
         },
         "state": {

--- a/tests/data/devices/tze200-aoclfnxz-ts0601.json
+++ b/tests/data/devices/tze200-aoclfnxz-ts0601.json
@@ -362,17 +362,17 @@
           "group_id": null,
           "enum": "KeypadLockoutEnum",
           "options": [
-            "Unlock",
-            "Lock1",
-            "Lock2",
-            "Lock3",
-            "Lock4"
+            "unlock",
+            "lock1",
+            "lock2",
+            "lock3",
+            "lock4"
           ]
         },
         "state": {
           "class_name": "KeypadLockout",
           "available": true,
-          "state": "Unlock"
+          "state": "unlock"
         }
       }
     ],

--- a/tests/data/devices/tze200-cirvgep4-ts0601-0x00000048.json
+++ b/tests/data/devices/tze200-cirvgep4-ts0601-0x00000048.json
@@ -206,8 +206,8 @@
           "group_id": null,
           "enum": "TuyaTempUnitConvert",
           "options": [
-            "Celsius",
-            "Fahrenheit"
+            "celsius",
+            "fahrenheit"
           ]
         },
         "state": {

--- a/tests/data/devices/tze200-cpmgn2cf-ts0601.json
+++ b/tests/data/devices/tze200-cpmgn2cf-ts0601.json
@@ -1322,17 +1322,17 @@
           "group_id": null,
           "enum": "KeypadLockoutEnum",
           "options": [
-            "Unlock",
-            "Lock1",
-            "Lock2",
-            "Lock3",
-            "Lock4"
+            "unlock",
+            "lock1",
+            "lock2",
+            "lock3",
+            "lock4"
           ]
         },
         "state": {
           "class_name": "KeypadLockout",
           "available": true,
-          "state": "Unlock"
+          "state": "unlock"
         }
       }
     ],

--- a/tests/data/devices/tze200-crq3r3la-ck-bl702-mws-01-7016.json
+++ b/tests/data/devices/tze200-crq3r3la-ck-bl702-mws-01-7016.json
@@ -557,12 +557,12 @@
           "group_id": null,
           "enum": "TuyaPresenceStateV02",
           "options": [
-            "Unoccupied",
-            "Large",
-            "Medium",
-            "Small",
-            "Huge",
-            "Gigantic"
+            "unoccupied",
+            "large",
+            "medium",
+            "small",
+            "huge",
+            "gigantic"
           ]
         },
         "state": {

--- a/tests/data/devices/tze200-gjldowol-ts0601-0x00000050.json
+++ b/tests/data/devices/tze200-gjldowol-ts0601-0x00000050.json
@@ -279,9 +279,9 @@
           "group_id": null,
           "enum": "TuyaSensitivityMode",
           "options": [
-            "Low",
-            "Medium",
-            "High"
+            "low",
+            "medium",
+            "high"
           ]
         },
         "state": {

--- a/tests/data/devices/tze200-hhrtiq0x-ts0601-0x00000055.json
+++ b/tests/data/devices/tze200-hhrtiq0x-ts0601-0x00000055.json
@@ -316,17 +316,17 @@
           "group_id": null,
           "enum": "KeypadLockoutEnum",
           "options": [
-            "Unlock",
-            "Lock1",
-            "Lock2",
-            "Lock3",
-            "Lock4"
+            "unlock",
+            "lock1",
+            "lock2",
+            "lock3",
+            "lock4"
           ]
         },
         "state": {
           "class_name": "KeypadLockout",
           "available": true,
-          "state": "Unlock"
+          "state": "unlock"
         }
       }
     ],

--- a/tests/data/devices/tze200-jva8ink8-ts0601.json
+++ b/tests/data/devices/tze200-jva8ink8-ts0601.json
@@ -536,7 +536,7 @@
         "state": {
           "class_name": "EnumSensor",
           "available": true,
-          "state": "CheckSuccess"
+          "state": "checksuccess"
         }
       }
     ],

--- a/tests/data/devices/tze200-kb5noeto-ts0601.json
+++ b/tests/data/devices/tze200-kb5noeto-ts0601.json
@@ -443,9 +443,9 @@
           "group_id": null,
           "enum": "TuyaMotionDetectionMode",
           "options": [
-            "Only PIR",
-            "PIR and radar",
-            "Only radar"
+            "only_pir",
+            "pir_and_radar",
+            "only_radar"
           ]
         },
         "state": {

--- a/tests/data/devices/tze200-locansqn-ts0601-0x00000048.json
+++ b/tests/data/devices/tze200-locansqn-ts0601-0x00000048.json
@@ -559,14 +559,14 @@
           "group_id": null,
           "enum": "TuyaTempUnitConvert",
           "options": [
-            "Celsius",
-            "Fahrenheit"
+            "celsius",
+            "fahrenheit"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Celsius"
+          "state": "celsius"
         }
       }
     ],
@@ -743,7 +743,7 @@
         "state": {
           "class_name": "EnumSensor",
           "available": true,
-          "state": "Canceled"
+          "state": "canceled"
         }
       },
       {
@@ -771,7 +771,7 @@
         "state": {
           "class_name": "EnumSensor",
           "available": true,
-          "state": "Canceled"
+          "state": "canceled"
         }
       }
     ],

--- a/tests/data/devices/tze200-mudxchsu-ts0601-0x00000045.json
+++ b/tests/data/devices/tze200-mudxchsu-ts0601-0x00000045.json
@@ -915,17 +915,17 @@
           "group_id": null,
           "enum": "KeypadLockoutEnum",
           "options": [
-            "Unlock",
-            "Lock1",
-            "Lock2",
-            "Lock3",
-            "Lock4"
+            "unlock",
+            "lock1",
+            "lock2",
+            "lock3",
+            "lock4"
           ]
         },
         "state": {
           "class_name": "KeypadLockout",
           "available": true,
-          "state": "Unlock"
+          "state": "unlock"
         }
       }
     ],

--- a/tests/data/devices/tze200-qrztc3ev-ts0601.json
+++ b/tests/data/devices/tze200-qrztc3ev-ts0601.json
@@ -434,8 +434,8 @@
           "group_id": null,
           "enum": "TuyaTempUnitConvert",
           "options": [
-            "Celsius",
-            "Fahrenheit"
+            "celsius",
+            "fahrenheit"
           ]
         },
         "state": {

--- a/tests/data/devices/tze200-sur6q7ko-ts0601-0x00000045.json
+++ b/tests/data/devices/tze200-sur6q7ko-ts0601-0x00000045.json
@@ -802,17 +802,17 @@
           "group_id": null,
           "enum": "KeypadLockoutEnum",
           "options": [
-            "Unlock",
-            "Lock1",
-            "Lock2",
-            "Lock3",
-            "Lock4"
+            "unlock",
+            "lock1",
+            "lock2",
+            "lock3",
+            "lock4"
           ]
         },
         "state": {
           "class_name": "KeypadLockout",
           "available": true,
-          "state": "Unlock"
+          "state": "unlock"
         }
       }
     ],

--- a/tests/data/devices/tze200-t1blo2bj-ts0601.json
+++ b/tests/data/devices/tze200-t1blo2bj-ts0601.json
@@ -228,24 +228,24 @@
           "group_id": null,
           "enum": "NeoAlarmMelody18",
           "options": [
-            "Melody 01",
-            "Melody 02",
-            "Melody 03",
-            "Melody 04",
-            "Melody 05",
-            "Melody 06",
-            "Melody 07",
-            "Melody 08",
-            "Melody 09",
-            "Melody 10",
-            "Melody 11",
-            "Melody 12",
-            "Melody 13",
-            "Melody 14",
-            "Melody 15",
-            "Melody 16",
-            "Melody 17",
-            "Melody 18"
+            "melody_01",
+            "melody_02",
+            "melody_03",
+            "melody_04",
+            "melody_05",
+            "melody_06",
+            "melody_07",
+            "melody_08",
+            "melody_09",
+            "melody_10",
+            "melody_11",
+            "melody_12",
+            "melody_13",
+            "melody_14",
+            "melody_15",
+            "melody_16",
+            "melody_17",
+            "melody_18"
           ]
         },
         "state": {
@@ -275,9 +275,9 @@
           "group_id": null,
           "enum": "NeoAlarmVolume",
           "options": [
-            "Low",
-            "Medium",
-            "High"
+            "low",
+            "medium",
+            "high"
           ]
         },
         "state": {

--- a/tests/data/devices/tze200-viy9ihs7-ts0601.json
+++ b/tests/data/devices/tze200-viy9ihs7-ts0601.json
@@ -346,10 +346,10 @@
           "group_id": null,
           "enum": "BacklightMode",
           "options": [
-            "Off",
-            "Low",
-            "Medium",
-            "High"
+            "off",
+            "low",
+            "medium",
+            "high"
           ]
         },
         "state": {
@@ -379,9 +379,9 @@
           "group_id": null,
           "enum": "PresetModeV03",
           "options": [
-            "Auto",
-            "Manual",
-            "Temporary Manual"
+            "auto",
+            "manual",
+            "temporary_manual"
           ]
         },
         "state": {
@@ -411,9 +411,9 @@
           "group_id": null,
           "enum": "SensorMode",
           "options": [
-            "Air",
-            "Floor",
-            "Both"
+            "air",
+            "floor",
+            "both"
           ]
         },
         "state": {
@@ -443,10 +443,10 @@
           "group_id": null,
           "enum": "WorkingDayV01",
           "options": [
-            "Disabled",
-            "Six One",
-            "Five Two",
-            "Seven"
+            "disabled",
+            "six_one",
+            "five_two",
+            "seven"
           ]
         },
         "state": {

--- a/tests/data/devices/tze200-vvmbj46n-ts0601-0x00000048.json
+++ b/tests/data/devices/tze200-vvmbj46n-ts0601-0x00000048.json
@@ -453,8 +453,8 @@
           "group_id": null,
           "enum": "TuyaTempUnitConvert",
           "options": [
-            "Celsius",
-            "Fahrenheit"
+            "celsius",
+            "fahrenheit"
           ]
         },
         "state": {

--- a/tests/data/devices/tze200-yjjdcqsq-ts0601.json
+++ b/tests/data/devices/tze200-yjjdcqsq-ts0601.json
@@ -197,8 +197,8 @@
           "group_id": null,
           "enum": "TuyaTempUnitConvert",
           "options": [
-            "Celsius",
-            "Fahrenheit"
+            "celsius",
+            "fahrenheit"
           ]
         },
         "state": {

--- a/tests/data/devices/tze200-yojqa8xn-ts0601.json
+++ b/tests/data/devices/tze200-yojqa8xn-ts0601.json
@@ -305,11 +305,11 @@
           "group_id": null,
           "enum": "TuyaSirenRingtone",
           "options": [
-            "Ringtone 01",
-            "Ringtone 02",
-            "Ringtone 03",
-            "Ringtone 04",
-            "Ringtone 05"
+            "ringtone_01",
+            "ringtone_02",
+            "ringtone_03",
+            "ringtone_04",
+            "ringtone_05"
           ]
         },
         "state": {

--- a/tests/data/devices/tze204-1youk3hj-ts0601-0x0000004a.json
+++ b/tests/data/devices/tze204-1youk3hj-ts0601-0x0000004a.json
@@ -401,8 +401,8 @@
           "group_id": null,
           "enum": "TuyaMotionWorkMode",
           "options": [
-            "Manual",
-            "Auto"
+            "manual",
+            "auto"
           ]
         },
         "state": {

--- a/tests/data/devices/tze204-7ytb3h8u-ts0601.json
+++ b/tests/data/devices/tze204-7ytb3h8u-ts0601.json
@@ -427,14 +427,14 @@
           "group_id": null,
           "enum": "GiexIrrigationMode",
           "options": [
-            "Duration",
-            "Capacity"
+            "duration",
+            "capacity"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Duration"
+          "state": "duration"
         }
       },
       {
@@ -458,10 +458,10 @@
           "group_id": null,
           "enum": "GiexIrrigationWeatherDelay",
           "options": [
-            "NoDelay",
-            "TwentyFourHourDelay",
-            "FortyEightHourDelay",
-            "SeventyTwoHourDelay"
+            "nodelay",
+            "twentyfourhourdelay",
+            "fortyeighthourdelay",
+            "seventytwohourdelay"
           ]
         },
         "state": {

--- a/tests/data/devices/tze204-9yapgbuv-ts0601.json
+++ b/tests/data/devices/tze204-9yapgbuv-ts0601.json
@@ -190,8 +190,8 @@
           "group_id": null,
           "enum": "TuyaTempUnitConvert",
           "options": [
-            "Celsius",
-            "Fahrenheit"
+            "celsius",
+            "fahrenheit"
           ]
         },
         "state": {

--- a/tests/data/devices/tze204-chbyv06x-ts0601.json
+++ b/tests/data/devices/tze204-chbyv06x-ts0601.json
@@ -305,11 +305,11 @@
           "group_id": null,
           "enum": "TuyaSirenRingtone",
           "options": [
-            "Ringtone 01",
-            "Ringtone 02",
-            "Ringtone 03",
-            "Ringtone 04",
-            "Ringtone 05"
+            "ringtone_01",
+            "ringtone_02",
+            "ringtone_03",
+            "ringtone_04",
+            "ringtone_05"
           ]
         },
         "state": {

--- a/tests/data/devices/tze204-cirvgep4-ts0601-0x00000049.json
+++ b/tests/data/devices/tze204-cirvgep4-ts0601-0x00000049.json
@@ -215,8 +215,8 @@
           "group_id": null,
           "enum": "TuyaTempUnitConvert",
           "options": [
-            "Celsius",
-            "Fahrenheit"
+            "celsius",
+            "fahrenheit"
           ]
         },
         "state": {

--- a/tests/data/devices/tze204-dtzziy1e-ts0601.json
+++ b/tests/data/devices/tze204-dtzziy1e-ts0601.json
@@ -482,8 +482,8 @@
           "group_id": null,
           "enum": "TuyaBreakerMode",
           "options": [
-            "Standard",
-            "Local"
+            "standard",
+            "local"
           ]
         },
         "state": {
@@ -513,8 +513,8 @@
           "group_id": null,
           "enum": "TuyaBreakerPolarity",
           "options": [
-            "NC",
-            "NO"
+            "nc",
+            "no"
           ]
         },
         "state": {
@@ -544,8 +544,8 @@
           "group_id": null,
           "enum": "TuyaBreakerStatus",
           "options": [
-            "Off",
-            "On"
+            "off",
+            "on"
           ]
         },
         "state": {
@@ -575,10 +575,10 @@
           "group_id": null,
           "enum": "TuyaMotionSensorMode",
           "options": [
-            "On",
-            "Off",
-            "Occupied",
-            "Unoccupied"
+            "on",
+            "off",
+            "occupied",
+            "unoccupied"
           ]
         },
         "state": {
@@ -608,8 +608,8 @@
           "group_id": null,
           "enum": "TuyaStatusIndication",
           "options": [
-            "Off",
-            "On"
+            "off",
+            "on"
           ]
         },
         "state": {

--- a/tests/data/devices/tze204-gops3slb-ts0601-0x0000004a.json
+++ b/tests/data/devices/tze204-gops3slb-ts0601-0x0000004a.json
@@ -437,10 +437,10 @@
           "group_id": null,
           "enum": "BacklightMode",
           "options": [
-            "Off",
-            "Low",
-            "Medium",
-            "High"
+            "off",
+            "low",
+            "medium",
+            "high"
           ]
         },
         "state": {
@@ -470,9 +470,9 @@
           "group_id": null,
           "enum": "PresetModeV02",
           "options": [
-            "Manual",
-            "Auto",
-            "Temporary Manual"
+            "manual",
+            "auto",
+            "temporary_manual"
           ]
         },
         "state": {
@@ -502,9 +502,9 @@
           "group_id": null,
           "enum": "SensorMode",
           "options": [
-            "Air",
-            "Floor",
-            "Both"
+            "air",
+            "floor",
+            "both"
           ]
         },
         "state": {
@@ -534,10 +534,10 @@
           "group_id": null,
           "enum": "WorkingDayV02",
           "options": [
-            "Disabled",
-            "Five Two",
-            "Six One",
-            "Seven"
+            "disabled",
+            "five_two",
+            "six_one",
+            "seven"
           ]
         },
         "state": {

--- a/tests/data/devices/tze204-iaeejhvf-ts0601-0x0000004a.json
+++ b/tests/data/devices/tze204-iaeejhvf-ts0601-0x0000004a.json
@@ -989,8 +989,8 @@
           "group_id": null,
           "enum": "TuyaBreakerMode",
           "options": [
-            "Standard",
-            "Local"
+            "standard",
+            "local"
           ]
         },
         "state": {
@@ -1020,8 +1020,8 @@
           "group_id": null,
           "enum": "TuyaBreakerPolarity",
           "options": [
-            "NC",
-            "NO"
+            "nc",
+            "no"
           ]
         },
         "state": {
@@ -1051,8 +1051,8 @@
           "group_id": null,
           "enum": "TuyaBreakerStatus",
           "options": [
-            "Off",
-            "On"
+            "off",
+            "on"
           ]
         },
         "state": {
@@ -1082,10 +1082,10 @@
           "group_id": null,
           "enum": "TuyaMotionSensorMode",
           "options": [
-            "On",
-            "Off",
-            "Occupied",
-            "Unoccupied"
+            "on",
+            "off",
+            "occupied",
+            "unoccupied"
           ]
         },
         "state": {
@@ -1115,8 +1115,8 @@
           "group_id": null,
           "enum": "TuyaStatusIndication",
           "options": [
-            "Off",
-            "On"
+            "off",
+            "on"
           ]
         },
         "state": {

--- a/tests/data/devices/tze204-k7mfgaen-ts0601.json
+++ b/tests/data/devices/tze204-k7mfgaen-ts0601.json
@@ -276,10 +276,10 @@
           "group_id": null,
           "enum": "TuyaSirenState",
           "options": [
-            "Sound",
-            "Light",
-            "Sound and light",
-            "Normal"
+            "sound",
+            "light",
+            "sound_and_light",
+            "normal"
           ]
         },
         "state": {
@@ -309,19 +309,19 @@
           "group_id": null,
           "enum": "TuyaSirenRingtoneV02",
           "options": [
-            "Ringtone 01",
-            "Ringtone 02",
-            "Ringtone 03",
-            "Ringtone 04",
-            "Ringtone 05",
-            "Ringtone 06",
-            "Ringtone 07",
-            "Ringtone 08",
-            "Door",
-            "Water",
-            "Temperature",
-            "Entered",
-            "Left"
+            "ringtone_01",
+            "ringtone_02",
+            "ringtone_03",
+            "ringtone_04",
+            "ringtone_05",
+            "ringtone_06",
+            "ringtone_07",
+            "ringtone_08",
+            "door",
+            "water",
+            "temperature",
+            "entered",
+            "left"
           ]
         },
         "state": {
@@ -351,10 +351,10 @@
           "group_id": null,
           "enum": "TuyaAlarmVolume",
           "options": [
-            "Low",
-            "Medium",
-            "High",
-            "Mute"
+            "low",
+            "medium",
+            "high",
+            "mute"
           ]
         },
         "state": {

--- a/tests/data/devices/tze204-lpedvtvr-ts0601-0x0000004a.json
+++ b/tests/data/devices/tze204-lpedvtvr-ts0601-0x0000004a.json
@@ -404,17 +404,17 @@
           "group_id": null,
           "enum": "KeypadLockoutEnum",
           "options": [
-            "Unlock",
-            "Lock1",
-            "Lock2",
-            "Lock3",
-            "Lock4"
+            "unlock",
+            "lock1",
+            "lock2",
+            "lock3",
+            "lock4"
           ]
         },
         "state": {
           "class_name": "KeypadLockout",
           "available": true,
-          "state": "Unlock"
+          "state": "unlock"
         }
       }
     ],

--- a/tests/data/devices/tze204-ltwbm23f-ts0601-0x0000004a.json
+++ b/tests/data/devices/tze204-ltwbm23f-ts0601-0x0000004a.json
@@ -569,9 +569,9 @@
           "group_id": null,
           "enum": "TuyaDisplayBrightness",
           "options": [
-            "High",
-            "Medium",
-            "Low"
+            "high",
+            "medium",
+            "low"
           ]
         },
         "state": {
@@ -601,8 +601,8 @@
           "group_id": null,
           "enum": "TuyaDisplayOrientation",
           "options": [
-            "Up",
-            "Down"
+            "up",
+            "down"
           ]
         },
         "state": {
@@ -632,8 +632,8 @@
           "group_id": null,
           "enum": "TuyaHysteresis",
           "options": [
-            "Comfort",
-            "Eco"
+            "comfort",
+            "eco"
           ]
         },
         "state": {
@@ -663,9 +663,9 @@
           "group_id": null,
           "enum": "TuyaMotorThrust",
           "options": [
-            "Strong",
-            "Middle",
-            "Weak"
+            "strong",
+            "middle",
+            "weak"
           ]
         },
         "state": {
@@ -695,10 +695,10 @@
           "group_id": null,
           "enum": "TuyaPresetMode",
           "options": [
-            "Eco",
-            "Auto",
-            "Off",
-            "Heat"
+            "eco",
+            "auto",
+            "off",
+            "heat"
           ]
         },
         "state": {

--- a/tests/data/devices/tze204-ltwbm23f-ts0601-0x0000004e.json
+++ b/tests/data/devices/tze204-ltwbm23f-ts0601-0x0000004e.json
@@ -659,15 +659,15 @@
           "group_id": null,
           "enum": "TuyaDisplayBrightness",
           "options": [
-            "High",
-            "Medium",
-            "Low"
+            "high",
+            "medium",
+            "low"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "High"
+          "state": "high"
         }
       },
       {
@@ -691,14 +691,14 @@
           "group_id": null,
           "enum": "TuyaDisplayOrientation",
           "options": [
-            "Up",
-            "Down"
+            "up",
+            "down"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Up"
+          "state": "up"
         }
       },
       {
@@ -722,14 +722,14 @@
           "group_id": null,
           "enum": "TuyaHysteresis",
           "options": [
-            "Comfort",
-            "Eco"
+            "comfort",
+            "eco"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Comfort"
+          "state": "comfort"
         }
       },
       {
@@ -753,15 +753,15 @@
           "group_id": null,
           "enum": "TuyaMotorThrust",
           "options": [
-            "Strong",
-            "Middle",
-            "Weak"
+            "strong",
+            "middle",
+            "weak"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Weak"
+          "state": "weak"
         }
       },
       {
@@ -785,16 +785,16 @@
           "group_id": null,
           "enum": "TuyaPresetMode",
           "options": [
-            "Eco",
-            "Auto",
-            "Off",
-            "Heat"
+            "eco",
+            "auto",
+            "off",
+            "heat"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Heat"
+          "state": "heat"
         }
       }
     ],

--- a/tests/data/devices/tze204-lzriup1j-ts0601.json
+++ b/tests/data/devices/tze204-lzriup1j-ts0601.json
@@ -369,10 +369,10 @@
           "group_id": null,
           "enum": "BacklightMode",
           "options": [
-            "Off",
-            "Low",
-            "Medium",
-            "High"
+            "off",
+            "low",
+            "medium",
+            "high"
           ]
         },
         "state": {
@@ -402,9 +402,9 @@
           "group_id": null,
           "enum": "PresetModeV02",
           "options": [
-            "Manual",
-            "Auto",
-            "Temporary Manual"
+            "manual",
+            "auto",
+            "temporary_manual"
           ]
         },
         "state": {
@@ -434,9 +434,9 @@
           "group_id": null,
           "enum": "SensorMode",
           "options": [
-            "Air",
-            "Floor",
-            "Both"
+            "air",
+            "floor",
+            "both"
           ]
         },
         "state": {
@@ -466,10 +466,10 @@
           "group_id": null,
           "enum": "WorkingDayV02",
           "options": [
-            "Disabled",
-            "Five Two",
-            "Six One",
-            "Seven"
+            "disabled",
+            "five_two",
+            "six_one",
+            "seven"
           ]
         },
         "state": {

--- a/tests/data/devices/tze204-mtoaryre-ts0601-0x0000004a.json
+++ b/tests/data/devices/tze204-mtoaryre-ts0601-0x0000004a.json
@@ -512,8 +512,8 @@
           "group_id": null,
           "enum": "TuyaBreakerMode",
           "options": [
-            "Standard",
-            "Local"
+            "standard",
+            "local"
           ]
         },
         "state": {
@@ -543,8 +543,8 @@
           "group_id": null,
           "enum": "TuyaBreakerPolarity",
           "options": [
-            "NC",
-            "NO"
+            "nc",
+            "no"
           ]
         },
         "state": {
@@ -574,8 +574,8 @@
           "group_id": null,
           "enum": "TuyaBreakerStatus",
           "options": [
-            "Off",
-            "On"
+            "off",
+            "on"
           ]
         },
         "state": {
@@ -605,10 +605,10 @@
           "group_id": null,
           "enum": "TuyaMotionSensorMode",
           "options": [
-            "On",
-            "Off",
-            "Occupied",
-            "Unoccupied"
+            "on",
+            "off",
+            "occupied",
+            "unoccupied"
           ]
         },
         "state": {
@@ -638,8 +638,8 @@
           "group_id": null,
           "enum": "TuyaStatusIndication",
           "options": [
-            "Off",
-            "On"
+            "off",
+            "on"
           ]
         },
         "state": {

--- a/tests/data/devices/tze204-nlrfgpny-ts0601-0x00000049.json
+++ b/tests/data/devices/tze204-nlrfgpny-ts0601-0x00000049.json
@@ -344,10 +344,10 @@
           "group_id": null,
           "enum": "TuyaSirenState",
           "options": [
-            "Sound",
-            "Light",
-            "Sound and light",
-            "Normal"
+            "sound",
+            "light",
+            "sound_and_light",
+            "normal"
           ]
         },
         "state": {
@@ -377,9 +377,9 @@
           "group_id": null,
           "enum": "TuyaSirenRingtone",
           "options": [
-            "Ringtone 01",
-            "Ringtone 02",
-            "Ringtone 03"
+            "ringtone_01",
+            "ringtone_02",
+            "ringtone_03"
           ]
         },
         "state": {

--- a/tests/data/devices/tze204-p3lqqy2r-ts0601.json
+++ b/tests/data/devices/tze204-p3lqqy2r-ts0601.json
@@ -358,9 +358,9 @@
           "group_id": null,
           "enum": "PresetModeV01",
           "options": [
-            "Manual",
-            "Home",
-            "Away"
+            "manual",
+            "home",
+            "away"
           ]
         },
         "state": {
@@ -390,11 +390,11 @@
           "group_id": null,
           "enum": "RegulatorPeriod",
           "options": [
-            " 15 min",
-            " 30 min",
-            " 45 min",
-            " 60 min",
-            " 90 min"
+            "_15_min",
+            "_30_min",
+            "_45_min",
+            "_60_min",
+            "_90_min"
           ]
         },
         "state": {
@@ -424,9 +424,9 @@
           "group_id": null,
           "enum": "SensorMode",
           "options": [
-            "Air",
-            "Floor",
-            "Both"
+            "air",
+            "floor",
+            "both"
           ]
         },
         "state": {
@@ -456,8 +456,8 @@
           "group_id": null,
           "enum": "ThermostatMode",
           "options": [
-            "Regulator",
-            "Thermostat"
+            "regulator",
+            "thermostat"
           ]
         },
         "state": {

--- a/tests/data/devices/tze204-qyr2m29i-ts0601-0x0000004a.json
+++ b/tests/data/devices/tze204-qyr2m29i-ts0601-0x0000004a.json
@@ -526,9 +526,9 @@
           "group_id": null,
           "enum": "TuyaDisplayBrightness",
           "options": [
-            "High",
-            "Medium",
-            "Low"
+            "high",
+            "medium",
+            "low"
           ]
         },
         "state": {
@@ -558,8 +558,8 @@
           "group_id": null,
           "enum": "TuyaDisplayOrientation",
           "options": [
-            "Up",
-            "Down"
+            "up",
+            "down"
           ]
         },
         "state": {
@@ -589,8 +589,8 @@
           "group_id": null,
           "enum": "TuyaHysteresis",
           "options": [
-            "Comfort",
-            "Eco"
+            "comfort",
+            "eco"
           ]
         },
         "state": {
@@ -620,9 +620,9 @@
           "group_id": null,
           "enum": "TuyaMotorThrust",
           "options": [
-            "Strong",
-            "Middle",
-            "Weak"
+            "strong",
+            "middle",
+            "weak"
           ]
         },
         "state": {
@@ -652,10 +652,10 @@
           "group_id": null,
           "enum": "TuyaPresetMode",
           "options": [
-            "Eco",
-            "Auto",
-            "Off",
-            "Heat"
+            "eco",
+            "auto",
+            "off",
+            "heat"
           ]
         },
         "state": {

--- a/tests/data/devices/tze204-rtrmfadk-ts0601-0x00000049.json
+++ b/tests/data/devices/tze204-rtrmfadk-ts0601-0x00000049.json
@@ -496,8 +496,8 @@
           "group_id": null,
           "enum": "TuyaThermostatEcoMode",
           "options": [
-            "Comfort",
-            "Eco"
+            "comfort",
+            "eco"
           ]
         },
         "state": {

--- a/tests/data/devices/tze204-rtrmfadk-ts0601.json
+++ b/tests/data/devices/tze204-rtrmfadk-ts0601.json
@@ -538,14 +538,14 @@
           "group_id": null,
           "enum": "TuyaThermostatEcoMode",
           "options": [
-            "Comfort",
-            "Eco"
+            "comfort",
+            "eco"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Eco"
+          "state": "eco"
         }
       }
     ],

--- a/tests/data/devices/tze204-upagmta9-ts0601.json
+++ b/tests/data/devices/tze204-upagmta9-ts0601.json
@@ -221,14 +221,14 @@
           "group_id": null,
           "enum": "TuyaTempUnitConvert",
           "options": [
-            "Celsius",
-            "Fahrenheit"
+            "celsius",
+            "fahrenheit"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Celsius"
+          "state": "celsius"
         }
       }
     ],

--- a/tests/data/devices/tze204-xalsoe3m-ts0601-0x0000004a.json
+++ b/tests/data/devices/tze204-xalsoe3m-ts0601-0x0000004a.json
@@ -741,17 +741,17 @@
           "group_id": null,
           "enum": "KeypadLockoutEnum",
           "options": [
-            "Unlock",
-            "Lock1",
-            "Lock2",
-            "Lock3",
-            "Lock4"
+            "unlock",
+            "lock1",
+            "lock2",
+            "lock3",
+            "lock4"
           ]
         },
         "state": {
           "class_name": "KeypadLockout",
           "available": true,
-          "state": "Unlock"
+          "state": "unlock"
         }
       }
     ],

--- a/tests/data/devices/tze204-xnbkhhdr-ts0601-0x0000004a.json
+++ b/tests/data/devices/tze204-xnbkhhdr-ts0601-0x0000004a.json
@@ -353,10 +353,10 @@
           "group_id": null,
           "enum": "BacklightMode",
           "options": [
-            "Off",
-            "Low",
-            "Medium",
-            "High"
+            "off",
+            "low",
+            "medium",
+            "high"
           ]
         },
         "state": {
@@ -386,9 +386,9 @@
           "group_id": null,
           "enum": "PresetModeV03",
           "options": [
-            "Auto",
-            "Manual",
-            "Temporary Manual"
+            "auto",
+            "manual",
+            "temporary_manual"
           ]
         },
         "state": {
@@ -418,9 +418,9 @@
           "group_id": null,
           "enum": "SensorMode",
           "options": [
-            "Air",
-            "Floor",
-            "Both"
+            "air",
+            "floor",
+            "both"
           ]
         },
         "state": {
@@ -450,10 +450,10 @@
           "group_id": null,
           "enum": "WorkingDayV02",
           "options": [
-            "Disabled",
-            "Five Two",
-            "Six One",
-            "Seven"
+            "disabled",
+            "five_two",
+            "six_one",
+            "seven"
           ]
         },
         "state": {

--- a/tests/data/devices/tze204-yjjdcqsq-ts0601.json
+++ b/tests/data/devices/tze204-yjjdcqsq-ts0601.json
@@ -217,8 +217,8 @@
           "group_id": null,
           "enum": "TuyaTempUnitConvert",
           "options": [
-            "Celsius",
-            "Fahrenheit"
+            "celsius",
+            "fahrenheit"
           ]
         },
         "state": {

--- a/tests/data/devices/tze284-3mzb0sdz-ts0601-0x00000050.json
+++ b/tests/data/devices/tze284-3mzb0sdz-ts0601-0x00000050.json
@@ -366,8 +366,8 @@
           "group_id": null,
           "enum": "MotorDirection",
           "options": [
-            "Forward",
-            "Back"
+            "forward",
+            "back"
           ]
         },
         "state": {

--- a/tests/data/devices/tze284-kyyu8rbj-ts0601-0x0000004d.json
+++ b/tests/data/devices/tze284-kyyu8rbj-ts0601-0x0000004d.json
@@ -457,9 +457,9 @@
           "group_id": null,
           "enum": "TuyaLiquidState",
           "options": [
-            "Normal",
-            "Low",
-            "High"
+            "normal",
+            "low",
+            "high"
           ]
         },
         "state": {

--- a/tests/data/devices/tze284-upagmta9-ts0601-0x0000004d.json
+++ b/tests/data/devices/tze284-upagmta9-ts0601-0x0000004d.json
@@ -203,8 +203,8 @@
           "group_id": null,
           "enum": "TuyaTempUnitConvert",
           "options": [
-            "Celsius",
-            "Fahrenheit"
+            "celsius",
+            "fahrenheit"
           ]
         },
         "state": {

--- a/tests/data/devices/tze284-xnbkhhdr-ts0601-0x0000004d.json
+++ b/tests/data/devices/tze284-xnbkhhdr-ts0601-0x0000004d.json
@@ -468,16 +468,16 @@
           "group_id": null,
           "enum": "BacklightMode",
           "options": [
-            "Off",
-            "Low",
-            "Medium",
-            "High"
+            "off",
+            "low",
+            "medium",
+            "high"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "High"
+          "state": "high"
         }
       },
       {
@@ -501,15 +501,15 @@
           "group_id": null,
           "enum": "PresetModeV03",
           "options": [
-            "Auto",
-            "Manual",
-            "Temporary Manual"
+            "auto",
+            "manual",
+            "temporary_manual"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Manual"
+          "state": "manual"
         }
       },
       {
@@ -533,9 +533,9 @@
           "group_id": null,
           "enum": "SensorMode",
           "options": [
-            "Air",
-            "Floor",
-            "Both"
+            "air",
+            "floor",
+            "both"
           ]
         },
         "state": {
@@ -565,16 +565,16 @@
           "group_id": null,
           "enum": "WorkingDayV02",
           "options": [
-            "Disabled",
-            "Five Two",
-            "Six One",
-            "Seven"
+            "disabled",
+            "five_two",
+            "six_one",
+            "seven"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Disabled"
+          "state": "disabled"
         }
       }
     ],

--- a/tests/data/devices/ubisys-s1-5501-0x02600460.json
+++ b/tests/data/devices/ubisys-s1-5501-0x02600460.json
@@ -755,16 +755,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       },
       {
@@ -788,15 +788,15 @@
           "group_id": null,
           "enum": "InputMode",
           "options": [
-            "Toggle",
-            "Toggle switch",
-            "On off switch"
+            "toggle",
+            "toggle_switch",
+            "on_off_switch"
           ]
         },
         "state": {
           "class_name": "ZCLEnumSelectEntity",
           "available": true,
-          "state": "Toggle"
+          "state": "toggle"
         }
       }
     ],

--- a/tests/data/devices/uiot-uiot-windowcovring2-0402.json
+++ b/tests/data/devices/uiot-uiot-windowcovring2-0402.json
@@ -679,7 +679,7 @@
         "state": {
           "class_name": "WindowCoveringTypeSensor",
           "available": true,
-          "state": "Rollershade"
+          "state": "rollershade"
         }
       },
       {
@@ -707,7 +707,7 @@
         "state": {
           "class_name": "WindowCoveringTypeSensor",
           "available": true,
-          "state": "Rollershade"
+          "state": "rollershade"
         }
       },
       {
@@ -735,7 +735,7 @@
         "state": {
           "class_name": "WindowCoveringTypeSensor",
           "available": true,
-          "state": "Rollershade"
+          "state": "rollershade"
         }
       }
     ],

--- a/tests/data/devices/yooksmart-d10110-0x12046780.json
+++ b/tests/data/devices/yooksmart-d10110-0x12046780.json
@@ -418,7 +418,7 @@
         "state": {
           "class_name": "WindowCoveringTypeSensor",
           "available": true,
-          "state": "Rollershade"
+          "state": "rollershade"
         }
       }
     ],

--- a/tests/data/devices/zbeacon-ts0001.json
+++ b/tests/data/devices/zbeacon-ts0001.json
@@ -284,16 +284,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "PreviousValue"
+          "state": "previousvalue"
         }
       }
     ],

--- a/tests/data/devices/zbeacon-ts0505.json
+++ b/tests/data/devices/zbeacon-ts0505.json
@@ -563,16 +563,16 @@
           "group_id": null,
           "enum": "StartUpOnOff",
           "options": [
-            "Off",
-            "On",
-            "Toggle",
-            "PreviousValue"
+            "off",
+            "on",
+            "toggle",
+            "previousvalue"
           ]
         },
         "state": {
           "class_name": "StartupOnOffSelectEntity",
           "available": true,
-          "state": "Toggle"
+          "state": "toggle"
         }
       }
     ],

--- a/tests/data/devices/zen-within-zen-01-0x0000021f.json
+++ b/tests/data/devices/zen-within-zen-01-0x0000021f.json
@@ -576,17 +576,17 @@
           "group_id": null,
           "enum": "KeypadLockoutEnum",
           "options": [
-            "Unlock",
-            "Lock1",
-            "Lock2",
-            "Lock3",
-            "Lock4"
+            "unlock",
+            "lock1",
+            "lock2",
+            "lock3",
+            "lock4"
           ]
         },
         "state": {
           "class_name": "KeypadLockout",
           "available": true,
-          "state": "Unlock"
+          "state": "unlock"
         }
       }
     ],

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -388,7 +388,7 @@ async def test_quirks_v2_entity_discovery_e1_curtain(
     )
     assert (
         power_source_entity.state["state"]
-        == BasicCluster.PowerSource.Mains_single_phase.name
+        == BasicCluster.PowerSource.Mains_single_phase.name.lower()
     )
 
     hook_state_entity = get_entity(
@@ -397,7 +397,7 @@ async def test_quirks_v2_entity_discovery_e1_curtain(
         exact_entity_type=sensor.EnumSensor,
         qualifier_func=lambda e: e._enum == AqaraE1HookState,
     )
-    assert hook_state_entity.state["state"] == AqaraE1HookState.Unlocked.name
+    assert hook_state_entity.state["state"] == AqaraE1HookState.Unlocked.name.lower()
 
     error_detected_entity = get_entity(
         zha_device,

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -63,20 +63,24 @@ async def test_select(zha_gateway: Gateway) -> None:
     entity = get_entity(zha_device, platform=Platform.SELECT, qualifier=select_name)
     assert entity.state["state"] is None  # unknown in HA
     assert entity.info_object.options == [
-        "Stop",
-        "Burglar",
-        "Fire",
-        "Emergency",
-        "Police Panic",
-        "Fire Panic",
-        "Emergency Panic",
+        "stop",
+        "burglar",
+        "fire",
+        "emergency",
+        "police_panic",
+        "fire_panic",
+        "emergency_panic",
     ]
     assert entity._enum == security.IasWd.Warning.WarningMode
 
     # change value from client
-    await entity.async_select_option(security.IasWd.Warning.WarningMode.Burglar.name)
+    await entity.async_select_option(
+        security.IasWd.Warning.WarningMode.Burglar.name.lower()
+    )
     await zha_gateway.async_block_till_done()
-    assert entity.state["state"] == security.IasWd.Warning.WarningMode.Burglar.name
+    assert (
+        entity.state["state"] == security.IasWd.Warning.WarningMode.Burglar.name.lower()
+    )
 
 
 class MotionSensitivityQuirk(CustomDevice):
@@ -137,13 +141,13 @@ async def test_on_off_select_attribute_report(zha_gateway: Gateway) -> None:
     cluster = aqara_sensor.device.endpoints.get(1).opple_cluster
 
     entity = get_entity(aqara_sensor, platform=Platform.SELECT)
-    assert entity.state["state"] == AqaraMotionSensitivities.Medium.name
+    assert entity.state["state"] == AqaraMotionSensitivities.Medium.name.lower()
 
     # send attribute report from device
     await send_attributes_report(
         zha_gateway, cluster, {"motion_sensitivity": AqaraMotionSensitivities.Low}
     )
-    assert entity.state["state"] == AqaraMotionSensitivities.Low.name
+    assert entity.state["state"] == AqaraMotionSensitivities.Low.name.lower()
 
 
 (
@@ -210,13 +214,13 @@ async def test_on_off_select_attribute_report_v2(
     )
 
     # test that the state is in default medium state
-    assert entity.state["state"] == AqaraMotionSensitivities.Medium.name
+    assert entity.state["state"] == AqaraMotionSensitivities.Medium.name.lower()
 
     # send attribute report from device
     await send_attributes_report(
         zha_gateway, cluster, {"motion_sensitivity": AqaraMotionSensitivities.Low}
     )
-    assert entity.state["state"] == AqaraMotionSensitivities.Low.name
+    assert entity.state["state"] == AqaraMotionSensitivities.Low.name.lower()
 
     assert entity._attr_entity_category == EntityCategory.CONFIG
     assert entity._attr_entity_registry_enabled_default is True
@@ -239,10 +243,10 @@ async def test_on_off_select_attribute_report_v2(
         ),
         patch.object(cluster, "write_attributes", wraps=cluster.write_attributes),
     ):
-        await entity.async_select_option(AqaraMotionSensitivities.Medium.name)
+        await entity.async_select_option(AqaraMotionSensitivities.Medium.name.lower())
 
         await zha_gateway.async_block_till_done()
-        assert entity.state["state"] == AqaraMotionSensitivities.Medium.name
+        assert entity.state["state"] == AqaraMotionSensitivities.Medium.name.lower()
         assert cluster.write_attributes.call_count == 1
         assert cluster.write_attributes.call_args == call(
             {"motion_sensitivity": AqaraMotionSensitivities.Medium},
@@ -271,14 +275,16 @@ async def test_non_zcl_select_state_restoration(zha_gateway: Gateway) -> None:
     assert entity.state["state"] is None
 
     entity.restore_external_state_attributes(
-        state=security.IasWd.Warning.WarningMode.Burglar.name
+        state=security.IasWd.Warning.WarningMode.Burglar.name.lower()
     )
-    assert entity.state["state"] == security.IasWd.Warning.WarningMode.Burglar.name
+    assert (
+        entity.state["state"] == security.IasWd.Warning.WarningMode.Burglar.name.lower()
+    )
 
     entity.restore_external_state_attributes(
-        state=security.IasWd.Warning.WarningMode.Fire.name
+        state=security.IasWd.Warning.WarningMode.Fire.name.lower()
     )
-    assert entity.state["state"] == security.IasWd.Warning.WarningMode.Fire.name
+    assert entity.state["state"] == security.IasWd.Warning.WarningMode.Fire.name.lower()
 
 
 async def test_bega_color_temperature_channel_select(zha_gateway: Gateway) -> None:
@@ -296,8 +302,8 @@ async def test_bega_color_temperature_channel_select(zha_gateway: Gateway) -> No
         platform=Platform.SELECT,
         qualifier="switchable_white",
     )
-    assert entity.state["state"] == "Warm white"
-    assert entity.info_object.options == ["Warm white", "Cool white"]
+    assert entity.state["state"] == "warm_white"
+    assert entity.info_object.options == ["warm_white", "cool_white"]
 
     # send attribute report from device
     await send_attributes_report(
@@ -305,7 +311,7 @@ async def test_bega_color_temperature_channel_select(zha_gateway: Gateway) -> No
         cluster,
         {"switchable_white": BegaColorTemperatureChannel.Cool_white},
     )
-    assert entity.state["state"] == "Cool white"
+    assert entity.state["state"] == "cool_white"
 
     # test selecting an option
     Write_Attributes_rsp = foundation.GENERAL_COMMANDS[
@@ -325,9 +331,9 @@ async def test_bega_color_temperature_channel_select(zha_gateway: Gateway) -> No
         ),
         patch.object(cluster, "write_attributes", wraps=cluster.write_attributes),
     ):
-        await entity.async_select_option("Warm white")
+        await entity.async_select_option("warm_white")
         await zha_gateway.async_block_till_done()
-        assert entity.state["state"] == "Warm white"
+        assert entity.state["state"] == "warm_white"
         assert cluster.write_attributes.call_count == 1
         assert cluster.write_attributes.call_args == call(
             {"switchable_white": BegaColorTemperatureChannel.Warm_white},

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -82,6 +82,11 @@ async def test_select(zha_gateway: Gateway) -> None:
         entity.state["state"] == security.IasWd.Warning.WarningMode.Burglar.name.lower()
     )
 
+    # Backwards compatibility: the previous spaced option format is still accepted
+    await entity.async_select_option("Police Panic")
+    await zha_gateway.async_block_till_done()
+    assert entity.state["state"] == "police_panic"
+
 
 class MotionSensitivityQuirk(CustomDevice):
     """Quirk with motion sensitivity attribute."""
@@ -337,6 +342,15 @@ async def test_bega_color_temperature_channel_select(zha_gateway: Gateway) -> No
         assert cluster.write_attributes.call_count == 1
         assert cluster.write_attributes.call_args == call(
             {"switchable_white": BegaColorTemperatureChannel.Warm_white},
+            manufacturer=UNDEFINED,
+        )
+
+        # Backwards compatibility: the previous spaced option format is still accepted
+        cluster.write_attributes.reset_mock()
+        await entity.async_select_option("Cool white")
+        await zha_gateway.async_block_till_done()
+        assert cluster.write_attributes.call_args == call(
+            {"switchable_white": BegaColorTemperatureChannel.Cool_white},
             manufacturer=UNDEFINED,
         )
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -446,7 +446,7 @@ async def async_test_setpoint_change_source(
         cluster,
         {hvac.Thermostat.AttributeDefs.setpoint_change_source.id: 0x01},
     )
-    assert entity.state["state"] == "Schedule"
+    assert entity.state["state"] == "schedule"
 
 
 async def async_test_pi_heating_demand(
@@ -2102,7 +2102,7 @@ async def test_enum_sensor(zha_gateway: Gateway) -> None:
     zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
     entity = get_entity(zha_device, platform=Platform.SENSOR, qualifier="battery_size")
 
-    assert entity.state["state"] == "AAA"
+    assert entity.state["state"] == "aaa"
 
     zigpy_dev.endpoints[1].power.update_attribute(
         PowerConfiguration.AttributeDefs.battery_size.id,

--- a/zha/application/platforms/select.py
+++ b/zha/application/platforms/select.py
@@ -125,12 +125,18 @@ class SirenDefaultSelectEntity(BaseSelectEntity, PlatformEntity):
         if self._option_overrides is not None:
             self._option_to_member: dict[str, Enum] = self._option_overrides
         else:
-            self._option_to_member = {
-                entry.name.replace("_", " "): entry for entry in self._enum
-            }
+            self._option_to_member = {entry.name.lower(): entry for entry in self._enum}
         self._member_to_option = {m: o for o, m in self._option_to_member.items()}
         self._attr_options = list(self._option_to_member)
         super().__init__(endpoint=endpoint, device=device, **kwargs)
+
+    def _member_for_option(self, option: str) -> Enum:
+        """Resolve an option string to its enum member, tolerating legacy names."""
+        try:
+            return self._option_to_member[option]
+        except KeyError:
+            # Backwards compatibility with the previous spaced option names
+            return self._option_to_member[option.replace(" ", "_").lower()]
 
     @functools.cached_property
     def info_object(self) -> EnumSelectInfo:
@@ -166,7 +172,7 @@ class SirenDefaultSelectEntity(BaseSelectEntity, PlatformEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
-        self._siren().defaults[self._enum] = self._option_to_member[option]
+        self._siren().defaults[self._enum] = self._member_for_option(option)
         self.maybe_emit_state_changed_event()
 
     def restore_external_state_attributes(
@@ -175,7 +181,7 @@ class SirenDefaultSelectEntity(BaseSelectEntity, PlatformEntity):
         state: str,
     ) -> None:
         """Restore extra state attributes that are stored outside of the ZCL cache."""
-        self._siren().defaults[self._enum] = self._option_to_member[state]
+        self._siren().defaults[self._enum] = self._member_for_option(state)
 
 
 @register_entity(IasWd.cluster_id)
@@ -246,6 +252,7 @@ class ZCLEnumSelectEntity(BaseSelectEntity, PlatformEntity):
     _attribute_name: str
     _attr_entity_category = EntityCategory.CONFIG
     _enum: type[Enum]
+    _enum_member_by_option: dict[str, Enum]
 
     def __init__(
         self,
@@ -263,7 +270,12 @@ class ZCLEnumSelectEntity(BaseSelectEntity, PlatformEntity):
             self._enum = enum
 
         super().__init__(endpoint=endpoint, device=device, **kwargs)
-        self._attr_options = [entry.name.replace("_", " ") for entry in self._enum]
+        # Slugified enum member names are used as the (translatable) options.
+        # The mapping keeps a reference back to the actual enum member.
+        self._enum_member_by_option = {
+            entry.name.lower(): entry for entry in self._enum
+        }
+        self._attr_options = list(self._enum_member_by_option)
 
     def on_add(self) -> None:
         """Run when entity is added."""
@@ -310,14 +322,18 @@ class ZCLEnumSelectEntity(BaseSelectEntity, PlatformEntity):
         option = self._cluster.get(self._attribute_name)
         if option is None:
             return None
-        option = self._enum(option)
-        return option.name.replace("_", " ")
+        return self._enum(option).name.lower()
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
+        try:
+            member = self._enum_member_by_option[option]
+        except KeyError:
+            # Backwards compatibility with the previous spaced option names
+            member = self._enum[option.replace(" ", "_")]
         await write_attributes_safe(
             self._cluster,
-            {self._attribute_name: self._enum[option.replace(" ", "_")]},
+            {self._attribute_name: member},
         )
         self.maybe_emit_state_changed_event()
 

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -550,15 +550,15 @@ class EnumSensor(Sensor):
             self._enum = enum
 
         super().__init__(endpoint=endpoint, device=device, **kwargs)
-        self._attr_options = [e.name for e in self._enum]
+        self._attr_options = [e.name.lower() for e in self._enum]
 
         # XXX: This class is not meant to be initialized directly, as `unique_id`
         # depends on the value of `_attribute_name`
 
     def formatter(self, value: int) -> str | None:
-        """Use name of enum."""
+        """Use the slugified name of the enum member (used as translation key)."""
         assert self._enum is not None
-        return self._enum(value).name
+        return self._enum(value).name.lower()
 
 
 @register_entity(AnalogInput.cluster_id)


### PR DESCRIPTION
## Summary

Enum-based select (`ZCLEnumSelectEntity`, `SirenDefaultSelectEntity`) and sensor
(`EnumSensor`) entities currently expose their options/states as spaced,
title-cased strings derived from the enum member names (e.g. `"Police Panic"`,
`"Previous value"`). Home Assistant cannot translate these, because entity state
translation keys must be slugs.

This makes the option values and enum sensor states the **slugified** enum member
names (e.g. `"police_panic"`), so they can be translated through the entity's
`translation_key`.

This revives #86 (which stalled). It's the blocker referenced by
home-assistant/core#165493, which was closed with a pointer to that PR.

## Details

- `ZCLEnumSelectEntity`: options are now `entry.name.lower()`; a
  `_enum_member_by_option` map resolves the selected option back to the enum member.
- `SirenDefaultSelectEntity`: same slugification, via a `_member_for_option` helper.
- `EnumSensor`: `_attr_options` and `formatter` return the slugified member name.
- **Backwards compatibility**: `async_select_option` and the siren-default restore
  path fall back to the previous spaced names, so existing automations and restored
  state keep working.
- Device diagnostic snapshots (`tests/data/devices/*.json`) and the affected tests
  are regenerated / updated accordingly.

## Breaking change

Select option values and enum sensor states change from spaced/title-cased strings
(e.g. `Police Panic`) to slugs (e.g. `police_panic`). Automations that reference the
old values keep working through the compatibility fallback, but the displayed/stored
state changes (and is now translatable in Home Assistant).

## Companion PR

The matching Home Assistant `strings.json` translations (the `state` blocks for the
39 affected `translation_key`s) will be submitted to `home-assistant/core` once a
release including this change is available, since the `state` keys must match the new
slug options.

## Tests

Full suite passes (`1337 passed`).
