### PR TITLE
Add git-versioning `starting_version` for Dependabot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,14 @@ default-groups = ["testing"]
 
 [tool.setuptools-git-versioning]
 enabled = true
+# Fallback version used when no git tag is reachable, e.g. in a tagless
+# checkout. `zha-quirks` depends on `zha` (this project), so `zha[testing]`
+# forms a cycle: zha -> zha-quirks -> zha>=2.0.0. Locally and in CI the dynamic
+# version computes from the git tag and satisfies that constraint, but a
+# from-scratch resolve without tags (e.g. Dependabot) computes 0.0.1, which
+# fails `zha>=2.0.0` and makes the lock unsatisfiable. Pinning the fallback to
+# the current major keeps the cycle satisfiable everywhere. Bump on each major.
+starting_version = "2.0.0"
 
 [tool.codespell]
 skip = ["tests/data/devices/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,13 +67,9 @@ default-groups = ["testing"]
 
 [tool.setuptools-git-versioning]
 enabled = true
-# Fallback version used when no git tag is reachable, e.g. in a tagless
-# checkout. `zha-quirks` depends on `zha` (this project), so `zha[testing]`
-# forms a cycle: zha -> zha-quirks -> zha>=2.0.0. Locally and in CI the dynamic
-# version computes from the git tag and satisfies that constraint, but a
-# from-scratch resolve without tags (e.g. Dependabot) computes 0.0.1, which
-# fails `zha>=2.0.0` and makes the lock unsatisfiable. Pinning the fallback to
-# the current major keeps the cycle satisfiable everywhere. Bump on each major.
+# Fallback version for tagless checkouts (e.g. Dependabot). zha-quirks depends
+# on zha>=2.0.0, so the version must satisfy that or the lock is unsatisfiable.
+# Bump on each major.
 starting_version = "2.0.0"
 
 [tool.codespell]


### PR DESCRIPTION
## Problem

Dependabot fails to resolve dependencies on this repo with:

```
× No solution found when resolving dependencies for split (markers:
  python_full_version >= '3.15'):
╰─▶ ... we can conclude that zha:ci depends on itself at an incompatible
    version (zha>=2.0.0). And because your project requires zha[testing] and
    zha:ci, we can conclude that your project's requirements are unsatisfiable.
```

This is fallout from the recent refactor. `zha-quirks` now depends on `zha`, and `zha` pulls `zha-quirks` back in via the `testing` group (for device snapshots), forming a self-referential cycle:

```
zha[testing] -> zha-quirks -> zha>=2.0.0
```

uv satisfies `zha-quirks`'s `zha` requirement with the editable root project. That's fine **as long as the root's own version satisfies `zha>=2.0.0`**. Our version is dynamic (`setuptools-git-versioning`, from git tags):

- **Locally / in CI**, the latest tag `2.0.0` is reachable → the project resolves as `2.0.0` → the cycle closes → `uv lock`/`uv sync` succeed.
- **Dependabot** re-resolves from scratch in an environment with no reachable tags → `setuptools-git-versioning` falls back to `0.0.1` → `0.0.1 < 2.0.0` → the cycle is unsatisfiable.

The `python_full_version >= '3.15'` marker is incidental: `requires-python = ">=3.12"` has no upper bound, so uv forks the resolution across the Python range and that fork is just where the failure surfaced.

## Fix

Set `setuptools-git-versioning`'s `starting_version` to the current major, so a tagless checkout still computes a version that satisfies `zha>=2.0.0`:

```toml
[tool.setuptools-git-versioning]
enabled = true
starting_version = "2.0.0"
```

This attacks the root cause (the fallback version) rather than the cycle itself, and needs bumping on each major release.

## Why not a uv `override-dependencies` on `zha`?

That was the first candidate, but it doesn't work with the pinned uv (`uv>=0.11.16`): `override-dependencies = ["zha"]` references the project's own name, so uv requires a `[tool.uv.sources]` entry for it. The only valid source (`workspace = true`) collapses the lock from 214 → 46 packages, dropping the `homeassistant` extra and `zha-quirks` itself — i.e. exactly the deps the snapshot tests need.

## Verification

- Reproduced the **exact** Dependabot error locally via `git clone --no-tags` + `uv lock` on the base branch.
- With the fix, the same tagless clone computes version `2.0.0` and `uv lock` resolves cleanly.
- The committed `uv.lock` is **byte-identical** — locally/CI the git tag still drives the version, so nothing changes there. Only `pyproject.toml` is touched.
