### PR TITLE
Group non-zigpy Dependabot updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,16 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    open-pull-requests-limit: 10
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+        # The Zigbee radio stack and zha-quirks stay as individual PRs.
+        exclude-patterns:
+          - "zigpy*"
+          - "bellows"
+          - "zha-quirks"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Bundle all uv-ecosystem version updates into one grouped PR, except the Zigbee radio stack (zigpy*, bellows) and zha-quirks, which stay as individual PRs.

Also raise the open-PR limit to 10 to fit the grouped PR alongside the individual radio/quirks PRs.