### PR TITLE
Reset update percentage after install

### DIFF
--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -413,6 +413,8 @@ async def test_firmware_update_success(zha_gateway: Gateway) -> None:
         == f"0x{fw_image.firmware.header.file_version:08x}"
     )
     assert not entity.state[ATTR_IN_PROGRESS]
+    # The progress percentage is cleared once the update finishes
+    assert entity.state[ATTR_UPDATE_PERCENTAGE] is None
     assert entity.state[ATTR_LATEST_VERSION] == entity.state[ATTR_INSTALLED_VERSION]
 
     # If we send a progress notification incorrectly, it won't be handled
@@ -504,6 +506,10 @@ async def test_firmware_update_raises(zha_gateway: Gateway) -> None:
             version=f"0x{fw_image.firmware.header.file_version:08x}"
         )
         await zha_gateway.async_block_till_done()
+
+    # The progress state is cleared even when the update fails
+    assert not entity.state[ATTR_IN_PROGRESS]
+    assert entity.state[ATTR_UPDATE_PERCENTAGE] is None
 
 
 async def test_firmware_update_empty_exception_message(zha_gateway: Gateway) -> None:

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,5 +1,6 @@
 """Test ZHA firmware updates."""
 
+import asyncio
 from unittest.mock import ANY, AsyncMock, call, patch
 
 import pytest
@@ -553,6 +554,47 @@ async def test_firmware_update_empty_exception_message(zha_gateway: Gateway) -> 
     assert str(exc_info.value) == "Update was not successful: TimeoutError()"
     assert exc_info.value.__cause__ is raised
     assert not entity.state[ATTR_IN_PROGRESS]
+
+
+async def test_firmware_update_cancelled(zha_gateway: Gateway) -> None:
+    """A cancelled install must propagate and still clear the progress state."""
+    zigpy_device = zigpy_device_mock(zha_gateway)
+    zha_device, ota_cluster, fw_image, installed_fw_version = await setup_test_data(
+        zha_gateway, zigpy_device
+    )
+
+    entity = get_entity(zha_device, platform=Platform.UPDATE)
+
+    await ota_cluster._handle_query_next_image(
+        foundation.ZCLHeader.cluster(
+            tsn=0x12, command_id=general.Ota.ServerCommandDefs.query_next_image.id
+        ),
+        general.QueryNextImageCommand(
+            field_control=fw_image.firmware.header.field_control,
+            manufacturer_code=zha_device.manufacturer_code,
+            image_type=fw_image.firmware.header.image_type,
+            current_file_version=installed_fw_version,
+            hardware_version=1,
+        ),
+    )
+    await zha_gateway.async_block_till_done()
+
+    # `CancelledError` is a `BaseException`, so it must propagate untouched
+    # rather than being wrapped in a `ZHAException`.
+    with (
+        patch(
+            "zigpy.device.Device.update_firmware",
+            AsyncMock(side_effect=asyncio.CancelledError),
+        ),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await entity.async_install(
+            version=f"0x{fw_image.firmware.header.file_version:08x}"
+        )
+
+    # The progress state is still cleared when the install is cancelled
+    assert not entity.state[ATTR_IN_PROGRESS]
+    assert entity.state[ATTR_UPDATE_PERCENTAGE] is None
 
 
 async def test_firmware_update_downgrade(zha_gateway: Gateway) -> None:

--- a/zha/application/platforms/update.py
+++ b/zha/application/platforms/update.py
@@ -265,21 +265,18 @@ class BaseFirmwareUpdateEntity(PlatformEntity, ABC):
                 progress_callback=self._update_progress,
             )
         except Exception as ex:
-            self._attr_in_progress = False
-            self.maybe_emit_state_changed_event()
             raise ZHAException(
                 f"Update was not successful: {str(ex) or repr(ex)}"
             ) from ex
+        finally:
+            # Clear the progress state, regardless of the update's outcome
+            self._attr_in_progress = False
+            self._attr_update_percentage = None
+            self.maybe_emit_state_changed_event()
 
         # If the update finished but was not successful, we should also throw an error
         if result != Status.SUCCESS:
-            self._attr_in_progress = False
-            self.maybe_emit_state_changed_event()
             raise ZHAException(f"Update was not successful: {result}")
-
-        # Clear the state
-        self._attr_in_progress = False
-        self.maybe_emit_state_changed_event()
 
     async def on_remove(self) -> None:
         """Call when entity will be removed."""


### PR DESCRIPTION
**DRAFT.**

Reset `update_percentage` when a firmware update finishes

The firmware update entity set `in_progress` back to `False` when an install completed, failed, or raised, but never cleared `update_percentage`. This left the entity reporting a stale percentage (typically `100`) alongside `in_progress == False` — an internally inconsistent state at the library boundary.

Home Assistant's `update` platform happens to mask the percentage (`update_percentage if in_progress else None`), so an HA frontend user usually doesn't notice. But the ZHA library's own `state` dict and websocket contract emit the stale value directly, and relying on a downstream consumer to sanitize our output is fragile — the library should report correct state itself.

## Fix

The three exit paths (exception, non-`SUCCESS` status, success) each duplicated `self._attr_in_progress = False` + `maybe_emit_state_changed_event()`. These are collapsed into a single `finally` block that also clears `self._attr_update_percentage`, so the progress state is always cleared regardless of the update's outcome.

This also fixes a latent bug on **cancellation**. `asyncio.CancelledError` is a `BaseException`, so it was never caught by `except Exception`, and without a `finally` the old code skipped cleanup entirely — leaving the entity stuck at `in_progress: true` / `100%` indefinitely. The install call chain is unshielded end to end (HA `async_install_with_progress` → HA ZHA `async_install` → this entity → `zigpy` `update_firmware`), so a cancelled install task propagates `CancelledError` straight into this code. This is reachable in practice whenever the install task is cancelled while ZHA keeps running — e.g. an automation with `mode: restart` re-triggering, `automation.reload`/`script.reload`, or a `timeout:` wrapping `update.install`. The `finally` now clears the state and lets the `CancelledError` propagate untouched.

## Tests

- `test_firmware_update_success` — assert `update_percentage` is reset to `None` after a successful install (the primary regression; fails against the old code with `assert 100.0 is None`).
- `test_firmware_update_raises` — assert the progress state is cleared after a failed install.
- `test_firmware_update_cancelled` — new test: a `CancelledError` from `update_firmware` propagates untouched (not wrapped in `ZHAException`) and both `in_progress` and `update_percentage` are still cleared.
