### PR TITLE
Remove unused `_state` attribute from binary sensors

### DIFF
--- a/zha/application/platforms/binary_sensor/__init__.py
+++ b/zha/application/platforms/binary_sensor/__init__.py
@@ -111,7 +111,6 @@ class BinarySensor(BaseBinarySensor):
             )
 
         super().__init__(endpoint=endpoint, device=device, **kwargs)
-        self._state: bool = self.is_on
         self.recompute_capabilities()
 
     def _is_supported(self) -> bool:
@@ -145,7 +144,7 @@ class BinarySensor(BaseBinarySensor):
     @property
     def is_on(self) -> bool:
         """Return True if the switch is on based on the state machine."""
-        self._state = raw_state = self._cluster.get(self._attribute_name)
+        raw_state = self._cluster.get(self._attribute_name)
         if raw_state is None:
             return False
         if self._attribute_converter:
@@ -162,7 +161,6 @@ class BinarySensor(BaseBinarySensor):
         """Handle attribute updates from the cluster."""
         if self._attribute_name is None or self._attribute_name != event.attribute_name:
             return
-        self._state = bool(event.value)
         self.maybe_emit_state_changed_event()
 
     async def async_update(self) -> None:
@@ -177,7 +175,6 @@ class BinarySensor(BaseBinarySensor):
         )
         attr_value = result.get(attribute)
         if attr_value is not None:
-            self._state = attr_value
             self.maybe_emit_state_changed_event()
 
     @staticmethod


### PR DESCRIPTION
Addresses comment in:
- https://github.com/zigpy/zha/pull/803#discussion_r3478284956

## What

`BinarySensor._state` is only ever *assigned*, never *read*, so this drops the four dead write sites (`__init__`, `is_on`, `handle_attribute_updated`, `async_update`).

## Why

The state of a binary sensor is always recomputed directly from the cluster:

- the `state` property returns `self.is_on`,
- `is_on` reads `self._cluster.get(self._attribute_name)`, and
- `maybe_emit_state_changed_event` compares `self.state` (→ `is_on`).

Nothing reads `self._state` — not the module, not the base `PlatformEntity`, not the tests. (Other platforms such as `switch`, `light`, `lock` and `cover` genuinely use their own `_state`; this is specific to `binary_sensor`.)

Removing the attribute also means `__init__` no longer calls `is_on`, so the init-time guard added in #803 (`if not self.is_supported(): self._state = False`, to stop `is_on` raising while importing legacy diagnostics) is no longer needed — this can replace that hunk. See https://github.com/zigpy/zha/pull/803#discussion_r3478284956.