### PR TITLE
Test broad `except` when entity creation fails during discovery

### DIFF
--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -997,3 +997,37 @@ async def test_entityless_cluster_binds_via_virtual_entity(
     await zha_gateway.async_block_till_done(wait_background_tasks=True)
 
     assert len(philips_cluster.bind.mock_calls) == 1
+
+
+async def test_entity_creation_failure_is_skipped(
+    zha_gateway: Gateway,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test discovery skips (and logs) an entity that fails to instantiate."""
+    zigpy_device = create_mock_zigpy_device(
+        zha_gateway,
+        {
+            1: {
+                SIG_EP_INPUT: [
+                    zigpy.zcl.clusters.general.Basic.cluster_id,
+                    zigpy.zcl.clusters.general.OnOff.cluster_id,
+                ],
+                SIG_EP_OUTPUT: [],
+                SIG_EP_TYPE: zigpy.profiles.zha.DeviceType.ON_OFF_SWITCH,
+                SIG_EP_PROFILE: zigpy.profiles.zha.PROFILE_ID,
+            }
+        },
+    )
+
+    with mock.patch(
+        "zha.application.platforms.switch.Switch.__init__",
+        side_effect=RuntimeError("boom"),
+    ):
+        zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
+
+    # The broad except logged the failure and let discovery continue.
+    assert "Failed to create Switch entity" in caplog.text
+
+    # The switch entity was skipped, but the device still joined.
+    with pytest.raises(KeyError):
+        get_entity(zha_device, platform=Platform.SWITCH)


### PR DESCRIPTION
Addresses comment in:
- https://github.com/zigpy/zha/pull/821#issuecomment-4929756113

## What

Adds a test for the broad `except` in `discover_entities_for_endpoint` that skips (and logs) an entity whose instantiation raises, instead of aborting discovery for the rest of the endpoint.

## Why

`discover_entities_for_endpoint` wraps each entity instantiation in a broad `except` (`discovery.py:355-357`, logging `"Failed to create %s entity"`). This path used to be exercised incidentally: `BinarySensor.__init__` called `self._state = self.is_on`, which could raise and trip the except. #821 removed that dead `_state` assignment, so the except was no longer covered by the suite (entities that would fail are now filtered out earlier via `_is_supported`).

The test creates an on/off switch device, patches `Switch.__init__` to raise, joins the device, and asserts the failure is logged and the switch entity is skipped while the device still joins.