### PR TITLE
Fix `is_on` docstring wording on binary sensors

### DIFF
--- a/zha/application/platforms/binary_sensor/__init__.py
+++ b/zha/application/platforms/binary_sensor/__init__.py
@@ -143,7 +143,7 @@ class BinarySensor(BaseBinarySensor):
 
     @property
     def is_on(self) -> bool:
-        """Return True if the switch is on based on the state machine."""
+        """Return True if the binary sensor is on based on the state machine."""
         raw_state = self._cluster.get(self._attribute_name)
         if raw_state is None:
             return False


### PR DESCRIPTION
The `BinarySensor.is_on` docstring described a "switch" rather than a binary sensor, which is confusing in logs/docs. Reworded to "binary sensor". Reported by Copilot on #821.