### PR TITLE
Codex updated: Do not bind clusters whose entities are not created

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1200,6 +1200,31 @@ async def test_join_binding_reporting(zha_gateway: Gateway) -> None:
     ]
 
 
+async def test_quirks_v2_prevent_entity_excludes_cluster_configuration(
+    zha_gateway: Gateway,
+) -> None:
+    """Test a quirk-suppressed entity does not configure its cluster."""
+    zigpy_dev = await zigpy_device_from_json(
+        zha_gateway.application_controller,
+        "tests/data/devices/innr-sp-240-0x191e3685.json",
+    )
+
+    level = zigpy_dev.endpoints[1].level
+    on_off = zigpy_dev.endpoints[1].on_off
+
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
+
+    assert zha_device.quirk_applied
+
+    assert level.bind.mock_calls == []
+    assert level.configure_reporting_multiple.mock_calls == []
+    assert level.read_attributes.mock_calls == []
+
+    assert on_off.bind.mock_calls == [call()]
+    assert on_off.configure_reporting_multiple.call_count == 1
+    assert on_off.read_attributes.call_count == 2
+
+
 async def test_endpoint_none_profile(
     zha_gateway: Gateway,
     caplog: pytest.LogCaptureFixture,

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -371,10 +371,8 @@ class Device(LogMixin, EventBase):
 
         self._platform_entities: dict[tuple[Platform, str], PlatformEntity] = {}
         self._pending_entities: list[PlatformEntity] = []
-        # All entities discovered for this device, including ones removed by a quirk.
-        # Used for aggregating cluster configs so binding/reporting matches the
-        # legacy claim-during-discovery flow (which configured handlers even when
-        # the visible entity was filtered out later).
+        # Entities retained after quirk suppression, including virtual entities.
+        # Used for aggregating cluster configs for binding, reporting, and reads.
         self._discovered_entities: list[PlatformEntity] = []
         self._initialized: bool = False
         self.semaphore: asyncio.Semaphore = asyncio.Semaphore(3)
@@ -1087,10 +1085,10 @@ class Device(LogMixin, EventBase):
                 _LOGGER.exception("Failed to create entity during discovery")
                 continue
 
-            self._discovered_entities.append(entity)
-
             if self._is_entity_removed_by_quirk(entity):
                 continue
+
+            self._discovered_entities.append(entity)
 
             # Apply any metadata changes from quirks v2
             self._apply_entity_metadata_changes(entity)


### PR DESCRIPTION
This pull request was created with Codex and is an updated version of the pull request it supersedes.

Original pull request: https://github.com/zigpy/zha/pull/783

See https://github.com/zigpy/zha/issues/781.