### PR TITLE
Codex updated: Fix discovery crash from quirk removing ZCL attributes

### DIFF
--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from typing import Final
 from unittest.mock import call, patch
 
 import pytest
@@ -34,6 +35,7 @@ from tests.common import (
     get_group_entity,
     group_entity_availability_test,
     join_zigpy_device,
+    patch_cluster_for_testing,
     send_attributes_report,
     update_attribute_cache,
     zigpy_device_from_json,
@@ -43,6 +45,11 @@ from zha.application.gateway import Gateway
 from zha.application.platforms import GroupEntity, PlatformEntity
 from zha.exceptions import ZHAException
 from zha.quirks import QUIRK_REGISTRY_ENTRY_ATTR, DeviceRegistry
+from zha.zigbee.cluster_config import (
+    AggregatedAttrConfig,
+    AggregatedClusterConfig,
+    initialize_cluster_configs,
+)
 from zha.zigbee.device import Device
 from zha.zigbee.group import Group, GroupMemberReference
 
@@ -903,4 +910,72 @@ async def test_binary_output_cluster(zha_gateway: Gateway) -> None:
             only_cache=False,
             manufacturer=UNDEFINED,
         )
+    ]
+
+
+class MissingOnOffAttributesCluster(CustomCluster, general.OnOff):
+    """OnOff cluster without the standard attribute definitions."""
+
+    class AttributeDefs(zcl_f.BaseAttributeDefs):
+        """Attribute definitions not inheriting from OnOff.AttributeDefs."""
+
+        window_detection_temperature: Final = zcl_f.ZCLAttributeDef(
+            id=0x6000, type=t.int16s, is_manufacturer_specific=True
+        )
+
+
+async def test_switch_missing_standard_attribute_definitions(
+    zha_gateway: Gateway,
+) -> None:
+    """A quirk-replaced OnOff cluster does not abort device discovery."""
+    registry = DeviceRegistry()
+    zigpy_device = create_mock_zigpy_device(
+        zha_gateway,
+        ZIGPY_DEVICE,
+        manufacturer="Test_Manufacturer",
+        model="Test_Model",
+    )
+
+    (
+        QuirkBuilder(zigpy_device.manufacturer, zigpy_device.model)
+        .replaces(MissingOnOffAttributesCluster)
+        .add_to_registry(registry)
+    )
+
+    zigpy_device = registry.resolve(zigpy_device)
+    assert getattr(zigpy_device, QUIRK_REGISTRY_ENTRY_ATTR, None) is not None
+    assert isinstance(zigpy_device.endpoints[1].on_off, MissingOnOffAttributesCluster)
+    patch_cluster_for_testing(zigpy_device.endpoints[1].on_off)
+
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_device)
+
+    with pytest.raises(KeyError):
+        get_entity(zha_device, platform=Platform.SWITCH)
+
+
+async def test_missing_definition_does_not_suppress_valid_startup_read(
+    zha_gateway: Gateway,
+) -> None:
+    """An undefined config attribute does not suppress a valid startup read."""
+    zigpy_device = create_mock_zigpy_device(
+        zha_gateway,
+        ZIGPY_DEVICE,
+    )
+    cluster = zigpy_device.endpoints[1].on_off
+    configs = {
+        (1, general.OnOff.cluster_id, True): AggregatedClusterConfig(
+            cluster=cluster,
+            attributes={
+                general.OnOff.AttributeDefs.on_off.name: AggregatedAttrConfig(
+                    read_on_startup=True
+                ),
+                "missing_attribute": AggregatedAttrConfig(read_on_startup=True),
+            },
+        )
+    }
+
+    await initialize_cluster_configs(configs, from_cache=False)
+    assert cluster.read_attributes_raw.call_count == 1
+    assert cluster.read_attributes_raw.call_args.args[0] == [
+        general.OnOff.AttributeDefs.on_off.id
     ]

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -919,8 +919,9 @@ class AggregatedClusterPoller(VirtualEntity):
                 continue
             if not entity.enabled:
                 continue
-            if entity._attribute_name and self._cluster.is_attribute_unsupported(
-                entity._attribute_name
+            if entity._attribute_name and (
+                entity._attribute_name not in self._cluster.attributes_by_name
+                or self._cluster.is_attribute_unsupported(entity._attribute_name)
             ):
                 continue
             cfg = entity._server_cluster_config.get(self._cluster_id)
@@ -929,10 +930,14 @@ class AggregatedClusterPoller(VirtualEntity):
             for attr_def, attr_cfg in cfg.attributes.items():
                 if attr_cfg.reporting is None:
                     continue
-                if self._cluster.is_attribute_unsupported(attr_def):
+                attr_name = attr_def if isinstance(attr_def, str) else attr_def.name
+                if (
+                    attr_name not in self._cluster.attributes_by_name
+                    or self._cluster.is_attribute_unsupported(attr_name)
+                ):
                     continue
 
-                attrs.add(attr_def if isinstance(attr_def, str) else attr_def.name)
+                attrs.add(attr_name)
 
         if not attrs:
             return

--- a/zha/application/platforms/switch.py
+++ b/zha/application/platforms/switch.py
@@ -202,7 +202,10 @@ class Switch(PlatformEntity, BaseSwitch):
             )
 
     def _is_supported(self) -> bool:
-        if self._cluster.is_attribute_unsupported(self._attribute_name):
+        if (
+            self._attribute_name not in self._cluster.attributes_by_name
+            or self._cluster.is_attribute_unsupported(self._attribute_name)
+        ):
             _LOGGER.debug(
                 "%s is not supported - skipping %s entity creation",
                 self._attribute_name,
@@ -1041,8 +1044,8 @@ class WindowCoveringInversionSwitch(ConfigurableAttributeSwitch):
 
         # this entity needs a second attribute to function
         if (
-            self._cluster.is_attribute_unsupported(window_covering_mode_attr)
-            or window_covering_mode_attr not in self._cluster.attributes_by_name
+            window_covering_mode_attr not in self._cluster.attributes_by_name
+            or self._cluster.is_attribute_unsupported(window_covering_mode_attr)
             or self._cluster.get(window_covering_mode_attr) is None
         ):
             _LOGGER.debug(

--- a/zha/zigbee/cluster_config.py
+++ b/zha/zigbee/cluster_config.py
@@ -178,6 +178,15 @@ async def configure_cluster_configs(
         for attr_name, attr_config in agg.attributes.items():
             if attr_config.reporting is None:
                 continue
+            if attr_name not in agg.cluster.attributes_by_name:
+                _LOGGER.debug(
+                    "[%s] Attribute %s has no definition on cluster %s,"
+                    " skipping reporting configuration",
+                    agg.cluster.endpoint.device.ieee,
+                    attr_name,
+                    agg.cluster.ep_attribute,
+                )
+                continue
             attr_def = agg.cluster.find_attribute(attr_name)
             reporting_attrs[attr_def] = attr_config.reporting
 
@@ -248,16 +257,21 @@ async def initialize_cluster_configs(
 ) -> None:
     """Read initial attribute values from aggregated configs."""
     for agg in configs.values():
-        cached_attrs = [
-            attr_name
-            for attr_name, attr_config in agg.attributes.items()
-            if not attr_config.read_on_startup
-        ]
-        fresh_attrs = [
-            attr_name
-            for attr_name, attr_config in agg.attributes.items()
-            if attr_config.read_on_startup
-        ]
+        cached_attrs: list[str] = []
+        fresh_attrs: list[str] = []
+        for attr_name, attr_config in agg.attributes.items():
+            if attr_name not in agg.cluster.attributes_by_name:
+                _LOGGER.debug(
+                    "[%s] Attribute %s has no definition on cluster %s,"
+                    " skipping initialization",
+                    agg.cluster.endpoint.device.ieee,
+                    attr_name,
+                    agg.cluster.ep_attribute,
+                )
+                continue
+
+            attrs = fresh_attrs if attr_config.read_on_startup else cached_attrs
+            attrs.append(attr_name)
 
         if cached_attrs:
             try:


### PR DESCRIPTION
This pull request was created with Codex and is an updated version of the pull request it supersedes.

Original pull request: https://github.com/zigpy/zha/pull/788

DRAFT.

## Proposed change

This fixes an issue where a (custom) quirk can remove standard ZCL attributes. Most entity platforms already have guards checking if the attribute even exists, but some do not. This adds them.

## Additional information

I'm not sure if this is something we should add – quirks shouldn't misbehave like this. Or are there valid use-cases for deleting ZCL attributes...? But currently, ZHA startup breaks completely when using [these custom quirks](https://github.com/jacekk015/zha_quirks).

Should address:
- https://github.com/home-assistant/core/issues/173265

This "regression" was introduced with:
- https://github.com/zigpy/zha/pull/657

### AI summary

<details>
<summary>Issue and fix summary (CLICK TO EXPAND)</summary>

### Issue

Some custom v1 quirks fully replace a standard cluster's attribute definitions, e.g. the widely used `ts0601_trv_moes.py` from [jacekk015/zha_quirks](https://github.com/jacekk015/zha_quirks) does:

```python
class MoesWindowDetection(LocalDataCluster, OnOff):
    attributes = LocalDataCluster.attributes.copy()  # empty dict
    attributes.update({
        0x6000: ("window_detection_temperature", t.int16s),
        0x6001: ("window_detection_timeout_minutes", t.uint8_t),
    })
```

The resulting `OnOff` cluster has no `on_off`/`start_up_on_off` attribute definitions. `Cluster.is_attribute_unsupported()` (and `find_attribute()`) raise `KeyError` for attribute names without a definition.

Since #657, `Switch._is_supported()` calls `cluster.is_attribute_unsupported("on_off")` during entity discovery. The `KeyError` propagated through `Device._add_pending_entities()` → `Gateway.load_devices()` → HA's `async_setup_entry`, so **one broken custom quirk prevented the entire ZHA integration from starting** (`ConfigEntryNotReady` retry loop). Previously, the cluster-handler-based code tolerated these clusters.

### Affected code paths

- `Switch._is_supported()` was the only `_is_supported` implementation missing the `attributes_by_name` guard that all other platforms already had (the crash from the linked issue).
- `WindowCoveringInversionSwitch._is_supported()` had the guard, but evaluated `is_attribute_unsupported()` first.
- `configure_cluster_configs()` called `find_attribute()` unguarded on reporting attributes aggregated from entities not yet filtered by `is_supported()`, failing on device join/reconfigure.
- `AggregatedClusterPoller.async_update()` called `is_attribute_unsupported()` unguarded on sibling entities' cluster-config attributes during polling.

### Fix

Check `attr_name in cluster.attributes_by_name` before calling `is_attribute_unsupported()`/`find_attribute()` at the four sites above, treating attributes without definitions as unsupported (entity not created / reporting skipped with a debug log).

A regression test joins a device with a quirks v2 quirk (local registry) that replaces the `OnOff` cluster with one whose `AttributeDefs` does not inherit the standard definitions, reproducing the exact `KeyError: 'on_off'` from the issue on unfixed code, and asserts device initialization succeeds with no switch entity created.

</details>
