### PR TITLE
Exclude zigpy libs from Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,13 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 3
+      # The Zigbee radio stack and zha-quirks skip the cooldown (updated immediately).
+      exclude:
+        - "zigpy*"
+        - "bellows"
+        - "zha-quirks"
     groups:
       python-dependencies:
         patterns:


### PR DESCRIPTION
This PR excludes zigpy libraries from the newly introduced [Dependabot 3-day cooldown](https://github.blog/changelog/2026-07-14-dependabot-version-updates-introduce-default-package-cooldown/).

<details><summary>AI summary (click to expand)</summary>
<p>

## AI summary

Dependabot [now applies a default 3-day cooldown](https://github.blog/changelog/2026-07-14-dependabot-version-updates-introduce-default-package-cooldown/) before opening version-update PRs, to reduce the risk of picking up a compromised or broken release before the community catches it.

That's a sensible default for our third-party dependencies, but we don't want it for the first-party zigpy stack: the Zigbee radio libraries and zha-quirks are released by the same org, and ZHA often needs them promptly (coupled releases). This adds a `cooldown` block to the `uv` ecosystem that keeps the 3-day default for everything else while excluding the zigpy stack, so those still update immediately. The excluded set mirrors the packages already carved out of the grouped `python-dependencies` PR.

```yaml
    cooldown:
      default-days: 3
      # The Zigbee radio stack and zha-quirks skip the cooldown (updated immediately).
      exclude:
        - "zigpy*"
        - "bellows"
        - "zha-quirks"
```

Notes:
- `exclude` takes precedence over cooldown, so the listed packages skip the wait entirely.
- `cooldown` only affects version updates — security updates are never delayed.
- The `github-actions` ecosystem is left untouched.


</p>
</details> 

