### PR TITLE
Fix AnalogInput sensor for `resolution = 0`

### DIFF
--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -883,6 +883,32 @@ async def test_analog_input_complex(zha_gateway: Gateway) -> None:
     assert entity.info_object.suggested_display_precision == 2
 
 
+async def test_analog_input_zero_resolution(zha_gateway: Gateway) -> None:
+    """Test a device reporting a bogus `resolution` of 0 (issue #826)."""
+    zigpy_dev = await zigpy_device_from_json(
+        zha_gateway.application_controller,
+        "tests/data/devices/isilentllc-masterbed-light-controller.json",
+    )
+
+    analog_input = zigpy_dev.endpoints[2].analog_input
+    analog_input.update_attribute(
+        AnalogInput.AttributeDefs.description.id, "Some description"
+    )
+    # The ThirdReality 3RAP0149BZ answers reads of `resolution` with 0.0
+    analog_input.PLUGGED_ATTR_READS[AnalogInput.AttributeDefs.resolution.id] = 0.0
+
+    zha_dev = await join_zigpy_device(zha_gateway, zigpy_dev)
+    entity = get_entity(
+        zha_dev, platform=Platform.SENSOR, exact_entity_type=AnalogInputSensor
+    )
+    assert entity.info_object.suggested_display_precision is None
+
+    # The bogus resolution is cached in the zigpy database, so it must not
+    # abort the from-cache initialization on the next startup either
+    await zha_dev.async_initialize(from_cache=True)
+    get_entity(zha_dev, platform=Platform.SENSOR, exact_entity_type=AnalogInputSensor)
+
+
 def assert_state(entity: PlatformEntity, state: Any, unit_of_measurement: str) -> None:
     """Check that the state is what is expected.
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -883,10 +883,7 @@ async def test_analog_input_complex(zha_gateway: Gateway) -> None:
     assert entity.info_object.suggested_display_precision == 2
 
 
-@pytest.mark.parametrize(
-    "resolution",
-    [0.0, float("inf"), float("-inf"), float("nan")],
-)
+@pytest.mark.parametrize("resolution", [0.0, float("inf")])
 async def test_analog_input_bogus_resolution(
     zha_gateway: Gateway, resolution: float
 ) -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -903,11 +903,6 @@ async def test_analog_input_zero_resolution(zha_gateway: Gateway) -> None:
     )
     assert entity.info_object.suggested_display_precision is None
 
-    # The bogus resolution is cached in the zigpy database, so it must not
-    # abort the from-cache initialization on the next startup either
-    await zha_dev.async_initialize(from_cache=True)
-    get_entity(zha_dev, platform=Platform.SENSOR, exact_entity_type=AnalogInputSensor)
-
 
 def assert_state(entity: PlatformEntity, state: Any, unit_of_measurement: str) -> None:
     """Check that the state is what is expected.

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -883,8 +883,14 @@ async def test_analog_input_complex(zha_gateway: Gateway) -> None:
     assert entity.info_object.suggested_display_precision == 2
 
 
-async def test_analog_input_zero_resolution(zha_gateway: Gateway) -> None:
-    """Test a device reporting a bogus `resolution` of 0 (issue #826)."""
+@pytest.mark.parametrize(
+    "resolution",
+    [0.0, float("inf"), float("-inf"), float("nan")],
+)
+async def test_analog_input_bogus_resolution(
+    zha_gateway: Gateway, resolution: float
+) -> None:
+    """Test a device reporting a bogus analog input resolution."""
     zigpy_dev = await zigpy_device_from_json(
         zha_gateway.application_controller,
         "tests/data/devices/isilentllc-masterbed-light-controller.json",
@@ -894,8 +900,9 @@ async def test_analog_input_zero_resolution(zha_gateway: Gateway) -> None:
     analog_input.update_attribute(
         AnalogInput.AttributeDefs.description.id, "Some description"
     )
-    # The ThirdReality 3RAP0149BZ answers reads of `resolution` with 0.0
-    analog_input.PLUGGED_ATTR_READS[AnalogInput.AttributeDefs.resolution.id] = 0.0
+    analog_input.PLUGGED_ATTR_READS[AnalogInput.AttributeDefs.resolution.id] = (
+        resolution
+    )
 
     zha_dev = await join_zigpy_device(zha_gateway, zigpy_dev)
     entity = get_entity(

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -699,9 +699,12 @@ class AnalogInputSensor(Sensor):
                 self._cluster.get(AnalogInput.AttributeDefs.engineering_units.name)
             )
 
-        # Resolution indicates the minimum change in value that can be detected
+        # Resolution indicates the minimum change in value that can be detected.
+        # Some devices report a bogus resolution of 0 (e.g. ThirdReality
+        # 3RAP0149BZ), which must not abort device initialization.
+        self._attr_suggested_display_precision = None
         resolution = self._cluster.get(AnalogInput.AttributeDefs.resolution.name)
-        if resolution is not None:
+        if resolution is not None and math.isfinite(resolution) and resolution > 0:
             self._attr_suggested_display_precision = resolution_to_decimal_precision(
                 resolution
             )

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -700,8 +700,7 @@ class AnalogInputSensor(Sensor):
             )
 
         # Resolution indicates the minimum change in value that can be detected.
-        # Some devices report a bogus resolution of 0 (e.g. ThirdReality
-        # 3RAP0149BZ), which must not abort device initialization.
+        # Guard against 0 resolution reported by some devices.
         self._attr_suggested_display_precision = None
         resolution = self._cluster.get(AnalogInput.AttributeDefs.resolution.name)
         if resolution is not None and math.isfinite(resolution) and resolution > 0:


### PR DESCRIPTION
This fixes an issue where the `AnalogInput` sensor entity raised when `AnalogInput.resolution` is `0` for a device. See the original issue for more context:
- https://github.com/zigpy/zha/issues/826

In the future, we'll likely want to implement some of the guards from https://github.com/zigpy/zha/compare/dev...zigpy-bot/analog-input-zero-resolution as well. For now, this is just to get this patch into a HA patch release.

## AI summary

<details><summary>AI summary (click to expand)</summary>
<p>

Some devices report a bogus AnalogInput `resolution` attribute. The ThirdReality 3RAP0149BZ pressure sensor (firmware 1.00.24) answers reads of `resolution` with `0.0`, which tripped `assert resolution > 0` in `resolution_to_decimal_precision()`. That `AssertionError` propagated out of `AnalogInputSensor.recompute_capabilities()` and aborted the device's `async_initialize()`, so the device was left broken until ZHA was reloaded — and once the bad value was cached in the zigpy database it could take down gateway startup on the next boot (#826).

This guards the `resolution → suggested_display_precision` conversion so only a positive, finite resolution is converted, leaving the precision unset otherwise (mirroring how the light platform already defends against `color_temp_physical_min/max` of 0). `math.isfinite` is included because a `+inf` resolution would pass `> 0` and then raise `OverflowError` inside `resolution_to_decimal_precision()`.

```python
# Resolution indicates the minimum change in value that can be detected.
# Guard against 0 resolution reported by some devices.
self._attr_suggested_display_precision = None
resolution = self._cluster.get(AnalogInput.AttributeDefs.resolution.name)
if resolution is not None and math.isfinite(resolution) and resolution > 0:
    self._attr_suggested_display_precision = resolution_to_decimal_precision(resolution)
```

## Tests

Adds `test_analog_input_bogus_resolution`, parametrized over `0.0` (the real-world ThirdReality value, caught by `> 0`) and `float("inf")` (caught by `math.isfinite`). Both assert the entity is still created and its `suggested_display_precision` is left unset.

## Scope

This is a deliberately minimal fix intended for a Home Assistant patch release — it only stops a bogus `resolution` from aborting `AnalogInputSensor` initialization.

The `zigpy-bot/analog-input-zero-resolution` branch carries broader, more defensive changes to look at as a follow-up (per-entity isolation so a single misbehaving entity can't abort `_add_pending_entities()` / `recompute_entities()` for the rest of the device, extended to the `is_supported()` checks): https://github.com/zigpy/zha/compare/dev...zigpy-bot/analog-input-zero-resolution

Addresses part of:
- #826



</p>
</details> 