### PR TITLE
Fix device temperature entity divisor

### DIFF
--- a/tests/data/devices/aeotec-zga004.json
+++ b/tests/data/devices/aeotec-zga004.json
@@ -730,7 +730,7 @@
         "state": {
           "class_name": "DeviceTemperature",
           "available": true,
-          "state": 0.41
+          "state": 41.0
         }
       },
       {

--- a/tests/data/devices/aqara-lumi-motion-ac01-0x00000035.json
+++ b/tests/data/devices/aqara-lumi-motion-ac01-0x00000035.json
@@ -79,7 +79,7 @@
               "id": "0x0000",
               "name": "current_temperature",
               "zcl_type": "int16",
-              "value": 2700
+              "value": 27
             }
           ]
         },

--- a/tests/data/devices/aqara-lumi-switch-acn047-0x0000001c.json
+++ b/tests/data/devices/aqara-lumi-switch-acn047-0x0000001c.json
@@ -79,7 +79,7 @@
               "id": "0x0000",
               "name": "current_temperature",
               "zcl_type": "int16",
-              "value": 3500
+              "value": 35
             },
             {
               "id": "0x0010",

--- a/tests/data/devices/frient-a-s-splzb-141-0x00020009.json
+++ b/tests/data/devices/frient-a-s-splzb-141-0x00020009.json
@@ -7,8 +7,8 @@
   "friendly_manufacturer": "frient A/S",
   "friendly_model": "SPLZB-141",
   "name": "frient A/S SPLZB-141",
-  "quirk_applied": true,
-  "quirk_class": "zhaquirks.develco.power_plug:(frient A/S / SPLZB-141)",
+  "quirk_applied": false,
+  "quirk_class": "zigpy.device.Device",
   "exposes_features": [],
   "manufacturer_code": 4117,
   "power_source": "Mains",
@@ -723,11 +723,11 @@
       },
       {
         "info_object": {
-          "fallback_name": "Device temperature",
+          "fallback_name": null,
           "unique_id": "00:15:bc:00:2f:02:19:79-2-2",
           "migrate_unique_ids": [],
           "platform": "sensor",
-          "class_name": "Sensor",
+          "class_name": "DeviceTemperature",
           "translation_key": "device_temperature",
           "translation_placeholders": null,
           "device_class": "temperature",
@@ -744,9 +744,9 @@
           "unit": "\u00b0C"
         },
         "state": {
-          "class_name": "Sensor",
+          "class_name": "DeviceTemperature",
           "available": true,
-          "state": 32
+          "state": 32.0
         }
       },
       {

--- a/tests/data/devices/lumi-lumi-ctrl-neutral2.json
+++ b/tests/data/devices/lumi-lumi-ctrl-neutral2.json
@@ -78,7 +78,7 @@
               "id": "0x0000",
               "name": "current_temperature",
               "zcl_type": "int16",
-              "value": 2300
+              "value": 23
             }
           ]
         },

--- a/tests/data/devices/lumi-lumi-curtain-acn002-0x00000e1f.json
+++ b/tests/data/devices/lumi-lumi-curtain-acn002-0x00000e1f.json
@@ -97,7 +97,7 @@
               "id": "0x0000",
               "name": "current_temperature",
               "zcl_type": "int16",
-              "value": 2400
+              "value": 24
             }
           ]
         },

--- a/tests/data/devices/lumi-lumi-curtain-acn002-0x00000f20.json
+++ b/tests/data/devices/lumi-lumi-curtain-acn002-0x00000f20.json
@@ -648,7 +648,7 @@
         "state": {
           "class_name": "DeviceTemperature",
           "available": true,
-          "state": 0.3
+          "state": 30.0
         }
       },
       {

--- a/tests/data/devices/lumi-lumi-motion-agl04-0x00000019.json
+++ b/tests/data/devices/lumi-lumi-motion-agl04-0x00000019.json
@@ -97,7 +97,7 @@
               "id": "0x0000",
               "name": "current_temperature",
               "zcl_type": "int16",
-              "value": 2500
+              "value": 25
             }
           ]
         },

--- a/tests/data/devices/lumi-lumi-plug-maeu01-0x0000002d.json
+++ b/tests/data/devices/lumi-lumi-plug-maeu01-0x0000002d.json
@@ -79,7 +79,7 @@
               "id": "0x0000",
               "name": "current_temperature",
               "zcl_type": "int16",
-              "value": 1800
+              "value": 18
             }
           ]
         },

--- a/tests/data/devices/lumi-lumi-plug-maeu01.json
+++ b/tests/data/devices/lumi-lumi-plug-maeu01.json
@@ -568,7 +568,7 @@
         "state": {
           "class_name": "DeviceTemperature",
           "available": true,
-          "state": 0.29
+          "state": 29.0
         }
       },
       {

--- a/tests/data/devices/lumi-lumi-plug-maus01-0x0000000b.json
+++ b/tests/data/devices/lumi-lumi-plug-maus01-0x0000000b.json
@@ -109,7 +109,7 @@
               "id": "0x0000",
               "name": "current_temperature",
               "zcl_type": "int16",
-              "value": 4100
+              "value": 41
             }
           ]
         },

--- a/tests/data/devices/lumi-lumi-relay-c2acn01-0x00000024.json
+++ b/tests/data/devices/lumi-lumi-relay-c2acn01-0x00000024.json
@@ -97,7 +97,7 @@
               "id": "0x0000",
               "name": "current_temperature",
               "zcl_type": "int16",
-              "value": 4000
+              "value": 40
             }
           ]
         },

--- a/tests/data/devices/lumi-lumi-sensor-86sw2.json
+++ b/tests/data/devices/lumi-lumi-sensor-86sw2.json
@@ -103,7 +103,7 @@
               "id": "0x0000",
               "name": "current_temperature",
               "zcl_type": "int16",
-              "value": 2100
+              "value": 21
             }
           ]
         },

--- a/tests/data/devices/lumi-lumi-sensor-magnet-aq2.json
+++ b/tests/data/devices/lumi-lumi-sensor-magnet-aq2.json
@@ -97,7 +97,7 @@
               "id": "0x0000",
               "name": "current_temperature",
               "zcl_type": "int16",
-              "value": 2700
+              "value": 27
             }
           ]
         },

--- a/tests/data/devices/lumi-lumi-sensor-motion-aq2.json
+++ b/tests/data/devices/lumi-lumi-sensor-motion-aq2.json
@@ -103,7 +103,7 @@
               "id": "0x0000",
               "name": "current_temperature",
               "zcl_type": "int16",
-              "value": 2700
+              "value": 27
             }
           ]
         },

--- a/tests/data/devices/lumi-lumi-sensor-smoke.json
+++ b/tests/data/devices/lumi-lumi-sensor-smoke.json
@@ -115,7 +115,7 @@
               "id": "0x0000",
               "name": "current_temperature",
               "zcl_type": "int16",
-              "value": 2300
+              "value": 23
             }
           ]
         },

--- a/tests/data/devices/lumi-lumi-sensor-switch-aq2.json
+++ b/tests/data/devices/lumi-lumi-sensor-switch-aq2.json
@@ -103,7 +103,7 @@
               "id": "0x0000",
               "name": "current_temperature",
               "zcl_type": "int16",
-              "value": 2900
+              "value": 29
             }
           ]
         },

--- a/tests/data/devices/lumi-lumi-sensor-switch-aq3.json
+++ b/tests/data/devices/lumi-lumi-sensor-switch-aq3.json
@@ -97,7 +97,7 @@
               "id": "0x0000",
               "name": "current_temperature",
               "zcl_type": "int16",
-              "value": 2800
+              "value": 28
             }
           ]
         },

--- a/tests/data/devices/lumi-lumi-switch-b1lacn02.json
+++ b/tests/data/devices/lumi-lumi-switch-b1lacn02.json
@@ -78,7 +78,7 @@
               "id": "0x0000",
               "name": "current_temperature",
               "zcl_type": "int16",
-              "value": 1700
+              "value": 17
             }
           ]
         },

--- a/tests/data/devices/lumi-lumi-switch-b1laus01-0x00000020.json
+++ b/tests/data/devices/lumi-lumi-switch-b1laus01-0x00000020.json
@@ -365,7 +365,7 @@
         "state": {
           "class_name": "DeviceTemperature",
           "available": true,
-          "state": 0.2
+          "state": 20.0
         }
       }
     ],

--- a/tests/data/devices/lumi-lumi-switch-b1naus01-0x0000001f.json
+++ b/tests/data/devices/lumi-lumi-switch-b1naus01-0x0000001f.json
@@ -643,7 +643,7 @@
         "state": {
           "class_name": "DeviceTemperature",
           "available": true,
-          "state": 0.23
+          "state": 23.0
         }
       },
       {

--- a/tests/data/devices/lumi-lumi-switch-b2naus01.json
+++ b/tests/data/devices/lumi-lumi-switch-b2naus01.json
@@ -73,7 +73,7 @@
               "id": "0x0000",
               "name": "current_temperature",
               "zcl_type": "int16",
-              "value": 1400
+              "value": 14
             }
           ]
         },

--- a/tests/data/devices/lumi-lumi-switch-b2nc01.json
+++ b/tests/data/devices/lumi-lumi-switch-b2nc01.json
@@ -939,7 +939,7 @@
         "state": {
           "class_name": "DeviceTemperature",
           "available": true,
-          "state": 0.24
+          "state": 24.0
         }
       }
     ],

--- a/tests/data/devices/lumi-lumi-switch-l1aeu1-0x00000e0b.json
+++ b/tests/data/devices/lumi-lumi-switch-l1aeu1-0x00000e0b.json
@@ -388,7 +388,7 @@
         "state": {
           "class_name": "DeviceTemperature",
           "available": true,
-          "state": 0.3
+          "state": 30.0
         }
       }
     ],

--- a/tests/data/devices/lumi-lumi-switch-l2aeu1-0x00000e0b.json
+++ b/tests/data/devices/lumi-lumi-switch-l2aeu1-0x00000e0b.json
@@ -481,7 +481,7 @@
         "state": {
           "class_name": "DeviceTemperature",
           "available": true,
-          "state": 0.3
+          "state": 30.0
         }
       }
     ],

--- a/tests/data/devices/lumi-lumi-switch-n0agl1-0x0000001e.json
+++ b/tests/data/devices/lumi-lumi-switch-n0agl1-0x0000001e.json
@@ -869,7 +869,7 @@
         "state": {
           "class_name": "DeviceTemperature",
           "available": true,
-          "state": 0.18
+          "state": 18.0
         }
       },
       {

--- a/tests/data/devices/lumi-lumi-switch-n0agl1.json
+++ b/tests/data/devices/lumi-lumi-switch-n0agl1.json
@@ -869,7 +869,7 @@
         "state": {
           "class_name": "DeviceTemperature",
           "available": true,
-          "state": 0.18
+          "state": 18.0
         }
       },
       {

--- a/tests/data/devices/lumi-lumi-switch-n1aeu1.json
+++ b/tests/data/devices/lumi-lumi-switch-n1aeu1.json
@@ -637,7 +637,7 @@
         "state": {
           "class_name": "DeviceTemperature",
           "available": true,
-          "state": 0.28
+          "state": 28.0
         }
       },
       {

--- a/tests/data/devices/lumi-lumi-vibration-aq1.json
+++ b/tests/data/devices/lumi-lumi-vibration-aq1.json
@@ -105,7 +105,7 @@
               "id": "0x0000",
               "name": "current_temperature",
               "zcl_type": "int16",
-              "value": 2600
+              "value": 26
             }
           ]
         },

--- a/tests/data/devices/namron-as-4512785-0x0000000e.json
+++ b/tests/data/devices/namron-as-4512785-0x0000000e.json
@@ -7,8 +7,8 @@
   "friendly_manufacturer": "Namron AS",
   "friendly_model": "4512785",
   "name": "Namron AS 4512785",
-  "quirk_applied": false,
-  "quirk_class": "zigpy.device.Device",
+  "quirk_applied": true,
+  "quirk_class": "zhaquirks.namron.switch:(Namron AS / 4512785)",
   "exposes_features": [],
   "manufacturer_code": 4714,
   "power_source": "Mains",
@@ -794,11 +794,11 @@
       },
       {
         "info_object": {
-          "fallback_name": null,
+          "fallback_name": "Device temperature",
           "unique_id": "ab:cd:ef:12:4c:9e:2b:64-1-2",
           "migrate_unique_ids": [],
           "platform": "sensor",
-          "class_name": "DeviceTemperature",
+          "class_name": "Sensor",
           "translation_key": "device_temperature",
           "translation_placeholders": null,
           "device_class": "temperature",
@@ -815,9 +815,9 @@
           "unit": "\u00b0C"
         },
         "state": {
-          "class_name": "DeviceTemperature",
+          "class_name": "Sensor",
           "available": true,
-          "state": 3.52
+          "state": 35.2
         }
       },
       {

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -2680,7 +2680,7 @@ class DeviceTemperature(Sensor):
     _attr_device_class: SensorDeviceClass = SensorDeviceClass.TEMPERATURE
     _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
     _attr_translation_key: str = "device_temperature"
-    _divisor = 100
+    _divisor = 1
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_primary_weight = 1


### PR DESCRIPTION
We incorrectly treated the device temperature (a signed 16-bit integer, -32,768 to 32,767) as representing a scaled temperature. Strangely, it is _unscaled_: it represents the temperature in whole degrees C.

This PR removes the `100` divisor. Quirks PR: https://github.com/zigpy/zha-device-handlers/pull/5197