### PR TITLE
Properly tear down group entities on membership changes and group removal

### DIFF
--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -41,6 +41,7 @@ from zha.application.gateway import (
 from zha.application.helpers import ZHAData
 from zha.application.platforms import GroupEntity
 from zha.application.platforms.light.const import EFFECT_OFF, LightEntityFeature
+from zha.const import STATE_CHANGED
 from zha.quirks import DeviceMatch, DeviceRegistry, ModelInfo, QuirkRegistryEntry
 from zha.zigbee.device import Device, DeviceEntityAddedEvent, DeviceEntityRemovedEvent
 from zha.zigbee.group import Group, GroupMemberReference
@@ -1285,3 +1286,140 @@ async def test_group_on_remove_entity_failure(
 
     assert "Failed to remove group entity" in caplog.text
     assert "Group entity removal failed" in caplog.text
+
+
+async def test_group_entities_removed_when_group_shrinks(
+    zha_gateway: Gateway,
+) -> None:
+    """Test group entities are torn down when a group drops below 2 members."""
+    device_light_1 = await device_light_1_mock(zha_gateway)
+    device_light_2 = await device_light_2_mock(zha_gateway)
+
+    device_1_light_entity = get_entity(device_light_1, platform=Platform.LIGHT)
+    baseline_listener_count = len(
+        device_1_light_entity._listeners.get(STATE_CHANGED, [])
+    )
+
+    zha_group: Group = await zha_gateway.async_create_zigpy_group(
+        "Test Group",
+        [
+            GroupMemberReference(ieee=device_light_1.ieee, endpoint_id=1),
+            GroupMemberReference(ieee=device_light_2.ieee, endpoint_id=1),
+        ],
+    )
+    await zha_gateway.async_block_till_done()
+
+    group_entity = get_group_entity(zha_group, platform=Platform.LIGHT)
+    assert group_entity is not None
+    assert zha_group._entity_unsubs
+    # the group entity is subscribed to member entity state changes
+    assert (
+        len(device_1_light_entity._listeners[STATE_CHANGED])
+        == baseline_listener_count + 1
+    )
+
+    await zha_group.async_remove_members(
+        [GroupMemberReference(ieee=device_light_2.ieee, endpoint_id=1)]
+    )
+    await zha_gateway.async_block_till_done()
+
+    assert len(zha_group.members) == 1
+    assert not zha_group.group_entities
+    # all entity subscriptions are released
+    assert not zha_group._entity_unsubs
+    assert (
+        len(device_1_light_entity._listeners[STATE_CHANGED]) == baseline_listener_count
+    )
+
+
+async def test_group_platform_entity_removed_when_platform_drops_below_two(
+    zha_gateway: Gateway,
+) -> None:
+    """Test a platform's group entity is removed when it loses eligibility."""
+    device_light_1 = await device_light_1_mock(zha_gateway)
+    device_light_2 = await device_light_2_mock(zha_gateway)
+
+    switch_endpoint_config = {
+        1: {
+            SIG_EP_INPUT: [general.OnOff.cluster_id, general.Groups.cluster_id],
+            SIG_EP_OUTPUT: [],
+            SIG_EP_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+            SIG_EP_PROFILE: zha.PROFILE_ID,
+        }
+    }
+    device_switch_1 = await join_zigpy_device(
+        zha_gateway,
+        create_mock_zigpy_device(
+            zha_gateway, switch_endpoint_config, ieee="00:0d:6f:00:0a:90:69:e1"
+        ),
+    )
+    device_switch_2 = await join_zigpy_device(
+        zha_gateway,
+        create_mock_zigpy_device(
+            zha_gateway, switch_endpoint_config, ieee="00:0d:6f:00:0a:90:69:e2"
+        ),
+    )
+
+    zha_group: Group = await zha_gateway.async_create_zigpy_group(
+        "Test Group",
+        [
+            GroupMemberReference(ieee=device_light_1.ieee, endpoint_id=1),
+            GroupMemberReference(ieee=device_light_2.ieee, endpoint_id=1),
+            GroupMemberReference(ieee=device_switch_1.ieee, endpoint_id=1),
+            GroupMemberReference(ieee=device_switch_2.ieee, endpoint_id=1),
+        ],
+    )
+    await zha_gateway.async_block_till_done()
+
+    light_group_entity = get_group_entity(zha_group, platform=Platform.LIGHT)
+    switch_group_entity = get_group_entity(zha_group, platform=Platform.SWITCH)
+    assert light_group_entity is not None
+    assert switch_group_entity is not None
+
+    # drop the switch platform below 2 eligible members
+    await zha_group.async_remove_members(
+        [GroupMemberReference(ieee=device_switch_2.ieee, endpoint_id=1)]
+    )
+    await zha_gateway.async_block_till_done()
+
+    assert len(zha_group.members) == 3
+    with pytest.raises(KeyError):
+        get_group_entity(zha_group, platform=Platform.SWITCH)
+    # the light group entity is preserved
+    assert get_group_entity(zha_group, platform=Platform.LIGHT) is light_group_entity
+
+
+async def test_group_removed_tears_down_group_entities(
+    zha_gateway: Gateway,
+) -> None:
+    """Test group entities are torn down when the zigpy group is removed."""
+    device_light_1 = await device_light_1_mock(zha_gateway)
+    device_light_2 = await device_light_2_mock(zha_gateway)
+
+    device_1_light_entity = get_entity(device_light_1, platform=Platform.LIGHT)
+    baseline_listener_count = len(
+        device_1_light_entity._listeners.get(STATE_CHANGED, [])
+    )
+
+    zha_group: Group = await zha_gateway.async_create_zigpy_group(
+        "Test Group",
+        [
+            GroupMemberReference(ieee=device_light_1.ieee, endpoint_id=1),
+            GroupMemberReference(ieee=device_light_2.ieee, endpoint_id=1),
+        ],
+    )
+    await zha_gateway.async_block_till_done()
+
+    assert get_group_entity(zha_group, platform=Platform.LIGHT) is not None
+
+    # remove the zigpy group directly, without removing the members first
+    zha_gateway.application_controller.groups.pop(zha_group.group_id)
+    await zha_gateway.async_block_till_done()
+
+    assert zha_gateway.get_group(zha_group.group_id) is None
+    assert not zha_group.group_entities
+    # all entity subscriptions are released
+    assert not zha_group._entity_unsubs
+    assert (
+        len(device_1_light_entity._listeners[STATE_CHANGED]) == baseline_listener_count
+    )

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -28,6 +28,7 @@ from tests.common import (
 )
 from zha.application import Platform
 from zha.application.const import ZHA_GW_MSG, ZHA_GW_MSG_CONNECTION_LOST, RadioType
+from zha.application.discovery import discover_group_entities
 from zha.application.gateway import (
     ConnectionLostEvent,
     DeviceFullInitEvent,
@@ -1412,7 +1413,8 @@ async def test_group_removed_tears_down_group_entities(
 
     assert get_group_entity(zha_group, platform=Platform.LIGHT) is not None
 
-    # remove the zigpy group directly, without removing the members first
+    # `Groups.pop()` removes every member first, so the teardown here runs
+    # through the `group_member_removed` path
     zha_gateway.application_controller.groups.pop(zha_group.group_id)
     await zha_gateway.async_block_till_done()
 
@@ -1423,3 +1425,111 @@ async def test_group_removed_tears_down_group_entities(
     assert (
         len(device_1_light_entity._listeners[STATE_CHANGED]) == baseline_listener_count
     )
+
+
+async def test_gateway_group_removed_tears_down_group_entities(
+    zha_gateway: Gateway,
+) -> None:
+    """Test `Gateway.group_removed` tears down a group that still has entities."""
+    device_light_1 = await device_light_1_mock(zha_gateway)
+    device_light_2 = await device_light_2_mock(zha_gateway)
+
+    device_1_light_entity = get_entity(device_light_1, platform=Platform.LIGHT)
+    baseline_listener_count = len(
+        device_1_light_entity._listeners.get(STATE_CHANGED, [])
+    )
+
+    zha_group: Group = await zha_gateway.async_create_zigpy_group(
+        "Test Group",
+        [
+            GroupMemberReference(ieee=device_light_1.ieee, endpoint_id=1),
+            GroupMemberReference(ieee=device_light_2.ieee, endpoint_id=1),
+        ],
+    )
+    await zha_gateway.async_block_till_done()
+
+    assert get_group_entity(zha_group, platform=Platform.LIGHT) is not None
+    assert zha_group._entity_unsubs
+
+    # call the zigpy listener callback directly, so the group still has its
+    # members (and therefore its group entities) when it is removed
+    zha_gateway.group_removed(zha_group.zigpy_group)
+    await zha_gateway.async_block_till_done()
+
+    assert zha_gateway.get_group(zha_group.group_id) is None
+    assert not zha_group.group_entities
+    # all entity subscriptions are released
+    assert not zha_group._entity_unsubs
+    assert (
+        len(device_1_light_entity._listeners[STATE_CHANGED]) == baseline_listener_count
+    )
+
+
+async def test_group_on_remove_entity_failure_keeps_state_consistent(
+    zha_gateway: Gateway,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test `Group.on_remove` leaves consistent state when an entity fails to remove."""
+    device_light_1 = await device_light_1_mock(zha_gateway)
+    device_light_2 = await device_light_2_mock(zha_gateway)
+
+    zha_group: Group = await zha_gateway.async_create_zigpy_group(
+        "Test Group",
+        [
+            GroupMemberReference(ieee=device_light_1.ieee, endpoint_id=1),
+            GroupMemberReference(ieee=device_light_2.ieee, endpoint_id=1),
+        ],
+    )
+    await zha_gateway.async_block_till_done()
+
+    group_entity = get_group_entity(zha_group, platform=Platform.LIGHT)
+
+    with patch.object(
+        group_entity, "on_remove", side_effect=Exception("Group entity removal failed")
+    ):
+        await zha_group.on_remove()
+
+    assert "Failed to remove group entity" in caplog.text
+    # the failed entity is still unregistered, so both mappings stay in sync
+    assert not zha_group.group_entities
+    assert not zha_group._entity_unsubs
+
+    # unregistering it again must not raise
+    zha_group.unregister_group_entity(group_entity)
+
+
+async def test_unregister_group_entity_ignores_stale_entity(
+    zha_gateway: Gateway,
+) -> None:
+    """Test a delayed removal cannot unregister a recreated group entity."""
+    device_light_1 = await device_light_1_mock(zha_gateway)
+    device_light_2 = await device_light_2_mock(zha_gateway)
+
+    zha_group: Group = await zha_gateway.async_create_zigpy_group(
+        "Test Group",
+        [
+            GroupMemberReference(ieee=device_light_1.ieee, endpoint_id=1),
+            GroupMemberReference(ieee=device_light_2.ieee, endpoint_id=1),
+        ],
+    )
+    await zha_gateway.async_block_till_done()
+
+    original_entity = get_group_entity(zha_group, platform=Platform.LIGHT)
+
+    # the entity is unregistered, then recreated with the same unique id
+    # before its (delayed) `on_remove` gets to run
+    zha_group.unregister_group_entity(original_entity)
+    assert original_entity.unique_id not in zha_group.group_entities
+
+    for entity in discover_group_entities(zha_group):
+        entity.on_add()
+
+    recreated_entity = get_group_entity(zha_group, platform=Platform.LIGHT)
+    assert recreated_entity is not original_entity
+    assert recreated_entity.unique_id == original_entity.unique_id
+
+    await original_entity.on_remove()
+
+    # the recreated entity is still registered and still subscribed
+    assert zha_group.group_entities[recreated_entity.unique_id] is recreated_entity
+    assert recreated_entity.unique_id in zha_group._entity_unsubs

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -39,6 +39,7 @@ from zha.application.platforms import (  # noqa: F401 pylint: disable=unused-imp
     update,
     virtual,
 )
+from zha.async_ import create_eager_task
 from zha.zigbee.group import Group
 
 if TYPE_CHECKING:
@@ -109,6 +110,21 @@ def ignore_exceptions_during_iteration[**P, T](
     return inner
 
 
+def _remove_stale_group_entities(
+    group: Group, stale_entities: list[GroupEntity]
+) -> None:
+    """Unregister stale group entities and schedule their removal."""
+    for entity in stale_entities:
+        _LOGGER.info("Removing stale group entity %s from group %s", entity, group.name)
+        group.unregister_group_entity(entity)
+        group.gateway.track_task(
+            create_eager_task(
+                entity.on_remove(), name=f"remove_group_entity_{entity.unique_id}"
+            )
+        )
+    group.update_entity_subscriptions()
+
+
 @ignore_exceptions_during_iteration
 def discover_group_entities(group: Group) -> Iterator[GroupEntity]:
     """Process a group and create any entities that are needed."""
@@ -119,7 +135,8 @@ def discover_group_entities(group: Group) -> Iterator[GroupEntity]:
             group.name,
             group.group_id,
         )
-        group.group_entities.clear()
+        if group.group_entities:
+            _remove_stale_group_entities(group, list(group.group_entities.values()))
         return
 
     # We only create groups with two or more devices
@@ -132,10 +149,19 @@ def discover_group_entities(group: Group) -> Iterator[GroupEntity]:
         for entity in member.associated_entities:
             platform_counts[entity.PLATFORM] += 1
 
-    for platform, count in platform_counts.items():
-        if count < 2:
-            continue
+    eligible_platforms = {
+        platform for platform, count in platform_counts.items() if count >= 2
+    }
 
+    # Remove group entities for platforms that no longer have enough members
+    if stale_entities := [
+        entity
+        for entity in group.group_entities.values()
+        if entity.PLATFORM not in eligible_platforms
+    ]:
+        _remove_stale_group_entities(group, stale_entities)
+
+    for platform in eligible_platforms:
         for group_entity_class in GROUP_ENTITY_REGISTRY:
             if platform != group_entity_class.PLATFORM:
                 continue

--- a/zha/application/discovery.py
+++ b/zha/application/discovery.py
@@ -149,9 +149,10 @@ def discover_group_entities(group: Group) -> Iterator[GroupEntity]:
         for entity in member.associated_entities:
             platform_counts[entity.PLATFORM] += 1
 
-    eligible_platforms = {
+    # A list (not a set) so group entity creation order stays deterministic
+    eligible_platforms = [
         platform for platform, count in platform_counts.items() if count >= 2
-    }
+    ]
 
     # Remove group entities for platforms that no longer have enough members
     if stale_entities := [

--- a/zha/application/gateway.py
+++ b/zha/application/gateway.py
@@ -648,6 +648,9 @@ class Gateway(AsyncUtilMixin, EventBase):
         self._emit_group_gateway_message(zigpy_group, ZHA_GW_MSG_GROUP_REMOVED)
         zha_group = self._groups.pop(zigpy_group.group_id)
         zha_group.info("group_removed")
+        self.track_task(
+            create_eager_task(zha_group.on_remove(), name="Gateway.group_removed")
+        )
 
     def _emit_group_gateway_message(  # pylint: disable=unused-argument
         self,

--- a/zha/zigbee/group.py
+++ b/zha/zigbee/group.py
@@ -231,7 +231,9 @@ class Group(LogMixin):
 
     def unregister_group_entity(self, group_entity: GroupEntity) -> None:
         """Unregister a group entity."""
-        if group_entity.unique_id in self._group_entities:
+        # Only unregister if this exact entity is registered, so a delayed
+        # removal cannot unregister a recreated entity with the same unique id
+        if self._group_entities.get(group_entity.unique_id) is group_entity:
             self._group_entities.pop(group_entity.unique_id)
             self._entity_unsubs.pop(group_entity.unique_id)()
 
@@ -353,3 +355,7 @@ class Group(LogMixin):
                     group_entity,
                     exc_info=True,
                 )
+        # Unsubscribe any remaining member entity subscriptions
+        while self._entity_unsubs:
+            _, unsub = self._entity_unsubs.popitem()
+            unsub()

--- a/zha/zigbee/group.py
+++ b/zha/zigbee/group.py
@@ -235,7 +235,13 @@ class Group(LogMixin):
         # removal cannot unregister a recreated entity with the same unique id
         if self._group_entities.get(group_entity.unique_id) is group_entity:
             self._group_entities.pop(group_entity.unique_id)
-            self._entity_unsubs.pop(group_entity.unique_id)()
+            # `on_remove()` drains `_entity_unsubs` without touching
+            # `_group_entities`, so a group entity registered while it was
+            # running is left here without an unsubscribe callback
+            if (
+                unsub := self._entity_unsubs.pop(group_entity.unique_id, None)
+            ) is not None:
+                unsub()
 
     def _handle_maybe_update_group_members(self, event: EntityStateChangedEvent):
         """Handle the maybe update group members event."""
@@ -355,6 +361,10 @@ class Group(LogMixin):
                     group_entity,
                     exc_info=True,
                 )
+            # `GroupEntity.on_remove` unregisters the entity itself, but if it
+            # raised before getting there, unregister it here so that
+            # `_group_entities` and `_entity_unsubs` stay in sync
+            self.unregister_group_entity(group_entity)
         # Unsubscribe any remaining member entity subscriptions
         while self._entity_unsubs:
             _, unsub = self._entity_unsubs.popitem()


### PR DESCRIPTION
Group entity teardown was skipped in several places, leaking member entity subscriptions: member entities kept references to dead group entities and kept invoking their debounced updates.

### What was broken

- `discover_group_entities()` cleared `group_entities` with a bare `.clear()` when a group dropped below 2 members, without calling `on_remove()` or `unregister_group_entity()` — so the `Debouncer` and every member subscription stayed alive.
- It also never removed a *platform's* group entity when that platform alone dropped below 2 eligible members (e.g. a mixed light+switch group losing one of its two switches). The stale entity stayed registered and functional, backed by a single member.
- `Gateway.group_removed()` popped the group without calling `Group.on_remove()`, unlike `shutdown()` and `device_removed()`.
- `Group.on_remove()` only removed the group entities themselves, leaving the member entity subscriptions in `_entity_unsubs` dangling.

### What this changes

- `discover_group_entities()` now tears stale group entities down properly — `unregister_group_entity()` plus a scheduled `on_remove()` — both when the whole group drops below 2 members and when a single platform loses eligibility. Coordinator members are already excluded from the per-platform counts, so a "coordinator + one light" group now correctly loses its group entity too.
- `Gateway.group_removed()` schedules `Group.on_remove()`, so removing a group tears down its entities even when the members were not removed first.
- `Group.on_remove()` releases any remaining member entity subscriptions, and unregisters a group entity even if that entity's own `on_remove()` raised — otherwise `_group_entities` and `_entity_unsubs` could desync and a later `unregister_group_entity()` would raise `KeyError`.
- `unregister_group_entity()` verifies the exact entity instance is registered, so a delayed removal cannot unregister a *recreated* group entity that has the same unique id.

### Notes

- Removing a member *device* (rather than a member endpoint) still leaves a stale group entity behind: zigpy's `_remove_device()` does not remove the device's endpoints from groups, so no `group_member_removed` event fires and `Group.members` keeps its cached value. That is pre-existing and a different code path (`Gateway.device_removed`), so it is deliberately out of scope here.
- This is **not** a prerequisite for home-assistant/core#162307 ("Create device registry entries for ZHA group entities"). Home Assistant rebuilds its group entity set from the `GroupInfo.entities` snapshot on every group event, and that snapshot is correct either way. The two are complementary: without this PR, a platform that drops below two eligible members keeps a stale group entity that Home Assistant faithfully re-adds.
