### PR TITLE
Preserve previous speed when turning on Inovelli fans

### DIFF
--- a/tests/data/devices/inovelli-vzm36.json
+++ b/tests/data/devices/inovelli-vzm36.json
@@ -441,7 +441,7 @@
         "unique_id": "ab:cd:ef:12:25:9f:47:fc-2-514",
         "migrate_unique_ids": [],
         "platform": "fan",
-        "class_name": "Fan",
+        "class_name": "InovelliFan",
         "translation_key": "fan",
         "translation_placeholders": null,
         "device_class": null,

--- a/zha/application/platforms/fan/__init__.py
+++ b/zha/application/platforms/fan/__init__.py
@@ -586,6 +586,7 @@ class KofFan(Fan):
         """Return a dict from preset mode to name."""
         return {6: PRESET_MODE_SMART}
 
+
 @register_entity(hvac.Fan.cluster_id)
 class InovelliFan(Fan):
     """Representation of an Inovelli fan."""

--- a/zha/application/platforms/fan/__init__.py
+++ b/zha/application/platforms/fan/__init__.py
@@ -15,7 +15,7 @@ from zigpy.zcl import (
     AttributeWrittenEvent,
     ReportingConfig,
 )
-from zigpy.zcl.clusters import hvac
+from zigpy.zcl.clusters import general, hvac
 
 from zha.application import Platform
 from zha.application.helpers import safe_read, write_attributes_safe
@@ -585,3 +585,34 @@ class KofFan(Fan):
     def preset_modes_to_name(self) -> dict[int, str]:
         """Return a dict from preset mode to name."""
         return {6: PRESET_MODE_SMART}
+
+@register_entity(hvac.Fan.cluster_id)
+class InovelliFan(Fan):
+    """Representation of an Inovelli fan."""
+
+    _cluster_handler_match = ClusterHandlerMatch(
+        cluster_handlers=frozenset({CLUSTER_HANDLER_FAN}),
+        manufacturers=frozenset({"Inovelli"}),
+        models=frozenset({"VZM35-SN","VZM36",}),
+        feature_priority=(PlatformFeatureGroup.THERMOSTAT_FAN, 1),
+    )
+
+    async def async_turn_on(
+        self,
+        speed: str | None = None,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+    ) -> None:
+        """Turn the entity on."""
+        if speed is None and percentage is None and preset_mode is None:
+            on_off_cluster = self.endpoint.zigpy_endpoint.in_clusters[
+                general.OnOff.cluster_id
+            ]
+            await on_off_cluster.on()
+            return
+
+        await super().async_turn_on(
+            speed=speed,
+            percentage=percentage,
+            preset_mode=preset_mode,
+        )

--- a/zha/application/platforms/fan/__init__.py
+++ b/zha/application/platforms/fan/__init__.py
@@ -590,10 +590,15 @@ class KofFan(Fan):
 class InovelliFan(Fan):
     """Representation of an Inovelli fan."""
 
-    _cluster_handler_match = ClusterHandlerMatch(
-        cluster_handlers=frozenset({CLUSTER_HANDLER_FAN}),
+    _cluster_match = ClusterMatch(
+        server_clusters=frozenset({hvac.Fan.cluster_id}),
         manufacturers=frozenset({"Inovelli"}),
-        models=frozenset({"VZM35-SN","VZM36",}),
+        models=frozenset(
+            {
+                "VZM35-SN",
+                "VZM36",
+            }
+        ),
         feature_priority=(PlatformFeatureGroup.THERMOSTAT_FAN, 1),
     )
 


### PR DESCRIPTION
### Summary

Add an InovelliFan entity implementation for the VZM35-SN and VZM36 fan switches that overrides the default turn_on() behavior.

Today, calling fan.turn_on() without specifying a speed or percentage causes the generic ZHA fan implementation to use default_on_percentage, which results in a FanMode write (typically Medium for a 3-speed fan). This changes the fan speed to 50% instead of simply restoring the previous speed.

The Inovelli fan switches support independent power and speed control. Sending an On command via the On/Off cluster powers the fan on while preserving the previously selected speed. The device then reports its current fan_mode, allowing the entity state to remain synchronized.

This change adds a model-specific InovelliFan entity that:

Matches the VZM35-SN and VZM36.
Sends an On command on the On/Off cluster when fan.turn_on() is called without a speed, percentage, or preset.
Preserves the existing behavior for explicit speed/percentage requests by delegating to the generic Fan implementation.

This only affects the default "turn on" behavior for these specific models and leaves all other Zigbee fan implementations unchanged.

**Note:** The Zigbee Fan Control specification defines FanMode.On as the preferred mechanism for turning a fan on while preserving its current speed. That would likely be the ideal implementation for the generic ZHA fan entity. However, the current Inovelli firmware does not yet implement FanMode.On correctly, and it is unclear whether all Zigbee fan manufacturers support this mode consistently. Until support is more broadly understood, using the On/Off cluster provides the desired behavior for these devices while avoiding changes to the generic fan implementation.