### PR TITLE
Exclude weight 0 entities from primary entity election 

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -49,7 +49,7 @@ from zha.application.gateway import Gateway
 from zha.application.platforms import PlatformEntity
 from zha.application.platforms.binary_sensor import IASZone
 from zha.application.platforms.light import Light
-from zha.application.platforms.sensor import LQISensor, RSSISensor
+from zha.application.platforms.sensor import Battery, LQISensor, RSSISensor
 from zha.application.platforms.sensor.device_class import (
     SensorDeviceClass,
     SensorStateClass,
@@ -946,6 +946,31 @@ async def test_primary_entity_computation(
         assert primary == [
             get_entity(zha_device, primary_platform, entity_type=primary_entity_type)
         ]
+
+
+async def test_primary_entity_weight_0_not_elected(zha_gateway: Gateway) -> None:
+    """Test a weight-0 entity is not elected primary, even as the sole candidate."""
+
+    # Without the `Basic` cluster, no LQI/RSSI entities are created, so the
+    # battery entity is the only entity of this device
+    zigpy_dev = create_mock_zigpy_device(
+        zha_gateway,
+        {
+            1: {
+                SIG_EP_INPUT: [general.PowerConfiguration.cluster_id],
+                SIG_EP_OUTPUT: [],
+                SIG_EP_TYPE: zigpy.profiles.zha.DeviceType.SIMPLE_SENSOR,
+                SIG_EP_PROFILE: zigpy.profiles.zha.PROFILE_ID,
+            }
+        },
+    )
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
+
+    battery = get_entity(zha_device, Platform.SENSOR, entity_type=Battery)
+    assert list(zha_device.platform_entities.values()) == [battery]
+
+    # The weight-0 battery entity is not elected as the primary entity
+    assert not battery.primary
 
 
 async def test_quirks_v2_primary_entity(zha_gateway: Gateway) -> None:

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -1625,9 +1625,13 @@ class Device(LogMixin, EventBase):
         # It should not be possible for there to be more than one
         assert not explicitly_primary
 
-        # For weight matching, only consider non-counter entities and entities which are
-        # not explicitly marked as not primary
-        candidates = [e for e in entities if e.enabled and e._attr_primary is not False]
+        # For weight matching, only consider entities with a non-zero primary weight
+        # which are not explicitly marked as not primary
+        candidates = [
+            e
+            for e in entities
+            if e.enabled and e._attr_primary is not False and e.primary_weight > 0
+        ]
         candidates.sort(reverse=True, key=lambda e: e.primary_weight)
 
         if not candidates:


### PR DESCRIPTION
## Proposed change

This PR explicitly excludes entities with primary entity weight `0` from the primary entity election.

Currently, this was only done implicitly, as all entities have a default weight of `0` and all devices get LQI and RSSI entities with that weight, except for coordinators, where EZSP coordinators generally get multiple "device counter sensors".

If an entity has a primary weight of `0`, it's guaranteed to be an entity that needs more context than just the device name.

For an example, let's assume that LQI and RSSI entities didn't exist. If a remote then only provided a device temperature sensor entity, we wouldn't want that to be become primary because that would be misleading. Instead, it should still show up as "[Aqara remote] Device temperature" in HA.

On the other side, a normal temperature sensor entity does have a primary weight `>0`, so it's correct that it can become primary and assume the device name only, as it's most likely a normal temperature sensor you're dealing with. 

### Edit: LQI/RSSI and identify entity follow-up

EDIT 1: The LQI and RSSI entities are disabled-by-default, so they may not even be considered in the primary entity election currently. But I think the enabled-by-default identify entity would have a similar effect and it's present on many devices.

EDIT 2: Actually, I think HA Core just disables the RSSI/LQI entities too late, so because no recomputation is done there, and possibly because of the primary entity being stuck mentioned in https://github.com/zigpy/zha/pull/861, I think this basically already worked like RSSI/LQI entities were "enabled" and part of the election.

- https://github.com/zigpy/zha/pull/862 will address that part.

## Additional information

Note that no diagnostics snapshots needed to be regenerated.

There's a follow-up PR that's based on this PR's branch that removes `_attr_primary_weight = 1` for the device temperature sensor entity:
- https://github.com/zigpy/zha/pull/860 