### PR TITLE
Never mark device temperature sensor as primary entity 

### DIFF
--- a/tests/data/devices/lumi-lumi-sensor-86sw2.json
+++ b/tests/data/devices/lumi-lumi-sensor-86sw2.json
@@ -456,7 +456,7 @@
         "entity_category": "diagnostic",
         "entity_registry_enabled_default": true,
         "enabled": true,
-        "primary": true,
+        "primary": false,
         "extra_state_attribute_names": [],
         "device_ieee": "00:15:8d:00:02:54:cb:fa",
         "endpoint_id": 1,

--- a/tests/data/devices/lumi-lumi-sensor-magnet-aq2.json
+++ b/tests/data/devices/lumi-lumi-sensor-magnet-aq2.json
@@ -194,7 +194,7 @@
         "entity_category": null,
         "entity_registry_enabled_default": true,
         "enabled": true,
-        "primary": false,
+        "primary": true,
         "extra_state_attribute_names": [],
         "device_ieee": "00:15:8d:00:01:ab:40:52",
         "endpoint_id": 1,

--- a/tests/data/devices/lumi-lumi-sensor-switch-aq2.json
+++ b/tests/data/devices/lumi-lumi-sensor-switch-aq2.json
@@ -270,7 +270,7 @@
         "entity_category": "diagnostic",
         "entity_registry_enabled_default": true,
         "enabled": true,
-        "primary": true,
+        "primary": false,
         "extra_state_attribute_names": [],
         "device_ieee": "00:15:8d:00:02:13:91:38",
         "endpoint_id": 1,

--- a/tests/data/devices/lumi-lumi-sensor-switch-aq3.json
+++ b/tests/data/devices/lumi-lumi-sensor-switch-aq3.json
@@ -253,7 +253,7 @@
         "entity_category": "diagnostic",
         "entity_registry_enabled_default": true,
         "enabled": true,
-        "primary": true,
+        "primary": false,
         "extra_state_attribute_names": [],
         "device_ieee": "00:15:8d:00:02:b0:e5:91",
         "endpoint_id": 1,

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -2740,7 +2740,6 @@ class DeviceTemperature(Sensor):
     _divisor = 100
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_primary_weight = 1
     _cluster_id = DeviceTemperatureCluster.cluster_id
 
     _cluster_match = ClusterMatch(


### PR DESCRIPTION
## Proposed change

This PR changes the internal device temperature sensor entity from primary entity weight `1` to `0`, so it can never* become a primary entity. It is a diagnostics entity after all and there's likely no sensor you can buy today that only has a function of showing the internal device temperature of itself.

## Additional information

This fixes an issue for the Aqara `lumi.remote.b286acn01` remote that currently exposes "no normal entities", where the device temperature sensor entity currently became the primary entity as it had the highest weight (of `1`):

<img width="280" height="229" alt="Screenshot of diagnostics section on device page for older Aqara remote that shows the device temperature sensor entity being the primary entity, i.e. assuming the device name, instead of being named 'Device temperature'" src="https://github.com/user-attachments/assets/bcdcf843-fa86-4886-a343-43287ef357e6" />

As the review bot pointed out, this also fixes an issue for some Aqara door sensors where their binary sensor entity didn't become primary because it tied with the diagnostics device temperature entity.

### Diagnostics

Diagnostics were also regenerated and you can see this doesn't negatively affect any known devices.

### Note on "never become a primary entity"

__*__: Technically, "never become a primary entity" is currently not true. If we were to remove LQI and RSSI entities, which like all entities have a default weight of `0`, a device with no other entities would see the device temperature sensor become a primary entity again. The following PR makes this more explicitly by excluding primary weight `0` from the primary entity election:
- https://github.com/zigpy/zha/pull/859 