### PR TITLE
Ignore runtime enabled state in primary entity election

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1066,6 +1066,16 @@ async def test_primary_entity_election_ignores_enabled(zha_gateway: Gateway) -> 
     assert switch.primary
     assert not ias_zone.primary
 
+    # An explicitly primary entity also keeps its spot when disabled
+    ias_zone._attr_primary = True
+    await zha_device.recompute_entities()
+
+    ias_zone.disable()
+    await zha_device.recompute_entities()
+
+    assert ias_zone.primary
+    assert not switch.primary
+
 
 async def test_primary_entity_election_explicit_primary_takes_over(
     zha_gateway: Gateway,

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1022,8 +1022,12 @@ async def test_primary_entity_reelection(zha_gateway: Gateway) -> None:
     assert not ias_zone.primary
 
 
-async def test_primary_entity_election_disabled_winner(zha_gateway: Gateway) -> None:
-    """Test a disabled previous winner does not keep stale computed primary state."""
+async def test_primary_entity_election_ignores_enabled(zha_gateway: Gateway) -> None:
+    """Test the election ignores runtime enabled state.
+
+    The primary entity describes the main feature of the device, which does not
+    change when its entity is disabled (via the entity registry in HA).
+    """
 
     # A smart plug with an IAS zone
     zigpy_dev = create_mock_zigpy_device(
@@ -1048,15 +1052,14 @@ async def test_primary_entity_election_disabled_winner(zha_gateway: Gateway) -> 
     assert switch.primary
     assert not ias_zone.primary
 
-    # When the switch is disabled, it is no longer an election candidate and must
-    # not keep its computed primary state, so only the runner-up is primary
+    # A disabled entity stays primary, the runner-up does not take its spot
     switch.disable()
     await zha_device.recompute_entities()
 
-    assert not switch.primary
-    assert ias_zone.primary
+    assert switch.primary
+    assert not ias_zone.primary
 
-    # When the switch is re-enabled, it wins back the election
+    # Re-enabling changes nothing
     switch.enable()
     await zha_device.recompute_entities()
 

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -1638,11 +1638,12 @@ class Device(LogMixin, EventBase):
         assert not explicitly_primary
 
         # For weight matching, only consider entities with a non-zero primary weight
-        # which are not explicitly marked as not primary
+        # which are not explicitly marked as not primary. Entities disabled at runtime
+        # (via the entity registry in HA) deliberately stay candidates: the primary
+        # entity describes the main feature of the device, which does not change when
+        # its entity is disabled.
         candidates = [
-            e
-            for e in entities
-            if e.enabled and e._attr_primary is not False and e.primary_weight > 0
+            e for e in entities if e._attr_primary is not False and e.primary_weight > 0
         ]
         candidates.sort(reverse=True, key=lambda e: e.primary_weight)
 


### PR DESCRIPTION
Follow-up to #861 (see the enabled/disabled design discussion there).

The weight election previously filtered candidates on `e.enabled`, so an entity disabled via the entity registry in HA lost its primary spot to the runner-up on the next re-election. The primary entity describes the main feature of the device — a smart plug whose switch entity is disabled is still a smart plug — so a registry toggle should not reassign it. Since `primary` drives entity naming in HA (the primary entity takes the bare device name), reassigning it also caused naming churn when an entity was disabled and re-enabled.

In practice, the old behavior was timing-dependent anyway: HA Core only toggles the enabled flag on registry changes and nothing re-runs the election at that point, so a disabled winner kept `primary` until the next entity recomputation happened to run for an unrelated reason. HA Core also calls `disable()` for default-disabled entities only after the first election has already run, so the `enabled` filter effectively never influenced a first election either.

### Changes

- The weight election no longer filters candidates on `enabled` — disabled entities stay candidates and can keep (or win) the primary spot. Enabling/disabling an entity now never changes the election outcome. Together with #859, candidacy now simply means: non-zero primary weight and not explicitly excluded.
- This also makes the explicit-primary check and the weight election consistent: the explicit check never looked at `enabled`, so an explicitly primary but disabled entity already kept its spot.

### Tests

- `test_primary_entity_election_disabled_winner` is renamed to `test_primary_entity_election_ignores_enabled` and asserts the new semantics: the disabled switch stays primary, the IAS zone runner-up does not take its spot, and re-enabling changes nothing.
- It also pins the explicit half of the consistency claim: an explicitly primary entity keeps its spot when disabled.

### Notes

- No device snapshots change: entities are only ever disabled at runtime by HA Core, never during initial discovery, so the `enabled` filter never influenced a snapshot's election.
- Default-disabled weight-0 diagnostics (LQI/RSSI) are unaffected by re-admitting disabled entities: #859 already excludes weight-0 entities from candidacy regardless of enabled state.
- One deliberate behavior delta beyond the headline: disabling one of two tied equal-weight candidates (e.g. one gang of a 2-gang switch) no longer resolves the tie on a later re-election — the device keeps no primary entity. The old tie-break-by-disable was timing-dependent anyway (the first election at join always tied, since HA disables entities only afterwards).
- Resolves the review observations from #861: the explicit-primary path ignoring `enabled` is now consistent by design (documented in the code comment), and re-running the election on enable/disable is no longer needed since enable/disable is a no-op for the election.

