### PR TITLE
Drop Inovelli attribute init entries the quirk already covers

### DIFF
--- a/zha/application/platforms/virtual.py
+++ b/zha/application/platforms/virtual.py
@@ -1065,7 +1065,11 @@ class InovelliClientBind(VirtualEntity):
 
 @register_entity(INOVELLI_CLUSTER)
 class InovelliVzm30Init(VirtualEntity):
-    """Inovelli VZM30-SN switch attribute init."""
+    """Inovelli VZM30-SN switch attribute init.
+
+    Only attributes the quirk does not already read on startup. See
+    `InovelliVzm31Init` for what still has to live here.
+    """
 
     _unique_id_suffix = "inovelli_vzm30_init"
 
@@ -1078,42 +1082,17 @@ class InovelliVzm30Init(VirtualEntity):
             attributes={
                 name: AttrConfig(read_on_startup=fresh)
                 for name, fresh in {
-                    "dimming_speed_up_remote": False,
-                    "dimming_speed_up_local": False,
-                    "ramp_rate_off_to_on_remote": False,
-                    "ramp_rate_off_to_on_local": False,
-                    "dimming_speed_down_remote": False,
-                    "dimming_speed_down_local": False,
-                    "ramp_rate_on_to_off_remote": False,
-                    "ramp_rate_on_to_off_local": False,
-                    "minimum_level": False,
-                    "maximum_level": False,
-                    "invert_switch": False,
-                    "auto_off_timer": False,
-                    "default_level_local": False,
-                    "default_level_remote": False,
-                    "state_after_power_restored": False,
-                    "load_level_indicator_timeout": False,
+                    # no quirk entity
                     "active_power_reports": False,
                     "periodic_power_and_energy_reports": False,
                     "active_energy_reports": False,
                     "power_type": True,
                     "switch_type": True,
-                    "internal_temp_monitor": False,
-                    "overheated": False,
+                    # quirk entity initializes from cache, we want a fresh read
                     "button_delay": True,
                     "smart_bulb_mode": True,
-                    "led_color_when_on": False,
-                    "led_color_when_off": False,
-                    "led_intensity_when_on": False,
-                    "led_intensity_when_off": False,
-                    "led_scaling_mode": False,
-                    "aux_switch_scenes": False,
-                    "binding_off_to_on_sync_level": False,
                     "local_protection": True,
                     "output_mode": True,
-                    "firmware_progress_led": False,
-                    "disable_clear_notifications_double_tap": False,
                 }.items()
             },
         ),
@@ -1122,7 +1101,16 @@ class InovelliVzm30Init(VirtualEntity):
 
 @register_entity(INOVELLI_CLUSTER)
 class InovelliVzm31Init(VirtualEntity):
-    """Inovelli VZM31-SN dimmer attribute init."""
+    """Inovelli VZM31-SN dimmer attribute init.
+
+    Most of what this used to read is now covered by the quirk, whose entities
+    each declare their own startup read (zha-quirks #5122, ported out of ZHA in
+    #802). Two groups still have to be read here:
+
+    - attributes with no quirk entity at all, and
+    - attributes whose quirk entity initializes from the cache (the
+      `QuirkBuilder` default) where ZHA wants a fresh read from the device.
+    """
 
     _unique_id_suffix = "inovelli_vzm31_init"
 
@@ -1135,52 +1123,19 @@ class InovelliVzm31Init(VirtualEntity):
             attributes={
                 name: AttrConfig(read_on_startup=fresh)
                 for name, fresh in {
-                    "dimming_speed_up_remote": False,
-                    "dimming_speed_up_local": False,
-                    "ramp_rate_off_to_on_remote": False,
-                    "ramp_rate_off_to_on_local": False,
-                    "dimming_speed_down_remote": False,
-                    "dimming_speed_down_local": False,
-                    "ramp_rate_on_to_off_remote": False,
-                    "ramp_rate_on_to_off_local": False,
-                    "minimum_level": False,
-                    "maximum_level": False,
-                    "invert_switch": False,
-                    "auto_off_timer": False,
-                    "default_level_local": False,
-                    "default_level_remote": False,
-                    "state_after_power_restored": False,
-                    "load_level_indicator_timeout": False,
+                    # no quirk entity
                     "active_power_reports": False,
                     "periodic_power_and_energy_reports": False,
                     "active_energy_reports": False,
-                    "power_type": True,
-                    "switch_type": True,
                     "quick_start_time": False,
                     "quick_start_level": False,
-                    "increased_non_neutral_output": False,
-                    "leading_or_trailing_edge": False,
-                    "internal_temp_monitor": False,
-                    "overheated": False,
+                    "power_type": True,
+                    # quirk entity initializes from cache, we want a fresh read
+                    "switch_type": True,
                     "button_delay": True,
                     "smart_bulb_mode": True,
-                    "double_tap_up_enabled": False,
-                    "double_tap_down_enabled": False,
-                    "double_tap_up_level": False,
-                    "double_tap_down_level": False,
-                    "led_color_when_on": False,
-                    "led_color_when_off": False,
-                    "led_intensity_when_on": False,
-                    "led_intensity_when_off": False,
-                    "led_scaling_mode": False,
-                    "aux_switch_scenes": False,
-                    "binding_off_to_on_sync_level": False,
                     "local_protection": True,
                     "output_mode": True,
-                    "on_off_led_mode": False,
-                    "firmware_progress_led": False,
-                    "relay_click_in_on_off_mode": False,
-                    "disable_clear_notifications_double_tap": False,
                 }.items()
             },
         ),
@@ -1189,7 +1144,11 @@ class InovelliVzm31Init(VirtualEntity):
 
 @register_entity(INOVELLI_CLUSTER)
 class InovelliVzm35Init(VirtualEntity):
-    """Inovelli VZM35-SN fan switch attribute init."""
+    """Inovelli VZM35-SN fan switch attribute init.
+
+    Only attributes the quirk does not already read on startup. See
+    `InovelliVzm31Init` for what still has to live here.
+    """
 
     _unique_id_suffix = "inovelli_vzm35_init"
 
@@ -1202,43 +1161,17 @@ class InovelliVzm35Init(VirtualEntity):
             attributes={
                 name: AttrConfig(read_on_startup=fresh)
                 for name, fresh in {
-                    "dimming_speed_up_remote": False,
-                    "dimming_speed_up_local": False,
-                    "ramp_rate_off_to_on_local": False,
-                    "ramp_rate_off_to_on_remote": False,
-                    "dimming_speed_down_remote": False,
-                    "dimming_speed_down_local": False,
-                    "ramp_rate_on_to_off_local": False,
-                    "ramp_rate_on_to_off_remote": False,
-                    "minimum_level": False,
-                    "maximum_level": False,
-                    "invert_switch": False,
-                    "auto_off_timer": False,
-                    "default_level_local": False,
-                    "default_level_remote": False,
-                    "state_after_power_restored": False,
-                    "load_level_indicator_timeout": False,
-                    "power_type": True,
-                    "switch_type": True,
+                    # no quirk entity
                     "non_neutral_aux_med_gear_learn_value": False,
                     "non_neutral_aux_low_gear_learn_value": False,
+                    "power_type": True,
+                    # quirk entity initializes from cache, we want a fresh read
+                    "switch_type": True,
                     "quick_start_time": True,
                     "button_delay": True,
                     "smart_fan_mode": True,
-                    "double_tap_up_enabled": False,
-                    "double_tap_down_enabled": False,
-                    "double_tap_up_level": False,
-                    "double_tap_down_level": False,
-                    "led_color_when_on": False,
-                    "led_color_when_off": False,
-                    "led_intensity_when_on": False,
-                    "led_intensity_when_off": False,
-                    "aux_switch_scenes": False,
                     "local_protection": True,
                     "output_mode": True,
-                    "on_off_led_mode": False,
-                    "firmware_progress_led": False,
-                    "smart_fan_led_display_levels": False,
                 }.items()
             },
         ),


### PR DESCRIPTION
This removes some unnecessary attribute initialization for Inovelli virtual entities. With either of the following future PRs, we should be able to drop most of the rest as well:
- https://github.com/zigpy/zha-device-handlers/pull/5128
- https://github.com/zigpy/zha-device-handlers/pull/5171

## AI summary

zigpy/zha-device-handlers#5122 ported the Inovelli entities to quirks v2 and #802 removed their ZHA-native counterparts, but the `Inovelli*Init` virtual entities kept the full attribute lists they were written against. Each quirk entity now declares its own startup read, so most of those entries are dead weight: **90 of 119 across the three models**.

This drops exactly the entries whose quirk entity already produces an identical `AttrConfig`, which makes it a behaviour no-op — `AggregatedAttrConfig.merge` combines `read_on_startup` with `or`, so removing an entry the quirk reproduces cannot change the merged result. Checked per model by computing the merged per-attribute config from the quirk metadata plus the ZHA list, before and after:

| Model | Init entries | Effective startup reads |
| --- | --- | --- |
| VZM30-SN | 36 → 9 | 43 → 43 (identical) |
| VZM31-SN | 46 → 11 | 46 → 46 (identical) |
| VZM35-SN | 37 → 9 | 41 → 41 (identical) |

<details>
<summary>The 29 entries that stay, and what it would take to drop them (CLICK TO EXPAND)</summary>

### Group 1 — no quirk entity at all (14 entries)

Nothing on the quirks side reads these, so these entries are the only reason the values are ever fetched.

| Model | Attributes |
| --- | --- |
| VZM30-SN | `active_power_reports`, `periodic_power_and_energy_reports`, `active_energy_reports`, `power_type`, `switch_type` |
| VZM31-SN | `active_power_reports`, `periodic_power_and_energy_reports`, `active_energy_reports`, `quick_start_time`, `quick_start_level`, `power_type` |
| VZM35-SN | `non_neutral_aux_med_gear_learn_value`, `non_neutral_aux_low_gear_learn_value`, `power_type` |

Dropping these needs a quirks v2 way to read an attribute once on startup **without** an entity and **without** reporting. As currently drafted, both #5128 and #5171 take `reporting_config: ReportingConfig` as a required argument to `configures_reporting`, so `read_on_startup=True` is only reachable for an attribute that is also set up for reporting. A plain entity-less read looks like the one piece neither covers yet.

### Group 2 — quirk entity exists, but initializes from cache (15 entries)

`QuirkBuilder` defaults `attribute_initialized_from_cache=True` and `zhaquirks/inovelli/builder.py` never overrides it, so #5122 did not carry ZHA's fresh-read intent across. Drop these and the attributes silently become cache-only reads.

| Model | Attributes |
| --- | --- |
| VZM30-SN | `button_delay`, `smart_bulb_mode`, `local_protection`, `output_mode` |
| VZM31-SN | `switch_type`, `button_delay`, `smart_bulb_mode`, `local_protection`, `output_mode` |
| VZM35-SN | `switch_type`, `quick_start_time`, `button_delay`, `smart_fan_mode`, `local_protection`, `output_mode` |

This group needs no new API: passing `attribute_initialized_from_cache=False` for those entities in `zhaquirks/inovelli/builder.py` is enough, and can land independently of both PRs above.

(`switch_type` is in group 1 for the VZM30-SN, which has no quirk entity for it, and in group 2 for the other two models.)

### `InovelliBind` / `InovelliClientBind`

These stay too. No Inovelli quirk uses `reporting_config`, so nothing binds `0xFC31` on the quirks side today — these two are what make the device send its unsolicited button/LED reports. They are covered by `.binds()` (#5128) / `.binds_cluster()` (#5171).

</details>
