### PR TITLE
Remove the `primary_weight` pass-through property

### DIFF
--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -336,11 +336,6 @@ class BaseEntity(LogMixin, EventBase):
         return bool(self._attr_primary)
 
     @property
-    def primary_weight(self) -> int:
-        """Return the primary weight of the entity."""
-        return self._attr_primary_weight
-
-    @property
     def fallback_name(self) -> str | None:
         """Return the entity fallback name for when a translation key is unavailable."""
         return self._attr_fallback_name

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -1650,9 +1650,11 @@ class Device(LogMixin, EventBase):
         # entity describes the main feature of the device, which does not change when
         # its entity is disabled.
         candidates = [
-            e for e in entities if e._attr_primary is not False and e.primary_weight > 0
+            e
+            for e in entities
+            if e._attr_primary is not False and e._attr_primary_weight > 0
         ]
-        candidates.sort(reverse=True, key=lambda e: e.primary_weight)
+        candidates.sort(reverse=True, key=lambda e: e._attr_primary_weight)
 
         if not candidates:
             return
@@ -1661,7 +1663,7 @@ class Device(LogMixin, EventBase):
         others = candidates[1:]
 
         # We have a clear winner
-        if not others or winner.primary_weight > others[0].primary_weight:
+        if not others or winner._attr_primary_weight > others[0]._attr_primary_weight:
             self._primary_entity = winner
             return
 


### PR DESCRIPTION
Follow-up to a TODO in #861.

Removes the `primary_weight` pass-through property. Its only caller is the primary entity election, which already reads the raw `_attr_primary` hint directly — the election now uniformly consumes the `_attr_*` inputs.

No subclass overrides the property (all set the `_attr_primary_weight` class attribute), and no other consumer exists in ZHA, HA Core, or zha-quirks. Note that this is technically a public-API removal (the property shipped since 0.0.51), but the library's real consumers never used it.
