### PR TITLE
Do not activate and queue entities during reconfiguration

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -2026,6 +2026,39 @@ async def test_entity_recomputation(zha_gateway: Gateway) -> None:
     ]
 
 
+async def test_async_configure_does_not_queue_entities(zha_gateway: Gateway) -> None:
+    """Test a reconfigure does not leave half-added entities behind."""
+    zigpy_dev = await zigpy_device_from_json(
+        zha_gateway.application_controller,
+        "tests/data/devices/ikea-of-sweden-tradfri-bulb-gu10-ws-400lm-0x23095631.json",
+    )
+    zha_device = await join_zigpy_device(zha_gateway, zigpy_dev)
+
+    entities_before = dict(zha_device.platform_entities)
+
+    await zha_device.async_configure()
+
+    # Discovery ran for the cluster config aggregation, but no entities were
+    # activated via `on_add()` and queued (nothing would ever flush them here)
+    assert zha_device._discovered_entities
+    assert not zha_device._pending_entities
+    assert zha_device.platform_entities == entities_before
+
+    # After a rebuild (same-quirk re-interview), the device has no live entities
+    # anymore, so configuration must activate and queue the entities again (e.g.
+    # the IAS zone enrollment entity has to listen during CIE configuration)
+    await zha_device.async_rebuild_from_zigpy_device(zigpy_dev)
+    await zha_device.async_configure()
+
+    assert zha_device._pending_entities
+
+    # The following initialization adds them, like on the initial join
+    await zha_device.async_initialize(from_cache=True)
+
+    assert not zha_device._pending_entities
+    assert set(zha_device.platform_entities) == set(entities_before)
+
+
 async def test_add_entity_duplicate(zha_gateway: Gateway) -> None:
     """Test that adding a duplicate entity raises an error."""
     zigpy_dev = await zigpy_device_from_json(

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -1008,7 +1008,17 @@ class Device(LogMixin, EventBase):
             self.debug("applying quirks custom device configuration")
             await self._zigpy_device.apply_custom_configuration()
 
-        self._discover_new_entities()
+        # On a reconfigure of a live device, discovery is only needed to
+        # aggregate the cluster configs. The entities must not be queued for
+        # adding then: nothing flushes the pending entities, so they would
+        # linger with active `on_add()` side effects (e.g. cluster listeners)
+        # without ever being added — the live entities already listen. Without
+        # live entities (initial join, or a rebuild after a re-interview), the
+        # entities must be activated, however: e.g. the IAS zone enrollment
+        # entity has to answer a device-initiated enroll request right after
+        # `configure_cluster_configs` writes the CIE address below.
+        # `async_initialize()` adds them and cleans up its own re-discoveries.
+        self._discover_new_entities(add_entities=not self._platform_entities)
 
         # Configure binding and reporting from entity-level cluster configs
         aggregated = aggregate_cluster_configs(self._discovered_entities)
@@ -1078,7 +1088,13 @@ class Device(LogMixin, EventBase):
             )
             yield from discovery.discover_entities_for_endpoint(endpoint)
 
-    def _discover_new_entities(self) -> None:
+    def _discover_new_entities(self, *, add_entities: bool = True) -> None:
+        """Discover entities and queue them to be added to the device.
+
+        With `add_entities=False`, only `self._discovered_entities` is populated
+        (e.g. for aggregating cluster configs): the entities are neither activated
+        via `on_add()` nor queued for `_add_pending_entities`.
+        """
         self._discovered_entities.clear()
 
         # Iterate defensively so a failure in any single entity construction
@@ -1100,6 +1116,9 @@ class Device(LogMixin, EventBase):
 
             # Apply any metadata changes from quirks v2
             self._apply_entity_metadata_changes(entity)
+
+            if not add_entities:
+                continue
 
             entity.on_add()
             self._pending_entities.append(entity)


### PR DESCRIPTION
Fixes the second item of #725.

## Problem

`async_configure()` only discovers entities to aggregate their cluster configs for binding/reporting, but discovery also ran `entity.on_add()` (registering cluster listeners and other side effects) and queued the entities in `_pending_entities` — which nothing flushes on a reconfigure. On the initial join this was harmless (`async_initialize()` added the entities and cleaned up its duplicate re-discoveries), but every reconfigure of a live device leaked another set of never-added entities with active listeners (e.g. a second `IasZoneEnrollment` listener on the IAS cluster).

## Change

Discovery now skips activating and queueing the entities when the device still has live entities, as those already listen. Without live entities, the entities are still activated during configuration: e.g. the IAS zone enrollment entity has to answer a device-initiated enroll request right after the CIE address is written. `async_initialize()` then adds them and cleans up its own re-discoveries.

The gate is "does the device have live entities" rather than "is the device initialized", because a rebuild after a same-quirk re-interview tears down all entities while `_initialized` stays set — configuration must re-activate the entities there (verified that the IAS enrollment listener is live during the post-rebuild CIE handshake).

## Relation to #897 / #898

#898 fixes a different bug on the same `_pending_entities` list: two concurrent `async_initialize()` calls (startup mains polling racing a join / re-interview) draining it at the same time (#897). The two changes are independent and complementary: this PR keeps a reconfigure from queueing entities at all, #898 serializes the initialize rounds that drain the queue. Verified that this branch merges cleanly onto `dev` + #898 and that the full suite passes on the merged tree, in either merge order.

<details>
<summary>Known remaining gap (pre-existing, not addressed by either PR; fixed in #899)</summary>

`async_teardown` / `async_rebuild_from_zigpy_device` do not take the lock, so a removal or a re-interview rebuild can land while an initialization round (startup mains polling, an availability refresh) is still registering entities. The window is the registration step of that round: `_add_pending_entities` awaits `entity.on_remove()` for every entity it drops, and a teardown landing there clears the pending list but cannot take back the entities the round has already collected, which are registered afterwards. On a removed device they are announced to consumers after the device is gone; after a rebuild they are bound to the old zigpy device, and the re-interview's own initialization drops its fresh entities as duplicates, so the stale ones stay registered. Only unregistered entities get collected, so the exposure is a startup poll or availability refresh of a device that has just joined; a teardown landing during the round's device reads is harmless, since the pending list is cleared before the round registers anything. With this PR's live-entity gate, the stale registration also makes the following `async_configure()` skip activation. Fix: #899 (stacked on #898).

</details>

<details>
<summary>Tests</summary>

- `test_async_configure_does_not_queue_entities`: a reconfigure of a live device leaves no pending entities; after a rebuild, configuration queues them again and the following initialization restores the same entity set. Fails on `dev`.

</details>

