### PR TITLE
Exclude the entity itself from `is_supported_in_list`

### DIFF
--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -313,7 +313,10 @@ class BaseEntity(LogMixin, EventBase):
         return True
 
     def is_supported_in_list(self, entities: list[BaseEntity]) -> bool:
-        """Return if the entity is supported given all other entities."""
+        """Return if the entity is supported given all other entities.
+
+        Callers never include the entity itself in `entities`.
+        """
         return True
 
     def recompute_capabilities(self) -> None:

--- a/zha/application/platforms/button/__init__.py
+++ b/zha/application/platforms/button/__init__.py
@@ -143,7 +143,7 @@ class IdentifyButton(Button):
     def is_supported_in_list(self, entities: list[BaseEntity]) -> bool:
         """Check if this button is supported given the list of entities."""
         cls = type(self)
-        return not any(type(entity) is cls for entity in entities if entity is not self)
+        return not any(type(entity) is cls for entity in entities)
 
 
 class WriteAttributeButton(BaseButton):

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -3248,7 +3248,7 @@ class RSSISensor(Sensor):
     def is_supported_in_list(self, entities: list[BaseEntity]) -> bool:
         """Check if the sensor is supported given the list of entities."""
         cls = type(self)
-        return not any(type(entity) is cls for entity in entities if entity is not self)
+        return not any(type(entity) is cls for entity in entities)
 
     @property
     def native_value(self) -> str | int | float | None:

--- a/zha/zigbee/device.py
+++ b/zha/zigbee/device.py
@@ -1218,7 +1218,9 @@ class Device(LogMixin, EventBase):
         for entity in entities[:]:
             entity.recompute_capabilities()
 
-            if not entity.is_supported() or not entity.is_supported_in_list(entities):
+            if not entity.is_supported() or not entity.is_supported_in_list(
+                [e for e in entities if e is not entity]
+            ):
                 self.debug("Removing unsupported entity %s", entity)
                 await self._remove_entity(entity, remove=True)
                 entities.remove(entity)


### PR DESCRIPTION
Fixes the third item of #725.

`recompute_entities` passed the full entity list — including the entity being evaluated — to `is_supported_in_list`, forcing every implementation to defensively filter out `self` (the singleton checks in the RSSI sensor and identify button did). The caller now excludes the entity, matching `_add_pending_entities` (where the pending entity is never in the list, as it is only inserted after its own check), and the defensive checks are removed. The base docstring documents the contract.

No behavior change: `test_entity_recomputation` fails if the caller-side exclusion is removed while the implementations no longer self-filter, so the contract is pinned by the existing suite.
