### PR TITLE
Allow attribute reporting configs to override defaults

### DIFF
--- a/tests/test_cluster_config.py
+++ b/tests/test_cluster_config.py
@@ -82,7 +82,7 @@ def test_override_without_reporting_is_rejected() -> None:
 
 
 async def test_reporting_override_configures_relaxed_reporting(
-    zha_gateway: Gateway, caplog: pytest.LogCaptureFixture
+    zha_gateway: Gateway,
 ) -> None:
     """An entity's overriding reporting config replaces the built-in default."""
     zigpy_device = create_mock_zigpy_device(
@@ -131,12 +131,3 @@ async def test_reporting_override_configures_relaxed_reporting(
     assert configured[em_attrs.rms_voltage] == RELAXED
     # Attributes without an override keep the built-in default
     assert configured[em_attrs.active_power] == DEFAULT
-
-    # The discarded configs are traceable in the debug log
-    assert (
-        "ElectricalMeasurementRMSCurrent overrides reporting config for rms_voltage"
-        in caplog.text
-    ) or (
-        "Ignoring reporting config for rms_voltage on cluster electrical_measurement "
-        "from ElectricalMeasurementRMSVoltage" in caplog.text
-    )

--- a/tests/test_cluster_config.py
+++ b/tests/test_cluster_config.py
@@ -1,5 +1,7 @@
 """Tests for cluster configuration aggregation."""
 
+from unittest.mock import patch
+
 import pytest
 import zigpy.profiles.zha
 from zigpy.zcl import ReportingConfig
@@ -14,13 +16,7 @@ from tests.common import (
     join_zigpy_device,
 )
 from zha.application.gateway import Gateway
-from zha.application.platforms import (
-    ENTITY_REGISTRY,
-    AttrConfig,
-    ClusterConfig,
-    ClusterMatch,
-)
-from zha.application.platforms.virtual import VirtualEntity
+from zha.application.platforms import AttrConfig, ClusterConfig, sensor
 from zha.zigbee.cluster_config import AggregatedAttrConfig
 
 # A tight, non-overriding config, like the ones ZHA's built-in entities declare
@@ -86,47 +82,17 @@ def test_override_without_reporting_is_rejected() -> None:
 
 
 async def test_reporting_override_configures_relaxed_reporting(
-    zha_gateway: Gateway, monkeypatch: pytest.MonkeyPatch
+    zha_gateway: Gateway,
 ) -> None:
     """An entity's overriding reporting config replaces the built-in default."""
-    em_cluster_id = homeautomation.ElectricalMeasurement.cluster_id
-    em_attrs = homeautomation.ElectricalMeasurement.AttributeDefs
-
-    class RelaxedVoltageReporting(VirtualEntity):
-        """Device-specific (e.g. quirk-provided) entity relaxing `rms_voltage`.
-
-        Declares its reporting config for `rms_voltage` by attribute name (str),
-        like quirks do, while the built-in voltage entity uses the ZCLAttributeDef.
-        Both must aggregate to the same attribute.
-        """
-
-        _unique_id_suffix = "relaxed_voltage_reporting"
-        _cluster_id = em_cluster_id
-        _cluster_match = ClusterMatch(server_clusters=frozenset({em_cluster_id}))
-        _server_cluster_config = {
-            em_cluster_id: ClusterConfig(
-                attributes={
-                    em_attrs.rms_voltage.name: AttrConfig(
-                        read_on_startup=False,
-                        reporting=RELAXED,
-                        reporting_override=True,
-                    ),
-                },
-            )
-        }
-
-    # Register the entity for this test only, alongside the built-in EM entities
-    monkeypatch.setitem(
-        ENTITY_REGISTRY,
-        em_cluster_id,
-        [*ENTITY_REGISTRY[em_cluster_id], RelaxedVoltageReporting],
-    )
-
     zigpy_device = create_mock_zigpy_device(
         zha_gateway,
         {
             1: {
-                SIG_EP_INPUT: [general.Basic.cluster_id, em_cluster_id],
+                SIG_EP_INPUT: [
+                    general.Basic.cluster_id,
+                    homeautomation.ElectricalMeasurement.cluster_id,
+                ],
                 SIG_EP_OUTPUT: [],
                 SIG_EP_TYPE: zigpy.profiles.zha.DeviceType.SMART_PLUG,
                 SIG_EP_PROFILE: zigpy.profiles.zha.PROFILE_ID,
@@ -134,7 +100,31 @@ async def test_reporting_override_configures_relaxed_reporting(
         },
     )
     cluster = zigpy_device.endpoints[1].electrical_measurement
-    await join_zigpy_device(zha_gateway, zigpy_device)
+    em_attrs = homeautomation.ElectricalMeasurement.AttributeDefs
+
+    # Simulate a device-specific (e.g. quirk-provided) entity declaring a relaxed
+    # reporting config for `rms_voltage`, alongside the built-in voltage entity
+    # declaring the default one for the same attribute. Quirks key attributes by
+    # name (str) while built-in entities use the ZCLAttributeDef, so both spellings
+    # must aggregate to the same attribute.
+    override_config = {
+        homeautomation.ElectricalMeasurement.cluster_id: ClusterConfig(
+            bind=True,
+            attributes={
+                em_attrs.rms_voltage.name: AttrConfig(
+                    read_on_startup=False,
+                    reporting=RELAXED,
+                    reporting_override=True,
+                ),
+            },
+        )
+    }
+    with patch.object(
+        sensor.ElectricalMeasurementRMSCurrent,
+        "_server_cluster_config",
+        override_config,
+    ):
+        await join_zigpy_device(zha_gateway, zigpy_device)
 
     assert len(cluster.configure_reporting_multiple.mock_calls) == 1
     configured = cluster.configure_reporting_multiple.mock_calls[0].args[0]

--- a/tests/test_cluster_config.py
+++ b/tests/test_cluster_config.py
@@ -19,15 +19,8 @@ from zha.application.gateway import Gateway
 from zha.application.platforms import AttrConfig, ClusterConfig, sensor
 from zha.zigbee.cluster_config import AggregatedAttrConfig
 
-# ZHA's built-in reporting config for EM attributes, e.g. `rms_voltage`
-DEFAULT = (
-    sensor.ElectricalMeasurementRMSVoltage._server_cluster_config[
-        homeautomation.ElectricalMeasurement.cluster_id
-    ]
-    .attributes[homeautomation.ElectricalMeasurement.AttributeDefs.rms_voltage]
-    .reporting
-)
-assert DEFAULT is not None
+# A tight, non-overriding config, like the ones ZHA's built-in entities declare
+DEFAULT = ReportingConfig(min_interval=5, max_interval=900, reportable_change=1)
 RELAXED = ReportingConfig(min_interval=30, max_interval=3600, reportable_change=100)
 RELAXED_TIGHTER = ReportingConfig(
     min_interval=10, max_interval=1800, reportable_change=50

--- a/tests/test_cluster_config.py
+++ b/tests/test_cluster_config.py
@@ -1,7 +1,5 @@
 """Tests for cluster configuration aggregation."""
 
-from unittest.mock import patch
-
 import pytest
 import zigpy.profiles.zha
 from zigpy.zcl import ReportingConfig
@@ -16,7 +14,13 @@ from tests.common import (
     join_zigpy_device,
 )
 from zha.application.gateway import Gateway
-from zha.application.platforms import AttrConfig, ClusterConfig, sensor
+from zha.application.platforms import (
+    ENTITY_REGISTRY,
+    AttrConfig,
+    ClusterConfig,
+    ClusterMatch,
+)
+from zha.application.platforms.virtual import VirtualEntity
 from zha.zigbee.cluster_config import AggregatedAttrConfig
 
 # A tight, non-overriding config, like the ones ZHA's built-in entities declare
@@ -82,17 +86,47 @@ def test_override_without_reporting_is_rejected() -> None:
 
 
 async def test_reporting_override_configures_relaxed_reporting(
-    zha_gateway: Gateway,
+    zha_gateway: Gateway, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """An entity's overriding reporting config replaces the built-in default."""
+    em_cluster_id = homeautomation.ElectricalMeasurement.cluster_id
+    em_attrs = homeautomation.ElectricalMeasurement.AttributeDefs
+
+    class RelaxedVoltageReporting(VirtualEntity):
+        """Device-specific (e.g. quirk-provided) entity relaxing `rms_voltage`.
+
+        Declares its reporting config for `rms_voltage` by attribute name (str),
+        like quirks do, while the built-in voltage entity uses the ZCLAttributeDef.
+        Both must aggregate to the same attribute.
+        """
+
+        _unique_id_suffix = "relaxed_voltage_reporting"
+        _cluster_id = em_cluster_id
+        _cluster_match = ClusterMatch(server_clusters=frozenset({em_cluster_id}))
+        _server_cluster_config = {
+            em_cluster_id: ClusterConfig(
+                attributes={
+                    em_attrs.rms_voltage.name: AttrConfig(
+                        read_on_startup=False,
+                        reporting=RELAXED,
+                        reporting_override=True,
+                    ),
+                },
+            )
+        }
+
+    # Register the entity for this test only, alongside the built-in EM entities
+    monkeypatch.setitem(
+        ENTITY_REGISTRY,
+        em_cluster_id,
+        [*ENTITY_REGISTRY[em_cluster_id], RelaxedVoltageReporting],
+    )
+
     zigpy_device = create_mock_zigpy_device(
         zha_gateway,
         {
             1: {
-                SIG_EP_INPUT: [
-                    general.Basic.cluster_id,
-                    homeautomation.ElectricalMeasurement.cluster_id,
-                ],
+                SIG_EP_INPUT: [general.Basic.cluster_id, em_cluster_id],
                 SIG_EP_OUTPUT: [],
                 SIG_EP_TYPE: zigpy.profiles.zha.DeviceType.SMART_PLUG,
                 SIG_EP_PROFILE: zigpy.profiles.zha.PROFILE_ID,
@@ -100,31 +134,7 @@ async def test_reporting_override_configures_relaxed_reporting(
         },
     )
     cluster = zigpy_device.endpoints[1].electrical_measurement
-    em_attrs = homeautomation.ElectricalMeasurement.AttributeDefs
-
-    # Simulate a device-specific (e.g. quirk-provided) entity declaring a relaxed
-    # reporting config for `rms_voltage`, alongside the built-in voltage entity
-    # declaring the default one for the same attribute. Quirks key attributes by
-    # name (str) while built-in entities use the ZCLAttributeDef, so both spellings
-    # must aggregate to the same attribute.
-    override_config = {
-        homeautomation.ElectricalMeasurement.cluster_id: ClusterConfig(
-            bind=True,
-            attributes={
-                em_attrs.rms_voltage.name: AttrConfig(
-                    read_on_startup=False,
-                    reporting=RELAXED,
-                    reporting_override=True,
-                ),
-            },
-        )
-    }
-    with patch.object(
-        sensor.ElectricalMeasurementRMSCurrent,
-        "_server_cluster_config",
-        override_config,
-    ):
-        await join_zigpy_device(zha_gateway, zigpy_device)
+    await join_zigpy_device(zha_gateway, zigpy_device)
 
     assert len(cluster.configure_reporting_multiple.mock_calls) == 1
     configured = cluster.configure_reporting_multiple.mock_calls[0].args[0]

--- a/tests/test_cluster_config.py
+++ b/tests/test_cluster_config.py
@@ -82,7 +82,7 @@ def test_override_without_reporting_is_rejected() -> None:
 
 
 async def test_reporting_override_configures_relaxed_reporting(
-    zha_gateway: Gateway,
+    zha_gateway: Gateway, caplog: pytest.LogCaptureFixture
 ) -> None:
     """An entity's overriding reporting config replaces the built-in default."""
     zigpy_device = create_mock_zigpy_device(
@@ -131,3 +131,12 @@ async def test_reporting_override_configures_relaxed_reporting(
     assert configured[em_attrs.rms_voltage] == RELAXED
     # Attributes without an override keep the built-in default
     assert configured[em_attrs.active_power] == DEFAULT
+
+    # The discarded configs are traceable in the debug log
+    assert (
+        "ElectricalMeasurementRMSCurrent overrides reporting config for rms_voltage"
+        in caplog.text
+    ) or (
+        "Ignoring reporting config for rms_voltage on cluster electrical_measurement "
+        "from ElectricalMeasurementRMSVoltage" in caplog.text
+    )

--- a/tests/test_cluster_config.py
+++ b/tests/test_cluster_config.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import patch
 
+import pytest
 import zigpy.profiles.zha
 from zigpy.zcl import ReportingConfig
 from zigpy.zcl.clusters import general, homeautomation
@@ -18,7 +19,15 @@ from zha.application.gateway import Gateway
 from zha.application.platforms import AttrConfig, ClusterConfig, sensor
 from zha.zigbee.cluster_config import AggregatedAttrConfig
 
-DEFAULT = ReportingConfig(min_interval=5, max_interval=900, reportable_change=1)
+# ZHA's built-in reporting config for EM attributes, e.g. `rms_voltage`
+DEFAULT = (
+    sensor.ElectricalMeasurementRMSVoltage._server_cluster_config[
+        homeautomation.ElectricalMeasurement.cluster_id
+    ]
+    .attributes[homeautomation.ElectricalMeasurement.AttributeDefs.rms_voltage]
+    .reporting
+)
+assert DEFAULT is not None
 RELAXED = ReportingConfig(min_interval=30, max_interval=3600, reportable_change=100)
 RELAXED_TIGHTER = ReportingConfig(
     min_interval=10, max_interval=1800, reportable_change=50
@@ -73,13 +82,10 @@ def test_merge_multiple_overrides_take_tightest() -> None:
     assert agg.reporting == RELAXED_TIGHTER
 
 
-def test_merge_override_without_reporting_is_noop() -> None:
-    """An overriding attr config without reporting does not override anything."""
-    agg = AggregatedAttrConfig()
-    agg.merge(AttrConfig(read_on_startup=False, reporting=DEFAULT))
-    agg.merge(AttrConfig(read_on_startup=True, reporting_override=True))
-    assert agg.reporting_override is False
-    assert agg.reporting == DEFAULT
+def test_override_without_reporting_is_rejected() -> None:
+    """An overriding attr config must carry a reporting config."""
+    with pytest.raises(ValueError, match="requires a reporting config"):
+        AttrConfig(read_on_startup=True, reporting_override=True)
 
 
 async def test_reporting_override_configures_relaxed_reporting(
@@ -105,12 +111,14 @@ async def test_reporting_override_configures_relaxed_reporting(
 
     # Simulate a device-specific (e.g. quirk-provided) entity declaring a relaxed
     # reporting config for `rms_voltage`, alongside the built-in voltage entity
-    # declaring the default one for the same attribute.
+    # declaring the default one for the same attribute. Quirks key attributes by
+    # name (str) while built-in entities use the ZCLAttributeDef, so both spellings
+    # must aggregate to the same attribute.
     override_config = {
         homeautomation.ElectricalMeasurement.cluster_id: ClusterConfig(
             bind=True,
             attributes={
-                em_attrs.rms_voltage: AttrConfig(
+                em_attrs.rms_voltage.name: AttrConfig(
                     read_on_startup=False,
                     reporting=RELAXED,
                     reporting_override=True,

--- a/tests/test_cluster_config.py
+++ b/tests/test_cluster_config.py
@@ -1,0 +1,132 @@
+"""Tests for cluster configuration aggregation."""
+
+from unittest.mock import patch
+
+import zigpy.profiles.zha
+from zigpy.zcl import ReportingConfig
+from zigpy.zcl.clusters import general, homeautomation
+
+from tests.common import (
+    SIG_EP_INPUT,
+    SIG_EP_OUTPUT,
+    SIG_EP_PROFILE,
+    SIG_EP_TYPE,
+    create_mock_zigpy_device,
+    join_zigpy_device,
+)
+from zha.application.gateway import Gateway
+from zha.application.platforms import AttrConfig, ClusterConfig, sensor
+from zha.zigbee.cluster_config import AggregatedAttrConfig
+
+DEFAULT = ReportingConfig(min_interval=5, max_interval=900, reportable_change=1)
+RELAXED = ReportingConfig(min_interval=30, max_interval=3600, reportable_change=100)
+RELAXED_TIGHTER = ReportingConfig(
+    min_interval=10, max_interval=1800, reportable_change=50
+)
+
+
+def test_merge_tightest_wins_by_default() -> None:
+    """Without overrides, the tightest of each reporting field wins."""
+    agg = AggregatedAttrConfig()
+    agg.merge(AttrConfig(read_on_startup=False, reporting=RELAXED))
+    agg.merge(AttrConfig(read_on_startup=True, reporting=DEFAULT))
+    assert agg.read_on_startup is True
+    assert agg.reporting_override is False
+    assert agg.reporting == DEFAULT
+
+
+def test_merge_override_replaces_defaults() -> None:
+    """An overriding config replaces already merged non-overriding configs."""
+    agg = AggregatedAttrConfig()
+    agg.merge(AttrConfig(read_on_startup=True, reporting=DEFAULT))
+    agg.merge(
+        AttrConfig(read_on_startup=False, reporting=RELAXED, reporting_override=True)
+    )
+    assert agg.reporting_override is True
+    assert agg.reporting == RELAXED
+    # the fresh read is unaffected by the reporting override
+    assert agg.read_on_startup is True
+
+
+def test_merge_override_ignores_later_defaults() -> None:
+    """Non-overriding configs merged after an override do not tighten it."""
+    agg = AggregatedAttrConfig()
+    agg.merge(
+        AttrConfig(read_on_startup=False, reporting=RELAXED, reporting_override=True)
+    )
+    agg.merge(AttrConfig(read_on_startup=False, reporting=DEFAULT))
+    assert agg.reporting == RELAXED
+
+
+def test_merge_multiple_overrides_take_tightest() -> None:
+    """Multiple overriding configs are merged with each other."""
+    agg = AggregatedAttrConfig()
+    agg.merge(AttrConfig(read_on_startup=False, reporting=DEFAULT))
+    agg.merge(
+        AttrConfig(read_on_startup=False, reporting=RELAXED, reporting_override=True)
+    )
+    agg.merge(
+        AttrConfig(
+            read_on_startup=False, reporting=RELAXED_TIGHTER, reporting_override=True
+        )
+    )
+    assert agg.reporting == RELAXED_TIGHTER
+
+
+def test_merge_override_without_reporting_is_noop() -> None:
+    """An overriding attr config without reporting does not override anything."""
+    agg = AggregatedAttrConfig()
+    agg.merge(AttrConfig(read_on_startup=False, reporting=DEFAULT))
+    agg.merge(AttrConfig(read_on_startup=True, reporting_override=True))
+    assert agg.reporting_override is False
+    assert agg.reporting == DEFAULT
+
+
+async def test_reporting_override_configures_relaxed_reporting(
+    zha_gateway: Gateway,
+) -> None:
+    """An entity's overriding reporting config replaces the built-in default."""
+    zigpy_device = create_mock_zigpy_device(
+        zha_gateway,
+        {
+            1: {
+                SIG_EP_INPUT: [
+                    general.Basic.cluster_id,
+                    homeautomation.ElectricalMeasurement.cluster_id,
+                ],
+                SIG_EP_OUTPUT: [],
+                SIG_EP_TYPE: zigpy.profiles.zha.DeviceType.SMART_PLUG,
+                SIG_EP_PROFILE: zigpy.profiles.zha.PROFILE_ID,
+            }
+        },
+    )
+    cluster = zigpy_device.endpoints[1].electrical_measurement
+    em_attrs = homeautomation.ElectricalMeasurement.AttributeDefs
+
+    # Simulate a device-specific (e.g. quirk-provided) entity declaring a relaxed
+    # reporting config for `rms_voltage`, alongside the built-in voltage entity
+    # declaring the default one for the same attribute.
+    override_config = {
+        homeautomation.ElectricalMeasurement.cluster_id: ClusterConfig(
+            bind=True,
+            attributes={
+                em_attrs.rms_voltage: AttrConfig(
+                    read_on_startup=False,
+                    reporting=RELAXED,
+                    reporting_override=True,
+                ),
+            },
+        )
+    }
+    with patch.object(
+        sensor.ElectricalMeasurementRMSCurrent,
+        "_server_cluster_config",
+        override_config,
+    ):
+        await join_zigpy_device(zha_gateway, zigpy_device)
+
+    assert len(cluster.configure_reporting_multiple.mock_calls) == 1
+    configured = cluster.configure_reporting_multiple.mock_calls[0].args[0]
+    assert configured[em_attrs.rms_voltage] == RELAXED
+    # Attributes without an override keep the built-in default
+    assert configured[em_attrs.active_power] == DEFAULT

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -86,13 +86,18 @@ class AttrConfig:
     read_on_startup: bool
     reporting: ReportingConfig | None = None
 
-    # Whether `reporting` replaces, rather than merges with, the reporting configs
-    # other entities declare for the same attribute. By default the tightest config
-    # wins, which means a config can only ever make reporting more frequent. Device
-    # specific configs (e.g. from quirks) set this to relax ZHA's built-in defaults,
-    # such as for devices reporting with a high divisor. Multiple overriding configs
-    # are still merged with each other.
+    # Whether `reporting` replaces the non-overriding reporting configs other
+    # entities declare for the same attribute, instead of being merged with them.
+    # By default the tightest config wins, which means a config can only ever make
+    # reporting more frequent. Device specific configs (e.g. from quirks) set this to
+    # relax ZHA's built-in defaults, such as for devices reporting with a high
+    # divisor. Multiple overriding configs are still merged with each other.
     reporting_override: bool = False
+
+    def __post_init__(self) -> None:
+        """Validate the configuration."""
+        if self.reporting_override and self.reporting is None:
+            raise ValueError("reporting_override requires a reporting config")
 
 
 @dataclass(frozen=True)

--- a/zha/application/platforms/__init__.py
+++ b/zha/application/platforms/__init__.py
@@ -86,6 +86,14 @@ class AttrConfig:
     read_on_startup: bool
     reporting: ReportingConfig | None = None
 
+    # Whether `reporting` replaces, rather than merges with, the reporting configs
+    # other entities declare for the same attribute. By default the tightest config
+    # wins, which means a config can only ever make reporting more frequent. Device
+    # specific configs (e.g. from quirks) set this to relax ZHA's built-in defaults,
+    # such as for devices reporting with a high divisor. Multiple overriding configs
+    # are still merged with each other.
+    reporting_override: bool = False
+
 
 @dataclass(frozen=True)
 class ClusterConfig:

--- a/zha/zigbee/cluster_config.py
+++ b/zha/zigbee/cluster_config.py
@@ -111,12 +111,7 @@ def aggregate_cluster_configs(
             agg.entities.append(entity)
 
             for attr_def, attr_config in config.attributes.items():
-                attr_name = (
-                    attr_def.name if isinstance(attr_def, ZCLAttributeDef) else attr_def
-                )
-                if attr_name not in agg.attributes:
-                    agg.attributes[attr_name] = AggregatedAttrConfig()
-                agg.attributes[attr_name].merge(attr_config)
+                _merge_attr_config(agg, entity, attr_def, attr_config)
 
         for cluster_id, config in entity._client_cluster_config.items():
             cluster = entity.endpoint.zigpy_endpoint.out_clusters.get(cluster_id)
@@ -132,14 +127,51 @@ def aggregate_cluster_configs(
             agg.entities.append(entity)
 
             for attr_def, attr_config in config.attributes.items():
-                attr_name = (
-                    attr_def.name if isinstance(attr_def, ZCLAttributeDef) else attr_def
-                )
-                if attr_name not in agg.attributes:
-                    agg.attributes[attr_name] = AggregatedAttrConfig()
-                agg.attributes[attr_name].merge(attr_config)
+                _merge_attr_config(agg, entity, attr_def, attr_config)
 
     return result
+
+
+def _merge_attr_config(
+    agg: AggregatedClusterConfig,
+    entity: BaseEntity,
+    attr_def: ZCLAttributeDef | str,
+    attr_config: AttrConfig,
+) -> None:
+    """Merge one entity's attribute config into the aggregate, logging overrides.
+
+    Which reporting config wins depends on the entities discovered for the device
+    and is otherwise invisible (the configure reporting event only carries the
+    result), so make discarded configs traceable in debug logs.
+    """
+    attr_name = attr_def.name if isinstance(attr_def, ZCLAttributeDef) else attr_def
+    attr_agg = agg.attributes.setdefault(attr_name, AggregatedAttrConfig())
+
+    if attr_config.reporting is not None:
+        if attr_config.reporting_override and not attr_agg.reporting_override:
+            if attr_agg.reporting is not None:
+                _LOGGER.debug(
+                    "[%s] %s overrides reporting config for %s on cluster %s: %s -> %s",
+                    agg.cluster.endpoint.device.ieee,
+                    type(entity).__name__,
+                    attr_name,
+                    agg.cluster.ep_attribute,
+                    attr_agg.reporting,
+                    attr_config.reporting,
+                )
+        elif attr_agg.reporting_override and not attr_config.reporting_override:
+            _LOGGER.debug(
+                "[%s] Ignoring reporting config for %s on cluster %s from %s: %s "
+                "(overridden by %s)",
+                agg.cluster.endpoint.device.ieee,
+                attr_name,
+                agg.cluster.ep_attribute,
+                type(entity).__name__,
+                attr_config.reporting,
+                attr_agg.reporting,
+            )
+
+    attr_agg.merge(attr_config)
 
 
 async def configure_cluster_configs(

--- a/zha/zigbee/cluster_config.py
+++ b/zha/zigbee/cluster_config.py
@@ -111,7 +111,12 @@ def aggregate_cluster_configs(
             agg.entities.append(entity)
 
             for attr_def, attr_config in config.attributes.items():
-                _merge_attr_config(agg, entity, attr_def, attr_config)
+                attr_name = (
+                    attr_def.name if isinstance(attr_def, ZCLAttributeDef) else attr_def
+                )
+                if attr_name not in agg.attributes:
+                    agg.attributes[attr_name] = AggregatedAttrConfig()
+                agg.attributes[attr_name].merge(attr_config)
 
         for cluster_id, config in entity._client_cluster_config.items():
             cluster = entity.endpoint.zigpy_endpoint.out_clusters.get(cluster_id)
@@ -127,51 +132,14 @@ def aggregate_cluster_configs(
             agg.entities.append(entity)
 
             for attr_def, attr_config in config.attributes.items():
-                _merge_attr_config(agg, entity, attr_def, attr_config)
+                attr_name = (
+                    attr_def.name if isinstance(attr_def, ZCLAttributeDef) else attr_def
+                )
+                if attr_name not in agg.attributes:
+                    agg.attributes[attr_name] = AggregatedAttrConfig()
+                agg.attributes[attr_name].merge(attr_config)
 
     return result
-
-
-def _merge_attr_config(
-    agg: AggregatedClusterConfig,
-    entity: BaseEntity,
-    attr_def: ZCLAttributeDef | str,
-    attr_config: AttrConfig,
-) -> None:
-    """Merge one entity's attribute config into the aggregate, logging overrides.
-
-    Which reporting config wins depends on the entities discovered for the device
-    and is otherwise invisible (the configure reporting event only carries the
-    result), so make discarded configs traceable in debug logs.
-    """
-    attr_name = attr_def.name if isinstance(attr_def, ZCLAttributeDef) else attr_def
-    attr_agg = agg.attributes.setdefault(attr_name, AggregatedAttrConfig())
-
-    if attr_config.reporting is not None:
-        if attr_config.reporting_override and not attr_agg.reporting_override:
-            if attr_agg.reporting is not None:
-                _LOGGER.debug(
-                    "[%s] %s overrides reporting config for %s on cluster %s: %s -> %s",
-                    agg.cluster.endpoint.device.ieee,
-                    type(entity).__name__,
-                    attr_name,
-                    agg.cluster.ep_attribute,
-                    attr_agg.reporting,
-                    attr_config.reporting,
-                )
-        elif attr_agg.reporting_override and not attr_config.reporting_override:
-            _LOGGER.debug(
-                "[%s] Ignoring reporting config for %s on cluster %s from %s: %s "
-                "(overridden by %s)",
-                agg.cluster.endpoint.device.ieee,
-                attr_name,
-                agg.cluster.ep_attribute,
-                type(entity).__name__,
-                attr_config.reporting,
-                attr_agg.reporting,
-            )
-
-    attr_agg.merge(attr_config)
 
 
 async def configure_cluster_configs(

--- a/zha/zigbee/cluster_config.py
+++ b/zha/zigbee/cluster_config.py
@@ -33,27 +33,42 @@ class AggregatedAttrConfig:
 
     read_on_startup: bool = False
     reporting: ReportingConfig | None = None
+    reporting_override: bool = False
 
     def merge(self, config: AttrConfig) -> None:
-        """Merge another attribute config (fresh read and tightest reporting win)."""
+        """Merge another attribute config.
+
+        A fresh read wins over a cached one. For reporting, the tightest config wins,
+        except that overriding configs (`AttrConfig.reporting_override`) replace
+        non-overriding ones entirely and are only merged with other overriding configs.
+        """
         self.read_on_startup = self.read_on_startup or config.read_on_startup
 
-        if config.reporting is not None:
-            if self.reporting is None:
-                self.reporting = config.reporting
-            else:
-                self.reporting = ReportingConfig(
-                    min_interval=min(
-                        self.reporting.min_interval, config.reporting.min_interval
-                    ),
-                    max_interval=min(
-                        self.reporting.max_interval, config.reporting.max_interval
-                    ),
-                    reportable_change=min(
-                        self.reporting.reportable_change,
-                        config.reporting.reportable_change,
-                    ),
-                )
+        if config.reporting is None:
+            return
+
+        if config.reporting_override and not self.reporting_override:
+            # First overriding config: discard whatever the defaults merged to
+            self.reporting = config.reporting
+            self.reporting_override = True
+        elif self.reporting_override and not config.reporting_override:
+            # Non-overriding configs cannot tighten an override
+            return
+        elif self.reporting is None:
+            self.reporting = config.reporting
+        else:
+            self.reporting = ReportingConfig(
+                min_interval=min(
+                    self.reporting.min_interval, config.reporting.min_interval
+                ),
+                max_interval=min(
+                    self.reporting.max_interval, config.reporting.max_interval
+                ),
+                reportable_change=min(
+                    self.reporting.reportable_change,
+                    config.reporting.reportable_change,
+                ),
+            )
 
 
 @dataclass


### PR DESCRIPTION
## Proposed change

Allow an attribute reporting config to override, instead of merge with, the reporting configs other entities declare for the same attribute.

`AggregatedAttrConfig.merge` always takes the minimum of `min_interval`, `max_interval` and `reportable_change` across all entities that declare a config for an attribute ("tightest wins"). That is the right default when several ZHA entities share an attribute, but it means a device-specific config can only ever make reporting *more* frequent. A quirks v2 entity (or the entity-less `configures_reporting` proposed in zigpy/zha-device-handlers#5128 and zigpy/zha-device-handlers#5171) that wants to relax ZHA's built-in default for e.g. `rms_voltage` currently loses to the built-in `reportable_change=1`.

This adds `AttrConfig.reporting_override: bool = False`. Semantics in `AggregatedAttrConfig.merge`:

- The first overriding config replaces whatever the non-overriding configs merged to.
- Non-overriding configs aggregated afterwards are ignored for reporting (they can still request a fresh read via `read_on_startup`, and binding is unaffected).
- Multiple overriding configs are merged with each other (tightest wins), so two device-specific configs behave like today.

The result is independent of the order entities are aggregated in.

`AttrConfig(reporting_override=True)` without a `reporting` config raises, since "override with nothing" would otherwise silently fall back to the default. Suppressing reporting for an attribute entirely is not covered by this PR.

## Additional information

- **Scope:** only reporting is overridable. `bind` still ORs across entities, so a quirk cannot prevent a bind with this. That is a separate concern (a bound cluster without reporting is harmless) and can follow if needed.
- **Why not just drop quirk-removed entities from aggregation?** `_discovered_entities` also includes entities a quirk removes, so a quirk that *replaces* ZHA's voltage sensor could relax reporting today by excluding those. That does not cover a quirk that keeps the built-in entity and only wants looser reporting, and removed entities also contribute the divisor/multiplier reads, so an explicit flag is the cleaner tool.
- **Entry point for entity-less reporting:** zigpy/zha-device-handlers#5128 yields a `VirtualEntity` with a per-instance `_server_cluster_config`, so it flows through the same aggregation and just needs `reporting_override=True` on its `AttrConfig`.
- **Polling is unaffected:** `AggregatedClusterPoller` walks each entity's own config, not the aggregated result, so relaxing reporting via an override does not change poll intervals for polled devices.
- **Alternative shape considered:** a `reporting_priority: int` (highest tier wins, tightest within a tier) would subsume the bool and allow more tiers later. Kept the bool for now since there are only two tiers (ZHA defaults vs device-specific); happy to switch if preferred.
- **Motivating case:** the SONOFF S60ZBTPF/S60ZBTPG reports `rms_voltage`/`rms_current` with a divisor of 100, so ZHA's raw `reportable_change=1` is 0.01 V / 0.01 A and the plug reports at every 5 second minimum interval. With this PR, the S60 quirk can declare 1 V / 0.05 A and have it applied.
- **Follow-up in zha-device-handlers:** pass `reporting_override=True` when building the `AttrConfig` from quirk `reporting_config` metadata in `zhaquirks/builder/discovery.py`, so quirk-provided reporting configs win over ZHA defaults. The new field has a default, so current zhaquirks releases keep working with this ZHA change. The quirks side needs to bump its `zha` dependency once this is released, since the keyword does not exist on older ZHA.
- **Related:** a follow-up PR makes the EM reportable changes divisor-aware for all devices, which fixes the common case generically. This PR gives quirks the per-device escape hatch.

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass
- [x] Tests have been added to verify that the new code works
