### PR TITLE
Relax voltage/current reporting for Sonoff S60 plugs

### DIFF
--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2193,17 +2193,23 @@ async def test_em_poller_runs_independently_of_entity_enabled_state(
 
 
 @pytest.mark.parametrize(
-    ("device_file", "expected_voltage_change", "expected_current_change"),
+    (
+        "device_file",
+        "divisors",
+        "expected_voltage_change",
+        "expected_current_change",
+    ),
     [
-        # SONOFF S60 reports with a divisor of 100: 1 V / 0.05 A
-        ("sonoff-s60zbtpg-0x00001002.json", 100, 5),
+        # SONOFF S60 reports with divisors of 100: raw 100 / 5 are 1 V / 0.05 A
+        ("sonoff-s60zbtpg-0x00001002.json", (100, 100), 100, 5),
         # Other devices keep the default raw reportable change
-        ("shelly-1pm.json", 1, 1),
+        ("shelly-1pm.json", (100, 1000), 1, 1),
     ],
 )
 async def test_sonoff_s60_electrical_measurement_reporting(
     zha_gateway: Gateway,
     device_file: str,
+    divisors: tuple[int, int],
     expected_voltage_change: int,
     expected_current_change: int,
 ) -> None:
@@ -2213,6 +2219,12 @@ async def test_sonoff_s60_electrical_measurement_reporting(
     )
     cluster = zigpy_device.endpoints[1].electrical_measurement
     await join_zigpy_device(zha_gateway, zigpy_device)
+
+    # The raw reportable changes only mean 1 V / 0.05 A for these divisors
+    assert (
+        cluster.get(EMAttrs.ac_voltage_divisor.id),
+        cluster.get(EMAttrs.ac_current_divisor.id),
+    ) == divisors
 
     assert len(cluster.configure_reporting_multiple.mock_calls) == 1
     configured = cluster.configure_reporting_multiple.call_args.args[0]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2190,3 +2190,39 @@ async def test_em_poller_runs_independently_of_entity_enabled_state(
     active_power.enable()
     assert active_power.enabled is True
     assert not poll_task.done()
+
+
+@pytest.mark.parametrize(
+    ("device_file", "expected_voltage_change", "expected_current_change"),
+    [
+        # SONOFF S60 reports with a divisor of 100: 1 V / 0.05 A
+        ("sonoff-s60zbtpg-0x00001002.json", 100, 5),
+        # Other devices keep the default raw reportable change
+        ("shelly-1pm.json", 1, 1),
+    ],
+)
+async def test_sonoff_s60_electrical_measurement_reporting(
+    zha_gateway: Gateway,
+    device_file: str,
+    expected_voltage_change: int,
+    expected_current_change: int,
+) -> None:
+    """The SONOFF S60 plugs get relaxed voltage/current reporting configured."""
+    zigpy_device = await zigpy_device_from_json(
+        zha_gateway.application_controller, f"tests/data/devices/{device_file}"
+    )
+    cluster = zigpy_device.endpoints[1].electrical_measurement
+    await join_zigpy_device(zha_gateway, zigpy_device)
+
+    assert len(cluster.configure_reporting_multiple.mock_calls) == 1
+    configured = cluster.configure_reporting_multiple.mock_calls[0].args[0]
+    assert configured[EMAttrs.rms_voltage] == ReportingConfig(
+        min_interval=5, max_interval=900, reportable_change=expected_voltage_change
+    )
+    assert configured[EMAttrs.rms_current] == ReportingConfig(
+        min_interval=5, max_interval=900, reportable_change=expected_current_change
+    )
+    # Other attributes are unaffected
+    assert configured[EMAttrs.active_power] == ReportingConfig(
+        min_interval=5, max_interval=900, reportable_change=1
+    )

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2215,7 +2215,7 @@ async def test_sonoff_s60_electrical_measurement_reporting(
     await join_zigpy_device(zha_gateway, zigpy_device)
 
     assert len(cluster.configure_reporting_multiple.mock_calls) == 1
-    configured = cluster.configure_reporting_multiple.mock_calls[0].args[0]
+    configured = cluster.configure_reporting_multiple.call_args.args[0]
     assert configured[EMAttrs.rms_voltage] == ReportingConfig(
         min_interval=5, max_interval=900, reportable_change=expected_voltage_change
     )

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -1021,12 +1021,13 @@ class ElectricalMeasurementReportingDevice(VirtualEntity):
 
 
 @register_entity(ElectricalMeasurement.cluster_id)
-class SonoffS60ElectricalMeasurementReporting(VirtualEntity):
+class SonoffS60RelaxedElectricalMeasurementReporting(VirtualEntity):
     """Relaxed voltage/current reporting for the SONOFF S60 plugs.
 
-    These plugs report `rms_voltage` and `rms_current` with a divisor of 100, so
-    the default raw reportable change of 1 is 0.01 V / 0.01 A and the device
-    reports at every minimum interval. Override with 1 V / 0.05 A.
+    These plugs report `rms_voltage` and `rms_current` with `ac_voltage_divisor` and
+    `ac_current_divisor` of 100 (verified on S60ZBTPG firmware 0x00001002), so the
+    default raw reportable change of 1 is 0.01 V / 0.01 A and the device reports at
+    every 5 second minimum interval. Override with 1 V / 0.05 A.
 
     Temporary: superseded by divisor-aware reportable changes for all devices.
     """
@@ -1040,6 +1041,7 @@ class SonoffS60ElectricalMeasurementReporting(VirtualEntity):
     )
     _server_cluster_config = {
         ElectricalMeasurement.cluster_id: ClusterConfig(
+            bind=True,
             attributes={
                 ElectricalMeasurement.AttributeDefs.rms_voltage: AttrConfig(
                     read_on_startup=False,

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -1021,6 +1021,46 @@ class ElectricalMeasurementReportingDevice(VirtualEntity):
 
 
 @register_entity(ElectricalMeasurement.cluster_id)
+class SonoffS60ElectricalMeasurementReporting(VirtualEntity):
+    """Relaxed voltage/current reporting for the SONOFF S60 plugs.
+
+    These plugs report `rms_voltage` and `rms_current` with a divisor of 100, so
+    the default raw reportable change of 1 is 0.01 V / 0.01 A and the device
+    reports at every minimum interval. Override with 1 V / 0.05 A.
+
+    Temporary: superseded by divisor-aware reportable changes for all devices.
+    """
+
+    _unique_id_suffix = "sonoff_s60_em_reporting"
+    _cluster_id = ElectricalMeasurement.cluster_id
+    _cluster_match = ClusterMatch(
+        server_clusters=frozenset({ElectricalMeasurement.cluster_id}),
+        manufacturers=frozenset({"SONOFF"}),
+        models=frozenset({"S60ZBTPF", "S60ZBTPG"}),
+    )
+    _server_cluster_config = {
+        ElectricalMeasurement.cluster_id: ClusterConfig(
+            attributes={
+                ElectricalMeasurement.AttributeDefs.rms_voltage: AttrConfig(
+                    read_on_startup=False,
+                    reporting=ReportingConfig(
+                        min_interval=5, max_interval=900, reportable_change=100
+                    ),
+                    reporting_override=True,
+                ),
+                ElectricalMeasurement.AttributeDefs.rms_current: AttrConfig(
+                    read_on_startup=False,
+                    reporting=ReportingConfig(
+                        min_interval=5, max_interval=900, reportable_change=5
+                    ),
+                    reporting_override=True,
+                ),
+            },
+        ),
+    }
+
+
+@register_entity(ElectricalMeasurement.cluster_id)
 class ElectricalMeasurementActivePower(BaseElectricalMeasurement):
     """Active power measurement."""
 

--- a/zha/application/platforms/sensor/__init__.py
+++ b/zha/application/platforms/sensor/__init__.py
@@ -1021,48 +1021,6 @@ class ElectricalMeasurementReportingDevice(VirtualEntity):
 
 
 @register_entity(ElectricalMeasurement.cluster_id)
-class SonoffS60RelaxedElectricalMeasurementReporting(VirtualEntity):
-    """Relaxed voltage/current reporting for the SONOFF S60 plugs.
-
-    These plugs report `rms_voltage` and `rms_current` with `ac_voltage_divisor` and
-    `ac_current_divisor` of 100 (verified on S60ZBTPG firmware 0x00001002), so the
-    default raw reportable change of 1 is 0.01 V / 0.01 A and the device reports at
-    every 5 second minimum interval. Override with 1 V / 0.05 A.
-
-    Temporary: superseded by divisor-aware reportable changes for all devices.
-    """
-
-    _unique_id_suffix = "sonoff_s60_em_reporting"
-    _cluster_id = ElectricalMeasurement.cluster_id
-    _cluster_match = ClusterMatch(
-        server_clusters=frozenset({ElectricalMeasurement.cluster_id}),
-        manufacturers=frozenset({"SONOFF"}),
-        models=frozenset({"S60ZBTPF", "S60ZBTPG"}),
-    )
-    _server_cluster_config = {
-        ElectricalMeasurement.cluster_id: ClusterConfig(
-            bind=True,
-            attributes={
-                ElectricalMeasurement.AttributeDefs.rms_voltage: AttrConfig(
-                    read_on_startup=False,
-                    reporting=ReportingConfig(
-                        min_interval=5, max_interval=900, reportable_change=100
-                    ),
-                    reporting_override=True,
-                ),
-                ElectricalMeasurement.AttributeDefs.rms_current: AttrConfig(
-                    read_on_startup=False,
-                    reporting=ReportingConfig(
-                        min_interval=5, max_interval=900, reportable_change=5
-                    ),
-                    reporting_override=True,
-                ),
-            },
-        ),
-    }
-
-
-@register_entity(ElectricalMeasurement.cluster_id)
 class ElectricalMeasurementActivePower(BaseElectricalMeasurement):
     """Active power measurement."""
 

--- a/zha/application/platforms/virtual.py
+++ b/zha/application/platforms/virtual.py
@@ -881,51 +881,6 @@ class SonoffPresenceSensorInit(VirtualEntity):
     }
 
 
-@register_entity(ElectricalMeasurement.cluster_id)
-class SonoffS60RelaxedElectricalMeasurementReporting(VirtualEntity):
-    """Relaxed voltage/current reporting for the SONOFF S60 plugs.
-
-    These plugs report `rms_voltage` and `rms_current` with `ac_voltage_divisor` and
-    `ac_current_divisor` of 100 (verified on S60ZBTPG firmware 0x00001002), so the
-    default raw reportable change of 1 is 0.01 V / 0.01 A and the device reports at
-    the 5-second minimum interval. Override with 1 V / 0.05 A.
-
-    Temporary workaround. Overriding configs are merged with each other (tightest
-    wins), so this must be removed in the same release the S60 quirk starts
-    declaring its own reporting override; it becomes redundant once reportable
-    changes are divisor-aware for all devices.
-    """
-
-    _unique_id_suffix = "sonoff_s60_em_reporting"
-    _cluster_id = ElectricalMeasurement.cluster_id
-    _cluster_match = ClusterMatch(
-        server_clusters=frozenset({ElectricalMeasurement.cluster_id}),
-        manufacturers=frozenset({"SONOFF"}),
-        models=frozenset({"S60ZBTPF", "S60ZBTPG"}),
-    )
-    _server_cluster_config = {
-        ElectricalMeasurement.cluster_id: ClusterConfig(
-            bind=True,
-            attributes={
-                ElectricalMeasurement.AttributeDefs.rms_voltage: AttrConfig(
-                    read_on_startup=False,
-                    reporting=ReportingConfig(
-                        min_interval=5, max_interval=900, reportable_change=100
-                    ),
-                    reporting_override=True,
-                ),
-                ElectricalMeasurement.AttributeDefs.rms_current: AttrConfig(
-                    read_on_startup=False,
-                    reporting=ReportingConfig(
-                        min_interval=5, max_interval=900, reportable_change=5
-                    ),
-                    reporting_override=True,
-                ),
-            },
-        ),
-    }
-
-
 @register_entity(TUYA_MANUFACTURER_CLUSTER)
 class TuyaManufacturerBind(VirtualEntity):
     """Bind the Tuya manufacturer cluster on every device that exposes it."""
@@ -1286,6 +1241,53 @@ class InovelliVzm35Init(VirtualEntity):
                     "firmware_progress_led": False,
                     "smart_fan_led_display_levels": False,
                 }.items()
+            },
+        ),
+    }
+
+
+# === Model-specific reporting overrides on standard clusters ===
+
+
+@register_entity(ElectricalMeasurement.cluster_id)
+class SonoffS60RelaxedElectricalMeasurementReporting(VirtualEntity):
+    """Relaxed voltage/current reporting for the SONOFF S60 plugs.
+
+    These plugs report `rms_voltage` and `rms_current` with `ac_voltage_divisor` and
+    `ac_current_divisor` of 100 (verified on S60ZBTPG firmware 0x00001002), so the
+    default raw reportable change of 1 is 0.01 V / 0.01 A and the device reports at
+    the 5-second minimum interval. Override with 1 V / 0.05 A.
+
+    Temporary workaround. Overriding configs are merged with each other (tightest
+    wins), so this must be removed in the same release the S60 quirk starts
+    declaring its own reporting override; it becomes redundant once reportable
+    changes are divisor-aware for all devices.
+    """
+
+    _unique_id_suffix = "sonoff_s60_em_reporting"
+    _cluster_match = ClusterMatch(
+        server_clusters=frozenset({ElectricalMeasurement.cluster_id}),
+        manufacturers=frozenset({"SONOFF"}),
+        models=frozenset({"S60ZBTPF", "S60ZBTPG"}),
+    )
+    _server_cluster_config = {
+        ElectricalMeasurement.cluster_id: ClusterConfig(
+            bind=True,
+            attributes={
+                ElectricalMeasurement.AttributeDefs.rms_voltage: AttrConfig(
+                    read_on_startup=False,
+                    reporting=ReportingConfig(
+                        min_interval=5, max_interval=900, reportable_change=100
+                    ),
+                    reporting_override=True,
+                ),
+                ElectricalMeasurement.AttributeDefs.rms_current: AttrConfig(
+                    read_on_startup=False,
+                    reporting=ReportingConfig(
+                        min_interval=5, max_interval=900, reportable_change=5
+                    ),
+                    reporting_override=True,
+                ),
             },
         ),
     }

--- a/zha/application/platforms/virtual.py
+++ b/zha/application/platforms/virtual.py
@@ -24,6 +24,7 @@ from zigpy.zcl import (
 )
 from zigpy.zcl.clusters.closures import DoorLock, WindowCovering
 from zigpy.zcl.clusters.general import Identify, LevelControl, OnOff, Ota, Scenes
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
 from zigpy.zcl.clusters.lighting import Color
 from zigpy.zcl.clusters.lightlink import LightLink
 from zigpy.zcl.clusters.security import IasZone
@@ -875,6 +876,51 @@ class SonoffPresenceSensorInit(VirtualEntity):
         SONOFF_CLUSTER: ClusterConfig(
             attributes={
                 "last_illumination_state": AttrConfig(read_on_startup=False),
+            },
+        ),
+    }
+
+
+@register_entity(ElectricalMeasurement.cluster_id)
+class SonoffS60RelaxedElectricalMeasurementReporting(VirtualEntity):
+    """Relaxed voltage/current reporting for the SONOFF S60 plugs.
+
+    These plugs report `rms_voltage` and `rms_current` with `ac_voltage_divisor` and
+    `ac_current_divisor` of 100 (verified on S60ZBTPG firmware 0x00001002), so the
+    default raw reportable change of 1 is 0.01 V / 0.01 A and the device reports at
+    the 5-second minimum interval. Override with 1 V / 0.05 A.
+
+    Temporary workaround. Overriding configs are merged with each other (tightest
+    wins), so this must be removed in the same release the S60 quirk starts
+    declaring its own reporting override; it becomes redundant once reportable
+    changes are divisor-aware for all devices.
+    """
+
+    _unique_id_suffix = "sonoff_s60_em_reporting"
+    _cluster_id = ElectricalMeasurement.cluster_id
+    _cluster_match = ClusterMatch(
+        server_clusters=frozenset({ElectricalMeasurement.cluster_id}),
+        manufacturers=frozenset({"SONOFF"}),
+        models=frozenset({"S60ZBTPF", "S60ZBTPG"}),
+    )
+    _server_cluster_config = {
+        ElectricalMeasurement.cluster_id: ClusterConfig(
+            bind=True,
+            attributes={
+                ElectricalMeasurement.AttributeDefs.rms_voltage: AttrConfig(
+                    read_on_startup=False,
+                    reporting=ReportingConfig(
+                        min_interval=5, max_interval=900, reportable_change=100
+                    ),
+                    reporting_override=True,
+                ),
+                ElectricalMeasurement.AttributeDefs.rms_current: AttrConfig(
+                    read_on_startup=False,
+                    reporting=ReportingConfig(
+                        min_interval=5, max_interval=900, reportable_change=5
+                    ),
+                    reporting_override=True,
+                ),
             },
         ),
     }


### PR DESCRIPTION
## Proposed change

Quick, temporary ZHA-side workaround for the SONOFF S60ZBTPF / S60ZBTPG smart plugs spamming voltage (and current) reports.

These plugs report `rms_voltage` and `rms_current` with `ac_voltage_divisor` / `ac_current_divisor` of 100 (`rms_voltage = 23384` is 233.84 V, verified on S60ZBTPG firmware 0x00001002). ZHA configures all electrical measurement attributes with a fixed raw `reportable_change=1`, which for this device is a 0.01 V / 0.01 A threshold. Mains voltage always drifts more than that, so the plug reports at every 5 second minimum interval.

This adds a model-matched `VirtualEntity` on the Electrical Measurement cluster, `SonoffS60RelaxedElectricalMeasurementReporting`, that uses the reporting override from #884 to configure `rms_voltage` with a raw change of 100 (1 V) and `rms_current` with 5 (0.05 A). Everything else (intervals, other attributes, other devices) is unchanged. It is a virtual entity, so nothing shows up in Home Assistant, no `unique_id` changes, and the device snapshots are untouched. It lives in `zha/application/platforms/virtual.py` next to the other manufacturer-specific bind/init virtual entities (`SonoffManufacturerBind`, `TuyaPlugManufacturerInit`, ...).

The new reporting config is applied on the next reconfigure or re-pair of the plug, as with any reporting change.

## Additional information

This is deliberately the smallest possible fix so it can go into a patch release. It is a hardcoded device entry in ZHA, which is what quirks normally exist to avoid, so it is marked temporary and should be removed again once either of these lands. Note that overriding configs merge with each other (tightest wins), so when the quirks-side override lands this entry has to be removed in the same release rather than just being outvoted; with the divisor-aware route it merely becomes redundant.

- **Long-term (generic):** make the reportable changes divisor-aware for all devices, so the threshold is expressed in physical units and scaled by the device's divisor/multiplier attributes when reporting is configured. Branch: https://github.com/TheJulianJES/zha/tree/tjj/em-scaled-reportable-change (resolving it against the device snapshots, 82 of the 100 devices with EM entities currently report with a needlessly fine threshold; PR to follow).
- **Shorter-term (quirks):** do the same override in the S60 quirk instead of ZHA, using the entity-less `configures_reporting` proposed in zigpy/zha-device-handlers#5128 / zigpy/zha-device-handlers#5171 together with the now merged #884 (the quirks side needs to pass `reporting_override=True` and bump its `zha` dependency).

Both need coordinated releases across ZHA and zha-quirks, which is why this ZHA-only patch comes first.

Unrelated to this change: the S60 is not in the `ElectricalMeasurementReportingDevice` model list, so the EM poller still polls it every 30 to 45 seconds. Whether to add it there is a separate decision.

## Checklist

- [x] The changes are tested and work correctly
- [x] `pre-commit` checks pass
- [x] Tests have been added to verify that the new code works
